### PR TITLE
Set default API URL

### DIFF
--- a/shakenfist/client/main.py
+++ b/shakenfist/client/main.py
@@ -36,7 +36,7 @@ def filter_dict(d, allowed_keys):
 @click.option('--verbose/--no-verbose', default=False)
 @click.option('--namespace', envvar='SHAKENFIST_NAMESPACE', default=None)
 @click.option('--token', envvar='SHAKENFIST_TOKEN', default=None)
-@click.option('--apiurl', envvar='SHAKENFIST_API_URL', default=None)
+@click.option('--apiurl', envvar='SHAKENFIST_API_URL', default='http://localhost:13000')
 @click.pass_context
 def cli(ctx, output, verbose, namespace, token, apiurl):
     if not ctx.obj:


### PR DESCRIPTION
This fixes an error when a namespace is specifed without an API URL.

  File "/usr/local/lib/python3.6/dist-packages/shakenfist/client/apiclient.py", line 142, in create_instance
    r = self._request_url('POST', self.base_url + '/instances',
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'