### PR TITLE
Instance memory is measured in MB

### DIFF
--- a/docs/standards.md
+++ b/docs/standards.md
@@ -1,0 +1,20 @@
+Concepts and Standards
+===
+### Ensuring a Common Language within the code base
+
+This document records the standards and common language used within the Shaken Fist software system.
+
+It should also record why the choice was made.
+
+(This is actually just notes to save our future selves from tripping over the same problems.)
+
+
+Memory
+------
+* Memory is measured in MiB
+* All references to memory size are stored/transmitted in MiB
+
+Gigabytes can be too big if you want a lot of small machines. Kilobytes is just too many numbers to type.
+
+### Interactions
+The ```libvirt``` API measures memory in KiB. Therefore, interactions with the library need to be careful to convert from MiB to KiB.

--- a/shakenfist/client/main.py
+++ b/shakenfist/client/main.py
@@ -592,7 +592,7 @@ def _parse_spec(spec):
                   help=('Create an instance.\n\n'
                         'NAME:      The name of the instance.\n'
                         'CPUS:      The number of vCPUs for the instance.\n'
-                        'MEMORY:    The amount of RAM for the instance in GB.\n'
+                        'MEMORY:    The amount of RAM for the instance in MB.\n'
                         '\n'
                         'Options (may be repeated, must be specified at least once):\n'
                         '--network/-n:   The uuid of the network to attach the instance to.\n'
@@ -633,6 +633,10 @@ def instance_create(ctx, name=None, cpus=None, memory=None, network=None, networ
                     encodeduserdata=None, placement=None, namespace=None):
     if len(disk) < 1 and len(diskspec) < 1:
         print('You must specify at least one disk')
+
+    if memory < 256:
+        print('WARNING: Assuming you have specified memory in GB\n')
+        memory *= 1024
 
     sshkey_content = None
     if sshkey:

--- a/shakenfist/daemons/resources.py
+++ b/shakenfist/daemons/resources.py
@@ -48,12 +48,12 @@ def _get_stats():
     except Exception:
         pass
 
-    # Memory info
+    # Memory info - libvirt returns memory in KiB
     memory_status = conn.getMemoryStats(
         libvirt.VIR_NODE_MEMORY_STATS_ALL_CELLS)
     retval.update({
-        'memory_max': memory_status['total'],
-        'memory_available': memory_status['free'],
+        'memory_max': memory_status['total'] // 1024,
+        'memory_available': memory_status['free'] // 1024,
     })
 
     # Disk info
@@ -98,8 +98,8 @@ def _get_stats():
     retval.update({
         'cpu_total_instance_vcpus': total_instance_vcpus,
         'cpu_total_instance_cpu_time': total_instance_cpu_time,
-        'memory_total_instance_max_memory': total_instance_max_memory,
-        'memory_total_instance_actual_memory': total_instance_actual_memory,
+        'memory_total_instance_max_memory': total_instance_max_memory // 1024,
+        'memory_total_instance_actual_memory': total_instance_actual_memory // 1024,
         'instances_total': total_instances,
         'instances_active': total_active_instances,
     })

--- a/shakenfist/tests/test_client_apiclient.py
+++ b/shakenfist/tests/test_client_apiclient.py
@@ -38,7 +38,7 @@ class ApiClientTestCase(testtools.TestCase):
 
     def test_create_instance(self):
         client = apiclient.Client()
-        client.create_instance('foo', 1, 2, ['netuuid1'], ['8@cirros'],
+        client.create_instance('foo', 1, 2048, ['netuuid1'], ['8@cirros'],
                                'sshkey', None, None)
 
         self.mock_request.assert_called_with(
@@ -46,7 +46,7 @@ class ApiClientTestCase(testtools.TestCase):
             data={
                 'name': 'foo',
                 'cpus': 1,
-                'memory': 2,
+                'memory': 2048,
                 'network': ['netuuid1'],
                 'disk': ['8@cirros'],
                 'ssh_key': 'sshkey',
@@ -56,7 +56,7 @@ class ApiClientTestCase(testtools.TestCase):
 
     def test_create_instance_user_data(self):
         client = apiclient.Client()
-        client.create_instance('foo', 1, 2, ['netuuid1'], ['8@cirros'],
+        client.create_instance('foo', 1, 2048, ['netuuid1'], ['8@cirros'],
                                'sshkey', 'userdatabeforebase64', None)
 
         self.mock_request.assert_called_with(
@@ -64,7 +64,7 @@ class ApiClientTestCase(testtools.TestCase):
             data={
                 'name': 'foo',
                 'cpus': 1,
-                'memory': 2,
+                'memory': 2048,
                 'network': ['netuuid1'],
                 'disk': ['8@cirros'],
                 'ssh_key': 'sshkey',

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -408,7 +408,7 @@ class Instance(object):
         # spent _ages_ finding a bug related to it.
         xml = t.render(
             uuid=self.db_entry['uuid'],
-            memory=self.db_entry['memory'] * 1024 * 1024,
+            memory=self.db_entry['memory'] * 1024,
             vcpus=self.db_entry['cpus'],
             disks=self.db_entry['block_devices']['devices'],
             networks=networks,


### PR DESCRIPTION
Discussion topic: Should the CLI specify memory in MB or GB??

My previous changes regarding this assumed that the CLI would use MB. I even changed the README. I liked MB because it differentiated the CPU and memory spec to the casual user.

This PR discovered the CLI usage help was not changed. Also found the memory utilisation numbers was also broken for memory_mb.

As a compromise, the CLI will accept GB memory specification with a warning.

Take aim! Discuss!