### PR TITLE
Return more relevant HTTP codes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 Andy McCallum <andy@mandoon.com>
 Brad Hards <bradh@frogmouth.net>
 Michael Still <mikal@stillhq.com>
+Mike Carden <mike.carden@gmail.com>
 mandoonandy <andy@mandoon.com>


### PR DESCRIPTION
This took longer than I hoped chasing many rabbits down holes.
flask-restful is broken with regards to error handling - there are some hacks to fix it.

jwt-extended is not handling exceptions from the jwt library.

Cleanest method is to catch them and return the correct HTTP code. When the libraries are cleaned up, we should not see the exceptions.