### PR TITLE
Cascading delete and mock bug

### DIFF
--- a/shakenfist/client/apiclient.py
+++ b/shakenfist/client/apiclient.py
@@ -150,6 +150,12 @@ class Client(object):
                               '/instances', data={'all': all})
         return r.json()
 
+    def delete_all_instances(self, namespace):
+        r = self._request_url('DELETE', self.base_url + '/instances',
+                              data={'confirm': True,
+                                    'namespace': namespace})
+        return r.json()
+
     def get_instance(self, instance_uuid):
         r = self._request_url('GET', self.base_url +
                               '/instances/' + instance_uuid)
@@ -261,6 +267,12 @@ class Client(object):
     def delete_network(self, network_uuid):
         r = self._request_url('DELETE', self.base_url +
                               '/networks/' + network_uuid)
+        return r.json()
+
+    def delete_all_networks(self, namespace):
+        r = self._request_url('DELETE', self.base_url + '/networks',
+                              data={'confirm': True,
+                                    'namespace': namespace})
         return r.json()
 
     def get_network_events(self, instance_uuid):

--- a/shakenfist/client/main.py
+++ b/shakenfist/client/main.py
@@ -27,38 +27,37 @@ class GroupCatchExceptions(click.Group):
             return self.main(*args, **kwargs)
 
         except apiclient.RequestMalformedException as e:
-            click.echo("ERROR: Malformed Request: %s" % error_text(e.text))
+            click.echo('ERROR: Malformed Request: %s' % error_text(e.text))
             sys.exit(1)
 
         except apiclient.UnauthorizedException:
-            click.echo("ERROR: Not authorized")
+            click.echo('ERROR: Not authorized')
             sys.exit(1)
 
         except apiclient.ResourceCannotBeDeletedException as e:
-            click.echo("ERROR: Cannot delete resource: %s" %
-                       error_text(e.text))
+            click.echo('ERROR: Cannot delete resource: %s' % error_text(e.text))
             sys.exit(1)
 
         except apiclient.ResourceNotFoundException as e:
-            click.echo("ERROR: Resource not found: %s" % error_text(e.text))
+            click.echo('ERROR: Resource not found: %s' % error_text(e.text))
             sys.exit(1)
 
         except apiclient.ResourceInUseException as e:
-            click.echo("ERROR: Resource in use:\n%s" % error_text(e.text))
+            click.echo('ERROR: Resource in use:\n%s' % error_text(e.text))
             sys.exit(1)
 
         except apiclient.InternalServerError as e:
             # Print full error since server should not fail
-            click.echo("ERROR: Internal Server Error:\n%s" % e.text)
+            click.echo('ERROR: Internal Server Error:\n%s' % e.text)
             sys.exit(1)
 
         except apiclient.InsufficientResourcesException as e:
-            click.echo("ERROR: Insufficient Resources:\n%s" %
+            click.echo('ERROR: Insufficient Resources:\n%s' %
                        error_text(e.text))
             sys.exit(1)
 
         except apiclient.requests.exceptions.ConnectionError as e:
-            click.echo("ERROR: Unable to connect to server: %s" % e)
+            click.echo('ERROR: Unable to connect to server: %s' % e)
 
 
 def error_text(json_text):
@@ -77,7 +76,7 @@ def auto_complete(func):
 
     if not CLIENT:
         CLIENT = apiclient.Client(
-            namespace=os.getenv("SHAKENFIST_NAMESPACE"),
+            namespace=os.getenv('SHAKENFIST_NAMESPACE'),
             key=os.getenv('SHAKENFIST_KEY'),
             base_url=os.getenv('SHAKENFIST_API_URL', 'http://localhost:13000'),
         )
@@ -255,13 +254,13 @@ def namespace_show(ctx, namespace=None):
 
 
 @namespace.command(name='clean',
-                   help=('Clean (delete) namespace of all instances and networks\n\n'))
+                   help=('Clean (delete) namespace of all instances and networks'))
 @click.option('--confirm',  is_flag=True)
 @click.option('--namespace', type=click.STRING)
 @click.pass_context
 def namespace_clean(ctx, confirm=False, namespace=None):
     if not confirm:
-        print("You must be sure. Use option --confirm.")
+        print('You must be sure. Use option --confirm.')
         return
 
     CLIENT.delete_all_instances(namespace)
@@ -446,7 +445,7 @@ def network_create(ctx, netblock=None, name=None, dhcp=None, nat=None, namespace
 @click.pass_context
 def network_delete_all(ctx, confirm=False, namespace=None):
     if not confirm:
-        print("You must be sure. Use option --confirm.")
+        print('You must be sure. Use option --confirm.')
         return
 
     CLIENT.delete_all_networks(namespace)
@@ -748,7 +747,7 @@ def instance_create(ctx, name=None, cpus=None, memory=None, network=None, networ
         try:
             size_int = int(size)
         except:
-            print("Disk size is not an integer")
+            print('Disk size is not an integer')
             return
 
         diskdefs.append({
@@ -762,7 +761,8 @@ def instance_create(ctx, name=None, cpus=None, memory=None, network=None, networ
         for elem in d.split(','):
             s = elem.split('=')
             if len(s) != 2:
-                print('Error in disk specification - should be key=value: %s' % elem)
+                print('Error in disk specification -'
+                      ' should be key=value: %s' % elem)
                 return
             defn[s[0]] = s[1]
         diskdefs.append(defn)
@@ -781,7 +781,8 @@ def instance_create(ctx, name=None, cpus=None, memory=None, network=None, networ
         for elem in n.split(','):
             s = elem.split('=')
             if len(s) != 2:
-                print("Error in network specification - should be key=value: %s" % elem)
+                print('Error in network specification -'
+                      ' should be key=value: %s' % elem)
                 return
             defn[s[0]] = s[1]
         netdefs.append(defn)
@@ -808,7 +809,7 @@ def instance_delete(ctx, instance_uuid=None):
 @click.pass_context
 def instance_delete_all(ctx, confirm=False, namespace=None):
     if not confirm:
-        print("You must be sure. Use option --confirm.")
+        print('You must be sure. Use option --confirm.')
         return
 
     CLIENT.delete_all_instances(namespace)

--- a/shakenfist/client/main.py
+++ b/shakenfist/client/main.py
@@ -201,7 +201,7 @@ def namespace_create(ctx, namespace=None):
 
 @namespace.command(name='delete',
                    help=('delete a namespace.\n\n'
-                         'namespace: The name of the namespace'))
+                         'NAMESPACE: The name of the namespace'))
 @click.argument('namespace', type=click.STRING)
 @click.pass_context
 def namespace_delete(ctx, namespace=None):
@@ -252,6 +252,20 @@ def _show_namespace(ctx, namespace):
 @click.pass_context
 def namespace_show(ctx, namespace=None):
     _show_namespace(ctx, namespace)
+
+
+@namespace.command(name='clean',
+                   help=('Clean (delete) namespace of all instances and networks\n\n'))
+@click.option('--confirm',  is_flag=True)
+@click.option('--namespace', type=click.STRING)
+@click.pass_context
+def namespace_clean(ctx, confirm=False, namespace=None):
+    if not confirm:
+        print("You must be sure. Use option --confirm.")
+        return
+
+    CLIENT.delete_all_instances(namespace)
+    CLIENT.delete_all_networks(namespace)
 
 
 @namespace.command(name='add-key',
@@ -424,6 +438,18 @@ def network_show(ctx, network_uuid=None):
 def network_create(ctx, netblock=None, name=None, dhcp=None, nat=None, namespace=None):
     _show_network(ctx, CLIENT.allocate_network(
         netblock, dhcp, nat, name, namespace))
+
+
+@network.command(name='delete-all', help='Delete ALL networks')
+@click.option('--confirm',  is_flag=True)
+@click.option('--namespace', type=click.STRING)
+@click.pass_context
+def network_delete_all(ctx, confirm=False, namespace=None):
+    if not confirm:
+        print("You must be sure. Use option --confirm.")
+        return
+
+    CLIENT.delete_all_networks(namespace)
 
 
 @network.command(name='events', help='Display events for a network')
@@ -774,6 +800,18 @@ def instance_delete(ctx, instance_uuid=None):
     CLIENT.delete_instance(instance_uuid)
     if ctx.obj['OUTPUT'] == 'json':
         print('{}')
+
+
+@instance.command(name='delete-all', help='Delete ALL instances')
+@click.option('--confirm',  is_flag=True)
+@click.option('--namespace', type=click.STRING)
+@click.pass_context
+def instance_delete_all(ctx, confirm=False, namespace=None):
+    if not confirm:
+        print("You must be sure. Use option --confirm.")
+        return
+
+    CLIENT.delete_all_instances(namespace)
 
 
 @instance.command(name='events', help='Display events for an instance')

--- a/shakenfist/client/main.py
+++ b/shakenfist/client/main.py
@@ -57,6 +57,9 @@ class GroupCatchExceptions(click.Group):
                        error_text(e.text))
             sys.exit(1)
 
+        except apiclient.requests.exceptions.ConnectionError as e:
+            click.echo("ERROR: Unable to connect to server: %s" % e)
+
 
 def error_text(json_text):
     try:

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -113,8 +113,8 @@ def generic_wrapper(func):
             return error(400, str(e))
 
         except DecodeError:
-            # Send a more informative message than "Not enough segments"
-            return error(401, "Invalid JWT in Authorization Header")
+            # Send a more informative message than 'Not enough segments'
+            return error(401, 'invalid JWT in Authorization header')
 
         except (JWTDecodeError,
                 NoAuthorizationError,
@@ -128,7 +128,7 @@ def generic_wrapper(func):
             return error(401, str(e))
 
         except Exception:
-            return error(500, 'Server Error')
+            return error(500, 'server error')
 
     return wrapper
 
@@ -138,7 +138,7 @@ class Resource(flask_restful.Resource):
 
 
 def caller_is_admin(func):
-    # Ensure only users in the "system" namespace can call this method
+    # Ensure only users in the 'system' namespace can call this method
     def wrapper(*args, **kwargs):
         if get_jwt_identity() != 'system':
             return error(401, 'unauthorized')
@@ -618,19 +618,19 @@ class Instances(Resource):
 
         # Sanity check
         if not disk:
-            return error(400, "Instance must specify at least one disk")
+            return error(400, 'instance must specify at least one disk')
         for d in disk:
             if not isinstance(d, dict):
-                return error(400, "Disk specification should contain JSON objects")
+                return error(400, 'disk specification should contain JSON objects')
 
         if network:
             for n in network:
                 if not isinstance(n, dict):
                     return error(400,
-                                 "Network specification should contain JSON objects")
+                                 'network specification should contain JSON objects')
 
                 if 'network_uuid' not in n:
-                    return error(400, "Network specification is missing network_uuid")
+                    return error(400, 'network specification is missing network_uuid')
 
         if not namespace:
             namespace = get_jwt_identity()
@@ -795,23 +795,24 @@ class Instances(Resource):
 
     @jwt_required
     def delete(self, confirm=False, namespace=None):
-        '''Delete all instances in namespace
-        '''
+        """Delete all instances in the namespace."""
+
         if confirm != True:
-            return error(400, "Parameter confirm is not set true")
+            return error(400, 'parameter confirm is not set true')
 
         if get_jwt_identity() == 'system':
             if not isinstance(namespace, str):
-                return error(400, "system user must specify parameter namespace")
-            # If the system user wishes to delete all instances, then as
-            # confirmation of intention set the namespace parameter to system.
+                # A client using a system key must specify the namespace. This
+                # ensures that deleting all instances in the cluster (by
+                # specifying namespace='system') is a deliberate act.
+                return error(400, 'system user must specify parameter namespace')
 
         else:
             if namespace and namespace != get_jwt_identity():
-                return error(401, "you cannot delete other namespaces")
+                return error(401, 'you cannot delete other namespaces')
             namespace = get_jwt_identity()
 
-        instances_del =[]
+        instances_del = []
         for instance in list(db.get_instances(all=all, namespace=namespace)):
             if instance['state'] == 'deleted':
                 continue
@@ -1241,20 +1242,21 @@ class Networks(Resource):
     @jwt_required
     @redirect_to_network_node
     def delete(self, confirm=False, namespace=None):
-        '''Delete all networks in namespace
-        '''
+        """Delete all networks in the namespace."""
+
         if confirm != True:
-            return error(400, "Parameter confirm is not set true")
+            return error(400, 'parameter confirm is not set true')
 
         if get_jwt_identity() == 'system':
             if not isinstance(namespace, str):
-                return error(400, "system user must specify parameter namespace")
-            # If the system user wishes to delete all instances, then as
-            # confirmation of intention set the namespace parameter to system.
+                # A client using a system key must specify the namespace. This
+                # ensures that deleting all networks in the cluster (by
+                # specifying namespace='system') is a deliberate act.
+                return error(400, 'system user must specify parameter namespace')
 
         else:
             if namespace and namespace != get_jwt_identity():
-                return error(401, "you cannot delete other namespaces")
+                return error(401, 'you cannot delete other namespaces')
             namespace = get_jwt_identity()
 
         networks_del =[]

--- a/shakenfist/tests/test_client_apiclient.py
+++ b/shakenfist/tests/test_client_apiclient.py
@@ -14,6 +14,7 @@ class ApiClientTestCase(testtools.TestCase):
         self.request_url = mock.patch(
             'shakenfist.client.apiclient.Client._request_url')
         self.mock_request = self.request_url.start()
+        self.addCleanup(self.request_url.stop)
 
     def test_get_instances(self):
         client = apiclient.Client()

--- a/shakenfist/tests/test_client_apiclient.py
+++ b/shakenfist/tests/test_client_apiclient.py
@@ -129,6 +129,22 @@ class ApiClientTestCase(testtools.TestCase):
         self.mock_request.assert_called_with(
             'DELETE', 'http://localhost:13000/instances/notreallyauuid')
 
+    def test_delete_all_instances(self):
+        client = apiclient.Client()
+        client.delete_all_instances(None)
+
+        self.mock_request.assert_called_with(
+            'DELETE', 'http://localhost:13000/instances',
+            data={'confirm':True, 'namespace':None})
+
+    def test_delete_all_instances_namespace(self):
+        client = apiclient.Client()
+        client.delete_all_instances('bobspace')
+
+        self.mock_request.assert_called_with(
+            'DELETE', 'http://localhost:13000/instances',
+            data={'confirm':True, 'namespace':'bobspace'})
+
     def test_cache_image(self):
         client = apiclient.Client()
         client.cache_image('imageurl')
@@ -228,6 +244,22 @@ class ApiClientTestCase(testtools.TestCase):
 
         self.mock_request.assert_called_with(
             'DELETE', 'http://localhost:13000/networks/notreallyauuid')
+
+    def test_delete_all_networks(self):
+        client = apiclient.Client()
+        client.delete_all_networks(None)
+
+        self.mock_request.assert_called_with(
+            'DELETE', 'http://localhost:13000/networks',
+            data={'confirm':True, 'namespace':None})
+
+    def test_delete_all_networks_namespace(self):
+        client = apiclient.Client()
+        client.delete_all_networks('bobspace')
+
+        self.mock_request.assert_called_with(
+            'DELETE', 'http://localhost:13000/networks',
+            data={'confirm':True, 'namespace':'bobspace'})
 
     def test_allocate_network(self):
         client = apiclient.Client()

--- a/shakenfist/tests/test_daemon_cleaner.py
+++ b/shakenfist/tests/test_daemon_cleaner.py
@@ -92,13 +92,16 @@ class CleanerTestCase(testtools.TestCase):
             'shakenfist.util.get_libvirt',
             return_value=FakeLibvirt())
         self.mock_libvirt = self.libvirt.start()
+        self.addCleanup(self.libvirt.stop)
 
         self.proctitle = mock.patch('setproctitle.setproctitle')
         self.mock_proctitle = self.proctitle.start()
+        self.addCleanup(self.proctitle.stop)
 
         self.config = mock.patch('shakenfist.config.parsed.get',
                                  fake_config)
         self.mock_config = self.config.start()
+        self.addCleanup(self.config.stop)
 
     @mock.patch('shakenfist.db.see_this_node')
     @mock.patch('shakenfist.etcd.get', side_effect=fake_get)

--- a/shakenfist/tests/test_dhcp.py
+++ b/shakenfist/tests/test_dhcp.py
@@ -48,10 +48,12 @@ class DHCPTestCase(testtools.TestCase):
         self.config = mock.patch('shakenfist.config.parsed.get',
                                  fake_config)
         self.mock_config = self.config.start()
+        self.addCleanup(self.config.stop)
 
         self.network = mock.patch('shakenfist.net.from_db',
                                   return_value=FakeNetwork())
         self.mock_network = self.network.start()
+        self.addCleanup(self.network.stop)
 
         with open('%s/files/dhcp.tmpl' % TEST_DIR) as f:
             dhcp_tmpl = f.read()
@@ -64,9 +66,11 @@ class DHCPTestCase(testtools.TestCase):
             if filename == 'dhcphosts.tmpl':
                 return jinja2.Template(dhcphosts_tmpl)
             raise Exception('Unknown template')
+
         self.template = mock.patch('shakenfist.dhcp.DHCP._read_template',
                                    fake_read_template)
         self.mock_template = self.template.start()
+        self.addCleanup(self.template.stop)
 
     def test_init(self):
         d = dhcp.DHCP('notauuid', 'eth0')

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -137,7 +137,7 @@ class AuthTestCase(testtools.TestCase):
 
     def test_auth_header_wrong(self):
         resp = self.client.post('/auth/namespaces',
-                                headers={'Authorization': "l33thacker"},
+                                headers={'Authorization': 'l33thacker'},
                                 data=json.dumps({
                                     'namespace': 'foo'
                                 }))
@@ -151,13 +151,13 @@ class AuthTestCase(testtools.TestCase):
 
     def test_auth_header_bad_jwt(self):
         resp = self.client.post('/auth/namespaces',
-                                headers={'Authorization': "Bearer l33thacker"},
+                                headers={'Authorization': 'Bearer l33thacker'},
                                 data=json.dumps({
                                     'namespace': 'foo'
                                 }))
         self.assertEqual(
             {
-                'error': "Invalid JWT in Authorization Header",
+                'error': 'invalid JWT in Authorization header',
                 'status': 401
             },
             _clean_traceback(resp.get_json()))
@@ -647,31 +647,31 @@ class ExternalApiGeneralTestCase(ExternalApiTestCase):
 
     @mock.patch('shakenfist.db.get_nodes',
                 return_value=[{
-                                "fqdn": "sf-1",
-                                "ip": "192.168.72.240",
-                                "lastseen": 1594952905.2100437,
-                                "version": "0.0.1"
+                                'fqdn': 'sf-1',
+                                'ip': '192.168.72.240',
+                                'lastseen': 1594952905.2100437,
+                                'version': '0.0.1'
                               },
                               {
-                                "fqdn": "sf-2",
-                                "ip": "192.168.72.230",
-                                "lastseen": 1594952904.8870885,
-                                "version": "0.0.1"
+                                'fqdn': 'sf-2',
+                                'ip': '192.168.72.230',
+                                'lastseen': 1594952904.8870885,
+                                'version': '0.0.1'
                                }])
     def test_get_node(self, mock_md_get):
         resp = self.client.get('/nodes',
                                headers={'Authorization': self.auth_header})
         self.assertEqual([{
-                            "name": "sf-1",
-                            "ip": "192.168.72.240",
-                            "lastseen": 1594952905.2100437,
-                            "version": "0.0.1"
+                            'name': 'sf-1',
+                            'ip': '192.168.72.240',
+                            'lastseen': 1594952905.2100437,
+                            'version': '0.0.1'
                           },
                           {
-                            "name": "sf-2",
-                            "ip": "192.168.72.230",
-                            "lastseen": 1594952904.8870885,
-                            "version": "0.0.1"
+                            'name': 'sf-2',
+                            'ip': '192.168.72.230',
+                            'lastseen': 1594952904.8870885,
+                            'version': '0.0.1'
                           }],
                          resp.get_json())
         self.assertEqual(200, resp.status_code)
@@ -693,19 +693,19 @@ class ExternalApiInstanceTestCase(ExternalApiTestCase):
     @mock.patch('shakenfist.external_api.app._delete_instance')
     @mock.patch('shakenfist.db.get_instances',
                 return_value=[{
-                                "namespace": "system",
-                                "node": "sf-2",
-                                "power_state": "initial",
-                                "state": "created",
-                                "uuid": "6a973b82-31b3-4780-93e4-04d99ae49f3f",
+                                'namespace': 'system',
+                                'node': 'sf-2',
+                                'power_state': 'initial',
+                                'state': 'created',
+                                'uuid': '6a973b82-31b3-4780-93e4-04d99ae49f3f',
                               },
                               {
-                                "name": "timma",
-                                "namespace": "system",
-                                "node": "sf-2",
-                                "power_state": "initial",
-                                "state": "created",
-                                "uuid": "847b0327-9b17-4148-b4ed-be72b6722c17",
+                                'name': 'timma',
+                                'namespace': 'system',
+                                'node': 'sf-2',
+                                'power_state': 'initial',
+                                'state': 'created',
+                                'uuid': '847b0327-9b17-4148-b4ed-be72b6722c17',
                               }])
     @mock.patch('shakenfist.etcd.put')
     @mock.patch('shakenfist.db.get_lock')
@@ -729,19 +729,19 @@ class ExternalApiInstanceTestCase(ExternalApiTestCase):
     @mock.patch('shakenfist.external_api.app._delete_instance')
     @mock.patch('shakenfist.db.get_instances',
                 return_value=[{
-                                "namespace": "system",
-                                "node": "sf-2",
-                                "power_state": "initial",
-                                "state": "deleted",
-                                "uuid": "6a973b82-31b3-4780-93e4-04d99ae49f3f",
+                                'namespace': 'system',
+                                'node': 'sf-2',
+                                'power_state': 'initial',
+                                'state': 'deleted',
+                                'uuid': '6a973b82-31b3-4780-93e4-04d99ae49f3f',
                               },
                               {
-                                "name": "timma",
-                                "namespace": "system",
-                                "node": "sf-2",
-                                "power_state": "initial",
-                                "state": "created",
-                                "uuid": "847b0327-9b17-4148-b4ed-be72b6722c17",
+                                'name': 'timma',
+                                'namespace': 'system',
+                                'node': 'sf-2',
+                                'power_state': 'initial',
+                                'state': 'created',
+                                'uuid': '847b0327-9b17-4148-b4ed-be72b6722c17',
                               }])
     @mock.patch('shakenfist.etcd.put')
     @mock.patch('shakenfist.db.get_lock')
@@ -779,16 +779,16 @@ class ExternalApiNetworkTestCase(ExternalApiTestCase):
         self.config = mock.patch('shakenfist.config.parsed.get',
                                  fake_config_network)
         self.mock_config = self.config.start()
-        # Without this cleanup, other test classes will have "config.parsed.get"
+        # Without this cleanup, other test classes will have 'config.parsed.get'
         # mocked during parallel testing by stestr.
         self.addCleanup(self.config.stop)
 
     @mock.patch('shakenfist.db.get_networks',
                 return_value=[{
-                                "floating_gateway": "10.10.0.150",
-                                "name": "bob",
-                                "state": "created",
-                                "uuid": "30f6da44-look-i-am-uuid",
+                                'floating_gateway': '10.10.0.150',
+                                'name': 'bob',
+                                'state': 'created',
+                                'uuid': '30f6da44-look-i-am-uuid',
                                 }])
     @mock.patch('shakenfist.db.get_network_interfaces', return_value=[])
     @mock.patch('shakenfist.db.get_ipmanager',
@@ -827,10 +827,10 @@ class ExternalApiNetworkTestCase(ExternalApiTestCase):
 
     @mock.patch('shakenfist.db.get_networks',
                 return_value=[{
-                                "floating_gateway": "10.10.0.150",
-                                "name": "bob",
-                                "state": "deleted",
-                                "uuid": "30f6da44-look-i-am-uuid",
+                                'floating_gateway': '10.10.0.150',
+                                'name': 'bob',
+                                'state': 'deleted',
+                                'uuid': '30f6da44-look-i-am-uuid',
                                 }])
     @mock.patch('shakenfist.db.get_network_interfaces', return_value=[])
     @mock.patch('shakenfist.db.get_ipmanager',

--- a/shakenfist/tests/test_net.py
+++ b/shakenfist/tests/test_net.py
@@ -12,16 +12,21 @@ class NetTestCase(testtools.TestCase):
         self.ipmanager_get = mock.patch(
             'shakenfist.db.get_ipmanager')
         self.mock_ipmanager_get = self.ipmanager_get.start()
+        self.addCleanup(self.ipmanager_get.stop)
 
         self.ipmanager_persist = mock.patch(
             'shakenfist.db.persist_ipmanager')
         self.mock_ipmanager_persist = self.ipmanager_persist.start()
+        self.addCleanup(self.ipmanager_persist.stop)
 
         self.etcd_client = mock.patch('etcd3.client')
         self.mock_etcd_client = self.etcd_client.start()
+        self.addCleanup(self.etcd_client.stop)
 
         self.etcd_lock = mock.patch('etcd3.Lock')
         self.mock_etcd_lock = self.etcd_lock.start()
+        self.addCleanup(self.etcd_lock.stop)
+
 
     def test_init(self):
         net.Network(uuid='notauuid', vxlan_id=42, provide_dhcp=True,

--- a/shakenfist/tests/test_virt.py
+++ b/shakenfist/tests/test_virt.py
@@ -38,6 +38,7 @@ class VirtTestCase(testtools.TestCase):
         self.config = mock.patch('shakenfist.config.parsed.get',
                                  fake_config)
         self.mock_config = self.config.start()
+        self.addCleanup(self.config.stop)
 
         # self.libvirt = mock.patch('libvirt')
         # self.mock_libvirt = self.libvirt.start()


### PR DESCRIPTION
Resolves #157 
Fixes pending test issue with mocks.

### Mocks
Mocks that are start()'ed are also required to be stop()'ed. If this is not done there are usually no consequences. Therefore the error goes undetected.

If two different test classes mock the same function without stop()'ing the mock then they will interfere with each other. This interference only occurs when the same process runs both test classes. This happens randomly during parallel testing by tools such as stestr.

### Cascading Delete
Implemented as separate endpoints, one each for instances and networks.

The sf-client uses the command "delete-all" for instance and network since this is an exact description ie. ```sf-client instance delete-all --confirm```

Note that for safety the command line requires the ```--confirm``` parameter. 

To avoid disasters the system namespace also requires that the ```--namespace``` is also specified.

For a cascading delete, the command ```sf-client namespace clean``` is available.
The command "delete-all" cannot be used on namespace since this would imply the keys and metadata is also deleted - thus "clean".

*Do not be backward in suggesting an alternative design to the above especially since we haven't previously discussed the design*