### PR TITLE
Protect against bad instances and interfaces in mesh maintenance.

### DIFF
--- a/shakenfist/dhcp.py
+++ b/shakenfist/dhcp.py
@@ -68,13 +68,16 @@ class DHCP(object):
 
         instances = []
         for ni in list(db.get_network_interfaces(self.network_uuid)):
-            hostname = db.get_instance(ni['instance_uuid'])
+            instance = db.get_instance(ni['instance_uuid'])
+            if not instance:
+                continue
+
             instances.append(
                 {
                     'uuid': ni['instance_uuid'],
                     'macaddr': ni['macaddr'],
                     'ipv4': ni['ipv4'],
-                    'name': hostname['name'].replace(',', '')
+                    'name': instance.get('name', 'instance').replace(',', '')
                 }
             )
         self.subst['instances'] = instances

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -340,6 +340,11 @@ class Network(object):
         node_fqdns = []
         for inst in instances:
             i = db.get_instance(inst)
+            if not i:
+                continue
+            if not i['node']:
+                continue
+
             if not i['node'] in node_fqdns:
                 node_fqdns.append(i['node'])
 


### PR DESCRIPTION
This was caused by another bug leaving bad data, but defence in
depth and all that. Fixes #194.