### PR TITLE
Be more consistent about logging power state transitions.

### DIFF
--- a/shakenfist/db.py
+++ b/shakenfist/db.py
@@ -254,9 +254,13 @@ def update_instance_state(instance_uuid, state):
     if i.get('state') == state:
         return
 
+    orig_state = i.get('state', 'unknown')
     i['state'] = state
     i['state_updated'] = time.time()
     etcd.put('instance', None, instance_uuid, i)
+
+    add_event('instance', instance_uuid, 'state changed',
+              '%s -> %s' % (orig_state, state), None, None)
 
 
 def update_instance_power_state(instance_uuid, state):

--- a/shakenfist/tests/test_daemon_cleaner.py
+++ b/shakenfist/tests/test_daemon_cleaner.py
@@ -104,12 +104,13 @@ class CleanerTestCase(testtools.TestCase):
         self.addCleanup(self.config.stop)
 
     @mock.patch('shakenfist.db.see_this_node')
+    @mock.patch('shakenfist.db.add_event')
     @mock.patch('shakenfist.etcd.get', side_effect=fake_get)
     @mock.patch('shakenfist.etcd.put', side_effect=fake_put)
     @mock.patch('os.path.exists', side_effect=fake_exists)
     @mock.patch('time.time', return_value=7)
     def test_update_power_states(self, mock_time, mock_exists, mock_put,
-                                 mock_get, mock_see):
+                                 mock_get, mock_event, mock_see):
         m = cleaner.monitor()
         m._update_power_states()
 

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -463,6 +463,8 @@ class Instance(object):
         db.update_instance_power_state(
             self.db_entry['uuid'],
             util.extract_power_state(libvirt, instance))
+        db.add_event(
+            'instance', self.db_entry['uuid'], 'poweron', 'complete', None, None)
 
     def power_off(self):
         libvirt = util.get_libvirt()
@@ -481,6 +483,9 @@ class Instance(object):
             instance.destroy()
         except libvirt.libvirtError as e:
             LOG.error('%s: Failed to delete domain: %s' % (self, e))
+
+        db.add_event(
+            'instance', self.db_entry['uuid'], 'poweron', 'complete', None, None)
 
     def _snapshot_device(self, source, destination):
         images.snapshot(source, destination)
@@ -525,6 +530,9 @@ class Instance(object):
         else:
             instance.reset()
 
+        db.add_event(
+            'instance', self.db_entry['uuid'], 'reboot', 'complete', None, None)
+
     def pause(self):
         libvirt = util.get_libvirt()
         instance = self._get_domain()
@@ -533,6 +541,9 @@ class Instance(object):
             self.db_entry['uuid'],
             util.extract_power_state(libvirt, instance))
 
+        db.add_event(
+            'instance', self.db_entry['uuid'], 'pause', 'complete', None, None)
+
     def unpause(self):
         libvirt = util.get_libvirt()
         instance = self._get_domain()
@@ -540,6 +551,9 @@ class Instance(object):
         db.update_instance_power_state(
             self.db_entry['uuid'],
             util.extract_power_state(libvirt, instance))
+
+        db.add_event(
+            'instance', self.db_entry['uuid'], 'unpause', 'complete', None, None)
 
     def get_console_data(self, length):
         console_path = os.path.join(self.instance_path, 'console.log')


### PR DESCRIPTION
Fixes #203 and helps debug our "why is this instance powered off" issues.