### PR TITLE
Catch libvirt unsupported config errors in API

### DIFF
--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -822,8 +822,17 @@ class Instances(Resource):
                     n.ensure_mesh()
                     n.update_dhcp()
 
-            with util.RecordedOperation('instance creation', instance) as _:
-                instance.create(lock=lock)
+            libvirt = util.get_libvirt()
+            try:
+                with util.RecordedOperation('instance creation',
+                                            instance) as _:
+                    instance.create(lock=lock)
+
+            except libvirt.libvirtError as e:
+                code = e.get_error_code()
+                if code == libvirt.VIR_ERR_CONFIG_UNSUPPORTED:
+                    return error_with_cleanup(400, e.get_error_message())
+                raise e
 
             for iface in db.get_instance_interfaces(instance.db_entry['uuid']):
                 db.update_network_interface_state(iface['uuid'], 'created')


### PR DESCRIPTION
Now prints:
```
root@sf-1:/srv/shakenfist# sf-client instance create rubbishvideo 1 1024 -d8 -V model=rubbish,memory=888 -n a6b3669e-a771-43d5-9061-4d1aac7dcb74 
ERROR: Malformed Request: unsupported configuration: unknown video model 'rubbish'
```

There might be more to this? I think using error_with_cleanup() should be sufficient.

The next step could be to actually remove the instance from the database but could compromise other cleanup steps?

*Testing for this should probably be done through integration testing via the API. Once next-gen CI replaces ansible-ci?? Start another issue?*