### PR TITLE
Fix github lint workflow silent failure

### DIFF
--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -18,24 +18,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code with two commits
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           sudo apt-get install -y -q tox
+
       - name: Lint with fast8
         run: |
           tox -efast8
+
       - name: Test with python 3.7
         run: |
           tox -epy37
+
       - name: Test with python 3.7 again
         run: |
           tox -epy37
+
       - name: Test with python 3.7 again again
         run: |
           tox -epy37


### PR DESCRIPTION
Lint was silently failing... who would check?

Turns out that actions/checkout@v2 only checks the last commit.