### PR TITLE
Handle bad instance config and deleted networks

### DIFF
--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -13,7 +13,6 @@ from oslo_concurrency import processutils
 from shakenfist import config
 from shakenfist import db
 from shakenfist import dhcp
-from shakenfist import db
 from shakenfist import util
 
 
@@ -25,6 +24,10 @@ LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
 def from_db(uuid):
     dbnet = db.get_network(uuid)
     if not dbnet:
+        return None
+
+    if dbnet['state'] == 'deleted':
+        LOG.info('network(%s) net.from_db() network is state=deleted' % uuid)
         return None
 
     return Network(uuid=dbnet['uuid'],


### PR DESCRIPTION
### Catching extra libvirt XML error 
Resolves #229 
Now responds:
```
root@sf-1:/srv/shakenfist# sf-client instance create bo 1 1024 -d1 -N network_uuid=7cd67842-2878-440a-a0b7-e8dd4457274d,macaddress=01:02:03:44:55:66
ERROR: Malformed Request: XML error: expected unicast mac address, found multicast '01:02:03:44:55:66'
```

### Change net.from_db() to not return deleted networks
Resolves #220 
I run through all the uses of the function. I do not believe this will break anything.
