### PR TITLE
Delete all allocated IP's on instance deletion

### DIFF
--- a/shakenfist/client/main.py
+++ b/shakenfist/client/main.py
@@ -44,16 +44,16 @@ class GroupCatchExceptions(click.Group):
             sys.exit(1)
 
         except apiclient.ResourceInUseException as e:
-            click.echo('ERROR: Resource in use:\n%s' % error_text(e.text))
+            click.echo('ERROR: Resource in use: %s' % error_text(e.text))
             sys.exit(1)
 
         except apiclient.InternalServerError as e:
             # Print full error since server should not fail
-            click.echo('ERROR: Internal Server Error:\n%s' % e.text)
+            click.echo('ERROR: Internal Server Error: %s' % e.text)
             sys.exit(1)
 
         except apiclient.InsufficientResourcesException as e:
-            click.echo('ERROR: Insufficient Resources:\n%s' %
+            click.echo('ERROR: Insufficient Resources: %s' %
                        error_text(e.text))
             sys.exit(1)
 

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Michael Still
 
 import base64
-import errno
 import jinja2
 import logging
 from logging import handlers as logging_handlers
@@ -16,7 +15,6 @@ import uuid
 from oslo_concurrency import processutils
 
 from shakenfist import config
-from shakenfist import db
 from shakenfist import db
 from shakenfist import images
 from shakenfist import net
@@ -257,8 +255,9 @@ class Instance(object):
             except Exception:
                 pass
 
-        with util.RecordedOperation('release network addreses', self) as _:
+        with util.RecordedOperation('release network addresses', self) as _:
             for ni in db.get_instance_interfaces(self.db_entry['uuid']):
+                db.update_network_interface_state(ni['uuid'], 'deleted')
                 with db.get_lock('sf/ipmanager/%s' % ni['network_uuid'],
                                  ttl=120) as _:
                     ipm = db.get_ipmanager(ni['network_uuid'])


### PR DESCRIPTION
Deletion of interfaces was completed before the release of network addresses. The meant that no addresses were released by the "release network addresses" process.

This change moves the network interface deletion into the same loop that releases the network address.

Resolves #227 