### PR TITLE
Directly pass flask.request.data on network node redirect

### DIFF
--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -260,7 +260,7 @@ def redirect_to_network_node(func):
                 % (config.parsed.get('NETWORK_NODE_IP'),
                    config.parsed.get('API_PORT'),
                    flask.request.environ['PATH_INFO']),
-                data=json.dumps(flask.request.get_json()),
+                data=flask.request.data,
                 headers={'Authorization': admin_token,
                          'User-Agent': util.get_user_agent()})
 


### PR DESCRIPTION
Previously when proxying a request to the network node, the request
body was parsed as JSON, and then dumped as a string again. As well as
being slightly inefficient, this would fail if the request body wasn't
valid JSON, for example when making a GET request.