### PR TITLE
Cleaner cannot place_instance() if not known in DB

### DIFF
--- a/shakenfist/daemons/cleaner.py
+++ b/shakenfist/daemons/cleaner.py
@@ -38,6 +38,14 @@ class monitor(object):
 
                 instance_uuid = domain.name().split(':')[1]
                 instance = db.get_instance(instance_uuid)
+                if not instance:
+                    # Instance is SF but not in database. Kill to reduce load.
+                    LOG.warning('Destroying unknown instance, domain_id=%s' % (
+                        instance_uuid, ))
+                    processutils.execute(
+                        'virsh destroy "sf:%s"' % instance_uuid, shell=True)
+                    continue
+
                 db.place_instance(
                     instance_uuid, config.parsed.get('NODE_NAME'))
                 seen.append(domain.name())


### PR DESCRIPTION
 Cleaner cannot place_instance() if not known in DB
    
    The Cleaner daemon can find processes with a SF ID that are not in
    the system database. Kill these processes since they are unmanaged
    and creating unnecessary CPU load.

Resolves #273 