### PR TITLE
Stop daemon:net recreating networks unnecessarily

### DIFF
--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -26,7 +26,7 @@ class monitor(object):
         host_networks = []
         seen_vxids = []
 
-        if not net.is_network_node():
+        if not util.is_network_node():
             # For normal nodes, just the ones we have instances for
             for inst in list(db.get_instances(only_node=config.parsed.get('NODE_NAME'))):
                 for iface in db.get_instance_interfaces(inst['uuid']):
@@ -104,7 +104,7 @@ class monitor(object):
             time.sleep(30)
 
             try:
-                LOG.info("Daeman:net: Checking networks")
+                LOG.info("Daemon:net: Checking networks")
                 self._maintain_networks()
             except Exception as e:
                 util.ignore_exception('network monitor', e)

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -26,7 +26,7 @@ class monitor(object):
         host_networks = []
         seen_vxids = []
 
-        if config.parsed.get('NODE_IP') != config.parsed.get('NETWORK_NODE_IP'):
+        if not net.is_network_node():
             # For normal nodes, just the ones we have instances for
             for inst in list(db.get_instances(only_node=config.parsed.get('NODE_NAME'))):
                 for iface in db.get_instance_interfaces(inst['uuid']):
@@ -46,7 +46,10 @@ class monitor(object):
                         LOG.info('Hard deleted stray network interface %s '
                                  'associated with absent instance %s'
                                  % (ni['uuid'], ni['instance_uuid']))
-                    elif inst.get('state', 'unknown') in ['deleted', 'error', 'unknown']:
+
+                    elif inst.get('state', 'unknown') in ['deleted',
+                                                          'error',
+                                                          'unknown']:
                         db.hard_delete_network_interface(ni['uuid'])
                         LOG.info('Hard deleted stray network interface %s '
                                  'associated with %s instance %s'
@@ -60,14 +63,17 @@ class monitor(object):
                 if not n:
                     continue
 
-                n.create()
+                if not n.is_okay():
+                    LOG.info("Daemon:net: maintain_networks() recreating %s",
+                             n.uuid)
+                    n.create()
                 n.ensure_mesh()
                 seen_vxids.append(n.vxlan_id)
 
         # Determine if there are any extra vxids
         extra_vxids = set(vxid_to_mac.keys()) - set(seen_vxids)
 
-        # For now, just log extra vxids
+        # Delete "deleted" SF networks and log unknown vxlans
         if extra_vxids:
             LOG.warn('Extra vxlans present! IDs are: %s'
                      % extra_vxids)
@@ -79,7 +85,8 @@ class monitor(object):
 
             for extra in extra_vxids:
                 if extra in vxid_to_uuid:
-                    with db.get_lock('sf/network/%s' % vxid_to_uuid[extra], ttl=120) as _:
+                    with db.get_lock('sf/network/%s' % vxid_to_uuid[extra],
+                                     ttl=120) as _:
                         n = net.from_db(vxid_to_uuid[extra])
                         n.delete()
                         LOG.info('Extra vxlan %s (network %s) removed.'
@@ -97,6 +104,7 @@ class monitor(object):
             time.sleep(30)
 
             try:
+                LOG.info("Daeman:net: Checking networks")
                 self._maintain_networks()
             except Exception as e:
                 util.ignore_exception('network monitor', e)

--- a/shakenfist/dhcp.py
+++ b/shakenfist/dhcp.py
@@ -92,18 +92,21 @@ class DHCP(object):
             shutil.rmtree(self.subst['config_dir'])
 
     def _send_signal(self, sig):
-        pidfile = os.path.join(self.subst['config_dir'], 'pid')
-        if os.path.exists(pidfile):
-            with open(pidfile) as f:
-                pid = int(f.read())
-
+        pid = self.get_pid()
+        if pid:
             if not psutil.pid_exists(pid):
                 return False
-
             os.kill(pid, sig)
             return True
-
         return False
+
+    def get_pid(self):
+        pid_file = os.path.join(self.subst['config_dir'], 'pid')
+        if os.path.exists(pid_file):
+            with open(pid_file) as f:
+                pid = int(f.read())
+                return pid
+        return None
 
     def remove_dhcpd(self):
         self._send_signal(signal.SIGKILL)

--- a/shakenfist/tests/test_net.py
+++ b/shakenfist/tests/test_net.py
@@ -7,25 +7,6 @@ from shakenfist import net
 from shakenfist import config
 
 
-class NetTestCase(testtools.TestCase):
-    #
-    # is_network_node_yes()
-    #
-    def test_is_network_node_yes(self):
-        config.CONFIG_DEFAULTS['NODE_IP'] = '1.1.1.1'
-        config.CONFIG_DEFAULTS['NETWORK_NODE_IP'] = '1.1.1.1'
-        config.parsed = config.Config()
-
-        self.assertTrue(net.is_network_node())
-
-    def test_is_network_node_no(self):
-        config.CONFIG_DEFAULTS['NODE_IP'] = '1.1.1.1'
-        config.CONFIG_DEFAULTS['NETWORK_NODE_IP'] = '2.2.2.2'
-        config.parsed = config.Config()
-
-        self.assertFalse(net.is_network_node())
-
-
 class NetworkTestCase(testtools.TestCase):
     def setUp(self):
         super(NetworkTestCase, self).setUp()
@@ -131,8 +112,16 @@ class NetworkNetNodeTestCase(NetworkTestCase):
 
     @mock.patch('shakenfist.net.Network.is_created', return_value=True)
     @mock.patch('shakenfist.net.Network.is_dnsmasq_running', return_value=False)
-    def test_is_okay_no_dns(self, mock_is_dnsmasq, mock_is_created):
+    def test_is_okay_no_masq(self, mock_is_dnsmasq, mock_is_created):
         n = net.Network(uuid='actualuuid', vxlan_id=42, provide_dhcp=True,
+                        provide_nat=True, physical_nic='eth0',
+                        ipblock='192.168.1.0/24')
+        self.assertFalse(n.is_okay())
+
+    @mock.patch('shakenfist.net.Network.is_created', return_value=True)
+    @mock.patch('shakenfist.net.Network.is_dnsmasq_running', return_value=False)
+    def test_is_okay_no_masq_no_dhcp(self, mock_is_dnsmasq, mock_is_created):
+        n = net.Network(uuid='actualuuid', vxlan_id=42, provide_dhcp=False,
                         provide_nat=True, physical_nic='eth0',
                         ipblock='192.168.1.0/24')
         self.assertFalse(n.is_okay())

--- a/shakenfist/tests/test_net.py
+++ b/shakenfist/tests/test_net.py
@@ -1,13 +1,34 @@
 import mock
 import testtools
 
+from oslo_concurrency import processutils
 
 from shakenfist import net
+from shakenfist import config
 
 
 class NetTestCase(testtools.TestCase):
+    #
+    # is_network_node_yes()
+    #
+    def test_is_network_node_yes(self):
+        config.CONFIG_DEFAULTS['NODE_IP'] = '1.1.1.1'
+        config.CONFIG_DEFAULTS['NETWORK_NODE_IP'] = '1.1.1.1'
+        config.parsed = config.Config()
+
+        self.assertTrue(net.is_network_node())
+
+    def test_is_network_node_no(self):
+        config.CONFIG_DEFAULTS['NODE_IP'] = '1.1.1.1'
+        config.CONFIG_DEFAULTS['NETWORK_NODE_IP'] = '2.2.2.2'
+        config.parsed = config.Config()
+
+        self.assertFalse(net.is_network_node())
+
+
+class NetworkTestCase(testtools.TestCase):
     def setUp(self):
-        super(NetTestCase, self).setUp()
+        super(NetworkTestCase, self).setUp()
 
         self.ipmanager_get = mock.patch(
             'shakenfist.db.get_ipmanager')
@@ -28,6 +49,7 @@ class NetTestCase(testtools.TestCase):
         self.addCleanup(self.etcd_lock.stop)
 
 
+class NetworkGeneralTestCase(NetworkTestCase):
     def test_init(self):
         net.Network(uuid='notauuid', vxlan_id=42, provide_dhcp=True,
                     provide_nat=True, physical_nic='eth0',
@@ -38,3 +60,156 @@ class NetTestCase(testtools.TestCase):
                         provide_nat=True, physical_nic='eth0',
                         ipblock='192.168.1.0/24')
         self.assertEqual('network(notauuid, vxid 42)', str(n))
+
+        config.CONFIG_DEFAULTS['NODE_IP'] = '1.1.1.1'
+        config.CONFIG_DEFAULTS['NETWORK_NODE_IP'] = '2.2.2.2'
+        config.parsed = config.Config()
+
+        self.assertFalse(net.is_network_node())
+
+
+class NetworkNormalNodeTestCase(NetworkTestCase):
+    def setUp(self):
+        super(NetworkNormalNodeTestCase, self).setUp()
+        config.CONFIG_DEFAULTS['NODE_IP'] = '1.1.1.2'
+        config.CONFIG_DEFAULTS['NETWORK_NODE_IP'] = '1.1.1.1'
+        config.parsed = config.Config()
+
+    #
+    #  is_okay()
+    #
+    @mock.patch('shakenfist.net.Network.is_created', return_value=True)
+    @mock.patch('shakenfist.net.Network.is_dnsmasq_running', return_value=True)
+    def test_is_okay_yes(self, mock_is_dnsmasq, mock_is_created):
+        n = net.Network(uuid='actualuuid', vxlan_id=42, provide_dhcp=True,
+                        provide_nat=True, physical_nic='eth0',
+                        ipblock='192.168.1.0/24')
+        self.assertTrue(n.is_okay())
+
+    @mock.patch('shakenfist.net.Network.is_created', return_value=False)
+    @mock.patch('shakenfist.net.Network.is_dnsmasq_running', return_value=True)
+    def test_is_okay_not_created(self, mock_is_dnsmasq, mock_is_created):
+        n = net.Network(uuid='actualuuid', vxlan_id=42, provide_dhcp=True,
+                        provide_nat=True, physical_nic='eth0',
+                        ipblock='192.168.1.0/24')
+        self.assertFalse(n.is_okay())
+
+    @mock.patch('shakenfist.net.Network.is_created', return_value=True)
+    @mock.patch('shakenfist.net.Network.is_dnsmasq_running', return_value=False)
+    def test_is_okay_no_dns(self, mock_is_dnsmasq, mock_is_created):
+        n = net.Network(uuid='actualuuid', vxlan_id=42, provide_dhcp=True,
+                        provide_nat=True, physical_nic='eth0',
+                        ipblock='192.168.1.0/24')
+        self.assertTrue(n.is_okay())
+
+
+class NetworkNetNodeTestCase(NetworkTestCase):
+    def setUp(self):
+        super(NetworkNetNodeTestCase, self).setUp()
+        config.CONFIG_DEFAULTS['NODE_IP'] = '1.1.1.1'
+        config.CONFIG_DEFAULTS['NETWORK_NODE_IP'] = '1.1.1.1'
+        config.parsed = config.Config()
+
+    #
+    #  is_okay()
+    #
+    @mock.patch('shakenfist.net.Network.is_created', return_value=True)
+    @mock.patch('shakenfist.net.Network.is_dnsmasq_running', return_value=True)
+    def test_is_okay_yes(self, mock_is_dnsmasq, mock_is_created):
+        n = net.Network(uuid='actualuuid', vxlan_id=42, provide_dhcp=True,
+                        provide_nat=True, physical_nic='eth0',
+                        ipblock='192.168.1.0/24')
+        self.assertTrue(n.is_okay())
+
+    @mock.patch('shakenfist.net.Network.is_created', return_value=False)
+    @mock.patch('shakenfist.net.Network.is_dnsmasq_running', return_value=True)
+    def test_is_okay_not_created(self, mock_is_dnsmasq, mock_is_created):
+        n = net.Network(uuid='actualuuid', vxlan_id=42, provide_dhcp=True,
+                        provide_nat=True, physical_nic='eth0',
+                        ipblock='192.168.1.0/24')
+        self.assertFalse(n.is_okay())
+
+    @mock.patch('shakenfist.net.Network.is_created', return_value=True)
+    @mock.patch('shakenfist.net.Network.is_dnsmasq_running', return_value=False)
+    def test_is_okay_no_dns(self, mock_is_dnsmasq, mock_is_created):
+        n = net.Network(uuid='actualuuid', vxlan_id=42, provide_dhcp=True,
+                        provide_nat=True, physical_nic='eth0',
+                        ipblock='192.168.1.0/24')
+        self.assertFalse(n.is_okay())
+
+    #
+    # is_created()
+    #
+    pgrep = ('1: br-vxlan-5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500'
+             + ''' qdisc noqueue state UP mode DEFAULT group default qlen 1000
+link/ether 1a:46:97:a1:c2:3a brd ff:ff:ff:ff:ff:ff
+''')
+
+    @mock.patch('oslo_concurrency.processutils.execute',
+                return_value=(pgrep, ''))
+    def test_is_created_yes(self, mock_execute):
+        n = net.Network(uuid='8abbc9a6-d923-4441-b498-4f8e3c166804',
+                        vxlan_id=5, provide_dhcp=True,
+                        provide_nat=True, physical_nic='eth0',
+                        ipblock='192.168.1.0/24')
+        self.assertTrue(n.is_created())
+
+    pgrep = ('1: br-vxlan-5: <BROADCAST,MULTICAST,DOWN,LOWER_UP> mtu 1500'
+             + ''' qdisc noqueue state UP mode DEFAULT group default qlen 1000
+link/ether 1a:46:97:a1:c2:3a brd ff:ff:ff:ff:ff:ff
+''')
+
+    @mock.patch('oslo_concurrency.processutils.execute',
+                return_value=(pgrep, ''))
+    def test_is_created_no(self, mock_execute):
+        n = net.Network(uuid='1111111-d923-4441-b498-4f8e3c166804',
+                        vxlan_id=111, provide_dhcp=True,
+                        provide_nat=True, physical_nic='eth0',
+                        ipblock='192.168.1.0/24')
+        self.assertFalse(n.is_created())
+
+    pgrep = 'Device "br-vxlan-45" does not exist.'
+
+    @mock.patch('oslo_concurrency.processutils.execute',
+                return_value=(pgrep, ''))
+    def test_is_created_no_bridge(self, mock_execute):
+        n = net.Network(uuid='1111111-d923-4441-b498-4f8e3c166804',
+                        vxlan_id=111, provide_dhcp=True,
+                        provide_nat=True, physical_nic='eth0',
+                        ipblock='192.168.1.0/24')
+        self.assertFalse(n.is_created())
+    #
+    # is_dnsmasq_running()
+    #
+    pgrep = '''
+5438 dnsmasq --conf-file=/srv/shakenfist/dhcp/29e83e99-ce0c-4340-9eab-4fc07217d002/config
+5812 dnsmasq --conf-file=/srv/shakenfist/dhcp/8abbc9a6-d923-4441-b498-4f8e3c166804/config
+6386 dnsmasq --conf-file=/srv/shakenfist/dhcp/0f5c73eb-708a-4f7c-b4d5-3b63146cac18/config
+'''
+
+    @mock.patch('oslo_concurrency.processutils.execute',
+                return_value=(pgrep, ''))
+    def test_is_dnsmasq_running_yes(self, mock_execute):
+        n = net.Network(uuid='8abbc9a6-d923-4441-b498-4f8e3c166804',
+                        vxlan_id=42, provide_dhcp=True,
+                        provide_nat=True, physical_nic='eth0',
+                        ipblock='192.168.1.0/24')
+        self.assertTrue(n.is_dnsmasq_running())
+
+    @mock.patch('oslo_concurrency.processutils.execute',
+                return_value=(pgrep, ''))
+    def test_is_dnsmasq_running_no(self, mock_execute):
+        n = net.Network(uuid='11111111-d923-4441-b498-4f8e3c166804',
+                        vxlan_id=42, provide_dhcp=True,
+                        provide_nat=True, physical_nic='eth0',
+                        ipblock='192.168.1.0/24')
+        self.assertFalse(n.is_dnsmasq_running())
+
+    @mock.patch('oslo_concurrency.processutils.execute',
+                side_effect=processutils.ProcessExecutionError)
+    def test_is_dnsmasq_running_no_processes(self, mock_execute):
+        n = net.Network(uuid='11111111-d923-4441-b498-4f8e3c166804',
+                        vxlan_id=42, provide_dhcp=True,
+                        provide_nat=True, physical_nic='eth0',
+                        ipblock='192.168.1.0/24')
+        self.assertFalse(n.is_dnsmasq_running())

--- a/shakenfist/tests/test_util.py
+++ b/shakenfist/tests/test_util.py
@@ -1,12 +1,26 @@
-import ipaddress
 import mock
 import testtools
 
 
 from shakenfist import util
+from shakenfist import config
 
 
 class UtilTestCase(testtools.TestCase):
+    def test_is_network_node_yes(self):
+        config.CONFIG_DEFAULTS['NODE_IP'] = '1.1.1.1'
+        config.CONFIG_DEFAULTS['NETWORK_NODE_IP'] = '1.1.1.1'
+        config.parsed = config.Config()
+
+        self.assertTrue(util.is_network_node())
+
+    def test_is_network_node_no(self):
+        config.CONFIG_DEFAULTS['NODE_IP'] = '1.1.1.1'
+        config.CONFIG_DEFAULTS['NETWORK_NODE_IP'] = '2.2.2.2'
+        config.parsed = config.Config()
+
+        self.assertFalse(util.is_network_node())
+
     @mock.patch('oslo_concurrency.processutils.execute',
                 return_value=(None, 'Device "banana0" does not exist.'))
     def test_check_for_interface_missing_interface(self, mock_execute):

--- a/shakenfist/util.py
+++ b/shakenfist/util.py
@@ -16,6 +16,7 @@ import traceback
 from oslo_concurrency import processutils
 
 from shakenfist import db
+from shakenfist import config
 
 
 LOG = logging.getLogger(__file__)
@@ -59,6 +60,11 @@ class RecordedOperation():
             object_uuid = 'null'
 
         return object_type, object_uuid
+
+
+def is_network_node():
+    """Test if this node is the network node"""
+    return config.parsed.get('NODE_IP') == config.parsed.get('NETWORK_NODE_IP')
 
 
 def check_for_interface(name):


### PR DESCRIPTION
Net daemon runs every 30 seconds on every node.
Each run the daemon recreates every network on it's respective node then sends the network node a request to recreate network.
Network node receives a request to recreate every network every 30 seconds from every node (including itself).

To avoid the storm, the daemon should do some checks of the network before recreation.

If the "network ok" checks are not sufficient then we add more checks.
This will let network creation bugs surface rather hiding them in the log storm.
