### PR TITLE
Add daemon names to log message prefix

### DIFF
--- a/shakenfist/client/apiclient.py
+++ b/shakenfist/client/apiclient.py
@@ -6,7 +6,7 @@ from pbr.version import VersionInfo
 import requests
 
 
-LOG = logging.getLogger(__file__)
+LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.INFO)
 
 

--- a/shakenfist/client/main.py
+++ b/shakenfist/client/main.py
@@ -14,7 +14,7 @@ from shakenfist.client import apiclient
 
 logging.basicConfig(level=logging.INFO)
 
-LOG = logging.getLogger(__file__)
+LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.INFO)
 
 

--- a/shakenfist/config.py
+++ b/shakenfist/config.py
@@ -2,16 +2,13 @@
 
 import copy
 import logging
-from logging import handlers as logging_handlers
 import os
 import socket
 
 from shakenfist import util
 
 
-LOG = logging.getLogger(__file__)
-LOG.setLevel(logging.INFO)
-LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
+LOG = logging.getLogger(__name__)
 
 
 node_name = socket.getfqdn()
@@ -89,6 +86,15 @@ CONFIG_DEFAULTS = {
 
     # Where on disk instances are stored
     'STORAGE_PATH': '/srv/shakenfist',
+
+    # LOGGING
+    # -------
+    'LOGLEVEL_SF_API': 'info',
+    'LOGLEVEL_SF_CLEANER': 'info',
+    'LOGLEVEL_SF_MAIN': 'info',
+    'LOGLEVEL_SF_NET': 'info',
+    'LOGLEVEL_SF_RESOURCES': 'info',
+    'LOGLEVEL_SF_TRIGGERS': 'info',
 }
 
 

--- a/shakenfist/config.py
+++ b/shakenfist/config.py
@@ -89,12 +89,12 @@ CONFIG_DEFAULTS = {
 
     # LOGGING
     # -------
-    'LOGLEVEL_SF_API': 'info',
-    'LOGLEVEL_SF_CLEANER': 'info',
-    'LOGLEVEL_SF_MAIN': 'info',
-    'LOGLEVEL_SF_NET': 'info',
-    'LOGLEVEL_SF_RESOURCES': 'info',
-    'LOGLEVEL_SF_TRIGGERS': 'info',
+    'LOGLEVEL_API': 'info',
+    'LOGLEVEL_CLEANER': 'info',
+    'LOGLEVEL_MAIN': 'info',
+    'LOGLEVEL_NET': 'info',
+    'LOGLEVEL_RESOURCES': 'info',
+    'LOGLEVEL_TRIGGERS': 'info',
 }
 
 

--- a/shakenfist/daemons/cleaner.py
+++ b/shakenfist/daemons/cleaner.py
@@ -1,28 +1,22 @@
 import etcd3
 import json
 import logging
-from logging import handlers as logging_handlers
 import os
-import setproctitle
 import time
 
 from oslo_concurrency import processutils
 
 from shakenfist import config
+from shakenfist.daemons import daemon
 from shakenfist import db
 from shakenfist import util
 from shakenfist import virt
 
 
-LOG = logging.getLogger(__file__)
-LOG.setLevel(logging.INFO)
-LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
+LOG = logging.getLogger(__name__)
 
 
-class monitor(object):
-    def __init__(self):
-        setproctitle.setproctitle('sf cleaner')
-
+class Monitor(daemon.Daemon):
     def _update_power_states(self):
         libvirt = util.get_libvirt()
         conn = libvirt.open(None)

--- a/shakenfist/daemons/daemon.py
+++ b/shakenfist/daemons/daemon.py
@@ -4,12 +4,12 @@ from shakenfist import util
 
 
 DAEMON_NAMES = {
-    'API': 'sf-api',
-    'CLEANER': 'sf-cleaner',
-    'MAIN': 'sf-main',
-    'NET': 'sf-net',
-    'RESOURCES': 'sf-resources',
-    'TRIGGERS': 'sf-triggers',
+    'api': 'sf-api',
+    'cleaner': 'sf-cleaner',
+    'main': 'sf-main',
+    'net': 'sf-net',
+    'resources': 'sf-resources',
+    'triggers': 'sf-triggers',
 }
 
 

--- a/shakenfist/daemons/daemon.py
+++ b/shakenfist/daemons/daemon.py
@@ -1,0 +1,25 @@
+import setproctitle
+
+from shakenfist import util
+
+
+DAEMON_NAMES = {
+    'API': 'sf-api',
+    'CLEANER': 'sf-cleaner',
+    'MAIN': 'sf-main',
+    'NET': 'sf-net',
+    'RESOURCES': 'sf-resources',
+    'TRIGGERS': 'sf-triggers',
+}
+
+
+def process_name(id):
+    if id not in DAEMON_NAMES:
+        raise Exception('Code Error: Bad process name: %s' % id)
+    return DAEMON_NAMES[id]
+
+
+class Daemon(object):
+    def __init__(self, id):
+        setproctitle.setproctitle(process_name(id))
+        self.log, self.handler = util.setup_logging(id)

--- a/shakenfist/daemons/external_api.py
+++ b/shakenfist/daemons/external_api.py
@@ -1,0 +1,19 @@
+import os
+
+from oslo_concurrency import processutils
+
+from shakenfist.daemons import daemon
+from shakenfist import config
+
+
+class Monitor(daemon.Daemon):
+    def run(self):
+        processutils.execute(
+            ('gunicorn3 --workers 10 --bind 0.0.0.0:%d '
+             '--log-syslog --log-syslog-prefix sf '
+             '--timeout %s --name "%s" '
+             'shakenfist.external_api.app:app'
+             % (config.parsed.get('API_PORT'),
+                config.parsed.get('API_TIMEOUT'),
+                daemon.process_name('API'))),
+            shell=True, env_variables=os.environ)

--- a/shakenfist/daemons/external_api.py
+++ b/shakenfist/daemons/external_api.py
@@ -15,5 +15,5 @@ class Monitor(daemon.Daemon):
              'shakenfist.external_api.app:app'
              % (config.parsed.get('API_PORT'),
                 config.parsed.get('API_TIMEOUT'),
-                daemon.process_name('API'))),
+                daemon.process_name('api'))),
             shell=True, env_variables=os.environ)

--- a/shakenfist/daemons/main.py
+++ b/shakenfist/daemons/main.py
@@ -1,7 +1,5 @@
 # Copyright 2019 Michael Still
 
-import logging
-from logging import handlers as logging_handlers
 import setproctitle
 import time
 import os
@@ -9,20 +7,20 @@ import os
 from oslo_concurrency import processutils
 
 from shakenfist import config
+from shakenfist.daemons import daemon
+from shakenfist.daemons import external_api as external_api_daemon
 from shakenfist.daemons import cleaner as cleaner_daemon
 from shakenfist.daemons import net as net_daemon
 from shakenfist.daemons import resources as resource_daemon
 from shakenfist.daemons import triggers as trigger_daemon
 from shakenfist import db
-from shakenfist.external_api import app as external_api_daemon
+
 from shakenfist import net
 from shakenfist import util
 from shakenfist import virt
 
 
-LOG = logging.getLogger(__file__)
-LOG.setLevel(logging.INFO)
-LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
+LOG, handler = util.setup_logging('MAIN')
 
 
 def restore_instances():
@@ -68,6 +66,8 @@ def main():
     for key in config.parsed.config:
         LOG.info('Configuration item %s = %s' % (key, config.parsed.get(key)))
 
+    util.log_setlevel(LOG, 'MAIN')
+
     # Check in early and often
     db.see_this_node()
 
@@ -75,7 +75,8 @@ def main():
     # might happen quite early on.
     resource_pid = os.fork()
     if resource_pid == 0:
-        resource_daemon.monitor().run()
+        LOG.removeHandler(handler)
+        resource_daemon.Monitor('RESOURCES').run()
 
     # If I am the network node, I need some setup
     if config.parsed.get('NODE_IP') == config.parsed.get('NETWORK_NODE_IP'):
@@ -124,24 +125,28 @@ def main():
     # Network mesh maintenance
     net_pid = os.fork()
     if net_pid == 0:
-        net_daemon.monitor().run()
+        LOG.removeHandler(handler)
+        net_daemon.Monitor('NET').run()
 
     # Old object deleter
     cleaner_pid = os.fork()
     if cleaner_pid == 0:
-        cleaner_daemon.monitor().run()
+        LOG.removeHandler(handler)
+        cleaner_daemon.Monitor('CLEANER').run()
 
     # REST API
     external_api_pid = os.fork()
     if external_api_pid == 0:
-        external_api_daemon.monitor().run()
+        LOG.removeHandler(handler)
+        external_api_daemon.Monitor('API').run()
 
     # Triggers
     trigger_pid = os.fork()
     if trigger_pid == 0:
-        trigger_daemon.monitor().run()
+        LOG.removeHandler(handler)
+        trigger_daemon.Monitor('TRIGGERS').run()
 
-    setproctitle.setproctitle('sf main')
+    setproctitle.setproctitle(daemon.process_name('MAIN'))
     LOG.info('network monitor pid is %d' % net_pid)
     LOG.info('external api pid is %d' % external_api_pid)
     LOG.info('resources monitor pid is %d' % resource_pid)

--- a/shakenfist/daemons/main.py
+++ b/shakenfist/daemons/main.py
@@ -20,7 +20,7 @@ from shakenfist import util
 from shakenfist import virt
 
 
-LOG, handler = util.setup_logging('MAIN')
+LOG, handler = util.setup_logging('main')
 
 
 def restore_instances():
@@ -66,7 +66,7 @@ def main():
     for key in config.parsed.config:
         LOG.info('Configuration item %s = %s' % (key, config.parsed.get(key)))
 
-    util.log_setlevel(LOG, 'MAIN')
+    util.log_setlevel(LOG, 'main')
 
     # Check in early and often
     db.see_this_node()
@@ -76,7 +76,7 @@ def main():
     resource_pid = os.fork()
     if resource_pid == 0:
         LOG.removeHandler(handler)
-        resource_daemon.Monitor('RESOURCES').run()
+        resource_daemon.Monitor('resources').run()
 
     # If I am the network node, I need some setup
     if config.parsed.get('NODE_IP') == config.parsed.get('NETWORK_NODE_IP'):
@@ -126,27 +126,27 @@ def main():
     net_pid = os.fork()
     if net_pid == 0:
         LOG.removeHandler(handler)
-        net_daemon.Monitor('NET').run()
+        net_daemon.Monitor('net').run()
 
     # Old object deleter
     cleaner_pid = os.fork()
     if cleaner_pid == 0:
         LOG.removeHandler(handler)
-        cleaner_daemon.Monitor('CLEANER').run()
+        cleaner_daemon.Monitor('cleaner').run()
 
     # REST API
     external_api_pid = os.fork()
     if external_api_pid == 0:
         LOG.removeHandler(handler)
-        external_api_daemon.Monitor('API').run()
+        external_api_daemon.Monitor('api').run()
 
     # Triggers
     trigger_pid = os.fork()
     if trigger_pid == 0:
         LOG.removeHandler(handler)
-        trigger_daemon.Monitor('TRIGGERS').run()
+        trigger_daemon.Monitor('triggers').run()
 
-    setproctitle.setproctitle(daemon.process_name('MAIN'))
+    setproctitle.setproctitle(daemon.process_name('main'))
     LOG.info('network monitor pid is %d' % net_pid)
     LOG.info('external api pid is %d' % external_api_pid)
     LOG.info('resources monitor pid is %d' % resource_pid)

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -13,7 +13,7 @@ LOG = logging.getLogger(__name__)
 
 class Monitor(daemon.Daemon):
     def _maintain_networks(self):
-        LOG.info("Maintaining networks")
+        LOG.info('Maintaining networks')
 
         # Discover what networks are present
         _, _, vxid_to_mac = util.discover_interfaces()
@@ -60,7 +60,7 @@ class Monitor(daemon.Daemon):
                     continue
 
                 if not n.is_okay():
-                    LOG.info("%s: Network not okay - recreating", n)
+                    LOG.info('%s: Network not okay - recreating', n)
                     n.create()
                 n.ensure_mesh()
                 seen_vxids.append(n.vxlan_id)

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -1,24 +1,20 @@
 import logging
-from logging import handlers as logging_handlers
-import setproctitle
 import time
 
 from shakenfist import config
+from shakenfist.daemons import daemon
 from shakenfist import db
 from shakenfist import net
 from shakenfist import util
 
 
-LOG = logging.getLogger(__file__)
-LOG.setLevel(logging.INFO)
-LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
+LOG = logging.getLogger(__name__)
 
 
-class monitor(object):
-    def __init__(self):
-        setproctitle.setproctitle('sf net')
-
+class Monitor(daemon.Daemon):
     def _maintain_networks(self):
+        LOG.info("Maintaining networks")
+
         # Discover what networks are present
         _, _, vxid_to_mac = util.discover_interfaces()
 
@@ -64,8 +60,7 @@ class monitor(object):
                     continue
 
                 if not n.is_okay():
-                    LOG.info("Daemon:net: maintain_networks() recreating %s",
-                             n.uuid)
+                    LOG.info("%s: Network not okay - recreating", n)
                     n.create()
                 n.ensure_mesh()
                 seen_vxids.append(n.vxlan_id)
@@ -104,7 +99,6 @@ class monitor(object):
             time.sleep(30)
 
             try:
-                LOG.info("Daemon:net: Checking networks")
                 self._maintain_networks()
             except Exception as e:
                 util.ignore_exception('network monitor', e)

--- a/shakenfist/daemons/resources.py
+++ b/shakenfist/daemons/resources.py
@@ -1,21 +1,17 @@
 import logging
-from logging import handlers as logging_handlers
 import os
 import psutil
-import setproctitle
 import time
 
 from prometheus_client import Gauge
 from prometheus_client import start_http_server
 
+from shakenfist.daemons import daemon
 from shakenfist import config
 from shakenfist import db
 from shakenfist import util
 
-
-LOG = logging.getLogger(__file__)
-LOG.setLevel(logging.INFO)
-LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
+LOG = logging.getLogger(__name__)
 
 
 def _get_stats():
@@ -120,12 +116,13 @@ def _get_stats():
     return retval
 
 
-class monitor(object):
-    def __init__(self):
-        setproctitle.setproctitle('sf resources')
+class Monitor(daemon.Daemon):
+    def __init__(self, id):
+        super(Monitor, self).__init__(id)
         start_http_server(config.parsed.get('PROMETHEUS_METRICS_PORT'))
 
     def run(self):
+        LOG.info("Starting...")
         gauges = {'updated_at': Gauge(
             'updated_at', 'The last time metrics were updated')}
 

--- a/shakenfist/daemons/resources.py
+++ b/shakenfist/daemons/resources.py
@@ -122,7 +122,7 @@ class Monitor(daemon.Daemon):
         start_http_server(config.parsed.get('PROMETHEUS_METRICS_PORT'))
 
     def run(self):
-        LOG.info("Starting...")
+        LOG.info('Starting...')
         gauges = {'updated_at': Gauge(
             'updated_at', 'The last time metrics were updated')}
 

--- a/shakenfist/daemons/triggers.py
+++ b/shakenfist/daemons/triggers.py
@@ -1,19 +1,16 @@
 import logging
-from logging import handlers as logging_handlers
 import multiprocessing
 import os
 import re
-import setproctitle
 import signal
 import time
 
 from shakenfist import config
+from shakenfist.daemons import daemon
 from shakenfist import db
 
 
-LOG = logging.getLogger(__file__)
-LOG.setLevel(logging.INFO)
-LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
+LOG = logging.getLogger(__name__)
 
 
 def observe(path, instance_uuid):
@@ -55,10 +52,7 @@ def observe(path, instance_uuid):
         time.sleep(1)
 
 
-class monitor(object):
-    def __init__(self):
-        setproctitle.setproctitle('sf triggers')
-
+class Monitor(daemon.Daemon):
     def run(self):
         observers = {}
 

--- a/shakenfist/db.py
+++ b/shakenfist/db.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Michael Still
 
 import logging
-from logging import handlers as logging_handlers
 import randmac
 import random
 import time
@@ -14,9 +13,7 @@ from shakenfist import ipmanager
 from shakenfist import util
 
 
-LOG = logging.getLogger(__file__)
-LOG.setLevel(logging.INFO)
-LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
+LOG = logging.getLogger(__name__)
 
 
 def see_this_node():

--- a/shakenfist/dhcp.py
+++ b/shakenfist/dhcp.py
@@ -2,7 +2,6 @@
 
 import jinja2
 import logging
-from logging import handlers as logging_handlers
 import os
 import psutil
 import shutil
@@ -14,9 +13,7 @@ from shakenfist import config
 from shakenfist import db
 from shakenfist import net
 
-LOG = logging.getLogger(__file__)
-LOG.setLevel(logging.INFO)
-LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
+LOG = logging.getLogger(__name__)
 
 
 class DHCP(object):

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -1,7 +1,6 @@
 import etcd3
 import json
 import logging
-from logging import handlers as logging_handlers
 import time
 
 ####################################################################
@@ -10,9 +9,7 @@ import time
 ####################################################################
 
 
-LOG = logging.getLogger(__file__)
-LOG.setLevel(logging.INFO)
-LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
+LOG = logging.getLogger(__name__)
 
 
 ETCD_ATTEMPTS = 5

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -38,7 +38,7 @@ from shakenfist import util
 from shakenfist import virt
 
 
-LOG, log_handler = util.setup_logging('API')
+LOG, log_handler = util.setup_logging('api')
 
 
 TESTING = False

--- a/shakenfist/image_resolver_cirros.py
+++ b/shakenfist/image_resolver_cirros.py
@@ -1,5 +1,4 @@
 import logging
-from logging import handlers as logging_handlers
 import re
 import requests
 
@@ -8,9 +7,7 @@ from shakenfist import exceptions
 from shakenfist import util
 
 
-LOG = logging.getLogger(__file__)
-LOG.setLevel(logging.INFO)
-LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
+LOG = logging.getLogger(__name__)
 
 CIRROS_URL = 'http://download.cirros-cloud.net/'
 

--- a/shakenfist/image_resolver_ubuntu.py
+++ b/shakenfist/image_resolver_ubuntu.py
@@ -1,5 +1,4 @@
 import logging
-from logging import handlers as logging_handlers
 import re
 import requests
 
@@ -8,9 +7,7 @@ from shakenfist import exceptions
 from shakenfist import util
 
 
-LOG = logging.getLogger(__file__)
-LOG.setLevel(logging.INFO)
-LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
+LOG = logging.getLogger(__name__)
 
 # The official Ubuntu download URL 'https://cloud-images.ubuntu.com' is unreliable.
 # We try it first, but then try an alternative location on failure.

--- a/shakenfist/images.py
+++ b/shakenfist/images.py
@@ -4,7 +4,6 @@ import email.utils
 import hashlib
 import json
 import logging
-from logging import handlers as logging_handlers
 import os
 import re
 import requests
@@ -20,9 +19,7 @@ from shakenfist import image_resolver_ubuntu
 from shakenfist import util
 
 
-LOG = logging.getLogger(__file__)
-LOG.setLevel(logging.INFO)
-LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
+LOG = logging.getLogger(__name__)
 
 
 resolvers = {

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-from logging import handlers as logging_handlers
 import os
 import psutil
 import re
@@ -17,9 +16,7 @@ from shakenfist import dhcp
 from shakenfist import util
 
 
-LOG = logging.getLogger(__file__)
-LOG.setLevel(logging.INFO)
-LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
+LOG = logging.getLogger(__name__)
 
 
 def from_db(uuid):

--- a/shakenfist/scheduler.py
+++ b/shakenfist/scheduler.py
@@ -2,7 +2,6 @@
 
 import copy
 import logging
-from logging import handlers as logging_handlers
 import random
 import time
 
@@ -11,9 +10,7 @@ from shakenfist import db
 from shakenfist import etcd
 from shakenfist import util
 
-LOG = logging.getLogger(__file__)
-LOG.setLevel(logging.INFO)
-LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
+LOG = logging.getLogger(__name__)
 
 
 class CandidateNodeNotFoundException(Exception):

--- a/shakenfist/tests/test_daemon_cleaner.py
+++ b/shakenfist/tests/test_daemon_cleaner.py
@@ -2,7 +2,6 @@ import mock
 import testtools
 
 
-from shakenfist import config
 from shakenfist.daemons import cleaner
 
 
@@ -61,7 +60,8 @@ def fake_exists(path):
 def fake_config(key):
     fc = {
         'NODE_NAME': 'abigcomputer',
-        'STORAGE_PATH': '/srv/shakenfist'
+        'STORAGE_PATH': '/srv/shakenfist',
+        'LOGLEVEL_SF_CLEANER': 'debug',
     }
 
     if key in fc:
@@ -111,7 +111,7 @@ class CleanerTestCase(testtools.TestCase):
     @mock.patch('time.time', return_value=7)
     def test_update_power_states(self, mock_time, mock_exists, mock_put,
                                  mock_get, mock_event, mock_see):
-        m = cleaner.monitor()
+        m = cleaner.Monitor('CLEANER')
         m._update_power_states()
 
         self.assertEqual(

--- a/shakenfist/tests/test_daemon_cleaner.py
+++ b/shakenfist/tests/test_daemon_cleaner.py
@@ -61,7 +61,7 @@ def fake_config(key):
     fc = {
         'NODE_NAME': 'abigcomputer',
         'STORAGE_PATH': '/srv/shakenfist',
-        'LOGLEVEL_SF_CLEANER': 'debug',
+        'LOGLEVEL_CLEANER': 'debug',
     }
 
     if key in fc:
@@ -111,7 +111,7 @@ class CleanerTestCase(testtools.TestCase):
     @mock.patch('time.time', return_value=7)
     def test_update_power_states(self, mock_time, mock_exists, mock_put,
                                  mock_get, mock_event, mock_see):
-        m = cleaner.Monitor('CLEANER')
+        m = cleaner.Monitor('cleaner')
         m._update_power_states()
 
         self.assertEqual(

--- a/shakenfist/util.py
+++ b/shakenfist/util.py
@@ -24,8 +24,11 @@ LOG = logging.getLogger(__name__)
 
 
 def log_setlevel(log, id):
+    # Check that id is a valid name
+    _ = daemon.process_name(id)
+
     # Check for configuration override
-    label = 'LOGLEVEL_' + daemon.process_name(id).replace('-', '_').upper()
+    label = 'LOGLEVEL_' + id.upper()
     level = config.parsed.get(label)
     if level:
         numeric_level = getattr(logging, level.upper(), None)

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -85,7 +85,7 @@ class Instance(object):
         disk_spec = self.db_entry['disk_spec']
         if not disk_spec:
             # This should not occur since the API will filter for zero disks.
-            LOG.error("_populate_block_devices(): Found disk spec empty: %s" %
+            LOG.error('_populate_block_devices(): Found disk spec empty: %s' %
                       self.db_entry)
 
             # Stop continuous crashing by falsely claiming disks are configured.

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -3,7 +3,6 @@
 import base64
 import jinja2
 import logging
-from logging import handlers as logging_handlers
 import io
 import json
 import os
@@ -21,9 +20,7 @@ from shakenfist import net
 from shakenfist import util
 
 
-LOG = logging.getLogger(__file__)
-LOG.setLevel(logging.INFO)
-LOG.addHandler(logging_handlers.SysLogHandler(address='/dev/log'))
+LOG = logging.getLogger(__name__)
 
 
 def from_definition(uuid=None, name=None, disks=None, memory_mb=None,


### PR DESCRIPTION
Start the process of log message standardisation.
Move log handler setup to one code location.
Associate module logging to the module name
Add option to set log levels.
External API log message HTTP header removed.

Also:
Removed my ugly "daemon:net" log messages
My newer "net daemon" log messages made more standard
Loggers are now associated with module name rather than absolute file location
Ineffective log code in external_api/app fixed and moved to debug level

Resolves #292 