### PR TITLE
Queuing tasks objects

### DIFF
--- a/shakenfist/daemons/main.py
+++ b/shakenfist/daemons/main.py
@@ -99,7 +99,7 @@ def main():
         if pid == 0:
             DAEMON_IMPLEMENTATIONS[d].Monitor(d).run()
         DAEMON_PIDS[pid] = d
-        LOG.withField('pid', pid).info('%s pid' % d)
+        LOG.withField('pid', pid).info('Started %s' % d)
 
     # Resource usage publisher, we need this early because scheduling decisions
     # might happen quite early on.

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -76,8 +76,8 @@ def handle(jobname, workitem):
             log_i.info("Task complete")
 
     except Exception as e:
+        util.ignore_exception(daemon.process_name('queues'), e)
         if instance_uuid:
-            util.ignore_exception(daemon.process_name('queues'), e)
             db.enqueue_instance_delete(config.parsed.get('NODE_NAME'),
                                        instance_uuid, 'error',
                                        'failed queue task: %s' % e)

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -42,7 +42,7 @@ def handle(jobname, workitem):
                 instance_uuid = None
                 log_i = log
 
-            log_i.withField('task_name', task.name()).info("Starting task")
+            log_i.withField('task_name', task.name()).info('Starting task')
 
             # TODO(andy) Should network events also come through here eventually?
             # Then this can be generalised to record events on networks/instances
@@ -90,9 +90,9 @@ def handle(jobname, workitem):
                     util.ignore_exception(daemon.process_name('queues'), e)
 
             else:
-                log_i.withField('task', task).error("Unhandled task - dropped")
+                log_i.withField('task', task).error('Unhandled task - dropped')
 
-            log_i.info("Task complete")
+            log_i.info('Task complete')
 
     except Exception as e:
         util.ignore_exception(daemon.process_name('queues'), e)

--- a/shakenfist/exceptions.py
+++ b/shakenfist/exceptions.py
@@ -65,3 +65,11 @@ class NoURLImageFetchTaskException(TaskException):
 
 class NoInstanceTaskException(TaskException):
     pass
+
+
+class NetworkNotListTaskException(TaskException):
+    pass
+
+
+class NoNextStateTaskException(TaskException):
+    pass

--- a/shakenfist/exceptions.py
+++ b/shakenfist/exceptions.py
@@ -51,17 +51,17 @@ class FlagException(Exception):
 
 
 # Tasks
-class QueueTaskException(Exception):
+class TaskException(Exception):
     pass
 
 
-class TaskUnknownTypeException(QueueTaskException):
+class UnknownTaskException(TaskException):
     pass
 
 
-class TaskImageFetchNoURLException(QueueTaskException):
+class NoURLImageFetchTaskException(TaskException):
     pass
 
 
-class TaskNoInstanceException(QueueTaskException):
+class NoInstanceTaskException(TaskException):
     pass

--- a/shakenfist/logutil.py
+++ b/shakenfist/logutil.py
@@ -173,7 +173,11 @@ def setup(name):
     log = logging.getLogger(name)
 
     if log.hasHandlers():
-        handler = log.handlers[0]
+        # The parent logger might have the handler, not this lower logger
+        if len(log.handlers) > 0:
+            # TODO(andy): Remove necessity to return handler or
+            # correctly obtain the handler without causing an exception
+            handler = log.handlers[0]
     else:
         # Add our handler
         handler = logging_handlers.SysLogHandler(address='/dev/log')

--- a/shakenfist/tasks.py
+++ b/shakenfist/tasks.py
@@ -1,0 +1,110 @@
+from shakenfist.exceptions import (NoURLImageFetchTaskException,
+                                   NoInstanceTaskException,
+                                   )
+
+
+class QueueTask(object):
+    '''QueueTask defines a validated task placed on the job queue.
+    '''
+    _name = None
+
+    @classmethod
+    def name(self):
+        return self._name
+
+    @classmethod
+    def pretty_task_name(self):
+        return self._name.replace('_', ' ')
+
+    def __repr__(self):
+        # All subclasses define json_dump()
+        return str(self.json_dump())
+
+
+#
+# Instance Tasks
+#
+class InstanceTask(QueueTask):
+    def __init__(self, instance_uuid, network=None):
+        super(InstanceTask, self).__init__()
+        self._instance_uuid = instance_uuid
+        self._network = network
+
+        # General checks
+        if not instance_uuid:
+            raise NoInstanceTaskException('No instance specified for InstanceTask')
+
+    def instance_uuid(self):
+        return self._instance_uuid
+
+    def network(self):
+        return self._network
+
+    def json_dump(self):
+        return {'task': self._name,
+                'instance_uuid': self._instance_uuid,
+                'network': self._network}
+
+
+class PreflightInstanceTask(InstanceTask):
+    _name = 'instance_preflight'
+
+
+class StartInstanceTask(InstanceTask):
+    _name = 'instance_start'
+
+
+class DeleteInstanceTask(InstanceTask):
+    _name = 'instance_delete'
+
+    def __init__(self, instance_uuid, next_state, next_state_message=None):
+        super(DeleteInstanceTask, self).__init__(instance_uuid)
+
+        # TODO(andy): next_state should be built into current state
+        self._next_state = next_state
+        self._next_state_message = next_state_message
+
+    def json_dump(self):
+        return {'task': self._name,
+                'instance_uuid': self._instance_uuid,
+                'next_state': self._next_state,
+                'next_state_message': self._next_state_message}
+
+    def next_state(self):
+        return self._next_state
+
+    def next_state_message(self):
+        return self._next_state_message
+
+
+#
+# Image Tasks
+#
+class ImageTask(QueueTask):
+    def __init__(self, url):
+        super(ImageTask, self).__init__()
+        self._url = url
+
+        if not url:
+            raise NoURLImageFetchTaskException
+
+    def json_dump(self):
+        return {'task': self._name,
+                'url': self._url,
+                'instance_uuid': self._instance_uuid}
+
+    # Data methods
+    def url(self):
+        return self._url
+
+
+class FetchImageTask(ImageTask):
+    _name = 'image_fetch'
+
+    def __init__(self, url, instance_uuid=None):
+        super(FetchImageTask, self).__init__(url)
+        self._instance_uuid = instance_uuid
+
+    # Data methods
+    def instance_uuid(self):
+        return self._instance_uuid

--- a/shakenfist/tests/test_etcd.py
+++ b/shakenfist/tests/test_etcd.py
@@ -1,0 +1,265 @@
+import mock
+import testtools
+
+from shakenfist import etcd
+from shakenfist import tasks
+
+
+class TaskEncodingETCDtestCase(testtools.TestCase):
+    @mock.patch('etcd3gw.Etcd3Client.put')
+    def test_put_PreflightInstanceTask(self, mock_put):
+        etcd.put('objecttype', 'subtype', 'name',
+                 tasks.PreflightInstanceTask('fake_uuid'))
+
+        path = '/sf/objecttype/subtype/name'
+        encoded = '''{
+    "instance_uuid": "fake_uuid",
+    "network": null,
+    "task": "instance_preflight"
+}'''
+        mock_put.assert_called_with(path, encoded, lease=None)
+
+    @mock.patch('etcd3gw.Etcd3Client.put')
+    def test_put_StartInstanceTask(self, mock_put):
+        etcd.put('objecttype', 'subtype', 'name',
+                 tasks.StartInstanceTask('fake_uuid', ['net_uuid']))
+
+        path = '/sf/objecttype/subtype/name'
+        encoded = '''{
+    "instance_uuid": "fake_uuid",
+    "network": [
+        "net_uuid"
+    ],
+    "task": "instance_start"
+}'''
+        mock_put.assert_called_with(path, encoded, lease=None)
+
+    @mock.patch('etcd3gw.Etcd3Client.put')
+    def test_put_DeleteInstanceTask(self, mock_put):
+        etcd.put('objecttype', 'subtype', 'name',
+                 tasks.DeleteInstanceTask('fake_uuid', 'next_state', 'dunno'))
+
+        path = '/sf/objecttype/subtype/name'
+        encoded = '''{
+    "instance_uuid": "fake_uuid",
+    "next_state": "next_state",
+    "next_state_message": "dunno",
+    "task": "instance_delete"
+}'''
+        mock_put.assert_called_with(path, encoded, lease=None)
+
+    @mock.patch('etcd3gw.Etcd3Client.put')
+    def test_put_FetchImageTask(self, mock_put):
+        etcd.put('objecttype', 'subtype', 'name',
+                 tasks.FetchImageTask('http://server/image'))
+
+        path = '/sf/objecttype/subtype/name'
+        encoded = '''{
+    "instance_uuid": null,
+    "task": "image_fetch",
+    "url": "http://server/image"
+}'''
+        mock_put.assert_called_with(path, encoded, lease=None)
+
+        etcd.put('objecttype', 'subtype', 'name',
+                 tasks.FetchImageTask('http://server/image',
+                                      instance_uuid='fake_uuid'))
+
+        path = '/sf/objecttype/subtype/name'
+        encoded = '''{
+    "instance_uuid": "fake_uuid",
+    "task": "image_fetch",
+    "url": "http://server/image"
+}'''
+        mock_put.assert_called_with(path, encoded, lease=None)
+
+
+#
+# Decode tasks from JSON
+#
+class TaskDecodingETCDtestCase(testtools.TestCase):
+    '''Test that decodeTasks does decode subclasses of QueueTasks.
+
+    Only need to check that JSON will convert to QueueTask objects. Testing of
+    the actual JSON conversion is in TaskDequeueTestCase.
+    '''
+    def test_decode_PreflightInstanceTask(self):
+        obs = etcd.decodeTasks({'tasks': [
+            {
+                'instance_uuid': 'fake_uuid',
+                'network': None,
+                'task': 'instance_preflight',
+             }
+            ]})
+
+        self.assertItemsEqual(
+            {'tasks': [tasks.PreflightInstanceTask('fake_uuid')]},
+            obs)
+
+    def test_decode_multi(self):
+        obs = etcd.decodeTasks({'tasks': [
+            {
+                'instance_uuid': 'fake_uuid',
+                'network': None,
+                'task': 'instance_preflight',
+            },
+            {
+                'instance_uuid': 'fake_uuid',
+                'task': 'image_fetch',
+                'url': 'http://whoknows'
+            }]})
+
+        self.assertItemsEqual(
+            {'tasks': [
+                tasks.PreflightInstanceTask('fake_uuid'),
+                tasks.FetchImageTask('http://whoknows', 'fake_uuid')
+                ]},
+            obs)
+
+
+#
+# Dequeue tasks from ETCD
+#
+class TaskDequeueTestCase(testtools.TestCase):
+    @mock.patch('etcd3gw.Etcd3Client.get_prefix', return_value=[(
+        '''{
+            "tasks": [
+                        {
+                            "instance_uuid": "diff_uuid",
+                            "task": "instance_preflight"
+                        }
+                     ]
+            }
+        ''',
+        {
+            'key': '/somejob'
+        },
+    )])
+    @mock.patch('shakenfist.etcd.get_lock')
+    @mock.patch('shakenfist.etcd.put')
+    @mock.patch('etcd3gw.Etcd3Client.delete')
+    def test_dequeue_preflight(self, m_delete, m_put, m_get_lock, m_get_prefix):
+        jobname, workitem = etcd.dequeue('node01')
+        self.assertEqual('somejob', jobname)
+        expected = [
+            tasks.PreflightInstanceTask('diff_uuid'),
+        ]
+        self.assertCountEqual(expected, workitem['tasks'])
+        self.assertSequenceEqual(set(expected), set(workitem['tasks']))
+
+    @mock.patch('etcd3gw.Etcd3Client.get_prefix', return_value=[(
+        '''{
+            "tasks": [
+                        {
+                            "instance_uuid": "fake_uuid",
+                            "task": "instance_start"
+                        }
+                     ]
+            }
+        ''',
+        {
+            'key': '/somejob'
+        },
+    )])
+    @mock.patch('shakenfist.etcd.get_lock')
+    @mock.patch('shakenfist.etcd.put')
+    @mock.patch('etcd3gw.Etcd3Client.delete')
+    def test_dequeue_start(self, m_delete, m_put, m_get_lock, m_get_prefix):
+        jobname, workitem = etcd.dequeue('node01')
+        self.assertEqual('somejob', jobname)
+        expected = [
+            tasks.StartInstanceTask('fake_uuid'),
+        ]
+        self.assertCountEqual(expected, workitem['tasks'])
+        self.assertSequenceEqual(set(expected), set(workitem['tasks']))
+
+    @mock.patch('etcd3gw.Etcd3Client.get_prefix', return_value=[(
+        '''{
+            "tasks": [
+                        {
+                            "instance_uuid": "fake_uuid",
+                            "task": "instance_delete",
+                            "next_state": "where_to"
+                        }
+                    ]
+            }
+        ''',
+        {
+            'key': '/somejob'
+        },
+    )])
+    @mock.patch('shakenfist.etcd.get_lock')
+    @mock.patch('shakenfist.etcd.put')
+    @mock.patch('etcd3gw.Etcd3Client.delete')
+    def test_dequeue_delete(self, m_delete, m_put, m_get_lock, m_get_prefix):
+        jobname, workitem = etcd.dequeue('node01')
+        self.assertEqual('somejob', jobname)
+        expected = [
+            tasks.DeleteInstanceTask('fake_uuid', 'where_to'),
+        ]
+        self.assertCountEqual(expected, workitem['tasks'])
+        self.assertSequenceEqual(set(expected), set(workitem['tasks']))
+
+    @mock.patch('etcd3gw.Etcd3Client.get_prefix', return_value=[(
+        '''{
+            "tasks": [
+                        {
+                            "instance_uuid": "diff_uuid",
+                            "task": "instance_preflight"
+                        },
+                        {
+                            "instance_uuid": "fake_uuid",
+                            "task": "instance_start"
+                        },
+                        {
+                            "instance_uuid": "fake_uuid",
+                            "task": "instance_delete",
+                            "next_state": "where_to"
+                        }
+                    ]
+            }
+        ''',
+        {
+            'key': '/somejob'
+        },
+    )])
+    @mock.patch('shakenfist.etcd.get_lock')
+    @mock.patch('shakenfist.etcd.put')
+    @mock.patch('etcd3gw.Etcd3Client.delete')
+    def test_dequeue_multi(self, m_delete, m_put, m_get_lock, m_get_prefix):
+        jobname, workitem = etcd.dequeue('node01')
+        self.assertEqual('somejob', jobname)
+        expected = [
+            tasks.PreflightInstanceTask('diff_uuid'),
+            tasks.StartInstanceTask('fake_uuid'),
+            tasks.DeleteInstanceTask('fake_uuid', 'where_to'),
+        ]
+        self.assertCountEqual(expected, workitem['tasks'])
+        self.assertSequenceEqual(set(expected), set(workitem['tasks']))
+
+    @mock.patch('etcd3gw.Etcd3Client.get_prefix', return_value=[(
+        '''{
+            "tasks": [
+                        {
+                            "instance_uuid": "fake_uuid",
+                            "task": "image_fetch",
+                            "url": "http://whoknows"
+                        }
+                    ]
+            }
+        ''',
+        {
+            'key': '/somejob'
+        },
+    )])
+    @mock.patch('shakenfist.etcd.get_lock')
+    @mock.patch('shakenfist.etcd.put')
+    @mock.patch('etcd3gw.Etcd3Client.delete')
+    def test_dequeue_image_fetch(self, m_delete, m_put, m_get_lock, m_get_prefix):
+        jobname, workitem = etcd.dequeue('node01')
+        self.assertEqual('somejob', jobname)
+        expected = [
+            tasks.FetchImageTask('http://whoknows', 'fake_uuid'),
+        ]
+        self.assertCountEqual(expected, workitem['tasks'])
+        self.assertSequenceEqual(set(expected), set(workitem['tasks']))

--- a/shakenfist/tests/test_tasks.py
+++ b/shakenfist/tests/test_tasks.py
@@ -1,0 +1,55 @@
+import testtools
+
+from shakenfist import tasks
+from shakenfist import exceptions
+
+
+class TasksEqTestCase(testtools.TestCase):
+    def test_QueueTask_eq(self):
+        self.assertEqual(tasks.PreflightInstanceTask('abcd'),
+                         tasks.PreflightInstanceTask('abcd'))
+
+        self.assertEqual(tasks.PreflightInstanceTask('abcd', []),
+                         tasks.PreflightInstanceTask('abcd', []))
+
+        self.assertEqual(tasks.PreflightInstanceTask('abcd', ['a1', 'b2']),
+                         tasks.PreflightInstanceTask('abcd', ['a1', 'b2']))
+
+        self.assertNotEqual(tasks.PreflightInstanceTask('abcd', ['a1', 'b2']),
+                            tasks.PreflightInstanceTask('abcd', ['a1']))
+
+        with testtools.ExpectedException(NotImplementedError):
+            self.assertEqual(tasks.PreflightInstanceTask('abcd', ['a1', 'b2']),
+                             42)
+
+        self.assertEqual(tasks.DeleteInstanceTask('abcd', 'somestate'),
+                         tasks.DeleteInstanceTask('abcd', 'somestate'))
+
+        self.assertNotEqual(tasks.DeleteInstanceTask('abcd', 'somestate'),
+                            tasks.DeleteInstanceTask('abcd', 'somestat'))
+
+        self.assertEqual(tasks.DeleteInstanceTask('abcd', 'somestate', 'dunno'),
+                         tasks.DeleteInstanceTask('abcd', 'somestate', 'dunno'))
+
+        self.assertEqual(tasks.ImageTask('http://someurl'),
+                         tasks.ImageTask('http://someurl'))
+
+
+class InstanceTasksTestCase(testtools.TestCase):
+    def test_InstanceTask(self):
+        with testtools.ExpectedException(exceptions.NoInstanceTaskException):
+            tasks.InstanceTask(None)
+
+        with testtools.ExpectedException(exceptions.NetworkNotListTaskException):
+            tasks.InstanceTask('uuid', 'not a list')
+
+    def test_DeleteInstanceTask(self):
+        with testtools.ExpectedException(exceptions.NoNextStateTaskException):
+            tasks.DeleteInstanceTask('uuid', None)
+
+    def test_FetchImageTask(self):
+        with testtools.ExpectedException(exceptions.NoURLImageFetchTaskException):
+            tasks.FetchImageTask(None)
+
+        with testtools.ExpectedException(exceptions.NoURLImageFetchTaskException):
+            tasks.FetchImageTask(1234)


### PR DESCRIPTION
I don't trust dict's for passing objects around. Classes verify the data on creation and can be relied upon to contain the correct data. Task creation can cause bugs if the wrong keys are used. 

This removes reliance on correct keys used in task dict's. Check `external/app.py` for the neat code improvement.

Plan:
1. Get consensus on this change
2. Add tests for this new code
3. Further improvements taking advantage of these objects eg. inter alia `next_state` removal

This PR branches from #343.