### PR TITLE
Fix network bug in DeleteInstanceTask

### DIFF
--- a/shakenfist/tasks.py
+++ b/shakenfist/tasks.py
@@ -79,7 +79,8 @@ class StartInstanceTask(InstanceTask):
 class DeleteInstanceTask(InstanceTask):
     _name = 'instance_delete'
 
-    def __init__(self, instance_uuid, next_state, next_state_message=None):
+    def __init__(self, instance_uuid, next_state, next_state_message=None,
+                 network=None):
         super(DeleteInstanceTask, self).__init__(instance_uuid)
 
         if not next_state:


### PR DESCRIPTION
DeleteInstanceTask forgot to handle network parameter. A consequence of refactoring when versions were added to queue tasks.

Resolves #387 