### PR TITLE
Bug 370 instance power off net

### DIFF
--- a/shakenfist/daemons/triggers.py
+++ b/shakenfist/daemons/triggers.py
@@ -29,7 +29,11 @@ def observe(path, instance_uuid):
     log_ctx.withField('path', path).info('Monitoring path for triggers')
     db.add_event('instance', instance_uuid, 'trigger monitor',
                  'detected console log', None, None)
-    os.lseek(fd, 0, os.SEEK_END)
+
+    # Sometimes the trigger process is slow to start, so rewind 4KB to ensure
+    # that the last few log lines are not missed. (4KB since Cloud-Init can be
+    # noisy after the login prompt.)
+    os.lseek(fd, max(0, os.fstat(fd).st_size - 4096), os.SEEK_SET)
 
     buffer = ''
     while True:
@@ -41,6 +45,7 @@ def observe(path, instance_uuid):
 
             for line in lines:
                 if line:
+                    log_ctx.withField('line', line).info('Trigger check')
                     for trigger in regexps:
                         m = regexps[trigger][1].match(line)
                         if m:
@@ -48,8 +53,9 @@ def observe(path, instance_uuid):
                                               ).info('Trigger matched')
                             db.add_event('instance', instance_uuid, 'trigger',
                                          None, None, trigger)
-
-        time.sleep(1)
+        else:
+            # Only pause if there was no data to read
+            time.sleep(1)
 
 
 class Monitor(daemon.Daemon):

--- a/shakenfist/daemons/triggers.py
+++ b/shakenfist/daemons/triggers.py
@@ -45,7 +45,6 @@ def observe(path, instance_uuid):
 
             for line in lines:
                 if line:
-                    log_ctx.withField('line', line).info('Trigger check')
                     for trigger in regexps:
                         m = regexps[trigger][1].match(line)
                         if m:


### PR DESCRIPTION
The failing test failed mainly because the triggers process can send multiple login_prompt events for the same login prompt. This tricked the test to continue when it shouldn't. Fixed by only looking at prompts after the test command has been issued.

Made faster by removing the reliance on sleep() and just allowing for a few initial test_ping fails.

The unpause() test always failed because it waited for login prompt.

You can see on my test cluster that the ping fails maximum of 1 despite no sleep() delays.

`test_state_changes.TestStateChanges.test_lifecycle_events` now looks like:

```
Started test instance d5da216e-be8e-4cb4-be66-928161b937ac
Started keep network alive instance
  ping test...
    _test_ping()  attempts=10
Instance Soft reboot
  ping test...
    _test_ping()  attempts=10
Instance Hard reboot
  ping test...
    _test_ping()  attempts=10
    _test_ping()  attempts=9
Power off
  ping test...
    _test_ping()  attempts=10
Instance Power on
  ping test...
    _test_ping()  attempts=10
    _test_ping()  attempts=9
Instance Pause
  ping test...
    _test_ping()  attempts=10
Instance Unpause
  ping test...
    _test_ping()  attempts=10
{0} shakenfist_ci.tests.test_state_changes.TestStateChanges.test_lifecycle_events [216.856081s] ... ok
```

Not sure this resolves all of #370 since it also uncovered the 5 min delay on the queue.