### PR TITLE
Don't copy base images during resize, create a COW chain instead.

### DIFF
--- a/shakenfist/images.py
+++ b/shakenfist/images.py
@@ -148,7 +148,7 @@ class Image(object):
             diff_field = self._new_image_available(resp)
             if diff_field:
                 self.log.withField('diff_field', diff_field).info(
-                                    'Fetch required due HTTP field change')
+                    'Fetch required due HTTP field change')
                 if related_object:
                     t, u = related_object.unique_label()
                     msg = '%s: %s -> %s' % diff_field
@@ -272,7 +272,8 @@ def resize(locks, image_path, size):
         return backing_file
 
     util.execute(locks,
-                 'cp %s %s' % (image_path + '.qcow2', backing_file))
+                 'qemu-img create -b %s.qcow2 -f qcow2 %s'
+                 % (image_path, backing_file))
     util.execute(locks,
                  'qemu-img resize %s %sG' % (backing_file, size))
 
@@ -327,8 +328,8 @@ def create_cow(locks, cache_file, disk_file):
         return
 
     util.execute(locks,
-                 'qemu-img create -b %s -f qcow2 %s' % (
-                     cache_file, disk_file))
+                 'qemu-img create -b %s -f qcow2 %s'
+                 % (cache_file, disk_file))
 
 
 def create_flat(locks, cache_file, disk_file):

--- a/shakenfist/tests/test_images.py
+++ b/shakenfist/tests/test_images.py
@@ -227,13 +227,13 @@ class ImageObjectTestCase(testtools.TestCase):
             'f0e6a6a97042a4f1f1c87f5f7d44315b2d852c2df5c7991cc66241bf7072d1c4',
             'sf-245',
             {
-              'url': 'http://example.com',
-              'checksum': '1abab',
-              'size': 1234,
-              'modified': None,
-              'fetched': None,
-              'file_version': 4,
-              'version': 1,
+                'url': 'http://example.com',
+                'checksum': '1abab',
+                'size': 1234,
+                'modified': None,
+                'fetched': None,
+                'file_version': 4,
+                'version': 1,
             })
 
     @mock.patch('shakenfist.config.parsed.get', return_value='/a/b/c')
@@ -382,7 +382,7 @@ class ImageObjectTestCase(testtools.TestCase):
         images.resize(None, '/a/b/c/hash', 8)
         mock_link.assert_not_called()
         mock_execute.assert_has_calls(
-            [mock.call(None, 'cp /a/b/c/hash.qcow2 /a/b/c/hash.qcow2.8G'),
+            [mock.call(None, 'qemu-img create -b /a/b/c/hash.qcow2 -f qcow2 /a/b/c/hash.qcow2.8G'),
              mock.call(None, 'qemu-img resize /a/b/c/hash.qcow2.8G 8G')]
         )
 


### PR DESCRIPTION
For large downloaded images, this is a significant performance and
IO workload improvement.

Fixes #453.