### PR TITLE
Include original qcow in backing store chain.

### DIFF
--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -201,10 +201,14 @@ class Instance(object):
                                     [lock], resized_image_path, disk['path'])
 
                             # Record the backing store for modern libvirts
-                            disk['backing'] = ('<backingStore type=\'file\'>\n'
-                                               '        <format type=\'qcow2\'/>\n'
-                                               '        <source file=\'%s\'/>\n'
-                                               '      </backingStore>' % resized_image_path)
+                            disk['backing'] = (
+                                '<backingStore type=\'file\'>\n'
+                                '        <format type=\'qcow2\'/><source file=\'%s\'/>\n'
+                                '        <backingStore type=\'file\'>\n'
+                                '                <format type=\'qcow2\'/><source file=\'%s.qcow2\'>\n'
+                                '                </backingStore>'
+                                '        </backingStore>'
+                                % (resized_image_path, hashed_image_path))
 
                         elif config.parsed.get('DISK_FORMAT') == 'qcow_flat':
                             with util.RecordedOperation('create flat layer', self):


### PR DESCRIPTION
When we introduced qcow2 chains for resizes to reduce IO, we omitted
to add them to the domain XML as a backing store entry. This stops
VMs from starting.

Fixes #460.