### PR TITLE
Find an available vxlan without a lock

### DIFF
--- a/shakenfist/db.py
+++ b/shakenfist/db.py
@@ -113,15 +113,9 @@ def allocate_network(netblock, provide_dhcp=True, provide_nat=False, name=None,
     ipm = ipmanager.NetBlock(netblock)
     etcd.put('ipmanager', None, net_id, ipm.save())
 
-    with etcd.get_lock('vxlan', None, 'all', op='Allocate network'):
-        vxid = 1
-        while etcd.get('vxlan', None, vxid):
-            vxid += 1
-
-        etcd.put('vxlan', None, vxid,
-                 {
-                     'network_uuid': net_id
-                 })
+    vxid = 1
+    while not etcd.create('vxlan', None, vxid, {'network_uuid': net_id}):
+        vxid += 1
 
     d = {
         'uuid': net_id,

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -190,6 +190,12 @@ def put(objecttype, subtype, name, data, ttl=None):
     Etcd3Client().put(path, encoded, lease=None)
 
 
+def create(objecttype, subtype, name, data, ttle=None):
+    path = _construct_key(objecttype, subtype, name)
+    encoded = json.dumps(data, indent=4, sort_keys=True, cls=JSONEncoderTasks)
+    return Etcd3Client().create(path, encoded, lease=None)
+
+
 def get(objecttype, subtype, name):
     path = _construct_key(objecttype, subtype, name)
     value = Etcd3Client().get(path, metadata=True)


### PR DESCRIPTION
The old implementation takes a lock and then tries successively higher
vxlan ids until it finds one which is free. A side effect of this is
that finding an available is needlessly serial, so two networks can't
be made in parallel.

Instead of taking a lock, this uses `create` which should attempt to
atomically create the vxlan entry in etcd with successively higher
vxland ids until it succeeds. Whilst still the same inefficient
algorithm, it should allow networks to be created in parallel.