### PR TITLE
Remove superfluous image resize step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ dmypy.json
 
 # Deployer git repos
 deploy/gitrepos/
+
+.vscode

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -42,7 +42,6 @@ from shakenfist.daemons import daemon
 from shakenfist.tasks import (DeleteInstanceTask,
                               DeployNetworkTask,
                               FetchImageTask,
-                              ResizeImageTask,
                               PreflightInstanceTask,
                               StartInstanceTask,
                               )
@@ -1106,14 +1105,10 @@ class Images(Resource):
         return images
 
     @jwt_required
-    def post(self, url=None, size=None):
-        tasks = [FetchImageTask(url)]
-        if size:
-            tasks.append(ResizeImageTask(url, size))
-
+    def post(self, url=None):
         db.add_event('image', url, 'api', 'cache', None, None)
         db.enqueue(config.parsed.get('NODE_NAME'), {
-            'tasks': tasks,
+            'tasks': [FetchImageTask(url)],
         })
 
 

--- a/shakenfist/tasks.py
+++ b/shakenfist/tasks.py
@@ -165,24 +165,3 @@ class FetchImageTask(ImageTask):
     # Data methods
     def instance_uuid(self):
         return self._instance_uuid
-
-
-class ResizeImageTask(ImageTask):
-    _name = 'image_resize'
-
-    def __init__(self, url, size, instance_uuid=None):
-        super(ResizeImageTask, self).__init__(url)
-        self._size = size
-        self._instance_uuid = instance_uuid
-
-    def json_dump(self):
-        return {**super(ResizeImageTask, self).json_dump(),
-                'instance_uuid': self._instance_uuid,
-                'size': self._size}
-
-    # Data methods
-    def instance_uuid(self):
-        return self._instance_uuid
-
-    def size(self):
-        return self._size

--- a/shakenfist/tests/test_images.py
+++ b/shakenfist/tests/test_images.py
@@ -404,12 +404,9 @@ class ImageObjectTestCase(testtools.TestCase):
                  '/a/b/c/image_cache/f0e6a6a97042a4f1f1c87f5f7d4431'
                  '5b2d852c2df5c7991cc66241bf7072d1c4.v000.qcow2 '
                  '-f qcow2 /a/b/c/image_cache/f0e6a6a97042a4f1f1c87f'
-                 '5f7d44315b2d852c2df5c7991cc66241bf7072d1c4.v000.qcow2.8G')),
-             mock.call(
-                 None,
-                 ('qemu-img resize '
-                  '/a/b/c/image_cache/f0e6a6a97042a4f1f1c87f5f7d4431'
-                  '5b2d852c2df5c7991cc66241bf7072d1c4.v000.qcow2.8G 8G'))]
+                 '5f7d44315b2d852c2df5c7991cc66241bf7072d1c4.v000.qcow2.8G 8G')
+                )
+             ]
         )
 
     @mock.patch('shakenfist.util.execute',
@@ -433,9 +430,9 @@ class ImageObjectTestCase(testtools.TestCase):
                 return_value=(None, None))
     @mock.patch('os.path.exists', return_value=False)
     def test_create_cow(self, mock_exists, mock_execute):
-        images.create_cow(None, '/a/b/c/base', '/a/b/c/cow')
+        images.create_cow(None, '/a/b/c/base', '/a/b/c/cow', 10)
         mock_execute.assert_called_with(
-            None, 'qemu-img create -b /a/b/c/base -f qcow2 /a/b/c/cow')
+            None, 'qemu-img create -b /a/b/c/base -f qcow2 /a/b/c/cow 10G')
 
     @mock.patch('shakenfist.util.execute',
                 return_value=(None, None))

--- a/shakenfist/tests/test_tasks.py
+++ b/shakenfist/tests/test_tasks.py
@@ -52,23 +52,11 @@ class TasksEqTestCase(testtools.TestCase):
         self.assertNotEqual(tasks.FetchImageTask('http://someurl'),
                             tasks.FetchImageTask('http://someurl', 'fake_uuid'))
 
-        self.assertEqual(tasks.ResizeImageTask('http://someurl', 100),
-                         tasks.ResizeImageTask('http://someurl', 100))
+        self.assertNotEqual(tasks.FetchImageTask('http://someurl', 'fake_uuid'),
+                            tasks.FetchImageTask('http://someurl', 'fake_uudd'))
 
-        self.assertEqual(tasks.ResizeImageTask('http://someurl', 100, 'uuid'),
-                         tasks.ResizeImageTask('http://someurl', 100, 'uuid'))
-
-        self.assertNotEqual(
-            tasks.ResizeImageTask('http://someurl', 100),
-            tasks.ResizeImageTask('http://someurl', 100, 'uuid'))
-
-        self.assertNotEqual(
-            tasks.ResizeImageTask('http://someurl', 100, 'uuid'),
-            tasks.ResizeImageTask('http://someurl', 101, 'uuid'))
-
-        self.assertNotEqual(
-            tasks.ResizeImageTask('http://someurl', 100, 'uuid1'),
-            tasks.ResizeImageTask('http://someurl', 100, 'uuid2'))
+        self.assertNotEqual(tasks.FetchImageTask('http://someurl', 'fake_uuid'),
+                            tasks.FetchImageTask('http://someurm', 'fake_uuid'))
 
 
 class InstanceTasksTestCase(testtools.TestCase):

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -191,33 +191,33 @@ class Instance(object):
                         disk['device'] = 'hd%s' % disk['device'][-1]
                         disk['bus'] = 'ide'
                     else:
-                        with util.RecordedOperation('resize image', self):
-                            resized_image_path = img.resize(
-                                [lock], disk['size'])
-
                         if config.parsed.get('DISK_FORMAT') == 'qcow':
                             with util.RecordedOperation('create copy on write layer', self):
-                                images.create_cow(
-                                    [lock], resized_image_path, disk['path'])
+                                images.create_cow([lock], hashed_image_path,
+                                                  disk['path'], disk['size'])
 
                             # Record the backing store for modern libvirts
                             disk['backing'] = (
                                 '<backingStore type=\'file\'>\n'
                                 '        <format type=\'qcow2\'/>\n'
                                 '        <source file=\'%s\'/>\n'
-                                '        <backingStore type=\'file\'>\n'
-                                '          <format type=\'qcow2\'/>\n'
-                                '          <source file=\'%s.qcow2\'/>\n'
-                                '        </backingStore>\n'
                                 '      </backingStore>\n'
-                                % (resized_image_path, hashed_image_path))
+                                % (hashed_image_path))
 
                         elif config.parsed.get('DISK_FORMAT') == 'qcow_flat':
+                            with util.RecordedOperation('resize image', self):
+                                resized_image_path = img.resize(
+                                    [lock], disk['size'])
+
                             with util.RecordedOperation('create flat layer', self):
                                 images.create_flat(
                                     [lock], resized_image_path, disk['path'])
 
                         elif config.parsed.get('DISK_FORMAT') == 'flat':
+                            with util.RecordedOperation('resize image', self):
+                                resized_image_path = img.resize(
+                                    [lock], disk['size'])
+
                             with util.RecordedOperation('create raw disk', self):
                                 images.create_raw(
                                     [lock], resized_image_path, disk['path'])


### PR DESCRIPTION
The majority of images use QCOW backed images. Requiring a resized COW layer adds unnecessary code complexity.

Resolves #481