### PR TITLE
Remove withLabel from logger

### DIFF
--- a/shakenfist/db.py
+++ b/shakenfist/db.py
@@ -429,8 +429,9 @@ def get_instance_snapshots(instance_uuid):
 
 def add_event(object_type, object_uuid, operation, phase, duration, message):
     t = time.time()
-    LOG.withLabel(object_type, object_uuid).withFields(
+    LOG.withFields(
         {
+            object_type: object_uuid,
             'fqdn': config.parsed.get('NODE_NAME'),
             'operation': operation,
             'phase': phase,

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -75,8 +75,8 @@ class ActualLock(Lock):
                     db.add_event(self.objecttype, self.objectname,
                                  'lock', 'acquired', None,
                                  'Waited %d seconds for lock' % duration)
-                    self.log_ctx.withFields({'duration': duration,
-                                             }).info('Acquiring a lock was slow')
+                    self.log_ctx.withField('duration', duration
+                                           ).info('Acquiring a lock was slow')
                 return self
 
             duration = time.time() - start_time

--- a/shakenfist/logutil.py
+++ b/shakenfist/logutil.py
@@ -40,9 +40,6 @@ class SFPyLogrus(logging.Logger, PyLogrusBase):
             raise Exception('Bad object - no unique_label() function: %s' % e)
         return SFCustomAdapter(self, {label: value})
 
-    def withLabel(self, label, value):
-        return SFCustomAdapter(self, {label: value})
-
     #
     # Use labelled convenience methods when ID is a string (not object)
     # Note: the helper method still handles objects
@@ -135,9 +132,6 @@ class SFCustomAdapter(logging.LoggerAdapter, PyLogrusBase):
                     'Bad object - no unique_label() function: %s' % e)
             extra.update({label: value})
         return SFCustomAdapter(self._logger, extra, self._prefix)
-
-    def withLabel(self, label, value):
-        return SFCustomAdapter(self, {label: value})
 
     #
     # Use labelled convenience methods when ID is a string (not object)


### PR DESCRIPTION
`withLabel()` duplicates `withField()`

The `SFCustomAdapter` function had a bug that dropped existing fields on logger. So log 'Added event' had no useful data.