### PR TITLE
Make config code slightly less verbose

### DIFF
--- a/shakenfist/configuration.py
+++ b/shakenfist/configuration.py
@@ -6,7 +6,6 @@ import os
 import socket
 
 from shakenfist import exceptions
-from shakenfist import util
 
 
 # NOTE(mikal): Dear future developer. Thanks ftheor dropping by! Remember that the type
@@ -99,6 +98,7 @@ CONFIG_DEFAULTS = {
     'LOGLEVEL_CLEANER': 'info',
     'LOGLEVEL_MAIN': 'info',
     'LOGLEVEL_NET': 'info',
+    'LOGLEVEL_QUEUES': 'info',
     'LOGLEVEL_RESOURCES': 'info',
     'LOGLEVEL_TRIGGERS': 'info',
     # Add method name and module line number to log messages
@@ -116,10 +116,9 @@ class Config(object):
         node_name = socket.getfqdn()
         try:
             node_ip = socket.gethostbyname(node_name)
-        except Exception as e:
+        except Exception:
             # Only for localhost development environments
             node_ip = '127.0.0.1'
-            util.ignore_exception('config parser', e)
 
         CONFIG_DEFAULTS['NODE_NAME'] = node_name
         CONFIG_DEFAULTS['NODE_IP'] = node_ip
@@ -149,7 +148,17 @@ class Config(object):
     def get(self, var):
         if not self.config:
             self.parse()
-        return self.config.get(var)
+        # Ensure an exception if code attempts to retrieve non-existent config
+        return self.config[var]
+
+    def node_name(self):
+        return self.get('NODE_NAME')
+
+    def node_ip(self):
+        return self.get('NODE_IP')
+
+    def network_node_ip(self):
+        return self.get('NETWORK_NODE_IP')
 
 
-parsed = Config()
+config = Config()

--- a/shakenfist/daemons/cleaner.py
+++ b/shakenfist/daemons/cleaner.py
@@ -3,7 +3,7 @@ import json
 import os
 import time
 
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist.daemons import daemon
 from shakenfist import db
 from shakenfist import logutil
@@ -39,8 +39,7 @@ class Monitor(daemon.Daemon):
                                  'virsh destroy "sf:%s"' % instance_uuid)
                     continue
 
-                db.place_instance(
-                    instance_uuid, config.parsed.get('NODE_NAME'))
+                db.place_instance(instance_uuid, config.node_name())
                 seen.append(domain.name())
 
                 if instance.get('state') == 'deleted':
@@ -108,11 +107,9 @@ class Monitor(daemon.Daemon):
                                      'deleted stray', 'complete', None, None)
                         continue
 
-                    db.place_instance(
-                        instance_uuid, config.parsed.get('NODE_NAME'))
+                    db.place_instance(instance_uuid, config.node_name())
                     instance_path = os.path.join(
-                        config.parsed.get('STORAGE_PATH'), 'instances',
-                        instance_uuid)
+                        config.get('STORAGE_PATH'), 'instances', instance_uuid)
 
                     if not os.path.exists(instance_path):
                         # If we're inactive and our files aren't on disk,
@@ -158,7 +155,7 @@ class Monitor(daemon.Daemon):
             self._update_power_states()
 
             # Cleanup soft deleted instances and networks
-            delay = config.parsed.get('CLEANER_DELAY')
+            delay = config.get('CLEANER_DELAY')
 
             for i in db.get_stale_instances(delay):
                 LOG.withInstance(i['uuid']).info('Hard deleting instance')

--- a/shakenfist/daemons/daemon.py
+++ b/shakenfist/daemons/daemon.py
@@ -1,7 +1,7 @@
 import logging
 import setproctitle
 
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist import logutil
 
 
@@ -27,8 +27,7 @@ def set_log_level(log, name):
     process_name(name)
 
     # Check for configuration override
-    label = 'LOGLEVEL_' + name.upper()
-    level = config.parsed.get(label)
+    level = config.get('LOGLEVEL_' + name.upper())
     if level:
         numeric_level = getattr(logging, level.upper(), None)
         if not isinstance(numeric_level, int):

--- a/shakenfist/daemons/external_api.py
+++ b/shakenfist/daemons/external_api.py
@@ -1,6 +1,6 @@
 import os
 
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist.daemons import daemon
 from shakenfist import logutil
 from shakenfist import util
@@ -12,11 +12,9 @@ LOG, _ = logutil.setup(__name__)
 class Monitor(daemon.Daemon):
     def run(self):
         LOG.info('Starting')
-        util.execute(None,
-                     (config.parsed.get('API_COMMAND_LINE')
-                      % {
-                         'port': config.parsed.get('API_PORT'),
-                          'timeout': config.parsed.get('API_TIMEOUT'),
-                          'name': daemon.process_name('api')
-                     }),
+        util.execute(None, (config.get('API_COMMAND_LINE') % {
+                            'port': config.get('API_PORT'),
+                            'timeout': config.get('API_TIMEOUT'),
+                            'name': daemon.process_name('api')
+                            }),
                      env_variables=os.environ)

--- a/shakenfist/daemons/main.py
+++ b/shakenfist/daemons/main.py
@@ -5,7 +5,7 @@ import time
 import os
 import psutil
 
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist.daemons import daemon
 from shakenfist.daemons import external_api as external_api_daemon
 from shakenfist.daemons import cleaner as cleaner_daemon
@@ -27,7 +27,7 @@ def restore_instances():
     # Ensure all instances for this node are defined
     networks = []
     instances = []
-    for inst in list(db.get_instances(only_node=config.parsed.get('NODE_NAME'))):
+    for inst in list(db.get_instances(only_node=config.node_name())):
         for iface in db.get_instance_interfaces(inst['uuid']):
             if not iface['network_uuid'] in networks:
                 networks.append(iface['network_uuid'])
@@ -86,9 +86,9 @@ def main():
     setproctitle.setproctitle(daemon.process_name('main'))
 
     # Log configuration on startup
-    config.parsed.parse()
-    for key in config.parsed.config:
-        LOG.info('Configuration item %s = %s' % (key, config.parsed.get(key)))
+    config.parse()
+    for key, value in config.config.items():
+        LOG.info('Configuration item %s = %s' % (key, value))
 
     daemon.set_log_level(LOG, 'main')
 
@@ -113,13 +113,13 @@ def main():
         # Bootstrap the floating network in the Networks table
         floating_network = db.get_network('floating')
         if not floating_network:
-            db.create_floating_network(config.parsed.get('FLOATING_NETWORK'))
+            db.create_floating_network(config.get('FLOATING_NETWORK'))
             floating_network = net.from_db('floating')
 
         subst = {
             'physical_bridge': util.get_safe_interface_name(
-                'phy-br-%s' % config.parsed.get('NODE_EGRESS_NIC')),
-            'physical_nic': config.parsed.get('NODE_EGRESS_NIC')
+                'phy-br-%s' % config.get('NODE_EGRESS_NIC')),
+            'physical_nic': config.get('NODE_EGRESS_NIC')
         }
 
         if not util.check_for_interface(subst['physical_bridge']):

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -1,6 +1,6 @@
 import time
 
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist.daemons import daemon
 from shakenfist import db
 from shakenfist import exceptions
@@ -29,7 +29,7 @@ class Monitor(daemon.Daemon):
 
         if not util.is_network_node():
             # For normal nodes, just the ones we have instances for
-            for inst in list(db.get_instances(only_node=config.parsed.get('NODE_NAME'))):
+            for inst in list(db.get_instances(only_node=config.node_name())):
                 for iface in db.get_instance_interfaces(inst['uuid']):
                     if not iface['network_uuid'] in host_networks:
                         host_networks.append(iface['network_uuid'])
@@ -98,8 +98,7 @@ class Monitor(daemon.Daemon):
             #                   % extra)
 
         # And record vxids in the database
-        db.persist_node_vxid_mapping(
-            config.parsed.get('NODE_NAME'), vxid_to_mac)
+        db.persist_node_vxid_mapping(config.node_name(), vxid_to_mac)
 
     def _process_network_node_workitems(self):
         jobname, workitem = db.dequeue('networknode')

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -5,7 +5,7 @@ import requests
 import setproctitle
 import time
 
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist.daemons import daemon
 from shakenfist import db
 from shakenfist import exceptions
@@ -81,7 +81,7 @@ def handle(jobname, workitem):
             elif isinstance(task, StartInstanceTask):
                 instance_start(instance_uuid, task.network())
                 db.update_instance_state(instance_uuid, 'created')
-                db.enqueue('%s-metrics' % config.parsed.get('NODE_NAME'), {})
+                db.enqueue('%s-metrics' % config.node_name(), {})
 
             elif isinstance(task, DeleteInstanceTask):
                 try:
@@ -98,8 +98,7 @@ def handle(jobname, workitem):
                     if task.error_msg():
                         db.update_instance_error_message(
                             instance_uuid, task.error_msg())
-                    db.enqueue('%s-metrics' %
-                               config.parsed.get('NODE_NAME'), {})
+                    db.enqueue('%s-metrics' % config.node_name(), {})
                 except Exception as e:
                     util.ignore_exception(daemon.process_name('queues'), e)
 
@@ -122,7 +121,7 @@ def handle(jobname, workitem):
                                       'failed queue task: %s' % e)
 
     finally:
-        db.resolve(config.parsed.get('NODE_NAME'), jobname)
+        db.resolve(config.node_name(), jobname)
         if instance_uuid:
             db.add_event('instance', instance_uuid, 'tasks complete',
                          'dequeued', None, 'Work item %s' % jobname)
@@ -138,7 +137,7 @@ def image_fetch(url, instance_uuid):
         # TODO(andy): Wait up to 15 mins for another queue process to download
         # the required image. This will be changed to queue on a
         # "waiting_image_fetch" queue but this works now.
-        with db.get_lock('image', config.parsed.get('NODE_NAME'),
+        with db.get_lock('image', config.node_name(),
                          Image.calc_unique_ref(url), timeout=15*60,
                          op='Image fetch') as lock:
             img = Image.from_url(url)
@@ -170,8 +169,7 @@ def instance_preflight(instance_uuid, network):
     instance = virt.from_db(instance_uuid)
 
     try:
-        s.place_instance(
-            instance, network, candidates=[config.parsed.get('NODE_NAME')])
+        s.place_instance(instance, network, candidates=[config.node_name()])
         return None
 
     except exceptions.LowResourceException as e:
@@ -189,7 +187,7 @@ def instance_preflight(instance_uuid, network):
         else:
             candidates = []
             for node in s.metrics.keys():
-                if node != config.parsed.get('NODE_NAME'):
+                if node != config.node_name():
                     candidates.append(node)
 
         candidates = s.place_instance(instance, network,
@@ -266,8 +264,7 @@ def instance_delete(instance_uuid):
 
         # Create list of networks used by all other instances
         host_networks = []
-        for inst in list(
-                db.get_instances(only_node=config.parsed.get('NODE_NAME'))):
+        for inst in list(db.get_instances(only_node=config.node_name())):
             if not inst['uuid'] == instance_uuid:
                 for iface in db.get_instance_interfaces(inst['uuid']):
                     if not iface['network_uuid'] in host_networks:
@@ -309,8 +306,7 @@ class Monitor(daemon.Daemon):
                         workers.remove(w)
 
                 if len(workers) < present_cpus / 2:
-                    jobname, workitem = db.dequeue(
-                        config.parsed.get('NODE_NAME'))
+                    jobname, workitem = db.dequeue(config.node_name())
                 else:
                     workitem = None
 

--- a/shakenfist/daemons/resources.py
+++ b/shakenfist/daemons/resources.py
@@ -6,7 +6,7 @@ from prometheus_client import Gauge
 from prometheus_client import start_http_server
 
 from shakenfist.daemons import daemon
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist import db
 from shakenfist import logutil
 from shakenfist import util
@@ -68,7 +68,7 @@ def _get_stats():
     retval.update(ksm_details)
 
     # Disk info
-    s = os.statvfs(config.parsed.get('STORAGE_PATH'))
+    s = os.statvfs(config.get('STORAGE_PATH'))
     disk_counters = psutil.disk_io_counters()
     retval.update({
         'disk_total': s.f_frsize * s.f_blocks,
@@ -111,7 +111,7 @@ def _get_stats():
 
     # Queue health statistics
     node_queue_processing, node_queue_waiting = db.get_queue_length(
-        config.parsed.get('NODE_NAME'))
+        config.node_name())
 
     retval.update({
         'cpu_total_instance_vcpus': total_instance_vcpus,
@@ -139,13 +139,13 @@ def _get_stats():
 class Monitor(daemon.Daemon):
     def __init__(self, id):
         super(Monitor, self).__init__(id)
-        start_http_server(config.parsed.get('PROMETHEUS_METRICS_PORT'))
+        start_http_server(config.get('PROMETHEUS_METRICS_PORT'))
 
     def run(self):
         LOG.info('Starting')
-        gauges = {
-            'updated_at': Gauge('updated_at', 'The last time metrics were updated')
-        }
+        gauges = {'updated_at': Gauge('updated_at',
+                                      'The last time metrics were updated')
+                  }
 
         last_metrics = 0
 
@@ -164,18 +164,17 @@ class Monitor(daemon.Daemon):
 
         while True:
             try:
-                jobname, _ = db.dequeue(
-                    '%s-metrics' % config.parsed.get('NODE_NAME'))
+                jobname, _ = db.dequeue('%s-metrics' % config.node_name())
                 if jobname:
                     if time.time() - last_metrics > 2:
                         update_metrics()
                         last_metrics = time.time()
-                    db.resolve('%s-metrics' % config.parsed.get('NODE_NAME'),
-                               jobname)
+                    db.resolve('%s-metrics' % config.node_name(), jobname)
                 else:
                     time.sleep(0.2)
 
-                if time.time() - last_metrics > config.parsed.get('SCHEDULER_CACHE_TIMEOUT'):
+                timer = time.time() - last_metrics
+                if timer > config.get('SCHEDULER_CACHE_TIMEOUT'):
                     update_metrics()
                     last_metrics = time.time()
 

--- a/shakenfist/daemons/triggers.py
+++ b/shakenfist/daemons/triggers.py
@@ -5,7 +5,7 @@ import setproctitle
 import signal
 import time
 
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist.daemons import daemon
 from shakenfist import db
 from shakenfist import logutil
@@ -78,7 +78,7 @@ class Monitor(daemon.Daemon):
             # Start missing observers
             extra_instances = list(observers.keys())
 
-            for inst in db.get_instances(only_node=config.parsed.get('NODE_NAME')):
+            for inst in db.get_instances(only_node=config.node_name()):
                 if inst['uuid'] in extra_instances:
                     extra_instances.remove(inst['uuid'])
 
@@ -86,8 +86,10 @@ class Monitor(daemon.Daemon):
                     continue
 
                 if inst['uuid'] not in observers:
-                    console_path = os.path.join(
-                        config.parsed.get('STORAGE_PATH'), 'instances', inst['uuid'], 'console.log')
+                    console_path = os.path.join(config.get('STORAGE_PATH'),
+                                                'instances',
+                                                inst['uuid'],
+                                                'console.log')
                     p = multiprocessing.Process(
                         target=observe, args=(console_path, inst['uuid']),
                         name='%s-%s' % (daemon.process_name('triggers'),

--- a/shakenfist/dhcp.py
+++ b/shakenfist/dhcp.py
@@ -6,7 +6,7 @@ import psutil
 import shutil
 import signal
 
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist import db
 from shakenfist import util
 
@@ -17,8 +17,8 @@ class DHCP(object):
 
         self.subst = {
             'config_dir': os.path.join(
-                config.parsed.get('STORAGE_PATH'), 'dhcp', self.network_uuid),
-            'zone': config.parsed.get('ZONE'),
+                config.get('STORAGE_PATH'), 'dhcp', self.network_uuid),
+            'zone': config.get('ZONE'),
 
             'router': network.router,
             'dhcp_start': network.dhcp_start,
@@ -36,7 +36,7 @@ class DHCP(object):
         return ('dhcp', self.network_uuid)
 
     def _read_template(self, template):
-        with open(os.path.join(config.parsed.get('STORAGE_PATH'),
+        with open(os.path.join(config.get('STORAGE_PATH'),
                                template)) as f:
             return jinja2.Template(f.read())
 

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -6,7 +6,7 @@ import time
 from etcd3gw.client import Etcd3Client
 from etcd3gw.lock import Lock
 
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist import db
 from shakenfist import exceptions
 from shakenfist import logutil
@@ -42,7 +42,7 @@ class ActualLock(Lock):
         # We override the UUID of the lock with something more helpful to debugging
         self._uuid = json.dumps(
             {
-                'node': config.parsed.get('NODE_NAME'),
+                'node': config.node_name(),
                 'pid': os.getpid(),
                 'operation': self.operation
             },
@@ -65,7 +65,7 @@ class ActualLock(Lock):
     def __enter__(self):
         start_time = time.time()
         slow_warned = False
-        threshold = int(config.parsed.get('SLOW_LOCK_THRESHOLD'))
+        threshold = int(config.get('SLOW_LOCK_THRESHOLD'))
 
         while time.time() - start_time < self.timeout:
             res = self.acquire()
@@ -152,7 +152,7 @@ def clear_stale_locks():
         node = holder['node']
         pid = int(holder['pid'])
 
-        if node == config.parsed.get('NODE_NAME') and not psutil.pid_exists(pid):
+        if node == config.node_name() and not psutil.pid_exists(pid):
             client.delete(metadata['key'])
             LOG.withFields({'lock': lockname,
                             'old-pid': pid,
@@ -340,4 +340,4 @@ def restart_queues():
     # we didn't complete them before crashing.
     if util.is_network_node():
         _restart_queue('networknode')
-    _restart_queue(config.parsed.get('NODE_NAME'))
+    _restart_queue(config.node_name())

--- a/shakenfist/image_resolver_cirros.py
+++ b/shakenfist/image_resolver_cirros.py
@@ -1,7 +1,7 @@
 import re
 import requests
 
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist import exceptions
 from shakenfist import logutil
 from shakenfist import util
@@ -37,7 +37,7 @@ def resolve(name):
             raise exceptions.VersionSpecificationError(
                 'Cannot parse version: %s' % name)
 
-    url = config.parsed.get('DOWNLOAD_URL_CIRROS') % {'vernum': vernum}
+    url = config.get('DOWNLOAD_URL_CIRROS') % {'vernum': vernum}
     log = LOG.withField('url', url)
 
     # Retrieve check sum file

--- a/shakenfist/image_resolver_ubuntu.py
+++ b/shakenfist/image_resolver_ubuntu.py
@@ -1,7 +1,7 @@
 import re
 import requests
 
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist import exceptions
 from shakenfist import logutil
 from shakenfist import util
@@ -18,8 +18,8 @@ def resolve(name):
     resp = requests.get(UBUNTU_URL,
                         headers={'User-Agent': util.get_user_agent()})
     if resp.status_code != 200:
-        raise exceptions.HTTPError(
-            'Failed to fetch %s, status code %d' % (UBUNTU_URL, resp.status_code))
+        raise exceptions.HTTPError('Failed to fetch %s, status code %d'
+                                   % (UBUNTU_URL, resp.status_code))
 
     num_to_name = {}
     name_to_num = {}
@@ -52,8 +52,8 @@ def resolve(name):
             raise exceptions.VersionSpecificationError(
                 'Cannot parse version: %s' % name)
 
-    url = (config.parsed.get('DOWNLOAD_URL_UBUNTU') % {'vernum': vernum,
-                                                       'vername': vername})
+    url = (config.get('DOWNLOAD_URL_UBUNTU') % {'vernum': vernum,
+                                                'vername': vername})
     log = LOG.withField('url', url)
 
     # Retrieve check sum file

--- a/shakenfist/images.py
+++ b/shakenfist/images.py
@@ -8,7 +8,7 @@ import requests
 import time
 
 from shakenfist import db
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist import exceptions
 from shakenfist import image_resolver_cirros
 from shakenfist import image_resolver_ubuntu
@@ -26,8 +26,7 @@ resolvers = {
 
 
 def _get_cache_path():
-    image_cache_path = os.path.join(
-        config.parsed.get('STORAGE_PATH'), 'image_cache')
+    image_cache_path = os.path.join(config.get('STORAGE_PATH'), 'image_cache')
     if not os.path.exists(image_cache_path):
         LOG.withField('image_cache_path',
                       image_cache_path).debug('Creating image cache')
@@ -82,7 +81,7 @@ class Image(object):
 
         # Check for existing metadata in DB
         db_data = db.get_image_metadata(Image.calc_unique_ref(url),
-                                        config.parsed.get('NODE_NAME'))
+                                        config.node_name())
 
         # Load DB data into new Image object
         if db_data:
@@ -114,8 +113,7 @@ class Image(object):
             'file_version': self.file_version,
             'version': 1,
         }
-        db.persist_image_metadata(self.unique_ref,
-                                  config.parsed.get('NODE_NAME'),
+        db.persist_image_metadata(self.unique_ref, config.node_name(),
                                   metadata)
 
     def get(self, locks, related_object):

--- a/shakenfist/logutil.py
+++ b/shakenfist/logutil.py
@@ -8,7 +8,7 @@ import re
 import setproctitle
 import traceback
 
-from shakenfist import config
+from shakenfist.configuration import config
 
 
 # These classes are extensions of the work in https://github.com/vmig/pylogrus
@@ -106,7 +106,7 @@ class SFCustomAdapter(logging.LoggerAdapter, PyLogrusBase):
         msg = '%s[%s] %s' % (setproctitle.getproctitle(), os.getpid(), msg)
         kwargs["extra"] = self.extra
 
-        if config.parsed.get('LOG_METHOD_TRACE'):
+        if config.get('LOG_METHOD_TRACE'):
             # Determine the name of the calling method
             filename = traceback.extract_stack()[-4].filename
             f_match = self.FILENAME_RE.match(filename)

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -5,7 +5,7 @@ import psutil
 import re
 
 
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist import db
 from shakenfist import dhcp
 from shakenfist import logutil
@@ -33,7 +33,7 @@ class Network(object):
     # on Linux is 15 user visible characters.
     def __init__(self, db_entry):
         self.db_entry = db_entry
-        self.physical_nic = config.parsed.get('NODE_EGRESS_NIC')
+        self.physical_nic = config.get('NODE_EGRESS_NIC')
 
         with db.get_lock('ipmanager', None, self.db_entry['uuid'], ttl=120,
                          op='Network object initialization'):
@@ -50,7 +50,8 @@ class Network(object):
             db.persist_ipmanager(self.db_entry['uuid'], ipm.save())
 
     def __str__(self):
-        return 'network(%s, vxid %s)' % (self.db_entry['uuid'], self.db_entry['vxid'])
+        return 'network(%s, vxid %s)' % (self.db_entry['uuid'],
+                                         self.db_entry['vxid'])
 
     def unique_label(self):
         return ('network', self.db_entry['uuid'])
@@ -64,7 +65,7 @@ class Network(object):
             'vx_veth_inner': 'veth-%s-i' % self.db_entry['vxid'],
 
             'physical_interface': self.physical_nic,
-            'physical_bridge': 'phy-br-%s' % config.parsed.get('NODE_EGRESS_NIC'),
+            'physical_bridge': 'phy-br-%s' % config.get('NODE_EGRESS_NIC'),
             'physical_veth_outer': 'phy-%s-o' % self.db_entry['vxid'],
             'physical_veth_inner': 'phy-%s-i' % self.db_entry['vxid'],
 
@@ -340,7 +341,7 @@ class Network(object):
             # NOTE(mikal): why not use DNS here? Well, DNS might be outside
             # the control of the deployer if we're running in a public cloud
             # as an overlay cloud...
-            node_ips = [config.parsed.get('NETWORK_NODE_IP')]
+            node_ips = [config.network_node_ip()]
             for fqdn in node_fqdns:
                 ip = db.get_node(fqdn)['ip']
                 if ip not in node_ips:

--- a/shakenfist/scheduler.py
+++ b/shakenfist/scheduler.py
@@ -4,7 +4,7 @@ import copy
 import random
 import time
 
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist import db
 from shakenfist import exceptions
 from shakenfist import logutil
@@ -33,27 +33,28 @@ class Scheduler(object):
 
     def _has_sufficient_cpu(self, cpus, node):
         max_cpu = (self.metrics[node].get('cpu_max', 0) *
-                   config.parsed.get('CPU_OVERCOMMIT_RATIO'))
+                   config.get('CPU_OVERCOMMIT_RATIO'))
         current_cpu = self.metrics[node].get('cpu_total_instance_vcpus', 0)
         if current_cpu + cpus > max_cpu:
             return False
         return True
 
     def _has_sufficient_ram(self, memory, node):
-        # There are two things to track here... We must always have RAM_SYSTEM_RESERVATION
-        # gb of RAM for operating system tasks -- assume there is no overlap with existing
-        # VMs when checking this. Note as well that metrics are in MB...
+        # There are two things to track here... We must always have
+        # RAM_SYSTEM_RESERVATION gb of RAM for operating system tasks -- assume
+        # there is no overlap with existing VMs when checking this. Note as
+        # well that metrics are in MB...
         available = (self.metrics[node].get('memory_available', 0) -
-                     (config.parsed.get('RAM_SYSTEM_RESERVATION') * 1024))
+                     (config.get('RAM_SYSTEM_RESERVATION') * 1024))
         if available - memory < 0.0:
             return False
 
-        # ...Secondly, if we're using KSM and over committing memory, we shouldn't
-        # overcommit more than by RAM_OVERCOMMIT_RATIO
-        instance_memory = (self.metrics[node].get('memory_total_instance_actual', 0) +
-                           memory)
+        # ...Secondly, if we're using KSM and over committing memory, we
+        # shouldn't overcommit more than by RAM_OVERCOMMIT_RATIO
+        instance_memory = (
+            self.metrics[node].get('memory_total_instance_actual', 0) + memory)
         if (instance_memory / self.metrics[node].get('memory_max', 0) >
-                config.parsed.get('RAM_OVERCOMMIT_RATIO')):
+                config.get('RAM_OVERCOMMIT_RATIO')):
             return False
 
         return True
@@ -154,7 +155,7 @@ class Scheduler(object):
             log_ctx = LOG.withObj(instance)
 
             diff = time.time() - self.metrics_updated
-            if diff > config.parsed.get('SCHEDULER_CACHE_TIMEOUT'):
+            if diff > config.get('SCHEDULER_CACHE_TIMEOUT'):
                 self.refresh_metrics()
 
             if candidates:

--- a/shakenfist/tests/test_config.py
+++ b/shakenfist/tests/test_config.py
@@ -1,6 +1,6 @@
 import mock
 
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist import exceptions
 from shakenfist.tests import test_shakenfist
 
@@ -9,39 +9,41 @@ class ConfigTestCase(test_shakenfist.ShakenFistTestCase):
     @mock.patch('socket.getfqdn', return_value='a.b.com')
     @mock.patch('socket.gethostbyname', return_value='1.1.1.1')
     def test_hostname(self, mock_hostname, mock_fqdn):
-        config.parsed.parse()
+        config.parse()
 
         mock_fqdn.assert_called()
         mock_hostname.assert_called()
 
-        self.assertEqual('a.b.com', config.parsed.get('NODE_NAME'))
-        self.assertEqual('1.1.1.1', config.parsed.get('NODE_IP'))
+        self.assertEqual('a.b.com', config.get('NODE_NAME'))
+        self.assertEqual('1.1.1.1', config.get('NODE_IP'))
 
     @mock.patch.dict('os.environ', {'SHAKENFIST_STORAGE_PATH': 'foo'})
     def test_string_override(self):
-        config.parsed.parse()
-        self.assertTrue(isinstance(config.parsed.get('STORAGE_PATH'), str))
-        self.assertEqual('foo', config.parsed.get('STORAGE_PATH'))
+        config.parse()
+        self.assertTrue(isinstance(config.get('STORAGE_PATH'), str))
+        self.assertEqual('foo', config.get('STORAGE_PATH'))
 
     @mock.patch.dict('os.environ', {'SHAKENFIST_CPU_OVERCOMMIT_RATIO': '1'})
     def test_int_override(self):
-        config.parsed.parse()
-        self.assertTrue(isinstance(
-            config.parsed.get('CPU_OVERCOMMIT_RATIO'), int))
-        self.assertEqual(1, config.parsed.get('CPU_OVERCOMMIT_RATIO'))
+        config.parse()
+        self.assertTrue(isinstance(config.get('CPU_OVERCOMMIT_RATIO'), int))
+        self.assertEqual(1, config.get('CPU_OVERCOMMIT_RATIO'))
 
-    @mock.patch.dict('os.environ', {'SHAKENFIST_RAM_SYSTEM_RESERVATION': '4.0'})
+    @mock.patch.dict('os.environ',
+                     {'SHAKENFIST_RAM_SYSTEM_RESERVATION': '4.0'})
     def test_float_override(self):
-        config.parsed.parse()
-        self.assertTrue(isinstance(config.parsed.get(
-            'RAM_SYSTEM_RESERVATION'), float))
-        self.assertEqual(4.0, config.parsed.get('RAM_SYSTEM_RESERVATION'))
+        config.parse()
+        self.assertTrue(
+            isinstance(config.get('RAM_SYSTEM_RESERVATION'), float))
+        self.assertEqual(4.0, config.get('RAM_SYSTEM_RESERVATION'))
 
-    @mock.patch.dict('os.environ', {'SHAKENFIST_RAM_SYSTEM_RESERVATION': 'banana'})
+    @mock.patch.dict('os.environ',
+                     {'SHAKENFIST_RAM_SYSTEM_RESERVATION': 'banana'})
     def test_bogus_override(self):
-        self.assertRaises(ValueError, config.parsed.parse)
+        self.assertRaises(ValueError, config.parse)
 
-    @mock.patch.dict('shakenfist.config.CONFIG_DEFAULTS', {'FOO': [1, 2, 3]})
+    @mock.patch.dict('shakenfist.configuration.CONFIG_DEFAULTS',
+                     {'FOO': [1, 2, 3]})
     @mock.patch.dict('os.environ', {'SHAKENFIST_FOO': '[1, 4, 6]'})
     def test_bogus_default(self):
-        self.assertRaises(exceptions.FlagException, config.parsed.parse)
+        self.assertRaises(exceptions.FlagException, config.parse)

--- a/shakenfist/tests/test_daemon_cleaner.py
+++ b/shakenfist/tests/test_daemon_cleaner.py
@@ -98,7 +98,7 @@ class CleanerTestCase(test_shakenfist.ShakenFistTestCase):
         self.mock_proctitle = self.proctitle.start()
         self.addCleanup(self.proctitle.stop)
 
-        self.config = mock.patch('shakenfist.config.parsed.get',
+        self.config = mock.patch('shakenfist.configuration.config.get',
                                  fake_config)
         self.mock_config = self.config.start()
         self.addCleanup(self.config.stop)

--- a/shakenfist/tests/test_dhcp.py
+++ b/shakenfist/tests/test_dhcp.py
@@ -46,7 +46,7 @@ class DHCPTestCase(testtools.TestCase):
                 return fc[key]
             raise Exception('Unknown config key')
 
-        self.config = mock.patch('shakenfist.config.parsed.get',
+        self.config = mock.patch('shakenfist.configuration.config.get',
                                  fake_config)
         self.mock_config = self.config.start()
         self.addCleanup(self.config.stop)

--- a/shakenfist/tests/test_etcd.py
+++ b/shakenfist/tests/test_etcd.py
@@ -26,7 +26,7 @@ class ActualLockTestCase(test_shakenfist.ShakenFistTestCase):
     def setUp(self):
         super(ActualLockTestCase, self).setUp()
 
-        self.config = mock.patch('shakenfist.config.parsed.get',
+        self.config = mock.patch('shakenfist.configuration.config.get',
                                  fake_config)
         self.mock_config = self.config.start()
         self.addCleanup(self.config.stop)

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -4,7 +4,7 @@ import json
 import mock
 
 
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist.external_api import app as external_api
 from shakenfist import ipmanager
 from shakenfist import net
@@ -22,7 +22,7 @@ class FakeResponse(object):
 
 class FakeScheduler(object):
     def place_instance(self, *args, **kwargs):
-        return config.parsed.get('NODE_NAME')
+        return config.node_name()
 
 
 class FakeInstance(object):
@@ -688,7 +688,7 @@ class ExternalApiInstanceTestCase(ExternalApiTestCase):
                 return fc[key]
             raise Exception('fake_config_instance() Unknown config key')
 
-        self.config = mock.patch('shakenfist.config.parsed.get',
+        self.config = mock.patch('shakenfist.configuration.config.get',
                                  fake_config_instance)
         self.mock_config = self.config.start()
 
@@ -961,11 +961,12 @@ class ExternalApiNetworkTestCase(ExternalApiTestCase):
                 return fc[key]
             raise Exception('fake_config_network() Unknown config key')
 
-        self.config = mock.patch('shakenfist.config.parsed.get',
+        self.config = mock.patch('shakenfist.configuration.config.get',
                                  fake_config_network)
         self.mock_config = self.config.start()
-        # Without this cleanup, other test classes will have 'config.parsed.get'
-        # mocked during parallel testing by stestr.
+        # Without this cleanup, other test classes will have
+        # 'shakenfist.configuration.config.get' mocked during parallel testing
+        # by stestr.
         self.addCleanup(self.config.stop)
 
     @mock.patch('shakenfist.db.get_networks',

--- a/shakenfist/tests/test_images.py
+++ b/shakenfist/tests/test_images.py
@@ -54,17 +54,18 @@ class FakeImage(object):
 
 
 class ImageUtilsTestCase(test_shakenfist.ShakenFistTestCase):
-    @mock.patch('shakenfist.config.parsed.get', return_value='/a/b/c')
+    @mock.patch('shakenfist.configuration.config.get', return_value='/a/b/c')
     @mock.patch('os.path.exists', return_value=True)
     def test_get_cache_path(self, mock_exists, mock_config):
         p = images._get_cache_path()
         mock_exists.assert_called_with('/a/b/c/image_cache')
         self.assertEqual('/a/b/c/image_cache', p)
 
-    @mock.patch('shakenfist.config.parsed.get', return_value='/a/b/c')
+    @mock.patch('shakenfist.configuration.config.get', return_value='/a/b/c')
     @mock.patch('os.path.exists', return_value=False)
     @mock.patch('os.makedirs')
-    def test_get_cache_path_create(self, mock_makedirs, mock_exists, mock_config):
+    def test_get_cache_path_create(self,
+                                   mock_makedirs, mock_exists, mock_config):
         p = images._get_cache_path()
         mock_exists.assert_called_with('/a/b/c/image_cache')
         mock_makedirs.assert_called_with('/a/b/c/image_cache')
@@ -149,7 +150,8 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
                 return_value=('!!!ubuntu!!!', '123abc'))
     @mock.patch('shakenfist.db.get_image_metadata', return_value=None)
     @mock.patch('os.makedirs')
-    def test_resolve_image(self, mock_mkdirs, mock_exists, mock_ubuntu, mock_centos):
+    def test_resolve_image(self, mock_mkdirs, mock_exists, mock_ubuntu,
+                           mock_centos):
         img = images.Image.from_url('win10')
         self.assertEqual('win10', img.url)
 
@@ -213,7 +215,7 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
         img = images.Image.from_url('http://example.com', '1abab')
         self.assertEqual('1abab', img.checksum)
 
-    @mock.patch('shakenfist.config.parsed.get', return_value='sf-245')
+    @mock.patch('shakenfist.configuration.config.get', return_value='sf-245')
     @mock.patch('shakenfist.db.get_image_metadata', return_value=None)
     @mock.patch('os.makedirs')
     @mock.patch('shakenfist.db.persist_image_metadata')
@@ -236,7 +238,7 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
                 'version': 1,
             })
 
-    @mock.patch('shakenfist.config.parsed.get', return_value='/a/b/c')
+    @mock.patch('shakenfist.configuration.config.get', return_value='/a/b/c')
     @mock.patch('shakenfist.db.get_image_metadata', return_value=None)
     @mock.patch('os.makedirs')
     def test_version_image_path(self, mock_mkdirs, mock_get_meta, mock_config):
@@ -294,7 +296,7 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertEqual(1, img.file_version)
         self.assertEqual(('size', 16338944, 200001), dirty_fields)
 
-    @mock.patch('shakenfist.config.parsed.get', return_value='/a/b/c')
+    @mock.patch('shakenfist.configuration.config.get', return_value='/a/b/c')
     @mock.patch('shakenfist.db.get_image_metadata', return_value=None)
     @mock.patch('os.makedirs')
     @mock.patch('requests.get',
@@ -314,7 +316,8 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
     @mock.patch('os.path.exists', return_value=True)
     @mock.patch('shakenfist.db.get_lock')
     @mock.patch('shakenfist.db.add_event')
-    def test_transcode_image_noop(self, mock_event, mock_lock, mock_exists, mock_execute):
+    def test_transcode_image_noop(self, mock_event, mock_lock, mock_exists,
+                                  mock_execute):
         images._transcode(None, '/a/b/c/hash', FakeImage())
         mock_execute.assert_not_called()
 
@@ -326,8 +329,8 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
     @mock.patch('os.link')
     @mock.patch('shakenfist.db.get_lock')
     @mock.patch('shakenfist.db.add_event')
-    def test_transcode_image_link(self, mock_event, mock_lock, mock_link, mock_identify, mock_exists,
-                                  mock_execute):
+    def test_transcode_image_link(self, mock_event, mock_lock, mock_link,
+                                  mock_identify, mock_exists, mock_execute):
         images._transcode(None, '/a/b/c/hash', FakeImage())
         mock_link.assert_called_with('/a/b/c/hash', '/a/b/c/hash.qcow2')
         mock_execute.assert_not_called()
@@ -340,14 +343,15 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
     @mock.patch('os.link')
     @mock.patch('shakenfist.db.get_lock')
     @mock.patch('shakenfist.db.add_event')
-    def test_transcode_image_convert(self, mock_event, mock_lock, mock_link, mock_identify, mock_exists,
-                                     mock_execute):
+    def test_transcode_image_convert(self, mock_event, mock_lock, mock_link,
+                                     mock_identify, mock_exists, mock_execute):
         images._transcode(None, '/a/b/c/hash', FakeImage())
         mock_link.assert_not_called()
         mock_execute.assert_called_with(
-            None, 'qemu-img convert -t none -O qcow2 /a/b/c/hash /a/b/c/hash.qcow2')
+            None,
+            'qemu-img convert -t none -O qcow2 /a/b/c/hash /a/b/c/hash.qcow2')
 
-    @mock.patch('shakenfist.config.parsed.get', return_value='/a/b/c')
+    @mock.patch('shakenfist.configuration.config.get', return_value='/a/b/c')
     @mock.patch('shakenfist.db.get_image_metadata', return_value=None)
     @mock.patch('os.makedirs')
     @mock.patch('shakenfist.util.execute',
@@ -357,13 +361,14 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
                 return_value={'virtual size': 8 * 1024 * 1024 * 1024})
     @mock.patch('os.link')
     def test_resize_image_noop(self, mock_link, mock_identify, mock_exists,
-                               mock_execute, mock_makedirs, mock_get_meta, mock_config):
+                               mock_execute, mock_makedirs, mock_get_meta,
+                               mock_config):
         img = images.Image.from_url('http://example.com')
         img.resize(None, 8)
         mock_link.assert_not_called()
         mock_execute.assert_not_called()
 
-    @mock.patch('shakenfist.config.parsed.get', return_value='/a/b/c')
+    @mock.patch('shakenfist.configuration.config.get', return_value='/a/b/c')
     @mock.patch('shakenfist.db.get_image_metadata', return_value=None)
     @mock.patch('os.makedirs')
     @mock.patch('shakenfist.util.execute',
@@ -373,7 +378,8 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
                 return_value={'virtual size': 8 * 1024 * 1024 * 1024})
     @mock.patch('os.link')
     def test_resize_image_link(self, mock_link, mock_identify, mock_exists,
-                               mock_execute, mock_makedirs, mock_get_meta, mock_config):
+                               mock_execute, mock_makedirs, mock_get_meta,
+                               mock_config):
         img = images.Image.from_url('http://example.com')
         img.resize(None, 8)
         mock_link.assert_called_with(
@@ -383,7 +389,7 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
             '4315b2d852c2df5c7991cc66241bf7072d1c4.v000.qcow2.8G')
         mock_execute.assert_not_called()
 
-    @mock.patch('shakenfist.config.parsed.get', return_value='/a/b/c')
+    @mock.patch('shakenfist.configuration.config.get', return_value='/a/b/c')
     @mock.patch('shakenfist.db.get_image_metadata', return_value=None)
     @mock.patch('os.makedirs')
     @mock.patch('shakenfist.util.execute',
@@ -393,7 +399,8 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
                 return_value={'virtual size': 4 * 1024 * 1024 * 1024})
     @mock.patch('os.link')
     def test_resize_image_resize(self, mock_link, mock_identify, mock_exists,
-                                 mock_execute, mock_makedirs, mock_get_meta, mock_config):
+                                 mock_execute, mock_makedirs, mock_get_meta,
+                                 mock_config):
         img = images.Image.from_url('http://example.com')
         img.resize(None, 8)
         mock_link.assert_not_called()
@@ -439,4 +446,5 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
     def test_snapshot(self, mock_execute):
         images.snapshot(None, '/a/b/c/base', '/a/b/c/snap')
         mock_execute.assert_called_with(
-            None, 'qemu-img convert --force-share -O qcow2 /a/b/c/base /a/b/c/snap')
+            None,
+            'qemu-img convert --force-share -O qcow2 /a/b/c/base /a/b/c/snap')

--- a/shakenfist/tests/test_net.py
+++ b/shakenfist/tests/test_net.py
@@ -1,7 +1,7 @@
 import mock
 
 from shakenfist import net
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist.tests import test_shakenfist
 
 
@@ -58,9 +58,13 @@ class NetworkGeneralTestCase(NetworkTestCase):
 class NetworkNormalNodeTestCase(NetworkTestCase):
     def setUp(self):
         super(NetworkNormalNodeTestCase, self).setUp()
-        config.CONFIG_DEFAULTS['NODE_IP'] = '1.1.1.2'
-        config.CONFIG_DEFAULTS['NETWORK_NODE_IP'] = '1.1.1.1'
-        config.parsed = config.Config()
+        os_environ = mock.patch.dict('os.environ', {
+            'SHAKENFIST_NODE_IP': '1.1.1.2',
+            'SHAKENFIST_NETWORK_NODE_IP': '1.1.1.1'
+            })
+        os_environ.start()
+        self.addCleanup(os_environ.stop)
+        config.parse()
 
     #
     #  is_okay()
@@ -97,9 +101,6 @@ class NetworkNormalNodeTestCase(NetworkTestCase):
 
     @mock.patch('shakenfist.net.Network.is_created', return_value=True)
     @mock.patch('shakenfist.net.Network.is_dnsmasq_running', return_value=False)
-    @mock.patch.dict('os.environ',
-                     {'SHAKENFIST_NODE_IP': '1.1.1.1',
-                      'SHAKENFIST_NETWORK_NODE_IP': '1.1.1.2'})
     def test_is_okay_no_dns(self, mock_is_dnsmasq, mock_is_created):
         n = net.Network(
             {
@@ -117,9 +118,12 @@ class NetworkNormalNodeTestCase(NetworkTestCase):
 class NetworkNetNodeTestCase(NetworkTestCase):
     def setUp(self):
         super(NetworkNetNodeTestCase, self).setUp()
-        config.CONFIG_DEFAULTS['NODE_IP'] = '1.1.1.1'
-        config.CONFIG_DEFAULTS['NETWORK_NODE_IP'] = '1.1.1.1'
-        config.parsed = config.Config()
+        os_environ = mock.patch.dict('os.environ', {
+            'SHAKENFIST_NODE_IP': '1.1.1.1',
+            'SHAKENFIST_NETWORK_NODE_IP': '1.1.1.1'
+            })
+        os_environ.start()
+        self.addCleanup(os_environ.stop)
 
     #
     #  is_okay()

--- a/shakenfist/tests/test_scheduler.py
+++ b/shakenfist/tests/test_scheduler.py
@@ -82,7 +82,7 @@ class SchedulerTestCase(test_shakenfist.ShakenFistTestCase):
                 raise Exception('fake_config() Unknown key')
             return data[key]
 
-        self.mock_config = mock.patch('shakenfist.config.parsed.get',
+        self.mock_config = mock.patch('shakenfist.configuration.config.get',
                                       fake_config)
         self.mock_config.start()
         self.addCleanup(self.mock_config.stop)

--- a/shakenfist/tests/test_util.py
+++ b/shakenfist/tests/test_util.py
@@ -1,7 +1,7 @@
 import mock
 
+from shakenfist.configuration import config
 from shakenfist import util
-from shakenfist import config
 from shakenfist.tests import test_shakenfist
 
 
@@ -10,14 +10,20 @@ class UtilTestCase(test_shakenfist.ShakenFistTestCase):
                      {'SHAKENFIST_NODE_IP': '1.1.1.1',
                       'SHAKENFIST_NETWORK_NODE_IP': '1.1.1.1'})
     def test_is_network_node_yes(self):
-        config.parsed.parse()
+        # Parse the config with the mock edit of os.environ. Smarter developers
+        # would mock the os.environ when accessed during the get() inside
+        # is_network_node().
+        config.parse()
         self.assertTrue(util.is_network_node())
 
     @mock.patch.dict('os.environ',
                      {'SHAKENFIST_NODE_IP': '1.1.1.1',
                       'SHAKENFIST_NETWORK_NODE_IP': '1.1.1.2'})
     def test_is_network_node_no(self):
-        config.parsed.parse()
+        # Parse the config with the mock edit of os.environ. Smarter developers
+        # would mock the os.environ when accessed during the get() inside
+        # is_network_node().
+        config.parse()
         self.assertFalse(util.is_network_node())
 
     @mock.patch('shakenfist.util.execute',

--- a/shakenfist/tests/test_virt.py
+++ b/shakenfist/tests/test_virt.py
@@ -36,7 +36,7 @@ class VirtTestCase(test_shakenfist.ShakenFistTestCase):
                 return 'node01'
             raise Exception('Unknown key')
 
-        self.config = mock.patch('shakenfist.config.parsed.get',
+        self.config = mock.patch('shakenfist.configuration.config.get',
                                  fake_config)
         self.mock_config = self.config.start()
         self.addCleanup(self.config.stop)

--- a/shakenfist/util.py
+++ b/shakenfist/util.py
@@ -16,7 +16,7 @@ import traceback
 from oslo_concurrency import processutils
 
 from shakenfist import db
-from shakenfist import config
+from shakenfist.configuration import config
 from shakenfist import logutil
 
 
@@ -65,7 +65,7 @@ class RecordedOperation():
 
 def is_network_node():
     """Test if this node is the network node."""
-    return config.parsed.get('NODE_IP') == config.parsed.get('NETWORK_NODE_IP')
+    return config.node_ip() == config.network_node_ip()
 
 
 def check_for_interface(name, up=False):


### PR DESCRIPTION
Ensure that misspelt config names cause an error.
Discovered that Queues daemon did not have a default log level in configuration.

Resolves #498 