### PR TITLE
Network delete collision

### DIFF
--- a/shakenfist/daemons/main.py
+++ b/shakenfist/daemons/main.py
@@ -124,11 +124,11 @@ def main():
 
         if not util.check_for_interface(subst['physical_bridge']):
             # NOTE(mikal): Adding the physical interface to the physical bridge
-            # is considered outside the scope of the orchestration software as it
-            # will cause the node to lose network connectivity. So instead all we
-            # do is create a bridge if it doesn't exist and the wire everything up
-            # to it. We can do egress NAT in that state, even if floating IPs
-            # don't work.
+            # is considered outside the scope of the orchestration software as
+            # it will cause the node to lose network connectivity. So instead
+            # all we do is create a bridge if it doesn't exist and the wire
+            # everything up to it. We can do egress NAT in that state, even if
+            # floating IPs don't work.
             with util.RecordedOperation('create physical bridge', None):
                 # No locking as read only
                 ipm = db.get_ipmanager('floating')
@@ -139,20 +139,23 @@ def main():
                 util.execute(None,
                              'ip link set %(physical_bridge)s up' % subst)
                 util.execute(None,
-                             'ip addr add %(master_float)s/%(netmask)s dev %(physical_bridge)s' % subst)
+                             'ip addr add %(master_float)s/%(netmask)s '
+                             'dev %(physical_bridge)s' % subst)
 
                 util.execute(None,
-                             'iptables -A FORWARD -o %(physical_nic)s -i %(physical_bridge)s -j ACCEPT' % subst)
+                             'iptables -A FORWARD -o %(physical_nic)s '
+                             '-i %(physical_bridge)s -j ACCEPT' % subst)
                 util.execute(None,
-                             'iptables -A FORWARD -i %(physical_nic)s -o %(physical_bridge)s -j ACCEPT' % subst)
+                             'iptables -A FORWARD -i %(physical_nic)s '
+                             '-o %(physical_bridge)s -j ACCEPT' % subst)
                 util.execute(None,
-                             'iptables -t nat -A POSTROUTING -o %(physical_nic)s -j MASQUERADE' % subst)
+                             'iptables -t nat -A POSTROUTING '
+                             '-o %(physical_nic)s -j MASQUERADE' % subst)
 
     def _audit_daemons():
         running_daemons = []
         for pid in DAEMON_PIDS:
             running_daemons.append(DAEMON_PIDS[pid])
-        LOG.info('Daemons running: %s' % ', '.join(sorted(running_daemons)))
 
         for d in DAEMON_IMPLEMENTATIONS:
             if d not in running_daemons:

--- a/shakenfist/daemons/resources.py
+++ b/shakenfist/daemons/resources.py
@@ -159,7 +159,6 @@ class Monitor(daemon.Daemon):
                 gauges[metric].set(stats[metric])
 
             db.update_metrics_bulk(stats)
-            LOG.debug('Updated metrics')
             gauges['updated_at'].set_to_current_time()
 
         while True:

--- a/shakenfist/exceptions.py
+++ b/shakenfist/exceptions.py
@@ -87,3 +87,12 @@ class NoNetworkTaskException(TaskException):
 
 class NetworkNotListTaskException(TaskException):
     pass
+
+
+# Networks
+class NetworkException(Exception):
+    pass
+
+
+class DeadNetwork(NetworkException):
+    pass

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -71,8 +71,7 @@ def error(status_code, message):
     resp = flask.Response(json.dumps(body),
                           mimetype='application/json')
     resp.status_code = status_code
-    LOG.error('Returning API error: %d, %s\n    %s'
-              % (status_code, message, '\n    '.join(body.get('traceback', '').split('\n'))))
+    LOG.info('Returning API error: %d, %s' % (status_code, message))
     return resp
 
 
@@ -141,6 +140,7 @@ def generic_wrapper(func):
             return error(401, str(e))
 
         except Exception as e:
+            LOG.exception('Server error')
             return error(500, 'server error: %s' % repr(e))
 
     return wrapper
@@ -445,8 +445,10 @@ class AuthNamespace(Resource):
 
         networks = []
         for n in db.get_networks(all=True, namespace=namespace):
-            # Deliberately include 'deleting' networks as live since that is a
-            # transient state. If it hangs in that state we want to know.
+            # Networks in 'deleting' state are regarded as "live" networks.
+            # They in a transient state. If they hang in that state we want to
+            # know. They will block deletion of a namespace thus giving notice
+            # of the problem.
             if n['state'] not in ['deleted', 'error']:
                 networks.append(n['uuid'])
         if len(networks) > 0:
@@ -1204,8 +1206,9 @@ class Networks(Resource):
 
         # If accessing a foreign name namespace, we need to be an admin
         if get_jwt_identity() not in [namespace, 'system']:
-            return error(401,
-                         'only admins can create resources in a different namespace')
+            return error(
+                401,
+                'only admins can create resources in a different namespace')
 
         network = db.allocate_network(netblock, provide_dhcp,
                                       provide_nat, name, namespace)

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -23,7 +23,7 @@ def from_db(uuid):
     dbnet = db.get_network(uuid)
     if not dbnet:
         return None
-    if dbnet['state'] == 'deleted':
+    if dbnet['state'] in ('deleted', 'deleting'):
         LOG.withNetwork(uuid).info('Network is deleted, returning None.')
         return None
     return Network(dbnet)
@@ -131,21 +131,25 @@ class Network(object):
                 with util.RecordedOperation('create vxlan interface', self):
                     util.create_interface(
                         subst['vx_interface'], 'vxlan',
-                        'id %(vx_id)s dev %(physical_interface)s dstport 0' % subst)
+                        'id %(vx_id)s dev %(physical_interface)s dstport 0'
+                        % subst)
                     util.execute(None,
-                                 'sysctl -w net.ipv4.conf.%(vx_interface)s.arp_notify=1' % subst)
+                                 'sysctl -w net.ipv4.conf.'
+                                 '%(vx_interface)s.arp_notify=1' % subst)
 
             if not util.check_for_interface(subst['vx_bridge']):
                 with util.RecordedOperation('create vxlan bridge', self):
                     util.create_interface(subst['vx_bridge'], 'bridge', '')
                     util.execute(None,
-                                 'ip link set %(vx_interface)s master %(vx_bridge)s' % subst)
+                                 'ip link set %(vx_interface)s '
+                                 'master %(vx_bridge)s' % subst)
                     util.execute(None,
                                  'ip link set %(vx_interface)s up' % subst)
                     util.execute(None,
                                  'ip link set %(vx_bridge)s up' % subst)
                     util.execute(None,
-                                 'sysctl -w net.ipv4.conf.%(vx_bridge)s.arp_notify=1' % subst)
+                                 'sysctl -w net.ipv4.conf.'
+                                 '%(vx_bridge)s.arp_notify=1' % subst)
                     util.execute(None,
                                  'brctl setfd %(vx_bridge)s 0' % subst)
                     util.execute(None,
@@ -164,16 +168,21 @@ class Network(object):
                     util.create_interface(
                         subst['vx_veth_outer'], 'veth',
                         'peer name %(vx_veth_inner)s' % subst)
-                    util.execute(None,
-                                 'ip link set %(vx_veth_inner)s netns %(netns)s' % subst)
-                    util.execute(None,
-                                 'brctl addif %(vx_bridge)s %(vx_veth_outer)s' % subst)
+                    util.execute(
+                        None,
+                        'ip link set %(vx_veth_inner)s netns %(netns)s' % subst)
+                    util.execute(
+                        None,
+                        'brctl addif %(vx_bridge)s %(vx_veth_outer)s' % subst)
                     util.execute(None,
                                  'ip link set %(vx_veth_outer)s up' % subst)
-                    util.execute(None,
-                                 '%(in_netns)s ip link set %(vx_veth_inner)s up' % subst)
-                    util.execute(None,
-                                 '%(in_netns)s ip addr add %(router)s/%(netmask)s dev %(vx_veth_inner)s' % subst)
+                    util.execute(
+                        None,
+                        '%(in_netns)s ip link set %(vx_veth_inner)s up' % subst)
+                    util.execute(
+                        None,
+                        '%(in_netns)s ip addr add %(router)s/%(netmask)s '
+                        'dev %(vx_veth_inner)s' % subst)
 
             if not util.check_for_interface(subst['physical_veth_outer']):
                 with util.RecordedOperation('create physical veth', self):
@@ -181,11 +190,14 @@ class Network(object):
                         subst['physical_veth_outer'], 'veth',
                         'peer name %(physical_veth_inner)s' % subst)
                     util.execute(None,
-                                 'brctl addif %(physical_bridge)s %(physical_veth_outer)s' % subst)
+                                 'brctl addif %(physical_bridge)s '
+                                 '%(physical_veth_outer)s' % subst)
                     util.execute(None,
-                                 'ip link set %(physical_veth_outer)s up' % subst)
+                                 'ip link set %(physical_veth_outer)s up'
+                                 % subst)
                     util.execute(None,
-                                 'ip link set %(physical_veth_inner)s netns %(netns)s' % subst)
+                                 'ip link set %(physical_veth_inner)s '
+                                 'netns %(netns)s' % subst)
 
             self.deploy_nat()
             self.update_dhcp()
@@ -200,7 +212,8 @@ class Network(object):
 
         subst = self.subst_dict()
         if not self.db_entry['floating_gateway']:
-            with db.get_lock('ipmanager', None, 'floating', ttl=120, op='Network deploy NAT'):
+            with db.get_lock('ipmanager', None,
+                             'floating', ttl=120, op='Network deploy NAT'):
                 ipm = db.get_ipmanager('floating')
                 self.db_entry['floating_gateway'] = ipm.get_random_free_address()
                 db.persist_ipmanager('floating', ipm.save())
@@ -218,40 +231,51 @@ class Network(object):
                 raise DeadNetwork('network=%s' % self)
 
             with util.RecordedOperation('enable virtual routing', self):
-                if not subst['floating_gateway'] in list(util.get_interface_addresses(
-                        subst['netns'], subst['physical_veth_inner'])):
+                addresses = util.get_interface_addresses(
+                    subst['netns'],
+                    subst['physical_veth_inner'])
+                if not subst['floating_gateway'] in list(addresses):
                     util.execute(None,
-                                 '%(in_netns)s ip addr add %(floating_gateway)s/%(floating_netmask)s '
+                                 '%(in_netns)s ip addr add '
+                                 '%(floating_gateway)s/%(floating_netmask)s '
                                  'dev %(physical_veth_inner)s' % subst)
                     util.execute(None,
-                                 '%(in_netns)s ip link set %(physical_veth_inner)s up' % subst)
+                                 '%(in_netns)s ip link set '
+                                 '%(physical_veth_inner)s up' % subst)
 
                 default_routes = util.get_default_routes(subst['netns'])
                 if default_routes != [subst['floating_router']]:
                     if default_routes:
                         for default_route in default_routes:
                             util.execute(None,
-                                         '%s route del default gw %s' % (subst['in_netns'], default_route))
+                                         '%s route del default gw %s'
+                                         % (subst['in_netns'], default_route))
 
                     util.execute(None,
-                                 '%(in_netns)s route add default gw %(floating_router)s' % subst)
+                                 '%(in_netns)s route add default '
+                                 'gw %(floating_router)s' % subst)
 
             if not util.nat_rules_for_ipblock(self.network_address):
                 with util.RecordedOperation('enable nat', self):
                     util.execute(None,
                                  'echo 1 > /proc/sys/net/ipv4/ip_forward')
                     util.execute(None,
-                                 '%(in_netns)s iptables -A FORWARD -o %(physical_veth_inner)s '
+                                 '%(in_netns)s iptables -A FORWARD '
+                                 '-o %(physical_veth_inner)s '
                                  '-i %(vx_veth_inner)s -j ACCEPT' % subst)
                     util.execute(None,
-                                 '%(in_netns)s iptables -A FORWARD -i %(physical_veth_inner)s '
+                                 '%(in_netns)s iptables -A FORWARD '
+                                 '-i %(physical_veth_inner)s '
                                  '-o %(vx_veth_inner)s -j ACCEPT' % subst)
                     util.execute(None,
-                                 '%(in_netns)s iptables -t nat -A POSTROUTING -s %(ipblock)s/%(netmask)s '
-                                 '-o %(physical_veth_inner)s -j MASQUERADE' % subst)
+                                 '%(in_netns)s iptables -t nat -A POSTROUTING '
+                                 '-s %(ipblock)s/%(netmask)s '
+                                 '-o %(physical_veth_inner)s '
+                                 '-j MASQUERADE' % subst)
 
     def delete(self):
         subst = self.subst_dict()
+        LOG.withFields(subst).debug('net.delete()')
 
         # Cleanup local node
         with db.get_object_lock(self, ttl=120, op='Network delete'):
@@ -389,27 +413,29 @@ class Network(object):
                 added.append(node)
 
             if removed:
-                db.add_event('network', self.db_entry['uuid'], 'remove mesh elements',
-                             None, None, ' '.join(removed))
+                db.add_event(
+                    'network', self.db_entry['uuid'], 'remove mesh elements',
+                    None, None, ' '.join(removed))
             if added:
-                db.add_event('network', self.db_entry['uuid'], 'add mesh elements',
-                             None, None, ' '.join(added))
+                db.add_event(
+                    'network', self.db_entry['uuid'], 'add mesh elements',
+                    None, None, ' '.join(added))
 
     def _add_mesh_element(self, node):
         LOG.withObj(self).info('Adding new mesh element %s' % node)
         subst = self.subst_dict()
         subst['node'] = node
         util.execute(None,
-                     'bridge fdb append to 00:00:00:00:00:00 dst %(node)s dev %(vx_interface)s'
-                     % subst)
+                     'bridge fdb append to 00:00:00:00:00:00 '
+                     'dst %(node)s dev %(vx_interface)s' % subst)
 
     def _remove_mesh_element(self, node):
         LOG.withObj(self).info('Removing excess mesh element %s' % node)
         subst = self.subst_dict()
         subst['node'] = node
         util.execute(None,
-                     'bridge fdb del to 00:00:00:00:00:00 dst %(node)s dev %(vx_interface)s'
-                     % subst)
+                     'bridge fdb del to 00:00:00:00:00:00 dst %(node)s '
+                     'dev %(vx_interface)s' % subst)
 
     def add_floating_ip(self, floating_address, inner_address):
         LOG.withObj(self).info('Adding floating ip %s -> %s'
@@ -423,7 +449,8 @@ class Network(object):
                      'dev %(physical_veth_outer)s' % subst)
         util.execute(None,
                      '%(in_netns)s iptables -t nat -A PREROUTING '
-                     '-d %(floating_address)s -j DNAT --to-destination %(inner_address)s' % subst)
+                     '-d %(floating_address)s '
+                     '-j DNAT --to-destination %(inner_address)s' % subst)
 
     def remove_floating_ip(self, floating_address, inner_address):
         LOG.withObj(self).info('Removing floating ip %s -> %s'
@@ -437,4 +464,5 @@ class Network(object):
                      'dev %(physical_veth_outer)s' % subst)
         util.execute(None,
                      '%(in_netns)s iptables -t nat -D PREROUTING '
-                     '-d %(floating_address)s -j DNAT --to-destination %(inner_address)s' % subst)
+                     '-d %(floating_address)s '
+                     '-j DNAT --to-destination %(inner_address)s' % subst)

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -8,6 +8,7 @@ import re
 from shakenfist.configuration import config
 from shakenfist import db
 from shakenfist import dhcp
+from shakenfist.exceptions import DeadNetwork
 from shakenfist import logutil
 from shakenfist.tasks import (DeployNetworkTask,
                               UpdateDHCPNetworkTask,
@@ -106,10 +107,26 @@ class Network(object):
 
         return True
 
+    def is_dead(self):
+        """Check if the network is deleted or being deleted, or in error.
+
+        First, update the object model to the ensure latest configuration. Some
+        callers will wait on a lock before calling this function. In this case
+        we definitely need to update the in-memory object model.
+        """
+        # TODO(andy): To be improved when object model mirrors Image class
+        self.db_entry = db.get_network(self.db_entry['uuid'])
+
+        return self.db_entry['state'] in ('deleted', 'deleting', 'error')
+
     def create(self):
         subst = self.subst_dict()
 
         with db.get_object_lock(self, ttl=120, op='Network create'):
+            # Ensure network was not deleted whilst waiting for the lock.
+            if self.is_dead():
+                raise DeadNetwork('network=%s' % self)
+
             if not util.check_for_interface(subst['vx_interface']):
                 with util.RecordedOperation('create vxlan interface', self):
                     util.create_interface(
@@ -196,6 +213,10 @@ class Network(object):
         subst['floating_netmask'] = ipm.netmask
 
         with db.get_object_lock(self, ttl=120, op='Network deploy NAT'):
+            # Ensure network was not deleted whilst waiting for the lock.
+            if self.is_dead():
+                raise DeadNetwork('network=%s' % self)
+
             with util.RecordedOperation('enable virtual routing', self):
                 if not subst['floating_gateway'] in list(util.get_interface_addresses(
                         subst['netns'], subst['physical_veth_inner'])):
@@ -253,7 +274,8 @@ class Network(object):
                 if util.check_for_interface(subst['physical_veth_outer']):
                     with util.RecordedOperation('delete physical veth', self):
                         util.execute(
-                            None, 'ip link delete %(physical_veth_outer)s' % subst)
+                            None,
+                            'ip link delete %(physical_veth_outer)s' % subst)
 
                 if os.path.exists('/var/run/netns/%(netns)s' % subst):
                     with util.RecordedOperation('delete netns', self):
@@ -319,6 +341,10 @@ class Network(object):
 
     def ensure_mesh(self):
         with db.get_object_lock(self, ttl=120, op='Network ensure mesh'):
+            # Ensure network was not deleted whilst waiting for the lock.
+            if self.is_dead():
+                raise DeadNetwork('network=%s' % self)
+
             removed = []
             added = []
 

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -7,7 +7,6 @@ import mock
 from shakenfist.configuration import config
 from shakenfist.external_api import app as external_api
 from shakenfist import ipmanager
-from shakenfist import net
 from shakenfist.tests import test_shakenfist
 
 
@@ -969,6 +968,11 @@ class ExternalApiNetworkTestCase(ExternalApiTestCase):
         # by stestr.
         self.addCleanup(self.config.stop)
 
+    @mock.patch('shakenfist.db.get_network',
+                return_value={
+                    'uuid': '30f6da44-look-i-am-uuid',
+                    'state': 'created',
+                    })
     @mock.patch('shakenfist.db.get_networks',
                 return_value=[{
                     'floating_gateway': '10.10.0.150',
@@ -992,12 +996,8 @@ class ExternalApiNetworkTestCase(ExternalApiTestCase):
                                  mock_remove_dhcp,
                                  mock_get_ipmanager,
                                  mock_db_get_network_interfaces,
-                                 mock_db_get_networks):
-
-        mock_network = mock.patch('shakenfist.net.from_db',
-                                  return_value=net.Network({'uuid': 'foo'}))
-        mock_network.start()
-        self.addCleanup(mock_network.stop)
+                                 mock_db_get_networks,
+                                 mock_db_get_network):
 
         resp = self.client.delete('/networks',
                                   headers={'Authorization': self.auth_header},
@@ -1008,8 +1008,6 @@ class ExternalApiNetworkTestCase(ExternalApiTestCase):
         self.assertEqual(['30f6da44-look-i-am-uuid'],
                          resp.get_json())
         self.assertEqual(200, resp.status_code)
-
-        mock_network.stop()
 
     @mock.patch('shakenfist.db.get_networks',
                 return_value=[{

--- a/shakenfist/util.py
+++ b/shakenfist/util.py
@@ -182,7 +182,7 @@ def extract_power_state(libvirt, domain):
                  libvirt.VIR_DOMAIN_PMSUSPENDED]:
         return 'paused'
 
-    # Covers all "runnning states": BLOCKED, NOSTATE,
+    # Covers all "running states": BLOCKED, NOSTATE,
     # RUNNING, SHUTDOWN
     return 'on'
 


### PR DESCRIPTION
Stop the `net` and `queues` daemons creating networks that are simultaneously being deleted by the API daemon.

This issue manifested itself in many ways. The worst outcome was new networks reusing an old VXLAN ID whilst `sf-net` tried to recreate the old network components. Whilst the API deleted other parts of the networking infrastructure.

This PR introduces a new network state of `deleting` and the concept of a `dead` network. A network is `dead` to the system if it is in error, deleted or being deleted. A network that is `dead` to the system can not be re-created nor redeploy NAT.

Remove noisy log msgs, reduce client caused API errors to info.
Regular 'daemons running' logs are removed.
Exceptions that cause an API 500 code are logged as errors but client caused API errors are now logged as info.

Note there are two commits. The first are the networking changes. The second is lots of reformatting.

Further note, this PR comes with no guarantees. It probably still randomly fails CI....

Resolves #500 