### PR TITLE
Avoid Network deletion whilst loading from the DB

### DIFF
--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -1126,9 +1126,6 @@ def _delete_network(network_from_db):
     n = net.from_db(network_from_db['uuid'])
 
     with db.get_object_lock(n, ttl=120, op='Network deleting'):
-        # Inefficiently reload from DB to ensure nothing changed while waiting
-        # for the lock.
-        n = net.from_db(network_from_db['uuid'])
         if not n or n.is_dead():
             LOG.withFields({'network_uuid': n.db_entry['uuid'],
                             'state': n.db_entry['state']}).warning(

--- a/shakenfist/tasks.py
+++ b/shakenfist/tasks.py
@@ -20,7 +20,9 @@ class QueueTask(object):
 
     def __repr__(self):
         # All subclasses define json_dump()
-        return 'QUEUETASK:' + self.name() + ': ' + str(self.json_dump())
+        r = 'QueueTask:' + self.__class__.__name__ + ': '
+        r += str(self.json_dump())
+        return r
 
     def __eq__(self, other):
         if not QueueTask.__subclasscheck__(type(other)):


### PR DESCRIPTION
Lock Network whist loading the object from the DB

The avoids an Exception caused by the deletion of the Network whilst it is being loaded. The Exception is raised by attempting to load an already deleted IPManager.

Also removed an unnecessary Network DB reload.

Small modification to repr() of QueueTasks.