### PR TITLE
Retry downloads after checksum failures.

### DIFF
--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -137,9 +137,8 @@ def image_fetch(url, instance_uuid):
         # TODO(andy): Wait up to 15 mins for another queue process to download
         # the required image. This will be changed to queue on a
         # "waiting_image_fetch" queue but this works now.
-        with db.get_lock('image', config.NODE_NAME,
-                         Image.calc_unique_ref(url), timeout=15*60,
-                         op='Image fetch') as lock:
+        with db.get_lock('image', config.NODE_NAME, Image.calc_unique_ref(url),
+                         timeout=15*60, op='Image fetch') as lock:
             img = Image.from_url(url)
             img.get([lock], instance)
             db.add_event('image', url, 'fetch', None, None, 'success')

--- a/shakenfist/image_resolver_ubuntu.py
+++ b/shakenfist/image_resolver_ubuntu.py
@@ -73,6 +73,7 @@ def resolve(name):
             break
     if not checksum_url:
         log.warning('Did not find checksum')
+    checksum = checksum.strip()
 
     log.withField('checksum', checksum).info('Checksum check')
     return (url, checksum)


### PR DESCRIPTION
Previously, after a single download checksum failure, the instance start would be aborted.

The Image lock has moved above Image.get() therefore there is no lock to retry.

Resolves #509