### PR TITLE
Add ability to delay CI VM cleanup.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,11 +90,25 @@ pipeline {
               pip list
 
               echo "=============================="
-              cat /var/log/syslog'''
+              cat /var/log/syslog
+
+              echo "=============================="
+              etcdctl get --prefix /sf
+              '''
       }
     failure {
       sh '''  echo "Sleep for a long time in case we are debugging"
-              sleep 3600
+              echo "Create /keepme to extend the reboot time - up to 12 hours"
+              x=12
+              while [ $x -gt 0 ]
+              do
+                  echo Sleeping...
+                  sleep 3600
+                  x=$(( $x - 1 ))
+                  if [ ! -f /keep ]; then
+                      x=0
+                  fi
+              done
               '''
       }
     }


### PR DESCRIPTION
Creation of a file named /keepme before the one hour expiry will keep the instance alive up to 12 hours. Deletion of the file will cause a cleanup at the end of the current timer.

Also, add a listing of the etcd database to aid debugging.

Resolves #511