### PR TITLE
Tweak the name of persist_instance_metadata.

### DIFF
--- a/shakenfist/db.py
+++ b/shakenfist/db.py
@@ -170,7 +170,7 @@ def get_instances(only_node=None, all=False, namespace=None):
         yield i
 
 
-def persist_instance_metadata(instance_uuid, metadata):
+def persist_instance(instance_uuid, metadata):
     etcd.put('instance', None, instance_uuid, metadata)
 
 

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -177,7 +177,7 @@ class Instance(object):
 
             'version': 1
         }
-        db.persist_instance_metadata(self.uuid, metadata)
+        db.persist_instance(self.uuid, metadata)
 
     def __str__(self):
         return 'instance(%s)' % self.uuid


### PR DESCRIPTION
I feel like the term "metadata" is used in a different way elsewhere
in the codebase, and this method is really persisting the instance,
not data about the instance. Its a nit, but I found it confusing
while reading this code.