### PR TITLE
Require networks to have a minimum size.

### DIFF
--- a/deploy/shakenfist_ci/tests/test_networking.py
+++ b/deploy/shakenfist_ci/tests/test_networking.py
@@ -19,6 +19,17 @@ class TestNetworking(base.BaseNamespacedTestCase):
         self.net_four = self.test_client.allocate_network(
             '192.168.10.0/24', True, True, '%s-net-four' % self.namespace)
 
+    def test_network_validity(self):
+        self.assertRaises(apiclient.APIException, self.test_client.allocate_network,
+                          '192.168.242.2', True, True, '%s-validity1' % self.namespace)
+        self.assertRaises(apiclient.APIException, self.test_client.allocate_network,
+                          '192.168.242.2/32', True, True, '%s-validity2' % self.namespace)
+        self.assertRaises(apiclient.APIException, self.test_client.allocate_network,
+                          '192.168.242.0/30', True, True, '%s-validity3' % self.namespace)
+        n = self.test_client.allocate_network(
+            '192.168.10.0/29', True, True, '%s-validity2' % self.namespace)
+        self.test_client.delete_network(n['uuid'])
+
     def test_virtual_networks_are_separate(self):
         inst1 = self.test_client.create_instance(
             'cirros', 1, 1024,

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -1183,7 +1183,9 @@ class Networks(Resource):
     def post(self, netblock=None, provide_dhcp=None, provide_nat=None, name=None,
              namespace=None):
         try:
-            ipaddress.ip_network(netblock)
+            n = ipaddress.ip_network(netblock)
+            if n.num_addresses < 8:
+                return error(400, 'network is below minimum size of /29')
         except ValueError as e:
             return error(400, 'cannot parse netblock: %s' % e)
 


### PR DESCRIPTION
Its possible to create a /32 network at the moment, which will never
work and crashes the network daemon. Let's make /29 (8 IPs) the
minimum size.

Fixes #569.