### PR TITLE
The starting power state for an instance should be "initial".

### DIFF
--- a/shakenfist/db.py
+++ b/shakenfist/db.py
@@ -182,6 +182,8 @@ def delete_ipmanager(network_uuid):
 
 def create_instance(instance_uuid, metadata):
     set_instance_attribute(instance_uuid, 'state', {'state': 'initial'})
+    set_instance_attribute(instance_uuid, 'power_state',
+                           {'power_state': 'initial'})
     etcd.put('instance', None, instance_uuid, metadata)
 
 

--- a/shakenfist/tests/test_virt.py
+++ b/shakenfist/tests/test_virt.py
@@ -65,6 +65,11 @@ class VirtMetaTestCase(test_shakenfist.ShakenFistTestCase):
             ('attribute/instance', 'uuid42', 'state', {'state': 'initial'}),
             mock_put.mock_calls[0][1])
         self.assertEqual(
+            ('attribute/instance', 'uuid42',
+             'power_state', {'power_state': 'initial'}),
+            mock_put.mock_calls[1][1])
+
+        self.assertEqual(
             ('instance', None, 'uuid42',
              {'cpus': 1,
               'disk_spec': [{}],
@@ -77,7 +82,7 @@ class VirtMetaTestCase(test_shakenfist.ShakenFistTestCase):
               'uuid': 'uuid42',
               'version': 2,
               'video': {'memory': 16384, 'model': 'cirrus'}}),
-            mock_put.mock_calls[1][1])
+            mock_put.mock_calls[2][1])
 
     @mock.patch('shakenfist.etcd.get',
                 return_value={


### PR DESCRIPTION
This is causing some weird key errors in CI. Fixes #584.