### PR TITLE
Chasing these missing phy-XXX-i errors.

### DIFF
--- a/deploy/shakenfist_ci/tests/test_cloudinit.py
+++ b/deploy/shakenfist_ci/tests/test_cloudinit.py
@@ -49,6 +49,10 @@ sudo echo 'banana' >  /tmp/output"""
         self.assertIsNotNone(inst['uuid'])
         self._await_login_prompt(inst['uuid'])
 
+        # We need to refresh our view of the instance, as it might have
+        # changed as it started up
+        inst = self.test_client.get_instance(inst['uuid'])
+
         console = base.LoggingSocket(inst['node'], inst['console_port'])
         out = console.execute('cat /tmp/output')
         if not out.find('banana'):

--- a/deploy/shakenfist_ci/tests/test_disk_specs.py
+++ b/deploy/shakenfist_ci/tests/test_disk_specs.py
@@ -20,6 +20,10 @@ class TestDiskSpecifications(base.BaseNamespacedTestCase):
         self.assertIsNotNone(inst['uuid'])
         self._await_login_prompt(inst['uuid'])
 
+        # We need to refresh our view of the instance, as it might have
+        # changed as it started up
+        inst = self.test_client.get_instance(inst['uuid'])
+
         console = base.LoggingSocket(inst['node'], inst['console_port'])
         out = console.execute('df -h')
         if not out.find('vda'):
@@ -39,6 +43,10 @@ class TestDiskSpecifications(base.BaseNamespacedTestCase):
 
         self.assertIsNotNone(inst['uuid'])
         self._await_login_prompt(inst['uuid'])
+
+        # We need to refresh our view of the instance, as it might have
+        # changed as it started up
+        inst = self.test_client.get_instance(inst['uuid'])
 
         console = base.LoggingSocket(inst['node'], inst['console_port'])
         out = console.execute('df -h')
@@ -80,6 +88,10 @@ class TestDiskSpecifications(base.BaseNamespacedTestCase):
 
         self.assertIsNotNone(inst['uuid'])
         self._await_login_prompt(inst['uuid'])
+
+        # We need to refresh our view of the instance, as it might have
+        # changed as it started up
+        inst = self.test_client.get_instance(inst['uuid'])
 
         console = base.LoggingSocket(inst['node'], inst['console_port'])
 

--- a/deploy/shakenfist_ci/tests/test_multiple_nics.py
+++ b/deploy/shakenfist_ci/tests/test_multiple_nics.py
@@ -1,4 +1,5 @@
 import base64
+import time
 
 from shakenfist_ci import base
 
@@ -43,6 +44,10 @@ sudo /etc/init.d/S40network restart"""
             ], None, str(base64.b64encode(ud.encode('utf-8')), 'utf-8'))
 
         self.assertIsNotNone(inst['uuid'])
+
+        while inst['state'] not in ['created', 'error']:
+            time.sleep(1)
+            inst = self.test_client.get_instance(inst['uuid'])
 
         self._await_login_prompt(inst['uuid'])
 

--- a/deploy/shakenfist_ci/tests/test_networking.py
+++ b/deploy/shakenfist_ci/tests/test_networking.py
@@ -206,6 +206,9 @@ class TestNetworking(base.BaseNamespacedTestCase):
             time.sleep(1)
             inst = self.test_client.get_instance(inst['uuid'])
 
+        if inst['state'] != 'created':
+            self.fail('Instance is not in created state: %s' % inst)
+
         nics = self.test_client.get_instance_interfaces(inst['uuid'])
         ips = []
         for nic in nics:

--- a/deploy/shakenfist_ci/tests/test_networking.py
+++ b/deploy/shakenfist_ci/tests/test_networking.py
@@ -67,6 +67,11 @@ class TestNetworking(base.BaseNamespacedTestCase):
         self._await_login_prompt(inst1['uuid'])
         self._await_login_prompt(inst2['uuid'])
 
+        # We need to refresh our view of the instances, as it might have
+        # changed as they started up
+        inst1 = self.test_client.get_instance(inst1['uuid'])
+        inst2 = self.test_client.get_instance(inst2['uuid'])
+
         nics = self.test_client.get_instance_interfaces(inst2['uuid'])
 
         console = base.LoggingSocket(inst1['node'], inst1['console_port'])
@@ -111,6 +116,11 @@ class TestNetworking(base.BaseNamespacedTestCase):
         self._await_login_prompt(inst1['uuid'])
         self._await_login_prompt(inst2['uuid'])
 
+        # We need to refresh our view of the instances, as it might have
+        # changed as they started up
+        inst1 = self.test_client.get_instance(inst1['uuid'])
+        inst2 = self.test_client.get_instance(inst2['uuid'])
+
         nics = self.test_client.get_instance_interfaces(inst2['uuid'])
 
         console = base.LoggingSocket(inst1['node'], inst1['console_port'])
@@ -154,6 +164,11 @@ class TestNetworking(base.BaseNamespacedTestCase):
 
         self._await_login_prompt(inst1['uuid'])
         self._await_login_prompt(inst2['uuid'])
+
+        # We need to refresh our view of the instances, as it might have
+        # changed as they started up
+        inst1 = self.test_client.get_instance(inst1['uuid'])
+        inst2 = self.test_client.get_instance(inst2['uuid'])
 
         nics = self.test_client.get_instance_interfaces(inst2['uuid'])
 

--- a/deploy/shakenfist_ci/tests/test_serial_console.py
+++ b/deploy/shakenfist_ci/tests/test_serial_console.py
@@ -32,5 +32,9 @@ class TestSerialConsole(base.BaseNamespacedTestCase):
 
         self._await_login_prompt(inst['uuid'])
 
+        # We need to refresh our view of the instance, as it might have
+        # changed as it started up
+        inst = self.test_client.get_instance(inst['uuid'])
+
         console = base.LoggingSocket(inst['node'], inst['console_port'])
         self.assertTrue(console.execute('uptime').find('load average'))

--- a/deploy/shakenfist_ci/tests/test_state_changes.py
+++ b/deploy/shakenfist_ci/tests/test_state_changes.py
@@ -34,7 +34,6 @@ class TestStateChanges(base.BaseNamespacedTestCase):
                     'type': 'disk'
                 }
             ], None, None)
-        ip = self.test_client.get_instance_interfaces(inst['uuid'])[0]['ipv4']
         LOG.info('Started test instance %s', inst['uuid'])
 
         # We need to start a second instance on the same node / network so that
@@ -58,10 +57,16 @@ class TestStateChanges(base.BaseNamespacedTestCase):
         # Wait for our test instance to boot
         self.assertIsNotNone(inst['uuid'])
         self._await_login_prompt(inst['uuid'])
-        LOG.info('  ping test...')
+
+        # We need to refetch the instance to get a complete view of its state.
+        # It is also now safe to fetch the instance IP.
+        inst = self.test_client.get_instance(inst['uuid'])
+        ip = self.test_client.get_instance_interfaces(inst['uuid'])[0]['ipv4']
+
         # The network can be slow to start and may not be available after the
         # instance "login prompt" event. We are willing to forgive a few fails
         # while the network starts.
+        LOG.info('  ping test...')
         self._test_ping(inst['uuid'], self.net['uuid'], ip, True, 10)
 
         # Soft reboot

--- a/shakenfist/daemons/main.py
+++ b/shakenfist/daemons/main.py
@@ -39,9 +39,8 @@ def restore_instances():
             try:
                 n = net.Network.from_db(network)
                 LOG.withObj(n).info('Restoring network')
-                n.create()
+                n.create_on_hypervisor()
                 n.ensure_mesh()
-                n.update_dhcp()
             except Exception as e:
                 util.ignore_exception('restore network %s' % network, e)
 
@@ -59,7 +58,7 @@ def restore_instances():
                         continue
 
                     LOG.withObj(i).info('Restoring instance')
-                    i.create()
+                    i.create_on_hypervisor()
             except Exception as e:
                 util.ignore_exception('restore instance %s' % instance, e)
                 db.enqueue_instance_error(

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -198,8 +198,6 @@ def instance_preflight(instance_uuid, network):
 
 
 def instance_start(instance_uuid, network):
-    log = LOG.withField('instance', instance_uuid)
-
     with db.get_lock(
             'instance', None, instance_uuid, ttl=900, timeout=120,
             op='Instance start') as lock:

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -221,7 +221,7 @@ def instance_start(instance_uuid, network):
             for network_uuid in nets:
                 n = nets[network_uuid]
                 try:
-                    n.create()
+                    n.create_on_hypervisor()
                     n.ensure_mesh()
                     n.update_dhcp()
                 except exceptions.DeadNetwork as e:

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -237,7 +237,7 @@ class Network(object):
 
         return db_net['state'] in ('deleted', 'deleting', 'error')
 
-    def create(self):
+    def _create_common(self):
         subst = self.subst_dict()
 
         with db.get_object_lock(self, ttl=120, op='Network create'):
@@ -275,120 +275,118 @@ class Network(object):
                     util.execute(None,
                                  'brctl setageing %(vx_bridge)s 0' % subst)
 
-        if util.is_network_node():
-            if not os.path.exists('/var/run/netns/%(netns)s' % subst):
-                with util.RecordedOperation('create netns', self):
-                    util.execute(None,
-                                 'ip netns add %(netns)s' % subst)
+    def create_on_hypervisor(self):
+        self._create_common()
+        db.enqueue('networknode', DeployNetworkTask(self.uuid))
+        self.add_event('deploy', 'enqueued')
 
-            if not util.check_for_interface(subst['vx_veth_outer']):
-                with util.RecordedOperation('create router veth', self):
-                    util.create_interface(
-                        subst['vx_veth_outer'], 'veth',
-                        'peer name %(vx_veth_inner)s' % subst)
-                    util.execute(
-                        None,
-                        'ip link set %(vx_veth_inner)s netns %(netns)s' % subst)
-                    util.execute(
-                        None,
-                        'brctl addif %(vx_bridge)s %(vx_veth_outer)s' % subst)
-                    util.execute(None,
-                                 'ip link set %(vx_veth_outer)s up' % subst)
-                    util.execute(
-                        None,
-                        '%(in_netns)s ip link set %(vx_veth_inner)s up' % subst)
-                    util.execute(
-                        None,
-                        '%(in_netns)s ip addr add %(router)s/%(netmask)s '
-                        'dev %(vx_veth_inner)s' % subst)
-
-            if not util.check_for_interface(subst['physical_veth_outer']):
-                with util.RecordedOperation('create physical veth', self):
-                    util.create_interface(
-                        subst['physical_veth_outer'], 'veth',
-                        'peer name %(physical_veth_inner)s' % subst)
-                    util.execute(None,
-                                 'brctl addif %(physical_bridge)s '
-                                 '%(physical_veth_outer)s' % subst)
-                    util.execute(None,
-                                 'ip link set %(physical_veth_outer)s up'
-                                 % subst)
-                    util.execute(None,
-                                 'ip link set %(physical_veth_inner)s '
-                                 'netns %(netns)s' % subst)
-
-            self.deploy_nat()
-            self.update_dhcp()
-        else:
-            db.enqueue('networknode', DeployNetworkTask(self.uuid))
-            self.add_event('deploy', 'enqueued')
-
-    def deploy_nat(self):
-        if not self.provide_nat:
-            return
-
+    def create_on_network_node(self):
+        self._create_common()
         subst = self.subst_dict()
-        if not self.floating_gateway:
-            with db.get_lock('ipmanager', None,
-                             'floating', ttl=120, op='Network deploy NAT'):
-                ipm = IPManager.from_db('floating')
-                self.floating_gateway = ipm.get_random_free_address()
-                ipm.persist()
-                self.persist()
 
-        # No lock because no data changing
-        ipm = IPManager.from_db('floating')
-        subst['floating_router'] = ipm.get_address_at_index(1)
-        subst['floating_gateway'] = self.floating_gateway
-        subst['floating_netmask'] = ipm.netmask
+        if not os.path.exists('/var/run/netns/%(netns)s' % subst):
+            with util.RecordedOperation('create netns', self):
+                util.execute(None, 'ip netns add %(netns)s' % subst)
 
-        with db.get_object_lock(self, ttl=120, op='Network deploy NAT'):
-            # Ensure network was not deleted whilst waiting for the lock.
-            if self.is_dead():
-                raise DeadNetwork('network=%s' % self)
+        if not util.check_for_interface(subst['vx_veth_outer']):
+            with util.RecordedOperation('create router veth', self):
+                util.create_interface(
+                    subst['vx_veth_outer'], 'veth',
+                    'peer name %(vx_veth_inner)s' % subst)
+                util.execute(
+                    None,
+                    'ip link set %(vx_veth_inner)s netns %(netns)s' % subst)
+                util.execute(
+                    None,
+                    'brctl addif %(vx_bridge)s %(vx_veth_outer)s' % subst)
+                util.execute(None, 'ip link set %(vx_veth_outer)s up' % subst)
+                util.execute(
+                    None,
+                    '%(in_netns)s ip link set %(vx_veth_inner)s up' % subst)
+                util.execute(
+                    None,
+                    '%(in_netns)s ip addr add %(router)s/%(netmask)s '
+                    'dev %(vx_veth_inner)s' % subst)
 
-            with util.RecordedOperation('enable virtual routing', self):
-                addresses = util.get_interface_addresses(
-                    subst['netns'],
-                    subst['physical_veth_inner'])
-                if not subst['floating_gateway'] in list(addresses):
-                    util.execute(None,
-                                 '%(in_netns)s ip addr add '
-                                 '%(floating_gateway)s/%(floating_netmask)s '
-                                 'dev %(physical_veth_inner)s' % subst)
-                    util.execute(None,
-                                 '%(in_netns)s ip link set '
-                                 '%(physical_veth_inner)s up' % subst)
+        if not util.check_for_interface(subst['physical_veth_outer']):
+            with util.RecordedOperation('create physical veth', self):
+                util.create_interface(
+                    subst['physical_veth_outer'], 'veth',
+                    'peer name %(physical_veth_inner)s' % subst)
+                util.execute(None,
+                             'brctl addif %(physical_bridge)s '
+                             '%(physical_veth_outer)s' % subst)
+                util.execute(None,
+                             'ip link set %(physical_veth_outer)s up'
+                             % subst)
+                util.execute(None,
+                             'ip link set %(physical_veth_inner)s '
+                             'netns %(netns)s' % subst)
 
-                default_routes = util.get_default_routes(subst['netns'])
-                if default_routes != [subst['floating_router']]:
-                    if default_routes:
-                        for default_route in default_routes:
-                            util.execute(None,
-                                         '%s route del default gw %s'
-                                         % (subst['in_netns'], default_route))
+        if self.provide_nat:
+            if not self.floating_gateway:
+                with db.get_lock('ipmanager', None,
+                                 'floating', ttl=120, op='Network deploy NAT'):
+                    ipm = IPManager.from_db('floating')
+                    self.floating_gateway = ipm.get_random_free_address()
+                    ipm.persist()
+                    self.persist()
 
-                    util.execute(None,
-                                 '%(in_netns)s route add default '
-                                 'gw %(floating_router)s' % subst)
+            # No lock because no data changing
+            ipm = IPManager.from_db('floating')
+            subst['floating_router'] = ipm.get_address_at_index(1)
+            subst['floating_gateway'] = self.floating_gateway
+            subst['floating_netmask'] = ipm.netmask
 
-            if not util.nat_rules_for_ipblock(self.network_address):
-                with util.RecordedOperation('enable nat', self):
-                    util.execute(None,
-                                 'echo 1 > /proc/sys/net/ipv4/ip_forward')
-                    util.execute(None,
-                                 '%(in_netns)s iptables -A FORWARD '
-                                 '-o %(physical_veth_inner)s '
-                                 '-i %(vx_veth_inner)s -j ACCEPT' % subst)
-                    util.execute(None,
-                                 '%(in_netns)s iptables -A FORWARD '
-                                 '-i %(physical_veth_inner)s '
-                                 '-o %(vx_veth_inner)s -j ACCEPT' % subst)
-                    util.execute(None,
-                                 '%(in_netns)s iptables -t nat -A POSTROUTING '
-                                 '-s %(ipblock)s/%(netmask)s '
-                                 '-o %(physical_veth_inner)s '
-                                 '-j MASQUERADE' % subst)
+            with db.get_object_lock(self, ttl=120, op='Network deploy NAT'):
+                # Ensure network was not deleted whilst waiting for the lock.
+                if self.is_dead():
+                    raise DeadNetwork('network=%s' % self)
+
+                with util.RecordedOperation('enable virtual routing', self):
+                    addresses = util.get_interface_addresses(
+                        subst['netns'],
+                        subst['physical_veth_inner'])
+                    if not subst['floating_gateway'] in list(addresses):
+                        util.execute(None,
+                                     '%(in_netns)s ip addr add '
+                                     '%(floating_gateway)s/%(floating_netmask)s '
+                                     'dev %(physical_veth_inner)s' % subst)
+                        util.execute(None,
+                                     '%(in_netns)s ip link set '
+                                     '%(physical_veth_inner)s up' % subst)
+
+                    default_routes = util.get_default_routes(subst['netns'])
+                    if default_routes != [subst['floating_router']]:
+                        if default_routes:
+                            for default_route in default_routes:
+                                util.execute(None,
+                                             '%s route del default gw %s'
+                                             % (subst['in_netns'], default_route))
+
+                        util.execute(None,
+                                     '%(in_netns)s route add default '
+                                     'gw %(floating_router)s' % subst)
+
+                if not util.nat_rules_for_ipblock(self.network_address):
+                    with util.RecordedOperation('enable nat', self):
+                        util.execute(None,
+                                     'echo 1 > /proc/sys/net/ipv4/ip_forward')
+                        util.execute(None,
+                                     '%(in_netns)s iptables -A FORWARD '
+                                     '-o %(physical_veth_inner)s '
+                                     '-i %(vx_veth_inner)s -j ACCEPT' % subst)
+                        util.execute(None,
+                                     '%(in_netns)s iptables -A FORWARD '
+                                     '-i %(physical_veth_inner)s '
+                                     '-o %(vx_veth_inner)s -j ACCEPT' % subst)
+                        util.execute(None,
+                                     '%(in_netns)s iptables -t nat -A POSTROUTING '
+                                     '-s %(ipblock)s/%(netmask)s '
+                                     '-o %(physical_veth_inner)s '
+                                     '-j MASQUERADE' % subst)
+
+        self.update_dhcp()
 
     def delete(self):
         subst = self.subst_dict()

--- a/shakenfist/scheduler.py
+++ b/shakenfist/scheduler.py
@@ -81,8 +81,10 @@ class Scheduler(object):
         # how we do this to avoid repeatedly scanning the etcd repository.
         per_node = {}
         for inst in db.get_instances():
-            per_node.setdefault(inst['node'], [])
-            per_node[inst['node']].append(inst)
+            node = db.get_instance_attribute(inst['uuid'], 'placement')
+            if node.get('node'):
+                per_node.setdefault(node['node'], [])
+                per_node[node['node']].append(inst)
 
         candidates_network_matches = {}
         for node in candidates:

--- a/shakenfist/tests/test_scheduler.py
+++ b/shakenfist/tests/test_scheduler.py
@@ -305,9 +305,11 @@ class CorrectAllocationTestCase(SchedulerTestCase):
         self.mock_get_instances.start()
         self.addCleanup(self.mock_get_instances.stop)
 
-    @ mock.patch('shakenfist.images.Image.from_url')
-    @ mock.patch('shakenfist.db.get_image_metadata_all', return_value=None)
-    def test_any_node_but_not_network_node(self, mock_get_image_meta, mock_image_from_url):
+    @mock.patch('shakenfist.db.get_instance_attribute')
+    @mock.patch('shakenfist.images.Image.from_url')
+    @mock.patch('shakenfist.db.get_image_metadata_all', return_value=None)
+    def test_any_node_but_not_network_node(
+            self, mock_get_image_meta, mock_image_from_url, mock_attr):
         self.fake_db.set_node_metrics_same({
             'cpu_max_per_instance': 16,
             'cpu_max': 4,
@@ -330,9 +332,12 @@ class CorrectAllocationTestCase(SchedulerTestCase):
         self.assertSetEqual(set(self.fake_db.nodes)-{'node1_net', },
                             set(nodes))
 
-    @ mock.patch('shakenfist.images.Image.from_url')
-    @ mock.patch('shakenfist.db.get_image_metadata_all', return_value=None)
-    def test_single_node_that_has_network(self, mock_get_image_meta, mock_image_from_url):
+    @mock.patch('shakenfist.db.get_instance_attribute',
+                return_value={'node': 'node3'})
+    @mock.patch('shakenfist.images.Image.from_url')
+    @mock.patch('shakenfist.db.get_image_metadata_all', return_value=None)
+    def test_single_node_that_has_network(
+            self, mock_get_image_meta, mock_image_from_url, mock_attr):
         self.fake_db.set_node_metrics_same({
             'cpu_max_per_instance': 16,
             'cpu_max': 4,
@@ -382,27 +387,27 @@ class FindMostTestCase(SchedulerTestCase):
         mock_db_get_metrics.start()
         self.addCleanup(mock_db_get_metrics.stop)
 
-    @ mock.patch('shakenfist.db.get_image_metadata_all',
-                 return_value={
-                     '/sf/image/095fdd2b66625412aa/node2': {
-                         'checksum': None,
-                         'fetched': 'Tue, 20 Oct 2020 23:02:29 -0000',
-                         'file_version': 1,
-                         'modified': 'Tue, 10 Sep 2019 07:24:40 GMT',
-                         'size': 200000,
-                         'url': 'req_image1',
-                         'version': 1,
-                     },
-                     '/sf/image/aca41cefa18b052074e092/node3': {
-                         'checksum': None,
-                         'fetched': 'Tue, 20 Oct 2020 23:02:29 -0000',
-                         'file_version': 1,
-                         'modified': 'Tue, 10 Sep 2019 07:24:40 GMT',
-                         'size': 200000,
-                         'url': 'http://example.com',
-                         'version': 1,
-                     }
-                 })
+    @mock.patch('shakenfist.db.get_image_metadata_all',
+                return_value={
+                    '/sf/image/095fdd2b66625412aa/node2': {
+                        'checksum': None,
+                        'fetched': 'Tue, 20 Oct 2020 23:02:29 -0000',
+                        'file_version': 1,
+                        'modified': 'Tue, 10 Sep 2019 07:24:40 GMT',
+                        'size': 200000,
+                        'url': 'req_image1',
+                        'version': 1,
+                    },
+                    '/sf/image/aca41cefa18b052074e092/node3': {
+                        'checksum': None,
+                        'fetched': 'Tue, 20 Oct 2020 23:02:29 -0000',
+                        'file_version': 1,
+                        'modified': 'Tue, 10 Sep 2019 07:24:40 GMT',
+                        'size': 200000,
+                        'url': 'http://example.com',
+                        'version': 1,
+                    }
+                })
     def test_most_matching_images(self, mock_get_meta_all):
         req_images = ['req_image1']
         candidates = ['node1_net', 'node2', 'node3', 'node4']

--- a/shakenfist/util.py
+++ b/shakenfist/util.py
@@ -279,6 +279,8 @@ def _lock_refresher(locks):
 
 
 def execute(locks, command, check_exit_code=[0], env_variables=None):
+    LOG.info('Executing %s with locks %s' % (command, locks))
+
     if not locks:
         return processutils.execute(
             command, check_exit_code=check_exit_code,


### PR DESCRIPTION
- Network node setup is always done via a queue message, even if local.
- DHCP is no longer recreated for every instance on a freshly started
  hypervisor. Instead, we do that when the network node restarts.