### PR TITLE
Be less permissive of primitives not existing.

### DIFF
--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -209,36 +209,15 @@ def instance_start(instance_uuid, network):
             if netdesc['network_uuid'] not in nets:
                 n = net.Network.from_db(netdesc['network_uuid'])
                 if not n:
-                    db.enqueue_instance_error(instance_uuid, 'missing network')
+                    db.enqueue_instance_error(
+                        instance_uuid, 'missing network: %s' % netdesc['network_uuid'])
                     return
+
+                if n.state != 'created':
+                    db.enqueue_instance_error(
+                        instance_uuid, 'network is not active: %s' % n['uuid'])
 
                 nets[netdesc['network_uuid']] = n
-
-        # Wait for the networks to be in a created state
-        started_waiting = time.time()
-        with util.RecordedOperation('ensure networks exist', instance):
-            while nets:
-                for network_uuid in copy.copy(nets):
-                    n = db.get_network(network_uuid)
-                    if n['state'] in ['deleted', 'error']:
-                        db.enqueue_instance_error(
-                            instance_uuid, 'tried to use network in terminal state: %s' % network_uuid)
-                        return
-
-                    if n['state'] == 'created':
-                        n = nets[network_uuid]
-                        n.ensure_mesh()
-                        n.update_dhcp()
-
-                        del nets[network_uuid]
-
-                if len(nets) > 0:
-                    time.sleep(1)
-
-                if time.time() - started_waiting > 300:
-                    db.enqueue_instance_error(
-                        instance_uuid, 'timed out waiting for networks: %s' % ', '.join(nets))
-                    return
 
         # Allocate console and VDI ports
         instance.allocate_instance_ports()

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -849,7 +849,19 @@ class ExternalApiInstanceTestCase(ExternalApiTestCase):
             resp.get_json())
         self.assertEqual(400, resp.status_code)
 
-    def test_post_instance_only_system_specifies_namespaces(self):
+    @mock.patch('shakenfist.db.get_network',
+                return_value={
+                    'uuid': '87c15186-5f73-4947-a9fb-2183c4951efc',
+                    'state': 'created',
+                    'vxid': 1,
+                    'namespace': 'nonespace',
+                    'name': 'bob',
+                    'netblock': '10.10.0.0/24',
+                })
+    @mock.patch('shakenfist.db.get_lock')
+    @mock.patch('shakenfist.ipmanager.IPManager.from_db')
+    def test_post_instance_only_system_specifies_namespaces(
+            self, mock_ipmanager, mock_lock, mock_net):
         resp = self.client.post(
             '/auth', data=json.dumps({'namespace': 'banana', 'key': 'foo'}))
         self.assertEqual(200, resp.status_code)


### PR DESCRIPTION
Don't poll or wait if the network or instance being managed doesn't
exist, just tell the client to come back later. This fixes #595.