### PR TITLE
Add experimental new API using FastAPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,10 @@ bcrypt              # apache2
 gunicorn            # mit
 pylogrus            # mit
 pydantic            # mit
+fastapi             # mit
+python-multipart    # apache2
+python-jose
+cryptography
 
 # Is difficult to get install working, use system packages instead. On Ubuntu
 # those are: libvirt-daemon-system libvirt-dev python3-libvirt

--- a/shakenfist/fast_api/app.py
+++ b/shakenfist/fast_api/app.py
@@ -1,0 +1,502 @@
+# Experimental external API using FastAPI
+from datetime import datetime, timedelta
+from typing import List, Optional, Union
+
+import base64
+import bcrypt
+from fastapi import Depends, FastAPI, HTTPException, status, Body
+from fastapi.responses import PlainTextResponse
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from functools import partial
+from jose import JWTError, jwt
+from pydantic import BaseModel, Field
+from shakenfist import logutil
+from shakenfist.daemons import daemon
+from shakenfist import db as sf_db
+from shakenfist.config import config
+from shakenfist.util import get_version
+from shakenfist import virt
+
+
+_jwt_secret = config.AUTH_SECRET_SEED.get_secret_value()
+ACCESS_TOKEN_EXPIRES_MINUTES = 30
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+
+tags_metadata = [
+    {
+        "name": "authentication",
+        "description": "Authentication and operations on namespaces.",
+    },
+    {
+        "name": "instances",
+        "description": "Operations on instances.",
+    },
+    {
+        "name": "networks",
+        "description": "Operations on networks",
+    },
+]
+
+app = FastAPI(
+    title="Shaken Fist API",
+    description="The REST API for Shaken Fist",
+    version=get_version(),
+    openapi_tags=tags_metadata,
+)
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+class Identity(BaseModel):
+    namespace: str = Field(..., example='system')
+
+
+async def get_identity(token: str = Depends(oauth2_scheme)):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, _jwt_secret, algorithms=['HS256'])
+        namespace: str = payload.get("sub")
+        if namespace is None:
+            raise credentials_exception
+        return Identity(namespace=namespace)
+    except JWTError:
+        raise credentials_exception
+
+
+async def get_admin(identity: Identity = Depends(get_identity)):
+    if identity.namespace == 'system':
+        return identity
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Not an admin")
+
+
+async def get_db():
+    return sf_db
+
+
+LOG, HANDLER = logutil.setup(__name__)
+daemon.set_log_level(LOG, 'api')
+
+
+TESTING = False
+SCHEDULER = None
+
+
+@app.get('/', response_class=PlainTextResponse)
+async def root():
+    "Return the banner"
+    return 'Shaken Fist REST API service'
+
+
+@app.get('/admin/locks')
+async def admin_locks(identity: Identity = Depends(get_admin),
+                      db=Depends(get_db)):
+    "Return all locks in etcd"
+    return db.get_existing_locks()
+
+
+@app.post('/token', tags=['authentication'], response_model=Token)
+async def login(form_data: OAuth2PasswordRequestForm = Depends()):
+    namespace = form_data.username
+    key = form_data.password
+    token = _get_token(namespace, key)
+    return {'access_token': token, 'token_type': 'bearer'}
+
+
+def _get_token(db, namespace: str, key: str) -> str:
+    service_key, keys = _get_keys(db, namespace)
+    if service_key and key == service_key:
+        return _create_access_token(
+            data={"sub": namespace},
+            expires_delta=ACCESS_TOKEN_EXPIRES_MINUTES,
+            )
+    for possible_key in keys:
+        if bcrypt.checkpw(key.encode('utf-8'), possible_key):
+            return _create_access_token(
+                data={"sub": namespace},
+                expires_delta=ACCESS_TOKEN_EXPIRES_MINUTES,
+            )
+    raise HTTPException(
+        status_code=400,
+        detail='Incorrect namespace or key',
+    )
+
+
+def _create_access_token(
+    data: dict,
+    expires_delta: Optional[timedelta] = None,
+):
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(minutes=15)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, _jwt_secret, algorithm='HS256')
+    return encoded_jwt
+
+
+def _get_keys(db, namespace):
+    rec = db.get_namespace(namespace)
+    if not rec:
+        return (None, [])
+
+    keys = []
+    for key_name in rec.get('keys', {}):
+        keys.append(base64.b64decode(rec['keys'][key_name]))
+    return (rec.get('service_key'), keys)
+
+
+class AuthRequest(BaseModel):
+    namespace: str
+    key: str
+
+
+@app.post('/auth', tags=['authentication'])
+async def auth(req: AuthRequest, db=Depends(get_db)):
+    'Request an auth token'
+    token = _get_token(db, req.namespace, req.key)
+    return {'access_token': token}
+
+
+@app.get('/auth/namespaces', tags=['authentication'], response_model=List[str])
+async def namespaces(identity: Identity = Depends(get_admin),
+                     db=Depends(get_db)):
+    'Return the names of all namespaces'
+    return [rec['name'] for rec in db.list_namespaces()]
+
+
+illegal_key_name = HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                 detail='illegal key name')
+
+
+def assert_valid_key_name(key_name):
+    if key_name == 'service_key':
+        raise illegal_key_name
+
+
+class NewEmptyNS(BaseModel):
+    namespace: str
+
+
+class UpdateNSKey(BaseModel):
+    key_name: str
+    key: str
+
+
+class NewSingletonNS(NewEmptyNS, UpdateNSKey):
+    pass
+
+
+NewNSRequest = Union[NewSingletonNS, NewEmptyNS]
+
+
+@app.post('/auth/namespaces', tags=['authentication'], response_model=str)
+async def new_namespace(ns: NewNSRequest,
+                        identity: Identity = Depends(get_admin),
+                        db=Depends(get_db)):
+    'Create a new namespace'
+    namespace = ns.namespace
+    with db.get_lock('namespace', None, 'all', op='Namespace update'):
+        rec = db.get_namespace(namespace)
+        if not rec:
+            rec = {
+                'name': namespace,
+                'keys': {}
+            }
+
+        # Allow shortcut of creating key at same time as the namespace
+        if ns.key_name:
+            key_name = ns.key_name
+            key = ns.key
+            assert_valid_key_name(key_name)
+
+            encoded = str(base64.b64encode(bcrypt.hashpw(
+                key.encode('utf-8'), bcrypt.gensalt())), 'utf-8')
+            rec['keys'][key_name] = encoded
+
+        # Initialise metadata
+        db.persist_metadata('namespace', namespace, {})
+        db.persist_namespace(namespace, rec)
+
+    return namespace
+
+
+@app.delete('/auth/namespaces/{namespace}', tags=['authentication'])
+async def delete_namespace(namespace: str,
+                           identity: Identity = Depends(get_admin),
+                           db=Depends(get_db)):
+    if namespace == 'system':
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail='you cannot delete the system namespace')
+
+    # The namespace must be empty
+    instances = []
+    deleted_instances = []
+    for i in virt.Instances([partial(virt.namespace_filter, namespace)]):
+        state = db.get_instance_attribute(i.uuid, 'state')
+        if state['state'] in ['deleted', 'error']:
+            deleted_instances.append(i.uuid)
+        else:
+            instances.append(i.uuid)
+    if len(instances) > 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='you cannot delete a namespace with instances')
+
+    networks = []
+    for n in db.get_networks(all=True, namespace=namespace):
+        # Networks in 'deleting' state are regarded as "live" networks.
+        # They in a transient state. If they hang in that state we want to
+        # know. They will block deletion of a namespace thus giving notice
+        # of the problem.
+        if n['state'] not in ['deleted', 'error']:
+            networks.append(n['uuid'])
+    if len(networks) > 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='you cannot delete a namespace with networks')
+
+    db.delete_namespace(namespace)
+    db.delete_metadata('namespace', namespace)
+
+
+@app.get('/auth/namespaces/{namespace}/keys', tags=['authentication'],
+         response_model=List[str])
+async def namespace_keys(namespace: str,
+                         identity: Identity = Depends(get_admin),
+                         db=Depends(get_db)):
+    'List all key names in a namespace'
+    rec = db.get_namespace(namespace)
+    if not rec:
+        raise no_such_namespace
+    return list(rec)
+
+
+no_such_namespace = HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                                  detail='namespace does not exist')
+
+
+@app.post('/auth/namespaces/{namespace}/keys', tags=['authentication'])
+async def new_namespace_key(namespace: str,
+                            u: UpdateNSKey,
+                            identity: Identity = Depends(get_admin)):
+    _namespace_keys_putpost(namespace, u)
+    return u.key_name
+
+
+def _namespace_keys_putpost(db, namespace: str, u: UpdateNSKey):
+    key_name = u.key_name
+    key = u.key
+    assert_valid_key_name(key_name)
+    with db.get_lock('namespace', None, 'all', op='Namespace key update'):
+        rec = db.get_namespace(namespace)
+        if not rec:
+            raise no_such_namespace
+        encoded = str(base64.b64encode(bcrypt.hashpw(
+            key.encode('utf-8'), bcrypt.gensalt())), 'utf-8')
+        rec['keys'][key_name] = encoded
+
+        db.persist_namespace(namespace, rec)
+
+
+no_such_key = HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail='key name not found in namespace')
+
+
+@app.delete('/auth/namespaces/{namespace}/keys/{key_name}',
+            tags=['authentication'])
+async def delete_namespace_key(namespace: str,
+                               key_name: str,
+                               identity: Identity = Depends(get_admin),
+                               db=Depends(get_db)):
+    with db.get_lock('namespace', None, namespace, op='Namespace key delete'):
+        ns = db.get_namespace(namespace)
+        if ns.get('keys') and key_name in ns['keys']:
+            del ns['keys'][key_name]
+        else:
+            raise no_such_key
+        db.persist_namespace(namespace, ns)
+
+
+@app.put('/auth/namespaces/{namespace}/keys/{key_name}',
+         tags=['authentication'])
+async def update_namespace_key(namespace: str, key_name: str,
+                               key: str = Body(...),
+                               identity: Identity = Depends(get_admin),
+                               db=Depends(get_db)):
+    rec = db.get_namespace(namespace)
+    if not rec:
+        raise no_such_namespace
+    if key_name not in rec['keys']:
+        raise no_such_key
+    _namespace_keys_putpost(db, namespace,
+                            UpdateNSKey(key_name=key_name, key=key))
+    return key_name
+
+
+@app.get('/auth/namespace/{namespace}/metadata', tags=['authentication'])
+async def auth_metadata():
+    pass
+
+
+@app.post('/auth/namespace/{namespace}/metadata', tags=['authentication'])
+async def new_auth_metadata():
+    pass
+
+
+@app.put('/auth/namespace/{namespace}/metadata/{key}',
+         tags=['authentication'])
+async def update_auth_metadatum():
+    pass
+
+
+@app.delete('/auth/namespace/{namespace}/metadata/{key}',
+            tags=['authentication'])
+async def delete_auth_metadatum():
+    pass
+
+
+@app.get('/instances', tags=['instances'])
+async def instances():
+    pass
+
+
+@app.get('/instances/{instance}', tags=['instances'])
+async def instance(instance: str):
+    pass
+
+
+@app.get('/instances/{instance}/events', tags=['instances'])
+async def instance_events(instance: str):
+    pass
+
+
+@app.get('/instances/{instance}/interfaces', tags=['instances'])
+async def instance_interfaces(instance: str):
+    pass
+
+
+@app.post('/instances/{instance}/snapshot', tags=['instances'])
+async def instance_snapshot(instance: str):
+    pass
+
+
+@app.post('/instances/{instance}/rebootsoft', tags=['instances'])
+async def instance_rebootsoft(instance: str):
+    pass
+
+
+@app.post('/instances/{instance}/reboothard', tags=['instances'])
+async def instance_reboothard(instance: str):
+    pass
+
+
+@app.post('/instances/{instance}/poweroff', tags=['instances'])
+async def instance_poweroff(instance: str):
+    pass
+
+
+@app.post('/instances/{instance}/poweron', tags=['instances'])
+async def instance_poweron(instance: str):
+    pass
+
+
+@app.post('/instances/{instance}/pause', tags=['instances'])
+async def instance_pause(instance: str):
+    pass
+
+
+@app.post('/instances/{instance}/unpause', tags=['instances'])
+async def instance_unpause(instance: str):
+    pass
+
+
+@app.get('/interfaces/{interface}')
+async def interface(interface: str):
+    pass
+
+
+@app.get('/interfaces/{interface}/float')
+async def interface_float(interface: str):
+    pass
+
+
+@app.get('/interfaces/{interface}/defloat')
+async def interface_defloat(interface: str):
+    pass
+
+
+@app.get('/instances/{instance}/metadata', tags=['instances'])
+async def instance_metadata(instance: str):
+    pass
+
+
+@app.get('/instances/{instance}/metadata/{key}', tags=['instances'])
+async def instance_metadatum(instance: str, key: str):
+    pass
+
+
+@app.get('/instances/{instance}/consoledata', tags=['instances'])
+async def instance_consoledata(instance: str):
+    pass
+
+
+@app.get('/images')
+async def images():
+    pass
+
+
+@app.get('/images/events')
+async def image_events():
+    pass
+
+
+@app.get('/networks', tags=['networks'])
+async def networks():
+    pass
+
+
+@app.get('/networks/{network}', tags=['networks'])
+async def network(network: str):
+    pass
+
+
+@app.get('/networks/{network}/events', tags=['networks'])
+async def network_events(network: str):
+    pass
+
+
+@app.get('/networks/{network}/interfaces', tags=['networks'])
+async def network_interfaces(network: str):
+    pass
+
+
+@app.get('/networks/{network}/metadata', tags=['networks'])
+async def network_metadata(network: str):
+    pass
+
+
+@app.get('/networks/{network}/metadata/{key}', tags=['networks'])
+async def network_metadatum(network: str, key: str):
+    pass
+
+
+@app.post('/networks/{network}/ping/{address}', tags=['networks'])
+async def network_ping(network: str, address: str):
+    pass
+
+
+@app.get('/nodes')
+async def nodes():
+    pass

--- a/shakenfist/tests/test_fast_api.py
+++ b/shakenfist/tests/test_fast_api.py
@@ -1,0 +1,1005 @@
+# For now this is just a copy and paste from the external_api
+# tests. It is nowhere near functional and it's still too flask-y.
+
+import base64
+import bcrypt
+import json
+import mock
+from fastapi.testclient import TestClient
+
+from shakenfist.config import config, SFConfigBase
+from shakenfist.fast_api import app as external_api
+from shakenfist.ipmanager import IPManager
+from shakenfist.tests import test_shakenfist
+
+
+class FakeResponse(object):
+    def __init__(self, status_code, text):
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return json.loads(self.text)
+
+
+class FakeScheduler(object):
+    def place_instance(self, *args, **kwargs):
+        return config.NODE_NAME
+
+
+class FakeInstance(object):
+    def __init__(self, uuid=None, namespace=None):
+        self.uuid = uuid
+        self.namespace = namespace
+
+    def unique_label(self):
+        return ('instance', self.uuid)
+
+
+def _encode_key(key):
+    return bcrypt.hashpw(key.encode('utf-8'), bcrypt.gensalt())
+
+
+def _clean_traceback(resp):
+    if 'traceback' in resp:
+        del resp['traceback']
+    return resp
+
+
+class AuthTestCase(test_shakenfist.ShakenFistTestCase):
+    def setUp(self):
+        super(AuthTestCase, self).setUp()
+
+        external_api.TESTING = True
+        external_api.app.testing = True
+        external_api.app.debug = False
+        self.client = TestClient(external_api.app)
+
+    def test_post_auth_no_args(self):
+        resp = self.client.post('/auth', data=json.dumps({}))
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual(
+            {
+                'error': 'missing namespace in request',
+                'status': 400
+            },
+            resp.get_json())
+
+    def test_post_auth_no_key(self):
+        resp = self.client.post(
+            '/auth', data=json.dumps({'namespace': 'banana'}))
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual(
+            {
+                'error': 'missing key in request',
+                'status': 400
+            },
+            resp.get_json())
+
+    def test_post_auth_bad_parameter(self):
+        resp = self.client.post(
+            '/auth', data=json.dumps({'namespace': 'banana', 'keyyy': 'pwd'}))
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual(
+            {
+                'error': "post() got an unexpected keyword argument 'keyyy'",
+                'status': 400
+            },
+            _clean_traceback(resp.get_json()))
+
+    def test_post_auth_key_non_string(self):
+        resp = self.client.post(
+            '/auth', data=json.dumps({'namespace': 'banana', 'key': 1234}))
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual(
+            {
+                'error': 'key is not a string',
+                'status': 400
+            },
+            resp.get_json())
+
+    @mock.patch('shakenfist.external_api.app.Auth._get_keys',
+                return_value=(None, [_encode_key('cheese')]))
+    def test_post_auth(self, mock_get_keys):
+        resp = self.client.post(
+            '/auth', data=json.dumps({'namespace': 'banana', 'key': 'cheese'}))
+        self.assertEqual(200, resp.status_code)
+        self.assertIn('access_token', resp.get_json())
+
+    @mock.patch('shakenfist.external_api.app.Auth._get_keys',
+                return_value=('cheese', [_encode_key('bacon')]))
+    def test_post_auth_not_authorized(self, mock_get_keys):
+        resp = self.client.post(
+            '/auth', data=json.dumps({'namespace': 'banana', 'key': 'hamster'}))
+        self.assertEqual(401, resp.status_code)
+        self.assertEqual(
+            {
+                'error': 'unauthorized',
+                'status': 401
+            },
+            resp.get_json())
+
+    @mock.patch('shakenfist.etcd.get',
+                return_value={
+                    'service_key': 'cheese',
+                    'keys': {
+                        'key1': str(base64.b64encode(_encode_key('bacon')), 'utf-8'),
+                        'key2': str(base64.b64encode(_encode_key('sausage')), 'utf-8')
+                    }
+                })
+    def test_post_auth_service_key(self, mock_get):
+        resp = self.client.post(
+            '/auth', data=json.dumps({'namespace': 'banana', 'key': 'cheese'}))
+        self.assertEqual(200, resp.status_code)
+        self.assertIn('access_token', resp.get_json())
+
+    def test_no_auth_header(self):
+        resp = self.client.post('/auth/namespaces',
+                                data=json.dumps({
+                                    'namespace': 'foo'
+                                }))
+        self.assertEqual(401, resp.status_code)
+        self.assertEqual(
+            {
+                'error': 'Missing Authorization Header',
+                'status': 401
+            },
+            _clean_traceback(resp.get_json()))
+
+    def test_auth_header_wrong(self):
+        resp = self.client.post('/auth/namespaces',
+                                headers={'Authorization': 'l33thacker'},
+                                data=json.dumps({
+                                    'namespace': 'foo'
+                                }))
+        self.assertEqual(
+            {
+                'error': "Bad Authorization header. Expected value 'Bearer <JWT>'",
+                'status': 401
+            },
+            _clean_traceback(resp.get_json()))
+        self.assertEqual(401, resp.status_code)
+
+    def test_auth_header_bad_jwt(self):
+        resp = self.client.post('/auth/namespaces',
+                                headers={'Authorization': 'Bearer l33thacker'},
+                                data=json.dumps({
+                                    'namespace': 'foo'
+                                }))
+        self.assertEqual(
+            {
+                'error': 'invalid JWT in Authorization header',
+                'status': 401
+            },
+            _clean_traceback(resp.get_json()))
+        self.assertEqual(401, resp.status_code)
+
+
+class ExternalApiTestCase(test_shakenfist.ShakenFistTestCase):
+    def setUp(self):
+        super(ExternalApiTestCase, self).setUp()
+
+        self.add_event = mock.patch(
+            'shakenfist.db.add_event')
+        self.mock_add_event = self.add_event.start()
+        self.addCleanup(self.add_event.stop)
+
+        self.scheduler = mock.patch(
+            'shakenfist.scheduler.Scheduler', FakeScheduler)
+        self.mock_scheduler = self.scheduler.start()
+        self.addCleanup(self.scheduler.stop)
+
+        external_api.TESTING = True
+        external_api.app.testing = True
+        external_api.app.debug = False
+
+        self.client = TestClient(external_api.app)
+
+        # Make a fake auth token
+        self.get_keys = mock.patch(
+            'shakenfist.external_api.app.Auth._get_keys',
+            return_value=('foo', ['bar'])
+        )
+        self.mock_get_keys = self.get_keys.start()
+        self.addCleanup(self.get_keys.stop)
+
+        resp = self.client.post(
+            '/auth', data=json.dumps({'namespace': 'system', 'key': 'foo'}))
+        print(resp.get_json())
+        self.assertEqual(200, resp.status_code)
+        self.auth_header = 'Bearer %s' % resp.get_json()['access_token']
+
+
+class ExternalApiGeneralTestCase(ExternalApiTestCase):
+    def setUp(self):
+        super(ExternalApiGeneralTestCase, self).setUp()
+
+    def test_get_root(self):
+        resp = self.client.get('/')
+        self.assertEqual('Shaken Fist REST API service',
+                         resp.get_data().decode('utf-8'))
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual('text/plain; charset=utf-8', resp.content_type)
+
+    def test_auth_add_key_missing_args(self):
+        resp = self.client.post('/auth/namespaces',
+                                headers={'Authorization': self.auth_header},
+                                data=json.dumps({}))
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual(
+            {
+                'error': 'no namespace specified',
+                'status': 400
+            },
+            resp.get_json())
+
+    @mock.patch('shakenfist.db.get_lock')
+    @mock.patch('shakenfist.etcd.get', return_value=None)
+    @mock.patch('shakenfist.etcd.put')
+    def test_auth_add_key_missing_keyname(self, mock_put, mock_get, mock_lock):
+        resp = self.client.post('/auth/namespaces',
+                                headers={'Authorization': self.auth_header},
+                                data=json.dumps({
+                                    'namespace': 'foo'
+                                }))
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual('foo', resp.get_json())
+
+    @mock.patch('shakenfist.db.get_lock')
+    @mock.patch('shakenfist.etcd.get', return_value=None)
+    @mock.patch('shakenfist.etcd.put')
+    def test_auth_add_key_missing_key(self, mock_put, mock_get, mock_lock):
+        resp = self.client.post('/auth/namespaces',
+                                headers={'Authorization': self.auth_header},
+                                data=json.dumps({
+                                    'namespace': 'foo',
+                                    'key_name': 'bernard'
+                                }))
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual(
+            {
+                'error': 'no key specified',
+                'status': 400
+            },
+            resp.get_json())
+
+    @mock.patch('shakenfist.db.get_lock')
+    @mock.patch('shakenfist.etcd.get', return_value=None)
+    def test_auth_add_key_illegal_keyname(self, mock_get, mock_lock):
+        resp = self.client.post('/auth/namespaces',
+                                headers={'Authorization': self.auth_header},
+                                data=json.dumps({
+                                    'namespace': 'foo',
+                                    'key_name': 'service_key',
+                                    'key': 'cheese'
+                                }))
+        self.assertEqual(
+            {
+                'error': 'illegal key name',
+                'status': 403
+            },
+            resp.get_json())
+        self.assertEqual(403, resp.status_code)
+
+    @mock.patch('shakenfist.db.get_lock')
+    @mock.patch('shakenfist.etcd.get', return_value=None)
+    @mock.patch('shakenfist.etcd.put')
+    @mock.patch('bcrypt.hashpw', return_value='terminator'.encode('utf-8'))
+    def test_auth_add_key_new_namespace(self, mock_hashpw, mock_put, mock_get, mock_lock):
+        resp = self.client.post('/auth/namespaces',
+                                headers={'Authorization': self.auth_header},
+                                data=json.dumps({
+                                    'namespace': 'foo',
+                                    'key_name': 'bernard',
+                                    'key': 'cheese'
+                                }))
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual('foo', resp.get_json())
+        mock_put.assert_called_with(
+            'namespace', None, 'foo',
+            {'name': 'foo', 'keys': {'bernard': 'dGVybWluYXRvcg=='}})
+
+    @mock.patch('shakenfist.etcd.get_all',
+                return_value=[
+                    ('/sf/namespace/aaa', {'name': 'aaa'}),
+                    ('/sf/namespace/bbb', {'name': 'bbb'}),
+                    ('/sf/namespace/ccc', {'name': 'ccc'})
+                ])
+    def test_get_namespaces(self, mock_get_all):
+        resp = self.client.get('/auth/namespaces',
+                               headers={'Authorization': self.auth_header})
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(['aaa', 'bbb', 'ccc'], resp.get_json())
+
+    def test_delete_namespace_missing_args(self):
+        resp = self.client.delete('/auth/namespaces',
+                                  headers={'Authorization': self.auth_header})
+        self.assertEqual(405, resp.status_code)
+        self.assertEqual(
+            {
+                'message': 'The method is not allowed for the requested URL.'
+            },
+            resp.get_json())
+
+    def test_delete_namespace_system(self):
+        resp = self.client.delete('/auth/namespaces/system',
+                                  headers={'Authorization': self.auth_header})
+        self.assertEqual(403, resp.status_code)
+        self.assertEqual(
+            {
+                'error': 'you cannot delete the system namespace',
+                'status': 403
+            },
+            resp.get_json())
+
+    @mock.patch('shakenfist.db.get_instance_attribute',
+                return_value={'state': 'created'})
+    @mock.patch('shakenfist.virt.Instances',
+                return_value=[FakeInstance(uuid='123')])
+    def test_delete_namespace_with_instances(self, mock_get_instances,
+                                             mock_get_instance_attribute):
+        resp = self.client.delete('/auth/namespaces/foo',
+                                  headers={'Authorization': self.auth_header})
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual(
+            {
+                'error': 'you cannot delete a namespace with instances',
+                'status': 400
+            },
+            resp.get_json())
+
+    @mock.patch('shakenfist.virt.Instances', return_value=[])
+    @mock.patch('shakenfist.db.get_networks',
+                return_value=[{'uuid': '123', 'state': 'created'}])
+    def test_delete_namespace_with_networks(self, mock_get_networks, mock_get_instances):
+        resp = self.client.delete('/auth/namespaces/foo',
+                                  headers={'Authorization': self.auth_header})
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual(
+            {
+                'error': 'you cannot delete a namespace with networks',
+                'status': 400
+            },
+            resp.get_json())
+
+    def test_delete_namespace_key_missing_args(self):
+        resp = self.client.delete('/auth/namespaces/system/',
+                                  headers={'Authorization': self.auth_header})
+        self.assertEqual(404, resp.status_code)
+        self.assertEqual(None, resp.get_json())
+
+    @mock.patch('shakenfist.db.get_lock')
+    @mock.patch('shakenfist.etcd.get', return_value={'keys': {}})
+    def test_delete_namespace_key_missing_key(self, mock_get, mock_lock):
+        resp = self.client.delete('/auth/namespaces/system/keys/mykey',
+                                  headers={'Authorization': self.auth_header})
+        self.assertEqual(404, resp.status_code)
+        self.assertEqual(
+            {
+                'error': 'key name not found in namespace',
+                'status': 404
+            },
+            resp.get_json())
+
+    @mock.patch('shakenfist.db.get_lock')
+    @mock.patch('shakenfist.etcd.get', return_value={'keys': {'mykey': 'foo'}})
+    @mock.patch('shakenfist.etcd.put')
+    def test_delete_namespace_key(self, mock_put, mock_get, mock_lock):
+        resp = self.client.delete('/auth/namespaces/system/keys/mykey',
+                                  headers={'Authorization': self.auth_header})
+        self.assertEqual(200, resp.status_code)
+        mock_put.assert_called_with('namespace', None, 'system', {'keys': {}})
+
+    @mock.patch('shakenfist.db.get_metadata', return_value={'a': 'a', 'b': 'b'})
+    def test_get_namespace_metadata(self, mock_md_get):
+        resp = self.client.get(
+            '/auth/namespaces/foo/metadata', headers={'Authorization': self.auth_header})
+        self.assertEqual({'a': 'a', 'b': 'b'}, resp.get_json())
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual('application/json', resp.content_type)
+
+    @mock.patch('shakenfist.db.get_metadata', return_value={})
+    @mock.patch('shakenfist.db.persist_metadata')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_put_namespace_metadata(self, mock_get_lock, mock_md_put,
+                                    mock_md_get):
+        resp = self.client.put('/auth/namespaces/foo/metadata/foo',
+                               headers={'Authorization': self.auth_header},
+                               data=json.dumps({
+                                   'key': 'foo',
+                                   'value': 'bar'
+                               }))
+        self.assertEqual(None, resp.get_json())
+        self.assertEqual(200, resp.status_code)
+        mock_md_put.assert_called_with('namespace', 'foo', {'foo': 'bar'})
+
+    @mock.patch('shakenfist.db.get_metadata', return_value={})
+    @mock.patch('shakenfist.db.persist_metadata')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_post_namespace_metadata(self, mock_get_lock, mock_md_put,
+                                     mock_md_get):
+        resp = self.client.post('/auth/namespaces/foo/metadata',
+                                headers={'Authorization': self.auth_header},
+                                data=json.dumps({
+                                    'key': 'foo',
+                                    'value': 'bar'
+                                }))
+        self.assertEqual(None, resp.get_json())
+        self.assertEqual(200, resp.status_code)
+        mock_md_put.assert_called_with('namespace', 'foo', {'foo': 'bar'})
+
+    @mock.patch('shakenfist.db.get_metadata', return_value={'foo': 'bar', 'real': 'smart'})
+    @mock.patch('shakenfist.db.persist_metadata')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_delete_namespace_metadata(self, mock_get_lock, mock_md_put,
+                                       mock_md_get):
+        resp = self.client.delete('/auth/namespaces/foo/metadata/foo',
+                                  headers={'Authorization': self.auth_header})
+        self.assertEqual(None, resp.get_json())
+        self.assertEqual(200, resp.status_code)
+        mock_md_put.assert_called_with('namespace', 'foo', {'real': 'smart'})
+
+    @mock.patch('shakenfist.db.get_metadata', return_value={})
+    @mock.patch('shakenfist.db.persist_metadata')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_delete_namespace_metadata_bad_key(self, mock_get_lock,
+                                               mock_md_put, mock_md_get):
+        resp = self.client.delete('/auth/namespaces/foo/metadata/wrong',
+                                  headers={'Authorization': self.auth_header})
+        self.assertEqual({'error': 'key not found', 'status': 404},
+                         resp.get_json())
+        self.assertEqual(404, resp.status_code)
+
+    @mock.patch('shakenfist.db.get_metadata', return_value={'foo': 'bar', 'real': 'smart'})
+    @mock.patch('shakenfist.db.persist_metadata')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_delete_namespace_metadata_no_keys(self, mock_get_lock,
+                                               mock_md_put, mock_md_get):
+        resp = self.client.delete('/auth/namespaces/foo/metadata/wrong',
+                                  headers={'Authorization': self.auth_header})
+        self.assertEqual({'error': 'key not found', 'status': 404},
+                         resp.get_json())
+        self.assertEqual(404, resp.status_code)
+
+    @mock.patch('shakenfist.virt.Instance._db_get_instance',
+                return_value={'uuid': '123',
+                              'cpus': 2,
+                              'memory': 4096,
+                              'name': 'banana',
+                              'namespace': 'foo',
+                              'disk_spec': [{'size': 4, 'base': 'foo'}]})
+    @mock.patch('shakenfist.db.get_instance_attribute',
+                return_value={})
+    def test_get_instance(self, mock_get_instance_attribute, mock_get_instance):
+        resp = self.client.get(
+            '/instances/foo', headers={'Authorization': self.auth_header})
+        self.assertEqual({
+            'cpus': 2,
+            'disk_spec': [{'base': 'foo', 'size': 4}],
+            'memory': 4096,
+            'name': 'banana',
+            'namespace': 'foo',
+            'requested_placement': None,
+            'ssh_key': None,
+            'user_data': None,
+            'uuid': '123',
+            'version': None,
+            'video': None
+        }, resp.get_json())
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual('application/json', resp.content_type)
+
+    @mock.patch('shakenfist.virt.Instance._db_get_instance', return_value=None)
+    def test_get_instance_not_found(self, mock_get_instance):
+        resp = self.client.get(
+            '/instances/foo', headers={'Authorization': self.auth_header})
+        self.assertEqual({'error': 'instance not found', 'status': 404},
+                         resp.get_json())
+        self.assertEqual(404, resp.status_code)
+        self.assertEqual('application/json', resp.content_type)
+
+    @mock.patch('shakenfist.virt.Instance._db_get_instance',
+                return_value={'uuid': 'foo',
+                              'name': 'banana',
+                              'namespace': 'foo',
+                              'disk_spec': [{'size': 4, 'base': 'foo'}]})
+    @mock.patch('shakenfist.db.get_metadata', return_value={'a': 'a', 'b': 'b'})
+    def test_get_instance_metadata(self, mock_get_instance, mock_md_get):
+        resp = self.client.get(
+            '/instances/foo/metadata', headers={'Authorization': self.auth_header})
+        self.assertEqual({'a': 'a', 'b': 'b'}, resp.get_json())
+        self.assertEqual('application/json', resp.content_type)
+        self.assertEqual(200, resp.status_code)
+
+    @mock.patch('shakenfist.virt.Instance._db_get_instance',
+                return_value={'uuid': 'foo',
+                              'name': 'banana',
+                              'namespace': 'foo',
+                              'disk_spec': [{'size': 4, 'base': 'foo'}]})
+    @mock.patch('shakenfist.db.get_metadata', return_value={})
+    @mock.patch('shakenfist.db.persist_metadata')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_put_instance_metadata(self, mock_get_lock, mock_md_put,
+                                   mock_md_get, mock_get_instance):
+        resp = self.client.put('/instances/foo/metadata/foo',
+                               headers={'Authorization': self.auth_header},
+                               data=json.dumps({
+                                   'key': 'foo',
+                                   'value': 'bar'
+                               }))
+        self.assertEqual(None, resp.get_json())
+        self.assertEqual(200, resp.status_code)
+        mock_md_put.assert_called_with('instance', 'foo', {'foo': 'bar'})
+
+    @mock.patch('shakenfist.virt.Instance._db_get_instance',
+                return_value={'uuid': 'foo',
+                              'name': 'banana',
+                              'namespace': 'foo',
+                              'disk_spec': [{'size': 4, 'base': 'foo'}]})
+    @mock.patch('shakenfist.db.get_metadata', return_value={})
+    @mock.patch('shakenfist.db.persist_metadata')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_post_instance_metadata(self, mock_get_lock, mock_md_put,
+                                    mock_md_get, mock_get_instance):
+        resp = self.client.post('/instances/foo/metadata',
+                                headers={'Authorization': self.auth_header},
+                                data=json.dumps({
+                                    'key': 'foo',
+                                    'value': 'bar'
+                                }))
+        self.assertEqual(None, resp.get_json())
+        self.assertEqual(200, resp.status_code)
+        mock_md_put.assert_called_with('instance', 'foo', {'foo': 'bar'})
+
+    @mock.patch('shakenfist.db.get_network',
+                return_value={'uuid': 'foo',
+                              'name': 'banana',
+                              'namespace': 'foo'})
+    @mock.patch('shakenfist.db.get_metadata', return_value={'a': 'a', 'b': 'b'})
+    def test_get_network_metadata(self, mock_md_get, mock_get_network):
+        resp = self.client.get(
+            '/networks/foo/metadata', headers={'Authorization': self.auth_header})
+        self.assertEqual({'a': 'a', 'b': 'b'}, resp.get_json())
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual('application/json', resp.content_type)
+
+    @mock.patch('shakenfist.db.get_network',
+                return_value={'uuid': 'foo',
+                              'name': 'banana',
+                              'namespace': 'foo'})
+    @mock.patch('shakenfist.db.get_metadata', return_value={})
+    @mock.patch('shakenfist.db.persist_metadata')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_put_network_metadata(self, mock_get_lock, mock_md_put,
+                                  mock_md_get, mock_get_network):
+        resp = self.client.put('/networks/foo/metadata/foo',
+                               headers={'Authorization': self.auth_header},
+                               data=json.dumps({
+                                   'key': 'foo',
+                                   'value': 'bar'
+                               }))
+        self.assertEqual(None, resp.get_json())
+        self.assertEqual(200, resp.status_code)
+        mock_md_put.assert_called_with('network', 'foo', {'foo': 'bar'})
+
+    @mock.patch('shakenfist.db.get_network',
+                return_value={'uuid': 'foo',
+                              'name': 'banana',
+                              'namespace': 'foo'})
+    @mock.patch('shakenfist.db.get_metadata', return_value={})
+    @mock.patch('shakenfist.db.persist_metadata')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_post_network_metadata(self, mock_get_lock, mock_md_put,
+                                   mock_md_get, mock_get_network):
+        resp = self.client.post('/networks/foo/metadata',
+                                headers={'Authorization': self.auth_header},
+                                data=json.dumps({
+                                    'key': 'foo',
+                                    'value': 'bar'
+                                }))
+        self.assertEqual(None, resp.get_json())
+        self.assertEqual(200, resp.status_code)
+        mock_md_put.assert_called_with('network', 'foo', {'foo': 'bar'})
+
+    @mock.patch('shakenfist.virt.Instance._db_get_instance',
+                return_value={'uuid': 'foo',
+                              'name': 'banana',
+                              'namespace': 'foo',
+                              'disk_spec': [{'size': 4, 'base': 'foo'}]})
+    @mock.patch('shakenfist.db.get_metadata', return_value={'foo': 'bar', 'real': 'smart'})
+    @mock.patch('shakenfist.db.persist_metadata')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_delete_instance_metadata(self, mock_get_lock, mock_md_put,
+                                      mock_md_get, mock_get_instance):
+        resp = self.client.delete('/instances/foo/metadata/foo',
+                                  headers={'Authorization': self.auth_header})
+        self.assertEqual(None, resp.get_json())
+        mock_md_put.assert_called_with('instance', 'foo', {'real': 'smart'})
+        self.assertEqual(200, resp.status_code)
+
+    @mock.patch('shakenfist.virt.Instance._db_get_instance',
+                return_value={'uuid': 'foo',
+                              'name': 'banana',
+                              'namespace': 'foo',
+                              'disk_spec': [{'size': 4, 'base': 'foo'}]})
+    @mock.patch('shakenfist.db.get_metadata', return_value={'foo': 'bar', 'real': 'smart'})
+    @mock.patch('shakenfist.db.persist_metadata')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_delete_instance_metadata_bad_key(self, mock_get_lock,
+                                              mock_md_put, mock_md_get,
+                                              mock_get_instance):
+        resp = self.client.delete('/instances/foo/metadata/wrong',
+                                  headers={'Authorization': self.auth_header})
+        self.assertEqual({'error': 'key not found', 'status': 404},
+                         resp.get_json())
+        self.assertEqual(404, resp.status_code)
+
+    @mock.patch('shakenfist.db.get_network',
+                return_value={'uuid': 'foo',
+                              'name': 'banana',
+                              'namespace': 'foo'})
+    @mock.patch('shakenfist.db.get_metadata', return_value={'foo': 'bar', 'real': 'smart'})
+    @mock.patch('shakenfist.db.persist_metadata')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_delete_network_metadata(self, mock_get_lock, mock_md_put,
+                                     mock_md_get, mock_get_network):
+        resp = self.client.delete('/networks/foo/metadata/foo',
+                                  headers={'Authorization': self.auth_header})
+        self.assertEqual(None, resp.get_json())
+        self.assertEqual(200, resp.status_code)
+        mock_md_put.assert_called_with('network', 'foo', {'real': 'smart'})
+
+    @mock.patch('shakenfist.db.get_network',
+                return_value={'uuid': 'foo',
+                              'name': 'banana',
+                              'namespace': 'foo'})
+    @mock.patch('shakenfist.db.get_metadata', return_value={'foo': 'bar', 'real': 'smart'})
+    @mock.patch('shakenfist.db.persist_metadata')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_delete_network_metadata_bad_key(self, mock_get_lock,
+                                             mock_md_put, mock_md_get,
+                                             mock_get_network):
+        resp = self.client.delete('/networks/foo/metadata/wrong',
+                                  headers={'Authorization': self.auth_header})
+        self.assertEqual({'error': 'key not found', 'status': 404},
+                         resp.get_json())
+        self.assertEqual(404, resp.status_code)
+
+    @mock.patch('shakenfist.db.get_nodes',
+                return_value=[{
+                    'fqdn': 'sf-1',
+                    'ip': '192.168.72.240',
+                    'lastseen': 1594952905.2100437,
+                    'version': '0.0.1'
+                },
+                    {
+                    'fqdn': 'sf-2',
+                    'ip': '192.168.72.230',
+                    'lastseen': 1594952904.8870885,
+                    'version': '0.0.1'
+                }])
+    def test_get_node(self, mock_md_get):
+        resp = self.client.get('/nodes',
+                               headers={'Authorization': self.auth_header})
+        self.assertEqual([{
+            'name': 'sf-1',
+            'ip': '192.168.72.240',
+            'lastseen': 1594952905.2100437,
+            'version': '0.0.1'
+        },
+            {
+            'name': 'sf-2',
+            'ip': '192.168.72.230',
+            'lastseen': 1594952904.8870885,
+            'version': '0.0.1'
+        }],
+            resp.get_json())
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual('application/json', resp.content_type)
+
+
+class ExternalApiInstanceTestCase(ExternalApiTestCase):
+    def setUp(self):
+        super(ExternalApiInstanceTestCase, self).setUp()
+
+        def fake_virt_from_db(uuid):
+            return {'uuid': uuid}
+
+        self.virt_from_db = mock.patch('shakenfist.virt.Instance.from_db',
+                                       fake_virt_from_db)
+        self.mock_virt_from_db = self.virt_from_db.start()
+        self.addCleanup(self.virt_from_db.stop)
+
+        class FakeConfig(SFConfigBase):
+            API_ASYNC_WAIT: int = 1
+            LOG_METHOD_TRACE: int = 1
+
+        fake_config = FakeConfig()
+
+        self.config = mock.patch('shakenfist.config.config', fake_config)
+        self.mock_config = self.config.start()
+
+        self.addCleanup(self.config.stop)
+
+    @mock.patch('shakenfist.db.get_instance_attribute',
+                side_effect=[{'state': 'created'}, {'state': 'created'},
+                             {'node': 'sf-2'}, {'node': 'sf-2'},
+                             {'state': 'deleted'}, {'state': 'created'},
+                             {'state': 'deleted'}, {'state': 'deleted'}])
+    @mock.patch('shakenfist.db.enqueue')
+    @mock.patch('shakenfist.virt.Instances',
+                return_value=[
+                    FakeInstance(
+                        namespace='system',
+                        uuid='6a973b82-31b3-4780-93e4-04d99ae49f3f'),
+                    FakeInstance(
+                        namespace='system',
+                        uuid='847b0327-9b17-4148-b4ed-be72b6722c17')])
+    @mock.patch('shakenfist.virt.Instance._db_get_instance',
+                return_value={
+                    'state': 'deleted',
+                },)
+    @mock.patch('shakenfist.etcd.put')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_delete_all_instances(
+            self, mock_db_get_lock, mock_etcd_put, mock_get_instance,
+            mock_get_instances, mock_enqueue, mock_get_instance_attribute):
+
+        resp = self.client.delete('/instances',
+                                  headers={'Authorization': self.auth_header},
+                                  data=json.dumps({
+                                      'confirm': True,
+                                      'namespace': 'foo'
+                                  }))
+        self.assertEqual([], resp.get_json())
+        self.assertEqual(200, resp.status_code)
+
+    @mock.patch('shakenfist.db.get_instance_attribute',
+                side_effect=[{'state': 'deleted'},
+                             {'state': 'created'},
+                             {'node': 'sf-2'},
+                             {'state': 'deleted'},
+                             {'state': 'deleted'},
+                             {'state': 'deleted'}])
+    @mock.patch('shakenfist.db.enqueue')
+    @mock.patch('shakenfist.virt.Instances',
+                return_value=[
+                    FakeInstance(
+                        namespace='system',
+                        uuid='6a973b82-31b3-4780-93e4-04d99ae49f3f'),
+                    FakeInstance(
+                        namespace='system',
+                        uuid='847b0327-9b17-4148-b4ed-be72b6722c17')])
+    @mock.patch('shakenfist.etcd.put')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_delete_all_instances_one_already_deleted(
+            self, mock_db_get_lock,  mock_etcd_put, mock_get_instances,
+            mock_enqueue, mock_get_instance_attribute):
+
+        resp = self.client.delete('/instances',
+                                  headers={'Authorization': self.auth_header},
+                                  data=json.dumps({
+                                      'confirm': True,
+                                      'namespace': 'foo'
+                                  }))
+        self.assertEqual([], resp.get_json())
+        self.assertEqual(200, resp.status_code)
+
+    def test_post_instance_no_disk(self):
+        resp = self.client.post('/instances',
+                                headers={'Authorization': self.auth_header},
+                                data=json.dumps({
+                                    'name': 'test_instance',
+                                    'cpus': 1,
+                                    'memory': 1024,
+                                    'network': [],
+                                    'disk': None,
+                                    'ssh_key': None,
+                                    'user_data': None,
+                                    'placed_on': None,
+                                    'namespace': None,
+                                }))
+        self.assertEqual(
+            {'error': 'instance must specify at least one disk', 'status': 400},
+            resp.get_json())
+        self.assertEqual(400, resp.status_code)
+
+    def test_post_instance_invalid_disk(self):
+        resp = self.client.post('/instances',
+                                headers={'Authorization': self.auth_header},
+                                data=json.dumps({
+                                    'name': 'test_instance',
+                                    'cpus': 1,
+                                    'memory': 1024,
+                                    'network': [],
+                                    'disk': ['8@cirros'],
+                                    'ssh_key': None,
+                                    'user_data': None,
+                                    'placed_on': None,
+                                    'namespace': None,
+                                }))
+        self.assertEqual(
+            {'error': 'disk specification should contain JSON objects', 'status': 400},
+            resp.get_json())
+        self.assertEqual(400, resp.status_code)
+
+    def test_post_instance_invalid_network(self):
+        resp = self.client.post('/instances',
+                                headers={'Authorization': self.auth_header},
+                                data=json.dumps({
+                                    'name': 'test_instance',
+                                    'cpus': 1,
+                                    'memory': 1024,
+                                    'network': ['87c15186-5f73-4947-a9fb-2183c4951efc'],
+                                    'disk': [{'size': 8,
+                                              'base': 'cirros'}],
+                                    'ssh_key': None,
+                                    'user_data': None,
+                                    'placed_on': None,
+                                    'namespace': None,
+                                }))
+        self.assertEqual(
+            {'error': 'network specification should contain JSON objects', 'status': 400},
+            resp.get_json())
+        self.assertEqual(400, resp.status_code)
+
+    def test_post_instance_invalid_network_uuid(self):
+        resp = self.client.post('/instances',
+                                headers={'Authorization': self.auth_header},
+                                data=json.dumps({
+                                    'name': 'test_instance',
+                                    'cpus': 1,
+                                    'memory': 1024,
+                                    'network': [
+                                        {'uuid': '87c15186-5f73-4947-a9fb-2183c4951efc'}],
+                                    'disk': [{'size': 8,
+                                              'base': 'cirros'}],
+                                    'ssh_key': None,
+                                    'user_data': None,
+                                    'placed_on': None,
+                                    'namespace': None,
+                                }))
+        self.assertEqual(
+            {'error': 'network specification is missing network_uuid', 'status': 400},
+            resp.get_json())
+        self.assertEqual(400, resp.status_code)
+
+    @mock.patch('shakenfist.db.get_network',
+                return_value={
+                    'uuid': '87c15186-5f73-4947-a9fb-2183c4951efc',
+                    'state': 'created',
+                    'vxid': 1,
+                    'namespace': 'nonespace',
+                    'name': 'bob',
+                    'netblock': '10.10.0.0/24',
+                })
+    @mock.patch('shakenfist.db.get_lock')
+    @mock.patch('shakenfist.ipmanager.IPManager.from_db')
+    def test_post_instance_only_system_specifies_namespaces(
+            self, mock_ipmanager, mock_lock, mock_net):
+        resp = self.client.post(
+            '/auth', data=json.dumps({'namespace': 'banana', 'key': 'foo'}))
+        self.assertEqual(200, resp.status_code)
+        non_system_auth_header = 'Bearer %s' % resp.get_json()['access_token']
+
+        resp = self.client.post('/instances',
+                                headers={
+                                    'Authorization': non_system_auth_header},
+                                data=json.dumps({
+                                    'name': 'test_instance',
+                                    'cpus': 1,
+                                    'memory': 1024,
+                                    'network': [
+                                        {'network_uuid': '87c15186-5f73-4947-a9fb-2183c4951efc'}],
+                                    'disk': [{'size': 8,
+                                              'base': 'cirros'}],
+                                    'ssh_key': None,
+                                    'user_data': None,
+                                    'placed_on': None,
+                                    'namespace': 'gerkin',
+                                }))
+        self.assertEqual(
+            {'error': 'only admins can create resources in a different namespace',
+             'status': 401},
+            resp.get_json())
+        self.assertEqual(401, resp.status_code)
+
+
+class ExternalApiNetworkTestCase(ExternalApiTestCase):
+    def setUp(self):
+        super(ExternalApiNetworkTestCase, self).setUp()
+
+        class FakeConfig(SFConfigBase):
+            NODE_NAME: str = 'seriously'
+            NODE_IP: str = '127.0.0.1'
+            NETWORK_NODE_IP = '127.0.0.1'
+            LOG_METHOD_TRACE: int = 1
+            NODE_EGRESS_NIC: str = 'eth0'
+
+        fake_config_network = FakeConfig()
+        self.config = mock.patch('shakenfist.config.config',
+                                 fake_config_network)
+        self.mock_config = self.config.start()
+        # Without this cleanup, other test classes will have
+        # 'shakenfist.config.config.get' mocked during parallel testing
+        # by stestr.
+        self.addCleanup(self.config.stop)
+
+    @mock.patch('shakenfist.ipmanager.IPManager.from_db')
+    @mock.patch('shakenfist.db.get_network',
+                return_value={
+                    'uuid': '30f6da44-look-i-am-uuid',
+                    'state': 'created',
+                    'vxid': 1,
+                    'namespace': 'nonespace',
+                    'name': 'bob',
+                    'netblock': '10.10.0.0/24',
+                })
+    @mock.patch('shakenfist.db.get_networks',
+                return_value=[{
+                    'floating_gateway': '10.10.0.150',
+                    'name': 'bob',
+                    'state': 'created',
+                    'uuid': '30f6da44-look-i-am-uuid',
+                    'vxid': 1,
+                    'namespace': 'nonespace',
+                    'netblock': '10.10.0.0/24',
+                }])
+    @mock.patch('shakenfist.db.get_network_interfaces', return_value=[])
+    @mock.patch('shakenfist.ipmanager.IPManager.from_db',
+                return_value=IPManager('uuid', '10.0.0.0/24'))
+    @mock.patch('shakenfist.net.Network.remove_dhcp')
+    @mock.patch('shakenfist.net.Network.delete')
+    @mock.patch('shakenfist.net.Network.state')
+    @mock.patch('shakenfist.etcd.put')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_delete_all_networks(self,
+                                 mock_db_get_lock,
+                                 mock_etcd_put,
+                                 mock_network_state,
+                                 mock_delete,
+                                 mock_remove_dhcp,
+                                 mock_get_ipmanager,
+                                 mock_db_get_network_interfaces,
+                                 mock_db_get_networks,
+                                 mock_db_get_network,
+                                 mock_ipmanager_from_db):
+
+        resp = self.client.delete('/networks',
+                                  headers={'Authorization': self.auth_header},
+                                  data=json.dumps({
+                                      'confirm': True,
+                                      'namespace': 'foo'
+                                  }))
+        self.assertEqual(['30f6da44-look-i-am-uuid'],
+                         resp.get_json())
+        self.assertEqual(200, resp.status_code)
+
+    @mock.patch('shakenfist.db.get_networks',
+                return_value=[{
+                    'floating_gateway': '10.10.0.150',
+                    'name': 'bob',
+                    'state': 'deleted',
+                    'uuid': '30f6da44-look-i-am-uuid',
+                }])
+    @mock.patch('shakenfist.db.get_network_interfaces', return_value=[])
+    @mock.patch('shakenfist.ipmanager.IPManager.from_db',
+                return_value=IPManager('uuid', '10.0.0.0/24'))
+    @mock.patch('shakenfist.net.Network.remove_dhcp')
+    @mock.patch('shakenfist.etcd.put')
+    @mock.patch('shakenfist.db.get_lock')
+    def test_delete_all_networks_none_to_delete(self,
+                                                mock_db_get_lock,
+                                                mock_etcd_put,
+                                                mock_remove_dhcp,
+                                                mock_get_ipmanager,
+                                                mock_db_get_network_interfaces,
+                                                mock_db_get_networks):
+
+        resp = self.client.delete('/networks',
+                                  headers={'Authorization': self.auth_header},
+                                  data=json.dumps({
+                                      'confirm': True,
+                                      'namespace': 'foo'
+                                  }))
+        self.assertEqual([], resp.get_json())


### PR DESCRIPTION
The current external API is written using flask_restful. This is functional, but currently requires separate documentation which may fall out of date.

In theory (at least) moving to FastAPI should allow documentation to be automatically generated it in the OpenAPI format, simplifying the work involved in writing a client as well reducing drift between documentation and implementation.

Currently, the only additions to the API, are a `/token` end point which accepts credentials as form data to support the bare minimum of OAuth 2 required for the docs to be interactive, and `/docs` (automatically added by FastAPI) which serves the the documentation.