### PR TITLE
Turn snapshot requests into task

### DIFF
--- a/shakenfist/db.py
+++ b/shakenfist/db.py
@@ -235,8 +235,16 @@ def create_snapshot(snapshot_uuid, device, instance_uuid, created):
             'uuid': snapshot_uuid,
             'device': device,
             'instance_uuid': instance_uuid,
-            'created': created
+            'created': created,
+            'status': 'creating'
         })
+
+
+def finalize_snapshot(snapshot_uuid, instance_uuid, created):
+    snapshot = etcd.get('snapshot', instance_uuid, created)
+    snapshot['status'] = 'created'
+    etcd.put(
+        'snapshot', instance_uuid, created, snapshot)
 
 
 def get_instance_snapshots(instance_uuid):

--- a/shakenfist/tasks.py
+++ b/shakenfist/tasks.py
@@ -99,6 +99,14 @@ class ErrorInstanceTask(InstanceTask):
         return self._error_msg
 
 
+class SnapshotInstanceTask(InstanceTask):
+    _name = 'instance_snapshot'
+
+    def __init__(self, instance_uuid, snap_uuid):
+        super(SnapshotInstanceTask, self).__init__(instance_uuid)
+        self.snap_uuid = snap_uuid
+
+
 #
 # Network Tasks
 #


### PR DESCRIPTION
Right now, snapshot aren't tasks. This is a problem since they are
definitely a long lived operation which we can reasonably expect to
time out.

A new field has been added to snapshots, `status`, to track whether or
not they're creating or ready for use. This is perhaps too ad-hoc and
will probably need to change once there's a more robust story around
snapshots.

The API now returns the a UUID for a snapshot immediately instead of
waiting for the operation to finish, since my (possibly wrong)
assumption is that it's very rare for a user to want to immediately
want to use a snapshot that they've made.