### PR TITLE
Minor things found whilst fiddling

### DIFF
--- a/shakenfist/baseobject.py
+++ b/shakenfist/baseobject.py
@@ -70,14 +70,17 @@ class DatabaseBackedObject(object):
     def _db_set_attribute(self, attribute, value):
         etcd.put('attribute/%s' % self.object_type, self.__uuid, attribute, value)
 
+    def get_lock_attr(self, name, op):
+        return db.get_lock('attribute/%s' % self.object_type,
+                           self.__uuid, name, op=op)
+
     # Properties common to all objects which are routed to attributes
     @property
     def state(self):
         return self._db_get_attribute('state')
 
     def update_state(self, state, error_message=None):
-        with db.get_lock('attribute/%s' % self.object_type, self.__uuid, 'state',
-                         op='State update'):
+        with self.get_lock_attr('state', 'State update'):
             dbstate = self.state
             orig_state = dbstate.get('state')
             dbstate['state'] = state

--- a/shakenfist/client/upgrade.py
+++ b/shakenfist/client/upgrade.py
@@ -89,7 +89,8 @@ def main():
                 if bad:
                     for ni in db.get_network_interfaces(n['uuid']):
                         db.enqueue_instance_error(
-                            ni['instance_uuid'], 'Instance was on invalid network at upgrade.')
+                            ni['instance_uuid'],
+                            'Instance was on invalid network at upgrade.')
 
                     # NOTE(mikal): we have to hard delete this network here, or
                     # it will cause a crash later in the Networks iterator.

--- a/shakenfist/daemons/cleaner.py
+++ b/shakenfist/daemons/cleaner.py
@@ -116,7 +116,7 @@ class Monitor(daemon.Daemon):
                     instance.place_instance(config.NODE_NAME)
 
                     dbpowerstate = instance.power_state
-                    if not os.path.exists(virt.instance_path(instance.uuid)):
+                    if not os.path.exists(instance.instance_path):
                         # If we're inactive and our files aren't on disk,
                         # we have a problem.
                         log_ctx.info('Detected error state for instance')

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -1,6 +1,8 @@
 import ipaddress
 import time
 
+from oslo_concurrency import processutils
+
 from shakenfist import baseobject
 from shakenfist.config import config
 from shakenfist.daemons import daemon
@@ -103,6 +105,8 @@ class Monitor(daemon.Daemon):
             except exceptions.DeadNetwork as e:
                 LOG.withField('exception', e).info(
                     'maintain_network attempted on dead network')
+            except processutils.ProcessExecutionError as e:
+                LOG.error('Network maintenance failure: %s', e)
 
         # Determine if there are any extra vxids
         extra_vxids = set(vxid_to_mac.keys()) - set(seen_vxids)

--- a/shakenfist/images.py
+++ b/shakenfist/images.py
@@ -123,8 +123,7 @@ class Image(baseobject.DatabaseBackedObject):
         return versions[sorted(versions)[-1]]
 
     def _add_download_version(self, size, modified, fetched_at):
-        with db.get_lock('attribute/image', self.uuid, 'download',
-                         op='Image version creation'):
+        with self.get_lock_attr('download', 'Image version creation'):
             new_version = self.latest_download_version['sequence'] + 1
             self._db_set_attribute('download_%d' % new_version,
                                    {

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -118,7 +118,8 @@ class Network(baseobject.DatabaseBackedObject):
         return Network(static_values)
 
     def external_view(self):
-        # If this is an external view, then mix back in attributes that users expect
+        # If this is an external view, then mix back in attributes that users
+        # expect
         n = {
             'uuid': self.uuid,
             'name': self.__name,
@@ -126,6 +127,7 @@ class Network(baseobject.DatabaseBackedObject):
             'netblock': self.__netblock,
             'provide_dhcp': self.__provide_dhcp,
             'provide_nat': self.__provide_nat,
+            'floating_gateway': self.floating_gateway,
             'vxid': self.__vxid,
             'version': self.version
         }

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -215,8 +215,7 @@ class Network(baseobject.DatabaseBackedObject):
         return fnet
 
     def update_floating_gateway(self, gateway):
-        with db.get_lock('attribute/instance', self.uuid, 'routing',
-                         op='Update floating gateway'):
+        with self.get_lock_attr('routing', 'Update floating gateway'):
             routing = self.routing
             routing['floating_gateway'] = gateway
             self._db_set_attribute('routing', routing)

--- a/shakenfist/tests/test_virt.py
+++ b/shakenfist/tests/test_virt.py
@@ -116,6 +116,8 @@ class VirtMetaTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertEqual('uuid42', inst.uuid)
         self.assertEqual(2, inst.version)
         self.assertEqual({'memory': 16384, 'model': 'cirrus'}, inst.video)
+        self.assertEqual('/a/b/c/instances/uuid42', inst.instance_path)
+        self.assertEqual('/a/b/c/instances/uuid42/libvirt.xml', inst.xml_file)
 
 
 class InstanceTestCase(test_shakenfist.ShakenFistTestCase):
@@ -294,12 +296,7 @@ class InstanceTestCase(test_shakenfist.ShakenFistTestCase):
                          etcd_write[1]['power_state_previous'])
 
     def test_helpers(self):
-        self.assertEqual('/a/b/c/instances/fakeuuid',
-                         virt.instance_path('fakeuuid'))
-        self.assertEqual('/a/b/c/snapshots',
-                         virt._snapshot_path('fakeuuid'))
-        self.assertEqual('/a/b/c/instances/fakeuuid/libvirt.xml',
-                         virt._xml_file('fakeuuid'))
+        self.assertEqual('/a/b/c/snapshots', virt._snapshot_path())
 
     def test_str(self):
         i = self._make_instance()

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -803,7 +803,7 @@ class Instance(baseobject.DatabaseBackedObject):
         self.add_event('unpause', 'complete')
 
     def get_console_data(self, length):
-        console_path = os.path.join(self.instance_path(), 'console.log')
+        console_path = os.path.join(self.instance_path, 'console.log')
         if not os.path.exists(console_path):
             return ''
 

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -288,11 +288,11 @@ class Instance(baseobject.DatabaseBackedObject):
         return self._db_get_attribute('block_devices')
 
     # Implementation
-    def get_lock(self, name, op):
+    def get_lock_attr(self, name, op):
         return db.get_lock('attribute/instance', self.uuid, name, op=op)
 
     def place_instance(self, location):
-        with self.get_lock('placement', 'Instance placement'):
+        with self.get_lock_attr('placement', 'Instance placement'):
             # We don't write unchanged things to the database
             placement = self.placement
             if placement.get('node') == location:
@@ -305,14 +305,14 @@ class Instance(baseobject.DatabaseBackedObject):
             self.add_event('placement', None, None, location)
 
     def enforced_deletes_increment(self):
-        with self.get_lock('enforced_deletes',
-                           'Instance enforced deletes increment'):
+        with self.get_lock_attr('enforced_deletes',
+                                'Instance enforced deletes increment'):
             enforced_deletes = self.enforced_deletes
             enforced_deletes['count'] = enforced_deletes.get('count', 0) + 1
             self._db_set_attribute('enforced_deletes', enforced_deletes)
 
     def update_power_state(self, state):
-        with self.get_lock('power_state', 'Instance power state update'):
+        with self.get_lock_attr('power_state', 'Instance power state update'):
             # We don't write unchanged things to the database
             dbstate = self.power_state
             if dbstate.get('power_state') == state:
@@ -409,7 +409,7 @@ class Instance(baseobject.DatabaseBackedObject):
         etcd.delete_all('event/instance', self.uuid)
 
     def allocate_instance_ports(self):
-        with self.get_lock('ports', 'Instance port allocation'):
+        with self.get_lock_attr('ports', 'Instance port allocation'):
             ports = self.ports
             if not ports:
                 self.ports = {
@@ -418,7 +418,7 @@ class Instance(baseobject.DatabaseBackedObject):
                 }
 
     def _configure_block_devices(self, lock):
-        with self.get_lock('block_devices', 'Initialize block devices'):
+        with self.get_lock_attr('block_devices', 'Initialize block devices'):
             # Create block devices if required
             block_devices = self.block_devices
             if not block_devices:

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -288,9 +288,6 @@ class Instance(baseobject.DatabaseBackedObject):
         return self._db_get_attribute('block_devices')
 
     # Implementation
-    def get_lock_attr(self, name, op):
-        return db.get_lock('attribute/instance', self.uuid, name, op=op)
-
     def place_instance(self, location):
         with self.get_lock_attr('placement', 'Instance placement'):
             # We don't write unchanged things to the database

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,flake8,cover
+envlist = py38,flake8,cover
 
 [testenv]
 deps =
@@ -30,9 +30,9 @@ envdir = {toxworkdir}/shared
 commands =
   bash tools/flake8wrap.sh -HEAD
 
-[testenv:py37]
+[testenv:py38]
 description =
-  Run python3.7 unit tests
+  Run python3.8 unit tests
 
 [testenv:cover]
 description =


### PR DESCRIPTION
* Avoid crashing daemon when VXLAN already exists. This should occur until Issue #609 is fixed.
* Minor instance property methods
* Start moving lock names to one location
* Avoid client errors return floating_gateway in net. This will return None initially since it has not been assigned but 
    subsequent requests give correct data. PR will be raised to request floating_gateway be assigned on instantiation, rather than network creation on network node.

The removal of hard coded attribute lock names uncovered a subtle bug at shakenfist/net.py#213