### PR TITLE
Correctly generate the weird not-quite uuids that images use.

### DIFF
--- a/shakenfist/images.py
+++ b/shakenfist/images.py
@@ -357,8 +357,9 @@ class Images(object):
         self.filters = filters
 
     def __iter__(self):
-        for _, i in etcd.get_all('image', None):
-            i = Image.from_db(i['uuid'])
+        for key, i in etcd.get_all('image', None):
+            image_node = '/'.join(key.split('/')[-2:])
+            i = Image.from_db(image_node)
             if not i:
                 continue
 

--- a/shakenfist/tests/test_scheduler.py
+++ b/shakenfist/tests/test_scheduler.py
@@ -396,8 +396,10 @@ class FindMostTestCase(SchedulerTestCase):
                 new_callable=mock.PropertyMock)
     @mock.patch('shakenfist.etcd.get_all',
                 return_value=[
-                    (None, {'uuid': '095fdd2b66625412aa/node2'}),
-                    (None, {'uuid': 'aca41cefa18b052074e092/node3'})
+                    ('/sf/image/095fdd2b66625412aa/node2',
+                     {'uuid': '095fdd2b66625412aa/node2'}),
+                    ('/sf/image/aca41cefa18b052074e092/node3',
+                     {'uuid': 'aca41cefa18b052074e092/node3'})
                 ])
     @mock.patch('shakenfist.images.Image.from_db',
                 side_effect=[
@@ -434,12 +436,18 @@ class FindMostTestCase(SchedulerTestCase):
                 new_callable=mock.PropertyMock)
     @mock.patch('shakenfist.etcd.get_all',
                 return_value=[
-                    (None, {'uuid': '095fdd2b66625412aa/node1_net'}),
-                    (None, {'uuid': '095fdd2b66635412aa/node1_net'}),
-                    (None, {'uuid': '095fdd2b66625412aa/node2'}),
-                    (None, {'uuid': '095fdd2b66625712a/node3'}),
-                    (None, {'uuid': '095fdd2b66625482aa/node4'}),
-                    (None, {'uuid': 'aca41cefa18b052974e092/node4'})
+                    ('/sf/image/095fdd2b66625412aa/node1_net',
+                     {'uuid': '095fdd2b66625412aa/node1_net'}),
+                    ('/sf/image/095fdd2b66635412aa/node1_net',
+                     {'uuid': '095fdd2b66635412aa/node1_net'}),
+                    ('/sf/image/095fdd2b66625412aa/node2',
+                     {'uuid': '095fdd2b66625412aa/node2'}),
+                    ('/sf/image/095fdd2b66625712a/node3',
+                     {'uuid': '095fdd2b66625712a/node3'}),
+                    ('/sf/image/095fdd2b66625482aa/node4',
+                     {'uuid': '095fdd2b66625482aa/node4'}),
+                    ('/sf/image/aca41cefa18b052974e092/node4',
+                     {'uuid': 'aca41cefa18b052974e092/node4'})
                 ])
     @mock.patch('shakenfist.images.Image.from_db',
                 side_effect=[
@@ -503,12 +511,18 @@ class FindMostTestCase(SchedulerTestCase):
                 new_callable=mock.PropertyMock)
     @mock.patch('shakenfist.etcd.get_all',
                 return_value=[
-                    (None, {'uuid': '095fdd2b66625412aa/node1_net'}),
-                    (None, {'uuid': '095fdd2b66635412aa/node1_net'}),
-                    (None, {'uuid': '095fdd2b66625412aa/node2'}),
-                    (None, {'uuid': '095fdd2b66625712a/node3'}),
-                    (None, {'uuid': '095fdd2b66625482aa/node4'}),
-                    (None, {'uuid': 'aca41cefa18b052974e092/node4'})
+                    ('/sf/image/095fdd2b66625412aa/node1_net',
+                     {'uuid': '095fdd2b66625412aa/node1_net'}),
+                    ('/sf/image/095fdd2b66635412aa/node1_net',
+                     {'uuid': '095fdd2b66635412aa/node1_net'}),
+                    ('/sf/image/095fdd2b66625412aa/node2',
+                     {'uuid': '095fdd2b66625412aa/node2'}),
+                    ('/sf/image/095fdd2b66625712a/node3',
+                     {'uuid': '095fdd2b66625712a/node3'}),
+                    ('/sf/image/095fdd2b66625482aa/node4',
+                     {'uuid': '095fdd2b66625482aa/node4'}),
+                    ('/sf/image/aca41cefa18b052974e092/node4',
+                     {'uuid': 'aca41cefa18b052974e092/node4'})
                 ])
     @mock.patch('shakenfist.images.Image.from_db',
                 side_effect=[
@@ -614,12 +628,18 @@ class FindMostTestCase(SchedulerTestCase):
                 new_callable=mock.PropertyMock)
     @mock.patch('shakenfist.etcd.get_all',
                 return_value=[
-                    (None, {'uuid': '095fdd2b66625412aa/node1_net'}),
-                    (None, {'uuid': '095fdd2b66635412aa/node1_net'}),
-                    (None, {'uuid': '095fdd2b66625412aa/node2'}),
-                    (None, {'uuid': '095fdd2b66625712a/node3'}),
-                    (None, {'uuid': '095fdd2b66625482aa/node4'}),
-                    (None, {'uuid': 'aca41cefa18b052974e092/node4'})
+                    ('/sf/image/095fdd2b66625412aa/node1_net',
+                     {'uuid': '095fdd2b66625412aa/node1_net'}),
+                    ('/sf/image/095fdd2b66635412aa/node1_net',
+                     {'uuid': '095fdd2b66635412aa/node1_net'}),
+                    ('/sf/image/095fdd2b66625412aa/node2',
+                     {'uuid': '095fdd2b66625412aa/node2'}),
+                    ('/sf/image/095fdd2b66625712a/node3',
+                     {'uuid': '095fdd2b66625712a/node3'}),
+                    ('/sf/image/095fdd2b66625482aa/node4',
+                     {'uuid': '095fdd2b66625482aa/node4'}),
+                    ('/sf/image/aca41cefa18b052974e092/node4',
+                     {'uuid': 'aca41cefa18b052974e092/node4'})
                 ])
     @mock.patch('shakenfist.images.Image.from_db',
                 side_effect=[


### PR DESCRIPTION
The iterator needs to understand how to create the per-machine uuids
that we use for images, instead of just plain old vanilla uuids.
Fixes #631.