### PR TITLE
Lock networks to prevent deletion during creation

### DIFF
--- a/shakenfist/baseobject.py
+++ b/shakenfist/baseobject.py
@@ -72,6 +72,12 @@ class DatabaseBackedObject(object):
     def _db_set_attribute(self, attribute, value):
         etcd.put('attribute/%s' % self.object_type, self.__uuid, attribute, value)
 
+    def get_lock(self, subtype=None, ttl=60, timeout=db.ETCD_ATTEMPT_TIMEOUT,
+                 relatedobjects=None, log_ctx=LOG, op=None):
+        return db.get_lock(self.object_type, subtype, self.uuid, ttl=ttl,
+                           timeout=timeout, relatedobjects=relatedobjects,
+                           log_ctx=log_ctx, op=op)
+
     def get_lock_attr(self, name, op):
         return db.get_lock('attribute/%s' % self.object_type,
                            self.__uuid, name, op=op)

--- a/shakenfist/baseobject.py
+++ b/shakenfist/baseobject.py
@@ -78,31 +78,29 @@ class DatabaseBackedObject(object):
     # Properties common to all objects which are routed to attributes
     @property
     def state(self):
-        return self._db_get_attribute('state')
+        db_data = self._db_get_attribute('state')
+        if not db_data:
+            return State(None, 0)
+        return State(**db_data)
 
     def update_state(self, state, error_message=None):
+        LOG.withField('state', state).error('update_state()')
         with self.get_lock_attr('state', 'State update'):
-            dbstate = self.state
-            orig_state = dbstate.get('state')
+            orig = self.state
 
             # Ensure state change is valid
-            if state not in self.state_targets[orig_state]:
+            if state not in self.state_targets[orig.state]:
                 raise exceptions.InvalidStateException(
                     'Invalid state change from %s to %s for object=%s uuid=%s',
                     orig_state, state, self.object_type, self.uuid)
 
-            dbstate['state'] = state
-            dbstate['state_updated'] = time.time()
-
-            if error_message:
-                dbstate['error_message'] = error_message
-
-            self._db_set_attribute('state', dbstate)
-            self.add_event('state changed', '%s -> %s' % (orig_state, state))
+            new = State(state, time.time(), error_message)
+            self._db_set_attribute('state', new)
+            self.add_event('state changed', '%s -> %s' % (orig.state, state))
 
 
 def state_filter(states, o):
-    return o.state.get('state') in states
+    return o.state.state in states
 
 
 active_states_filter = partial(
@@ -111,11 +109,45 @@ inactive_states_filter = partial(state_filter, ['error', 'deleted'])
 
 
 def state_age_filter(delay, o):
-    now = time.time()
-    return (now - o.state.get('state_updated', now)) > delay
+    return (time.time() - o.state.update_time) > delay
 
 
 def namespace_filter(namespace, o):
     if namespace == 'system':
         return True
     return o.namespace == namespace
+
+
+class State(object):
+    def __init__(self, state, update_time, error_msg=None):
+        self.__state = state
+        self.__update_time = update_time
+        self.__error_msg = error_msg
+
+    def __repr__(self):
+        return 'State(' + str(self.json_dump()) + ')'
+
+    def __eq__(self, other):
+        return self.__hash__() == other.__hash__()
+
+    def __hash__(self):
+        return hash(str(self.json_dump()))
+
+    @property
+    def state(self):
+        return self.__state
+
+    @property
+    def update_time(self):
+        return self.__update_time
+
+    @property
+    def error_msg(self):
+        return self.__error_msg
+
+    def json_dump(self):
+        return {
+            'state': self.__state,
+            'update_time': self.__update_time,
+            'error_msg': self.__error_msg,
+        }

--- a/shakenfist/baseobject.py
+++ b/shakenfist/baseobject.py
@@ -125,13 +125,13 @@ class State(object):
         self.__error_msg = error_msg
 
     def __repr__(self):
-        return 'State(' + str(self.json_dump()) + ')'
+        return 'State(' + str(self.obj_dict()) + ')'
 
     def __eq__(self, other):
         return self.__hash__() == other.__hash__()
 
     def __hash__(self):
-        return hash(str(self.json_dump()))
+        return hash(str(self.obj_dict()))
 
     @property
     def value(self):
@@ -145,7 +145,7 @@ class State(object):
     def error_msg(self):
         return self.__error_msg
 
-    def json_dump(self):
+    def obj_dict(self):
         return {
             'value': self.__value,
             'update_time': self.__update_time,

--- a/shakenfist/baseobject.py
+++ b/shakenfist/baseobject.py
@@ -125,10 +125,11 @@ class DatabaseBackedObject(object):
 
     @error_msg.setter
     def error_msg(self, msg):
-        if self.state.state != 'error':
+        s = self.state
+        if s.value != 'error':
             raise exceptions.InvalidStateException(
                 'Object not in error state (state=%s, object=%s)' % (
-                    self.state, self.object_type))
+                    s, self.object_type))
         self._db_set_attribute('error_msg', msg)
 
 

--- a/shakenfist/baseobject.py
+++ b/shakenfist/baseobject.py
@@ -116,6 +116,21 @@ class DatabaseBackedObject(object):
                     s, self.object_type))
         self._db_set_attribute('error_msg', msg)
 
+    @property
+    def error_msg(self):
+        db_data = self._db_get_attribute('error_msg')
+        if not db_data:
+            return None
+        return db_data
+
+    @error_msg.setter
+    def error_msg(self, msg):
+        if self.state.state != 'error':
+            raise exceptions.InvalidStateException(
+                'Object not in error state (state=%s, object=%s)' % (
+                    self.state, self.object_type))
+        self._db_set_attribute('error_msg', msg)
+
 
 def state_filter(states, o):
     return o.state.value in states

--- a/shakenfist/client/upgrade.py
+++ b/shakenfist/client/upgrade.py
@@ -124,7 +124,7 @@ def main():
                     new = baseobject.State('created', time.time())
                     etcd_client.put(
                         '/sf/attribute/network/%s/state' % n['uuid'],
-                        json.dumps(new.json_dump(), indent=4, sort_keys=True))
+                        json.dumps(new.obj_dict(), indent=4, sort_keys=True))
 
                     network['version'] = 2
                     etcd_client.put(
@@ -168,7 +168,7 @@ def main():
                         instance.pop(attr, None)
                     etcd_client.put(
                         '/sf/attribute/instance/%s/state' % instance['uuid'],
-                        json.dumps(state.json_dump(), indent=4, sort_keys=True))
+                        json.dumps(state.obj_dict(), indent=4, sort_keys=True))
 
                     data = {}
                     for attr in ['power_state', 'power_state_previous',
@@ -238,7 +238,7 @@ def main():
                     new = baseobject.State('created', time.time())
                     etcd_client.put(
                         '/sf/attribute/image/%s/state' % image_node,
-                        json.dumps(new.json_dump(), indent=4, sort_keys=True))
+                        json.dumps(new.obj_dict(), indent=4, sort_keys=True))
 
                     image['uuid'] = image_node
                     image['ref'], image['node'] = image_node.split('/')

--- a/shakenfist/daemons/cleaner.py
+++ b/shakenfist/daemons/cleaner.py
@@ -78,7 +78,7 @@ class Monitor(daemon.Daemon):
                 state = util.extract_power_state(libvirt, domain)
                 instance.update_power_state(state)
                 if state == 'crashed':
-                    instance.update_state('error')
+                    instance.state = 'error'
 
             # Inactive VMs just have a name, and are powered off
             # in our state system.
@@ -115,14 +115,14 @@ class Monitor(daemon.Daemon):
 
                     instance.place_instance(config.NODE_NAME)
 
-                    dbpowerstate = instance.power_state
+                    db_power = instance.power_state
                     if not os.path.exists(instance.instance_path):
                         # If we're inactive and our files aren't on disk,
                         # we have a problem.
                         log_ctx.info('Detected error state for instance')
-                        instance.update_state('error')
+                        instance.state = 'error'
 
-                    elif dbpowerstate['power_state'] != 'off':
+                    elif not db_power or db_power['power_state'] != 'off':
                         log_ctx.info('Detected power off for instance')
                         instance.update_power_state('off')
                         instance.add_event('detected poweroff', 'complete')

--- a/shakenfist/daemons/cleaner.py
+++ b/shakenfist/daemons/cleaner.py
@@ -47,11 +47,11 @@ class Monitor(daemon.Daemon):
                 seen.append(domain.name())
 
                 dbstate = instance.state
-                if dbstate.get('state') == 'deleted':
+                if dbstate.state == 'deleted':
                     # NOTE(mikal): a delete might be in-flight in the queue.
                     # We only worry about instances which should have gone
                     # away five minutes ago.
-                    if time.time() - dbstate['state_updated'] < 300:
+                    if time.time() - dbstate.update_time < 300:
                         continue
 
                     instance.enforced_deletes_increment()
@@ -100,11 +100,11 @@ class Monitor(daemon.Daemon):
                         continue
 
                     dbstate = instance.state
-                    if dbstate.get('state') == 'deleted':
+                    if dbstate.state == 'deleted':
                         # NOTE(mikal): a delete might be in-flight in the queue.
                         # We only worry about instances which should have gone
                         # away five minutes ago.
-                        if time.time() - instance['state_updated'] < 300:
+                        if time.time() - dbstate.update_time < 300:
                             continue
 
                         domain = conn.lookupByName(domain_name)

--- a/shakenfist/daemons/cleaner.py
+++ b/shakenfist/daemons/cleaner.py
@@ -46,12 +46,12 @@ class Monitor(daemon.Daemon):
                 instance.place_instance(config.NODE_NAME)
                 seen.append(domain.name())
 
-                dbstate = instance.state
-                if dbstate.state == 'deleted':
+                db_state = instance.state
+                if db_state.value == 'deleted':
                     # NOTE(mikal): a delete might be in-flight in the queue.
                     # We only worry about instances which should have gone
                     # away five minutes ago.
-                    if time.time() - dbstate.update_time < 300:
+                    if time.time() - db_state.update_time < 300:
                         continue
 
                     instance.enforced_deletes_increment()
@@ -99,12 +99,12 @@ class Monitor(daemon.Daemon):
                         domain.undefine()
                         continue
 
-                    dbstate = instance.state
-                    if dbstate.state == 'deleted':
+                    db_state = instance.state
+                    if db_state.value == 'deleted':
                         # NOTE(mikal): a delete might be in-flight in the queue.
                         # We only worry about instances which should have gone
                         # away five minutes ago.
-                        if time.time() - dbstate.update_time < 300:
+                        if time.time() - db_state.update_time < 300:
                             continue
 
                         domain = conn.lookupByName(domain_name)

--- a/shakenfist/daemons/main.py
+++ b/shakenfist/daemons/main.py
@@ -58,9 +58,10 @@ def restore_instances():
         for network in networks:
             try:
                 n = net.Network.from_db(network)
-                LOG.withObj(n).info('Restoring network')
-                n.create_on_hypervisor()
-                n.ensure_mesh()
+                if not n.is_dead():
+                    LOG.withObj(n).info('Restoring network')
+                    n.create_on_hypervisor()
+                    n.ensure_mesh()
             except Exception as e:
                 util.ignore_exception('restore network %s' % network, e)
 

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -66,8 +66,7 @@ class Monitor(daemon.Daemon):
                     if not inst:
                         stray = True
                     else:
-                        dbstate = inst.state
-                        if dbstate.get('state') in ['deleted', 'error', 'unknown']:
+                        if inst.state.state in ['deleted', 'error', 'unknown']:
                             stray = True
 
                     if stray:
@@ -85,7 +84,7 @@ class Monitor(daemon.Daemon):
 
                 seen_vxids.append(n.vxid)
 
-                if time.time() - n.state.get('state_updated', time.time()) < 60:
+                if time.time() - n.state.update_time < 60:
                     # Network state changed in the last minute, punt for now
                     continue
 

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -66,7 +66,7 @@ class Monitor(daemon.Daemon):
                     if not inst:
                         stray = True
                     else:
-                        if inst.state.state in ['deleted', 'error', 'unknown']:
+                        if inst.state.value in ['deleted', 'error', 'unknown']:
                             stray = True
 
                     if stray:

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -215,7 +215,7 @@ def instance_start(instance_uuid, network):
                         instance_uuid, 'missing network: %s' % netdesc['network_uuid'])
                     return
 
-                if n.state['state'] != 'created':
+                if n.state.state != 'created':
                     db.enqueue_instance_error(
                         instance_uuid, 'network is not active: %s' % n.uuid)
 

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -84,13 +84,13 @@ def handle(jobname, workitem):
 
             elif isinstance(task, DeleteInstanceTask):
                 try:
-                    instance_delete(instance_uuid, 'deleted')
+                    instance_delete(instance_uuid)
                 except Exception as e:
                     util.ignore_exception(daemon.process_name('queues'), e)
 
             elif isinstance(task, ErrorInstanceTask):
                 try:
-                    instance_delete(instance_uuid, 'error', task.error_msg())
+                    instance_error(instance_uuid, task.error_msg())
                     db.enqueue('%s-metrics' % config.NODE_NAME, {})
                 except Exception as e:
                     util.ignore_exception(daemon.process_name('queues'), e)
@@ -157,7 +157,7 @@ def instance_preflight(instance_uuid, network):
     if not instance:
         raise exceptions.InstanceNotInDBException(instance_uuid)
 
-    instance.update_state('preflight')
+    instance.state = 'preflight'
 
     # Try to place on this node
     s = scheduler.Scheduler()
@@ -243,7 +243,7 @@ def instance_start(instance_uuid, network):
             db.update_network_interface_state(iface['uuid'], 'created')
 
 
-def instance_delete(instance_uuid, new_state, error_msg=None):
+def instance_delete(instance_uuid):
     with db.get_lock('instance', None, instance_uuid, timeout=120,
                      op='Instance delete'):
         db.add_event('instance', instance_uuid, 'queued', 'delete', None, None)
@@ -265,9 +265,6 @@ def instance_delete(instance_uuid, new_state, error_msg=None):
         instance = virt.Instance.from_db(instance_uuid)
         if instance:
             instance.delete()
-            instance.update_state(new_state)
-            if error_msg:
-                instance.error_msg = error_msg
 
         # Check each network used by the deleted instance
         for network in instance_networks:
@@ -282,6 +279,14 @@ def instance_delete(instance_uuid, new_state, error_msg=None):
                     # Network not used by any other instance therefore delete
                     with util.RecordedOperation('remove network', n):
                         n.delete()
+        return instance
+
+
+def instance_error(instance_uuid, error_msg):
+    instance = instance_delete(instance_uuid)
+    if instance:
+        instance.state = 'error'
+        instance.error_msg = error_msg
 
 
 class Monitor(daemon.Daemon):

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -265,7 +265,9 @@ def instance_delete(instance_uuid, new_state, error_msg=None):
         instance = virt.Instance.from_db(instance_uuid)
         if instance:
             instance.delete()
-            instance.update_state(new_state, error_message=error_msg)
+            instance.update_state(new_state)
+            if error_msg:
+                instance.error_msg = error_msg
 
         # Check each network used by the deleted instance
         for network in instance_networks:

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -215,7 +215,7 @@ def instance_start(instance_uuid, network):
                         instance_uuid, 'missing network: %s' % netdesc['network_uuid'])
                     return
 
-                if n.state.state != 'created':
+                if n.state.value != 'created':
                     db.enqueue_instance_error(
                         instance_uuid, 'network is not active: %s' % n.uuid)
 

--- a/shakenfist/db.py
+++ b/shakenfist/db.py
@@ -11,8 +11,7 @@ from shakenfist import util
 from shakenfist.tasks import DeleteInstanceTask, ErrorInstanceTask
 
 
-# TODO(andy): Change back to 5 once network bugs fixed
-ETCD_ATTEMPT_TIMEOUT = 15
+ETCD_ATTEMPT_TIMEOUT = 60
 
 
 LOG, _ = logutil.setup(__name__)
@@ -67,17 +66,7 @@ def get_network_node():
 def get_lock(objecttype, subtype, name, ttl=60, timeout=ETCD_ATTEMPT_TIMEOUT,
              relatedobjects=None, log_ctx=LOG, op=None):
     return etcd.get_lock(objecttype, subtype, name, ttl=ttl, timeout=timeout,
-                         log_ctx=log_ctx, op=None)
-
-
-def get_object_lock(obj, ttl=60, timeout=ETCD_ATTEMPT_TIMEOUT,
-                    relatedobjects=None, log_ctx=LOG, op=None):
-    obj_type, obj_name = obj.unique_label()
-    if not (obj_type and obj_name):
-        raise exceptions.LockException(
-            'Could not derive lock name from %s' % obj)
-    return get_lock(obj_type, None, obj_name, ttl=ttl, timeout=timeout,
-                    relatedobjects=relatedobjects, log_ctx=log_ctx, op=op)
+                         log_ctx=log_ctx, op=op)
 
 
 def refresh_lock(lock, relatedobjects=None, log_ctx=LOG):

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -116,6 +116,7 @@ class ActualLock(Lock):
                                          'threshold': threshold,
                                          'holder-pid': pid,
                                          'holder-node': node,
+                                         'requesting-op': self.operation,
                                          }).info('Waiting for lock')
                 slow_warned = True
 
@@ -130,6 +131,7 @@ class ActualLock(Lock):
         self.log_ctx.withFields({'duration': duration,
                                  'holder-pid': pid,
                                  'holder-node': node,
+                                 'requesting-op': self.operation,
                                  }).info('Failed to acquire lock')
 
         raise exceptions.LockException(
@@ -138,6 +140,10 @@ class ActualLock(Lock):
 
     def __exit__(self, _exception_type, _exception_value, _traceback):
         if not self.release():
+            locks = list(get_all(LOCK_PREFIX, None))
+            self.log_ctx.withFields({'locks': locks,
+                                     'key': self.name,
+                                     }).error('Cannot release lock')
             raise exceptions.LockException(
                 'Cannot release lock: %s' % self.name)
 

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -208,9 +208,9 @@ def _construct_key(objecttype, subtype, name):
 class JSONEncoderTasks(json.JSONEncoder):
     def default(self, obj):
         if QueueTask.__subclasscheck__(type(obj)):
-            return obj.json_dump()
+            return obj.obj_dict()
         if type(obj) is baseobject.State:
-            return obj.json_dump()
+            return obj.obj_dict()
         return json.JSONEncoder.default(self, obj)
 
 

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -13,6 +13,7 @@ from shakenfist import exceptions
 from shakenfist import logutil
 from shakenfist import util
 from shakenfist.tasks import QueueTask
+from shakenfist import baseobject
 
 
 ####################################################################
@@ -207,6 +208,8 @@ def _construct_key(objecttype, subtype, name):
 class JSONEncoderTasks(json.JSONEncoder):
     def default(self, obj):
         if QueueTask.__subclasscheck__(type(obj)):
+            return obj.json_dump()
+        if type(obj) is baseobject.State:
             return obj.json_dump()
         return json.JSONEncoder.default(self, obj)
 

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -1157,16 +1157,14 @@ def _delete_network(network_from_db):
         return error(404, 'network does not exist')
 
     if n.is_dead():
+        # The network has been deleted. No need to attempt further effort.
         LOG.withFields({'network_uuid': n.uuid,
                         'state': n.state.value
                         }).warning('delete_network: network is dead')
         return error(404, 'network is deleted')
 
-    n.state = 'deleting'
     n.add_event('api', 'delete')
-    n.remove_dhcp()
     n.delete()
-    n.state = 'deleted'
 
 
 class Network(Resource):
@@ -1351,15 +1349,14 @@ class NetworkPing(Resource):
         if not n:
             return error(404, 'network %s not found' % network_uuid)
 
-        with db.get_object_lock(n, ttl=120, op='Network ping via API'):
-            out, err = util.execute(
-                None, 'ip netns exec %s ping -c 10 %s' % (
-                    network_uuid, address),
-                check_exit_code=[0, 1])
-            return {
-                'stdout': out,
-                'stderr': err
-            }
+        out, err = util.execute(
+            None, 'ip netns exec %s ping -c 10 %s' % (
+                network_uuid, address),
+            check_exit_code=[0, 1])
+        return {
+            'stdout': out,
+            'stderr': err
+        }
 
 
 class Nodes(Resource):

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -1162,11 +1162,11 @@ def _delete_network(network_from_db):
                         }).warning('delete_network: network is dead')
         return error(404, 'network is deleted')
 
-    n.update_state('deleting')
+    n.state = 'deleting'
     n.add_event('api', 'delete')
     n.remove_dhcp()
     n.delete()
-    n.update_state('deleted')
+    n.state = 'deleted'
 
 
 class Network(Resource):

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -242,7 +242,7 @@ def requires_instance_active(func):
             return error(404, 'instance not found')
 
         i = kwargs['instance_from_db']
-        if i.state.state in ['initial', 'preflight', 'creating']:
+        if i.state.value in ['initial', 'preflight', 'creating']:
             LOG.withInstance(i).info('Instance not active')
             return error(406, 'instance not active')
 
@@ -320,7 +320,8 @@ def requires_network_active(func):
             log.info('Network not found, kwarg missing')
             return error(404, 'network not found')
 
-        if kwargs['network_from_db'].state.state in ['initial', 'preflight', 'creating']:
+        state = kwargs['network_from_db'].state
+        if state.value in ['initial', 'preflight', 'creating']:
             log.info('Network not active')
             return error(406, 'network not active')
 
@@ -465,7 +466,7 @@ class AuthNamespace(Resource):
         instances = []
         deleted_instances = []
         for i in virt.Instances([partial(baseobject.namespace_filter, namespace)]):
-            if i.state.state in ['deleted', 'error']:
+            if i.state.value in ['deleted', 'error']:
                 deleted_instances.append(i.uuid)
             else:
                 instances.append(i.uuid)
@@ -478,7 +479,7 @@ class AuthNamespace(Resource):
             # They in a transient state. If they hang in that state we want to
             # know. They will block deletion of a namespace thus giving notice
             # of the problem.
-            if n.state.state not in ['deleted', 'error']:
+            if n.state.value not in ['deleted', 'error']:
                 networks.append(n.uuid)
         if len(networks) > 0:
             return error(400, 'you cannot delete a namespace with networks')
@@ -606,7 +607,7 @@ class Instance(Resource):
     @requires_instance_ownership
     def delete(self, instance_uuid=None, instance_from_db=None):
         # Check if instance has already been deleted
-        if instance_from_db.state.state == 'deleted':
+        if instance_from_db.state.value == 'deleted':
             return error(404, 'instance not found')
 
         # If this instance is not on a node, just do the DB cleanup locally
@@ -620,7 +621,7 @@ class Instance(Resource):
 
         start_time = time.time()
         while time.time() - start_time < config.get('API_ASYNC_WAIT'):
-            if instance_from_db.state.state in ['deleted', 'error']:
+            if instance_from_db.state.value in ['deleted', 'error']:
                 return
 
             time.sleep(0.5)
@@ -681,7 +682,7 @@ class Instances(Resource):
                                      'range of the network')
 
                 n = net.Network.from_db(netdesc['network_uuid'])
-                if n.state.state in ['initial', 'preflight', 'creating']:
+                if n.state.value in ['initial', 'preflight', 'creating']:
                     return error(406, 'network %s is not active' % n.uuid)
 
         if not video:
@@ -794,7 +795,7 @@ class Instances(Resource):
         # after a while and just return the current state
         start_time = time.time()
         while time.time() - start_time < config.get('API_ASYNC_WAIT'):
-            if instance.state.state in ['created', 'deleted', 'error']:
+            if instance.state.value in ['created', 'deleted', 'error']:
                 return instance.external_view()
             time.sleep(0.5)
         return instance.external_view()
@@ -840,7 +841,7 @@ class Instances(Resource):
         while (waiting_for and
                (time.time() - start_time < config.get('API_ASYNC_WAIT'))):
             for instance in copy.copy(waiting_for):
-                s = instance.state.state
+                s = instance.state.value
                 if s in ['deleted', 'error']:
                     waiting_for.remove(instance)
                 else:
@@ -1157,7 +1158,7 @@ def _delete_network(network_from_db):
 
     if n.is_dead():
         LOG.withFields({'network_uuid': n.uuid,
-                        'state': n.state.state
+                        'state': n.state.value
                         }).warning('delete_network: network is dead')
         return error(404, 'network is deleted')
 
@@ -1188,7 +1189,7 @@ class Network(Resource):
             return error(403, 'you cannot delete an in use network')
 
         # Check if network has already been deleted
-        if network_from_db.state.state in 'deleted':
+        if network_from_db.state.value in 'deleted':
             return error(404, 'network not found')
 
         return _delete_network(network_from_db)

--- a/shakenfist/images.py
+++ b/shakenfist/images.py
@@ -78,7 +78,7 @@ class Image(baseobject.DatabaseBackedObject):
             'version': cls.current_version
         })
         i = Image.from_db(uuid)
-        i.update_state('initial')
+        i.state = 'initial'
         i.update_checksum(checksum)
         i.add_event('db record creation', None)
         return i
@@ -201,7 +201,7 @@ class Image(baseobject.DatabaseBackedObject):
         # without verifying that no instance is using it, so we just mark the
         # image as deleted in the database and move on without removing things
         # from the cache. We will probably want to revisit this in the future.
-        self.update_state('deleted')
+        self.state = 'deleted'
 
     def get(self, locks, related_object):
         """Wrap three retries around the image get.
@@ -210,15 +210,15 @@ class Image(baseobject.DatabaseBackedObject):
         download, the locks will be refreshed. Any lock error should abort the
         get, since the lock will have been lost.
         """
-        self.update_state('creating')
+        self.state = 'creating'
         for _ in range(3):
             try:
                 image_path = self._get(locks, related_object)
-                self.update_state('created')
+                self.state = 'created'
                 return image_path
             except exceptions.BadCheckSum as e:
                 LOG.warning('Bad checksum while downloading image: %s' % e)
-                self.update_state('error')
+                self.state = 'error'
                 self.error_msg = 'Bad checksum while downloading image: %s' % e
                 exc = e
         raise exc

--- a/shakenfist/images.py
+++ b/shakenfist/images.py
@@ -32,7 +32,7 @@ class Image(baseobject.DatabaseBackedObject):
     object_type = 'image'
     current_version = 2
     state_targets = {
-        None: ('initial', ),
+        None: ('initial', 'creating'),
         'initial': ('initial', 'creating', 'error'),
         # TODO(andy): This is broken but will be accepted until Image class is
         # refactored. (hey, at least the state names will be valid)
@@ -150,10 +150,11 @@ class Image(baseobject.DatabaseBackedObject):
             'url': self.url,
             'node': self.node,
             'ref': self.unique_ref,
+            'state': self.state.value,
             'version': self.version
         }
 
-        for attrname in ['state', 'latest_checksum']:
+        for attrname in ['latest_checksum']:
             d = self._db_get_attribute(attrname)
             for key in d:
                 # We skip keys with no value

--- a/shakenfist/images.py
+++ b/shakenfist/images.py
@@ -32,8 +32,8 @@ class Image(baseobject.DatabaseBackedObject):
     object_type = 'image'
     current_version = 2
     state_targets = {
-        None: ('initial', 'error'),
-        'initial': ('creating', 'error'),
+        None: ('initial', ),
+        'initial': ('initial', 'creating', 'error'),
         # TODO(andy): This is broken but will be accepted until Image class is
         # refactored. (hey, at least the state names will be valid)
         'creating': ('initial', 'creating', 'created', 'deleted', 'error'),
@@ -217,9 +217,8 @@ class Image(baseobject.DatabaseBackedObject):
                 return image_path
             except exceptions.BadCheckSum as e:
                 LOG.warning('Bad checksum while downloading image: %s' % e)
-                self.update_state(
-                    'error',
-                    error_message='Bad checksum while downloading image: %s' % e)
+                self.update_state('error')
+                self.error_msg = 'Bad checksum while downloading image: %s' % e
                 exc = e
         raise exc
 

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -138,11 +138,12 @@ class Network(baseobject.DatabaseBackedObject):
             'provide_dhcp': self.__provide_dhcp,
             'provide_nat': self.__provide_nat,
             'floating_gateway': self.floating_gateway,
+            'state': self.state.value,
             'vxid': self.__vxid,
             'version': self.version
         }
 
-        for attrname in ['routing', 'state']:
+        for attrname in ['routing']:
             d = self._db_get_attribute(attrname)
             for key in d:
                 # We skip keys with no value
@@ -288,7 +289,7 @@ class Network(baseobject.DatabaseBackedObject):
         callers will wait on a lock before calling this function. In this case
         we definitely need to update the in-memory object model.
         """
-        return self.state.state in ('deleted', 'deleting', 'error')
+        return self.state.value in ('deleted', 'deleting', 'error')
 
     def _create_common(self):
         subst = self.subst_dict()

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -29,6 +29,7 @@ class Network(baseobject.DatabaseBackedObject):
     object_type = 'network'
     current_version = 2
     state_targets = {
+        None: ('initial', ),
         'initial': ('created', 'deleting', 'error'),
         # TODO(andy): Investigate whether networks should created->deleted
         'created': ('created', 'deleting', 'deleted', 'error'),
@@ -99,7 +100,7 @@ class Network(baseobject.DatabaseBackedObject):
         )
 
         n = Network.from_db(uuid)
-        n._db_set_attribute('state', {'state': 'initial'})
+        n.update_state('initial')
         n.add_event('db record creation', None)
 
         # Networks should immediately appear on the network node
@@ -287,7 +288,7 @@ class Network(baseobject.DatabaseBackedObject):
         callers will wait on a lock before calling this function. In this case
         we definitely need to update the in-memory object model.
         """
-        return self.state['state'] in ('deleted', 'deleting', 'error')
+        return self.state.state in ('deleted', 'deleting', 'error')
 
     def _create_common(self):
         subst = self.subst_dict()

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -294,107 +294,98 @@ class Network(baseobject.DatabaseBackedObject):
     def _create_common(self):
         subst = self.subst_dict()
 
-        with db.get_object_lock(self, ttl=120, op='Network create'):
-            # Ensure network was not deleted whilst waiting for the lock.
+        if not util.check_for_interface(subst['vx_interface']):
+            with util.RecordedOperation('create vxlan interface', self):
+                util.create_interface(
+                    subst['vx_interface'], 'vxlan',
+                    'id %(vx_id)s dev %(physical_interface)s dstport 0'
+                    % subst)
+                util.execute(None, 'sysctl -w net.ipv4.conf.'
+                                   '%(vx_interface)s.arp_notify=1' % subst)
+
+        if not util.check_for_interface(subst['vx_bridge']):
+            with util.RecordedOperation('create vxlan bridge', self):
+                util.create_interface(subst['vx_bridge'], 'bridge', '')
+                util.execute(None, 'ip link set %(vx_interface)s '
+                                   'master %(vx_bridge)s' % subst)
+                util.execute(None, 'ip link set %(vx_interface)s up' % subst)
+                util.execute(None, 'ip link set %(vx_bridge)s up' % subst)
+                util.execute(None, 'sysctl -w net.ipv4.conf.'
+                                   '%(vx_bridge)s.arp_notify=1' % subst)
+                util.execute(None, 'brctl setfd %(vx_bridge)s 0' % subst)
+                util.execute(None, 'brctl stp %(vx_bridge)s off' % subst)
+                util.execute(None, 'brctl setageing %(vx_bridge)s 0' % subst)
+
+    def create_on_hypervisor(self):
+        with self.get_lock(op='create_on_hypervisor'):
+            if self.is_dead():
+                raise DeadNetwork('network=%s' % self)
+            self._create_common()
+            db.enqueue('networknode', DeployNetworkTask(self.uuid))
+            self.add_event('deploy', 'enqueued')
+
+    def create_on_network_node(self):
+        with self.get_lock(op='create_on_network_node'):
             if self.is_dead():
                 raise DeadNetwork('network=%s' % self)
 
-            if not util.check_for_interface(subst['vx_interface']):
-                with util.RecordedOperation('create vxlan interface', self):
+            self._create_common()
+
+            subst = self.subst_dict()
+            if not os.path.exists('/var/run/netns/%(netns)s' % subst):
+                with util.RecordedOperation('create netns', self):
+                    util.execute(None, 'ip netns add %(netns)s' % subst)
+
+            if not util.check_for_interface(subst['vx_veth_outer']):
+                with util.RecordedOperation('create router veth', self):
                     util.create_interface(
-                        subst['vx_interface'], 'vxlan',
-                        'id %(vx_id)s dev %(physical_interface)s dstport 0'
-                        % subst)
+                        subst['vx_veth_outer'], 'veth',
+                        'peer name %(vx_veth_inner)s' % subst)
+                    util.execute(
+                        None,
+                        'ip link set %(vx_veth_inner)s netns %(netns)s' % subst)
+                    util.execute(
+                        None,
+                        'brctl addif %(vx_bridge)s %(vx_veth_outer)s' % subst)
+                    util.execute(None, 'ip link set %(vx_veth_outer)s up' % subst)
+                    util.execute(
+                        None,
+                        '%(in_netns)s ip link set %(vx_veth_inner)s up' % subst)
+                    util.execute(
+                        None,
+                        '%(in_netns)s ip addr add %(router)s/%(netmask)s '
+                        'dev %(vx_veth_inner)s' % subst)
+
+            if not util.check_for_interface(subst['physical_veth_outer']):
+                with util.RecordedOperation('create physical veth', self):
+                    util.create_interface(
+                        subst['physical_veth_outer'], 'veth',
+                        'peer name %(physical_veth_inner)s' % subst)
                     util.execute(None,
-                                 'sysctl -w net.ipv4.conf.'
-                                 '%(vx_interface)s.arp_notify=1' % subst)
-
-            if not util.check_for_interface(subst['vx_bridge']):
-                with util.RecordedOperation('create vxlan bridge', self):
-                    util.create_interface(subst['vx_bridge'], 'bridge', '')
+                                 'brctl addif %(physical_bridge)s '
+                                 '%(physical_veth_outer)s' % subst)
                     util.execute(None,
-                                 'ip link set %(vx_interface)s '
-                                 'master %(vx_bridge)s' % subst)
+                                 'ip link set %(physical_veth_outer)s up'
+                                 % subst)
                     util.execute(None,
-                                 'ip link set %(vx_interface)s up' % subst)
-                    util.execute(None,
-                                 'ip link set %(vx_bridge)s up' % subst)
-                    util.execute(None,
-                                 'sysctl -w net.ipv4.conf.'
-                                 '%(vx_bridge)s.arp_notify=1' % subst)
-                    util.execute(None,
-                                 'brctl setfd %(vx_bridge)s 0' % subst)
-                    util.execute(None,
-                                 'brctl stp %(vx_bridge)s off' % subst)
-                    util.execute(None,
-                                 'brctl setageing %(vx_bridge)s 0' % subst)
+                                 'ip link set %(physical_veth_inner)s '
+                                 'netns %(netns)s' % subst)
 
-    def create_on_hypervisor(self):
-        self._create_common()
-        db.enqueue('networknode', DeployNetworkTask(self.uuid))
-        self.add_event('deploy', 'enqueued')
+            if self.provide_nat:
+                # We don't always need this lock, but acquiring it here means
+                # we don't need to construct two identical ipmanagers one after
+                # the other.
+                with db.get_lock('ipmanager', None, 'floating', ttl=120,
+                                 op='Network deploy NAT'):
+                    ipm = IPManager.from_db('floating')
+                    if not self.floating_gateway:
+                        self.update_floating_gateway(
+                            ipm.get_random_free_address())
+                        ipm.persist()
 
-    def create_on_network_node(self):
-        self._create_common()
-        subst = self.subst_dict()
-
-        if not os.path.exists('/var/run/netns/%(netns)s' % subst):
-            with util.RecordedOperation('create netns', self):
-                util.execute(None, 'ip netns add %(netns)s' % subst)
-
-        if not util.check_for_interface(subst['vx_veth_outer']):
-            with util.RecordedOperation('create router veth', self):
-                util.create_interface(
-                    subst['vx_veth_outer'], 'veth',
-                    'peer name %(vx_veth_inner)s' % subst)
-                util.execute(
-                    None,
-                    'ip link set %(vx_veth_inner)s netns %(netns)s' % subst)
-                util.execute(
-                    None,
-                    'brctl addif %(vx_bridge)s %(vx_veth_outer)s' % subst)
-                util.execute(None, 'ip link set %(vx_veth_outer)s up' % subst)
-                util.execute(
-                    None,
-                    '%(in_netns)s ip link set %(vx_veth_inner)s up' % subst)
-                util.execute(
-                    None,
-                    '%(in_netns)s ip addr add %(router)s/%(netmask)s '
-                    'dev %(vx_veth_inner)s' % subst)
-
-        if not util.check_for_interface(subst['physical_veth_outer']):
-            with util.RecordedOperation('create physical veth', self):
-                util.create_interface(
-                    subst['physical_veth_outer'], 'veth',
-                    'peer name %(physical_veth_inner)s' % subst)
-                util.execute(None,
-                             'brctl addif %(physical_bridge)s '
-                             '%(physical_veth_outer)s' % subst)
-                util.execute(None,
-                             'ip link set %(physical_veth_outer)s up'
-                             % subst)
-                util.execute(None,
-                             'ip link set %(physical_veth_inner)s '
-                             'netns %(netns)s' % subst)
-
-        if self.provide_nat:
-            # We don't always need this lock, but acquiring it here means we don't
-            # need to construct two idential ipmanagers one after the other.
-            with db.get_lock('ipmanager', None, 'floating', ttl=120,
-                             op='Network deploy NAT'):
-                ipm = IPManager.from_db('floating')
-                if not self.floating_gateway:
-                    self.update_floating_gateway(ipm.get_random_free_address())
-                    ipm.persist()
-
-                subst['floating_router'] = ipm.get_address_at_index(1)
-                subst['floating_gateway'] = self.floating_gateway
-                subst['floating_netmask'] = ipm.netmask
-
-            with db.get_object_lock(self, ttl=120, op='Network deploy NAT'):
-                # Ensure network was not deleted whilst waiting for the lock.
-                if self.is_dead():
-                    raise DeadNetwork('network=%s' % self)
+                    subst['floating_router'] = ipm.get_address_at_index(1)
+                    subst['floating_gateway'] = self.floating_gateway
+                    subst['floating_netmask'] = ipm.netmask
 
                 with util.RecordedOperation('enable virtual routing', self):
                     addresses = util.get_interface_addresses(
@@ -438,52 +429,66 @@ class Network(baseobject.DatabaseBackedObject):
                                      '-s %(ipblock)s/%(netmask)s '
                                      '-o %(physical_veth_inner)s '
                                      '-j MASQUERADE' % subst)
-
+            self.state = 'created'
         self.update_dhcp()
-        self.state = 'created'
 
     def delete(self):
+        with self.get_lock(op='Network delete'):
+            if self.is_dead():
+                LOG.withObj(self).info('Network died whilst waiting for lock')
+                return
+            self._delete_on_node()
+            self.state = 'deleted'
+        self.remove_dhcp()
+
+    def delete_on_node_with_lock(self):
+        with self.get_lock(op='Network delete on node'):
+            if self.is_dead():
+                LOG.withObj(self).info('Network died whilst waiting for lock')
+                return
+            self._delete_on_node()
+
+    def _delete_on_node(self):
         subst = self.subst_dict()
-        LOG.withFields(subst).debug('net.delete()')
+        LOG.withFields(subst).debug('net.delete_on_node()')
 
         # Cleanup local node
-        with db.get_object_lock(self, ttl=120, op='Network delete'):
-            if util.check_for_interface(subst['vx_bridge']):
-                with util.RecordedOperation('delete vxlan bridge', self):
-                    util.execute(None, 'ip link delete %(vx_bridge)s' % subst)
+        if util.check_for_interface(subst['vx_bridge']):
+            with util.RecordedOperation('delete vxlan bridge', self):
+                util.execute(None, 'ip link delete %(vx_bridge)s' % subst)
 
-            if util.check_for_interface(subst['vx_interface']):
-                with util.RecordedOperation('delete vxlan interface', self):
+        if util.check_for_interface(subst['vx_interface']):
+            with util.RecordedOperation('delete vxlan interface', self):
+                util.execute(
+                    None, 'ip link delete %(vx_interface)s' % subst)
+
+        # If this is the network node do additional cleanup
+        if util.is_network_node():
+            if util.check_for_interface(subst['vx_veth_outer']):
+                with util.RecordedOperation('delete router veth', self):
                     util.execute(
-                        None, 'ip link delete %(vx_interface)s' % subst)
+                        None, 'ip link delete %(vx_veth_outer)s' % subst)
 
-            # If this is the network node do additional cleanup
-            if util.is_network_node():
-                if util.check_for_interface(subst['vx_veth_outer']):
-                    with util.RecordedOperation('delete router veth', self):
-                        util.execute(
-                            None, 'ip link delete %(vx_veth_outer)s' % subst)
+            if util.check_for_interface(subst['physical_veth_outer']):
+                with util.RecordedOperation('delete physical veth', self):
+                    util.execute(
+                        None,
+                        'ip link delete %(physical_veth_outer)s' % subst)
 
-                if util.check_for_interface(subst['physical_veth_outer']):
-                    with util.RecordedOperation('delete physical veth', self):
-                        util.execute(
-                            None,
-                            'ip link delete %(physical_veth_outer)s' % subst)
+            if os.path.exists('/var/run/netns/%(netns)s' % subst):
+                with util.RecordedOperation('delete netns', self):
+                    util.execute(None, 'ip netns del %(netns)s' % subst)
 
-                if os.path.exists('/var/run/netns/%(netns)s' % subst):
-                    with util.RecordedOperation('delete netns', self):
-                        util.execute(None, 'ip netns del %(netns)s' % subst)
+            if self.floating_gateway:
+                with db.get_lock('ipmanager', None, 'floating', ttl=120,
+                                 op='Network delete'):
+                    ipm = IPManager.from_db('floating')
+                    ipm.release(self.floating_gateway)
+                    ipm.persist()
+                    self.update_floating_gateway(None)
 
-                if self.floating_gateway:
-                    with db.get_lock('ipmanager', None, 'floating', ttl=120,
-                                     op='Network delete'):
-                        ipm = IPManager.from_db('floating')
-                        ipm.release(self.floating_gateway)
-                        ipm.persist()
-                        self.update_floating_gateway(None)
-
-            Network.deallocate_vxid(self.vxid)
-            IPManager.from_db(self.uuid).delete()
+        Network.deallocate_vxid(self.vxid)
+        IPManager.from_db(self.uuid).delete()
 
     def hard_delete(self):
         etcd.delete('network', None, self.uuid)
@@ -508,7 +513,7 @@ class Network(baseobject.DatabaseBackedObject):
         if util.is_network_node():
             subst = self.subst_dict()
             with util.RecordedOperation('update dhcp', self):
-                with db.get_object_lock(self, ttl=120, op='Network update DHCP'):
+                with self.get_lock(op='Network update DHCP'):
                     d = dhcp.DHCP(self, subst['vx_veth_inner'])
                     d.restart_dhcpd()
         else:
@@ -519,7 +524,7 @@ class Network(baseobject.DatabaseBackedObject):
         if util.is_network_node():
             subst = self.subst_dict()
             with util.RecordedOperation('remove dhcp', self):
-                with db.get_object_lock(self, ttl=120, op='Network remove DHCP'):
+                with self.get_lock(op='Network remove DHCP'):
                     d = dhcp.DHCP(self, subst['vx_veth_inner'])
                     d.remove_dhcpd()
         else:
@@ -538,7 +543,7 @@ class Network(baseobject.DatabaseBackedObject):
                 yield m.group(1)
 
     def ensure_mesh(self):
-        with db.get_object_lock(self, ttl=120, op='Network ensure mesh'):
+        with self.get_lock(op='Network ensure mesh'):
             # Ensure network was not deleted whilst waiting for the lock.
             if self.is_dead():
                 raise DeadNetwork('network=%s' % self)

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -100,7 +100,7 @@ class Network(baseobject.DatabaseBackedObject):
         )
 
         n = Network.from_db(uuid)
-        n.update_state('initial')
+        n.state = 'initial'
         n.add_event('db record creation', None)
 
         # Networks should immediately appear on the network node
@@ -440,7 +440,7 @@ class Network(baseobject.DatabaseBackedObject):
                                      '-j MASQUERADE' % subst)
 
         self.update_dhcp()
-        self.update_state('created')
+        self.state = 'created'
 
     def delete(self):
         subst = self.subst_dict()

--- a/shakenfist/tasks.py
+++ b/shakenfist/tasks.py
@@ -19,9 +19,9 @@ class QueueTask(object):
         return self._name.replace('_', ' ')
 
     def __repr__(self):
-        # All subclasses define json_dump()
+        # All subclasses define obj_dict()
         r = 'QueueTask:' + self.__class__.__name__ + ': '
-        r += str(self.json_dump())
+        r += str(self.obj_dict())
         return r
 
     def __eq__(self, other):
@@ -31,9 +31,9 @@ class QueueTask(object):
         return self.__hash__() == other.__hash__()
 
     def __hash__(self):
-        return hash(str(self.json_dump()))
+        return hash(str(self.obj_dict()))
 
-    def json_dump(self):
+    def obj_dict(self):
         return {'task': self._name,
                 'version': self._version}
 
@@ -66,8 +66,8 @@ class InstanceTask(QueueTask):
     def network(self):
         return self._network
 
-    def json_dump(self):
-        return {**super(InstanceTask, self).json_dump(),
+    def obj_dict(self):
+        return {**super(InstanceTask, self).obj_dict(),
                 'instance_uuid': self._instance_uuid,
                 'network': self._network}
 
@@ -91,8 +91,8 @@ class ErrorInstanceTask(InstanceTask):
         super(ErrorInstanceTask, self).__init__(instance_uuid)
         self._error_msg = error_msg
 
-    def json_dump(self):
-        return {**super(ErrorInstanceTask, self).json_dump(),
+    def obj_dict(self):
+        return {**super(ErrorInstanceTask, self).obj_dict(),
                 'error_msg': self._error_msg}
 
     def error_msg(self):
@@ -117,8 +117,8 @@ class NetworkTask(QueueTask):
     def network_uuid(self):
         return self._network_uuid
 
-    def json_dump(self):
-        return {**super(NetworkTask, self).json_dump(),
+    def obj_dict(self):
+        return {**super(NetworkTask, self).obj_dict(),
                 'network_uuid': self._network_uuid}
 
 
@@ -145,8 +145,8 @@ class ImageTask(QueueTask):
         if not isinstance(url, str):
             raise NoURLImageFetchTaskException
 
-    def json_dump(self):
-        return {**super(ImageTask, self).json_dump(),
+    def obj_dict(self):
+        return {**super(ImageTask, self).obj_dict(),
                 'url': self._url}
 
     # Data methods
@@ -161,8 +161,8 @@ class FetchImageTask(ImageTask):
         super(FetchImageTask, self).__init__(url)
         self._instance_uuid = instance_uuid
 
-    def json_dump(self):
-        return {**super(FetchImageTask, self).json_dump(),
+    def obj_dict(self):
+        return {**super(FetchImageTask, self).obj_dict(),
                 'instance_uuid': self._instance_uuid}
 
     # Data methods

--- a/shakenfist/tests/test_baseobject.py
+++ b/shakenfist/tests/test_baseobject.py
@@ -26,7 +26,7 @@ class StateTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertEqual(s.update_time, 3)
         self.assertEqual(s.error_msg, 'error msg')
 
-        self.assertEqual(s.json_dump(), {
+        self.assertEqual(s.obj_dict(), {
             'value': 'state1',
             'update_time': 3,
             'error_msg': 'error msg',

--- a/shakenfist/tests/test_baseobject.py
+++ b/shakenfist/tests/test_baseobject.py
@@ -7,9 +7,9 @@ from shakenfist.tests import test_shakenfist
 class DatabaseBackedObjectTestCase(test_shakenfist.ShakenFistTestCase):
     @mock.patch('shakenfist.baseobject.DatabaseBackedObject._db_get_attribute',
                 side_effect=[
-                    {'state': None, 'update_time': 2},
-                    {'state': 'initial', 'update_time': 4},
-                    {'state': 'created', 'update_time': 10},
+                    {'value': None, 'update_time': 2},
+                    {'value': 'initial', 'update_time': 4},
+                    {'value': 'created', 'update_time': 10},
                 ])
     def test_state_property(self, mock_get_attribute):
         d = DatabaseBackedObject('uuid')
@@ -22,12 +22,12 @@ class StateTestCase(test_shakenfist.ShakenFistTestCase):
     def test_state_object_full(self):
         s = State('state1', 3, 'error msg')
 
-        self.assertEqual(s.state, 'state1')
+        self.assertEqual(s.value, 'state1')
         self.assertEqual(s.update_time, 3)
         self.assertEqual(s.error_msg, 'error msg')
 
         self.assertEqual(s.json_dump(), {
-            'state': 'state1',
+            'value': 'state1',
             'update_time': 3,
             'error_msg': 'error msg',
         })
@@ -35,12 +35,12 @@ class StateTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertEqual(s, State('state1', 3, 'error msg'))
 
         self.assertEqual(str(s),
-                         "State({'state': 'state1', 'update_time': 3, "
+                         "State({'value': 'state1', 'update_time': 3, "
                          "'error_msg': 'error msg'})")
 
     def _test_state_object_def(self):
         s = State('state1', 4)
 
-        self.assertEqual(s.state, 'state1')
+        self.assertEqual(s.value, 'state1')
         self.assertEqual(s.update_time, 4)
         self.assertEqual(s.error_msg, None)

--- a/shakenfist/tests/test_baseobject.py
+++ b/shakenfist/tests/test_baseobject.py
@@ -1,6 +1,8 @@
 import mock
+import testtools
 
 from shakenfist.baseobject import DatabaseBackedObject, State
+from shakenfist import exceptions
 from shakenfist.tests import test_shakenfist
 
 
@@ -11,27 +13,42 @@ class DatabaseBackedObjectTestCase(test_shakenfist.ShakenFistTestCase):
                     {'value': 'initial', 'update_time': 4},
                     {'value': 'created', 'update_time': 10},
                 ])
-    def test_state_property(self, mock_get_attribute):
+    def test_state(self, mock_get_attribute):
         d = DatabaseBackedObject('uuid')
         self.assertEqual(d.state, State(None, 2))
         self.assertEqual(d.state, State('initial', 4))
         self.assertEqual(d.state, State('created', 10))
 
-
-class StateTestCase(test_shakenfist.ShakenFistTestCase):
-    def test_state_object_full(self):
-        s = State('state1', 3, 'error msg')
+    def test_property_state_object_full(self):
+        s = State('state1', 3)
 
         self.assertEqual(s.value, 'state1')
         self.assertEqual(s.update_time, 3)
-        self.assertEqual(s.error_msg, 'error msg')
 
         self.assertEqual(s.obj_dict(), {
             'value': 'state1',
             'update_time': 3,
         })
 
-        self.assertEqual(s, State('state1', 3, 'error msg'))
-
+        self.assertEqual(s, State('state1', 3))
         self.assertEqual(str(s),
                          "State({'value': 'state1', 'update_time': 3})")
+
+    @mock.patch('shakenfist.baseobject.DatabaseBackedObject._db_set_attribute')
+    @mock.patch('shakenfist.baseobject.DatabaseBackedObject._db_get_attribute',
+                side_effect=[
+                    None,
+                    'bad error',
+                    {'value': 'initial', 'update_time': 4},
+                    {'value': 'error', 'update_time': 4},
+                    'real bad',
+                ])
+    def test_property_error_msg(self, mock_get_attribute, mock_set_attribute):
+        d = DatabaseBackedObject('uuid')
+        self.assertEqual(d.error_msg, None)
+        self.assertEqual(d.error_msg, 'bad error')
+
+        with testtools.ExpectedException(exceptions.InvalidStateException):
+            d.error_msg = 'real bad'
+
+        d.error_msg = 'real bad'

--- a/shakenfist/tests/test_baseobject.py
+++ b/shakenfist/tests/test_baseobject.py
@@ -1,0 +1,46 @@
+import mock
+
+from shakenfist.baseobject import DatabaseBackedObject, State
+from shakenfist.tests import test_shakenfist
+
+
+class DatabaseBackedObjectTestCase(test_shakenfist.ShakenFistTestCase):
+    @mock.patch('shakenfist.baseobject.DatabaseBackedObject._db_get_attribute',
+                side_effect=[
+                    {'state': None, 'update_time': 2},
+                    {'state': 'initial', 'update_time': 4},
+                    {'state': 'created', 'update_time': 10},
+                ])
+    def test_state_property(self, mock_get_attribute):
+        d = DatabaseBackedObject('uuid')
+        self.assertEqual(d.state, State(None, 2))
+        self.assertEqual(d.state, State('initial', 4))
+        self.assertEqual(d.state, State('created', 10))
+
+
+class StateTestCase(test_shakenfist.ShakenFistTestCase):
+    def test_state_object_full(self):
+        s = State('state1', 3, 'error msg')
+
+        self.assertEqual(s.state, 'state1')
+        self.assertEqual(s.update_time, 3)
+        self.assertEqual(s.error_msg, 'error msg')
+
+        self.assertEqual(s.json_dump(), {
+            'state': 'state1',
+            'update_time': 3,
+            'error_msg': 'error msg',
+        })
+
+        self.assertEqual(s, State('state1', 3, 'error msg'))
+
+        self.assertEqual(str(s),
+                         "State({'state': 'state1', 'update_time': 3, "
+                         "'error_msg': 'error msg'})")
+
+    def _test_state_object_def(self):
+        s = State('state1', 4)
+
+        self.assertEqual(s.state, 'state1')
+        self.assertEqual(s.update_time, 4)
+        self.assertEqual(s.error_msg, None)

--- a/shakenfist/tests/test_baseobject.py
+++ b/shakenfist/tests/test_baseobject.py
@@ -29,18 +29,9 @@ class StateTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertEqual(s.obj_dict(), {
             'value': 'state1',
             'update_time': 3,
-            'error_msg': 'error msg',
         })
 
         self.assertEqual(s, State('state1', 3, 'error msg'))
 
         self.assertEqual(str(s),
-                         "State({'value': 'state1', 'update_time': 3, "
-                         "'error_msg': 'error msg'})")
-
-    def _test_state_object_def(self):
-        s = State('state1', 4)
-
-        self.assertEqual(s.value, 'state1')
-        self.assertEqual(s.update_time, 4)
-        self.assertEqual(s.error_msg, None)
+                         "State({'value': 'state1', 'update_time': 3})")

--- a/shakenfist/tests/test_daemon_cleaner.py
+++ b/shakenfist/tests/test_daemon_cleaner.py
@@ -92,6 +92,12 @@ def fake_put(objecttype, subtype, name, v):
     FAKE_ETCD_STATE['%s/%s/%s' % (objecttype, subtype, name)] = v
 
 
+def fake_get(objecttype, subtype, name):
+    global FAKE_ETCD_STATE
+    val = FAKE_ETCD_STATE.get('%s/%s/%s' % (objecttype, subtype, name))
+    return val
+
+
 class CleanerTestCase(test_shakenfist.ShakenFistTestCase):
     def setUp(self):
         super(CleanerTestCase, self).setUp()
@@ -110,27 +116,25 @@ class CleanerTestCase(test_shakenfist.ShakenFistTestCase):
         self.mock_config = self.config.start()
         self.addCleanup(self.config.stop)
 
-    @mock.patch('shakenfist.virt.Instance.state',
-                new_callable=mock.PropertyMock)
+    @mock.patch('shakenfist.etcd.get', side_effect=fake_get)
     @mock.patch('shakenfist.db.get_lock')
     @mock.patch('shakenfist.db.see_this_node')
     @mock.patch('shakenfist.db.add_event')
     @mock.patch('shakenfist.virt.Instance._db_get', side_effect=fake_instance_get)
-    @mock.patch('shakenfist.virt.Instance._db_get_attribute', return_value={})
     @mock.patch('shakenfist.etcd.put', side_effect=fake_put)
     @mock.patch('os.path.exists', side_effect=fake_exists)
     @mock.patch('time.time', return_value=7)
     def test_update_power_states(self, mock_time, mock_exists, mock_put,
-                                 mock_get_instance_attribute, mock_get_instance,
-                                 mock_event, mock_see, mock_lock,
-                                 mock_state_get):
-        mock_state_get.return_value = State('initial', 0)
+                                 mock_get_instance, mock_event, mock_see,
+                                 mock_lock, mock_etcd_get):
 
         m = cleaner.Monitor('cleaner')
         m._update_power_states()
 
         result = []
         for c in mock_put.mock_calls:
+            if type(c[1][3]) is dict and 'placement_attempts' in c[1][3]:
+                continue
             if type(c[1][3]) is State:
                 val = c[1][3]
             else:
@@ -140,18 +144,20 @@ class CleanerTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertEqual(
             [
                 ('attribute/instance', 'running',
-                 'placement', {'power_state': 'off'}),
-                ('attribute/instance', 'running',
-                 'power_state', {'power_state': 'off'}),
+                 'power_state', {'power_state': 'on'}),
                 ('attribute/instance', 'shutoff',
                  'power_state', {'power_state': 'off'}),
                 ('attribute/instance', 'crashed',
-                 'power_state', {'power_state': 'off'}),
+                 'power_state', {'power_state': 'crashed'}),
                 ('attribute/instance', 'crashed',
                  'state', State('error', 7)),
                 ('attribute/instance', 'paused',
-                 'power_state', {'power_state': 'off'}),
+                 'power_state', {'power_state': 'paused'}),
+                ('attribute/instance', 'suspended',
+                 'power_state', {'power_state': 'paused'}),
                 ('attribute/instance', 'foo',
+                 'power_state', {'power_state': 'off'}),
+                ('attribute/instance', 'bar',
                  'power_state', {'power_state': 'off'}),
                 ('attribute/instance', 'nofiles',
                  'state', State('error', 7))

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -44,7 +44,7 @@ class BaseFakeObject(object):
     def add_event(self, operation, phase, duration=None, msg=None):
         pass
 
-    def update_state(self, state, error_message=None):
+    def update_state(self, state):
         self._state = state
 
     def delete(self):

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -391,7 +391,7 @@ class ExternalApiGeneralTestCase(ExternalApiTestCase):
             resp.get_json())
 
     @mock.patch('shakenfist.virt.Instance._db_get_attribute',
-                return_value={'state': 'created', 'update_time': 2})
+                return_value={'value': 'created', 'update_time': 2})
     @mock.patch('shakenfist.virt.Instances',
                 return_value=[FakeInstance(uuid='123')])
     def test_delete_namespace_with_instances(self, mock_get_instances,
@@ -926,7 +926,7 @@ class ExternalApiInstanceTestCase(ExternalApiTestCase):
         self.assertEqual(400, resp.status_code)
 
     @mock.patch('shakenfist.net.Network._db_get_attribute',
-                return_value={'state': 'created', 'update_time': 2})
+                return_value={'value': 'created', 'update_time': 2})
     @mock.patch('shakenfist.net.Network.from_db',
                 return_value=FakeNetwork(
                     uuid='87c15186-5f73-4947-a9fb-2183c4951efc',
@@ -988,7 +988,7 @@ class ExternalApiNetworkTestCase(ExternalApiTestCase):
         self.addCleanup(self.config.stop)
 
     @mock.patch('shakenfist.net.Network._db_get_attribute',
-                return_value={'state': 'created', 'update_time': 2})
+                return_value={'value': 'created', 'update_time': 2})
     @mock.patch('shakenfist.ipmanager.IPManager.from_db')
     @mock.patch('shakenfist.net.Network.from_db',
                 return_value=FakeNetwork(

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -4,6 +4,7 @@ import json
 import mock
 
 
+from shakenfist.baseobject import State
 from shakenfist.config import config, SFConfigBase, SFConfig
 from shakenfist.external_api import app as external_api
 from shakenfist.ipmanager import IPManager
@@ -33,9 +34,9 @@ class BaseFakeObject(object):
         if isinstance(self._state, list):
             s = self._state[0]
             self._state = self._state[1:]
-            return {'state': s}
+            return State(s, 1)
         else:
-            return {'state': self._state}
+            return State(self._state, 1)
 
     def unique_label(self):
         return ('instance', self.uuid)
@@ -390,7 +391,7 @@ class ExternalApiGeneralTestCase(ExternalApiTestCase):
             resp.get_json())
 
     @mock.patch('shakenfist.virt.Instance._db_get_attribute',
-                return_value={'state': 'created'})
+                return_value={'state': 'created', 'update_time': 2})
     @mock.patch('shakenfist.virt.Instances',
                 return_value=[FakeInstance(uuid='123')])
     def test_delete_namespace_with_instances(self, mock_get_instances,
@@ -925,7 +926,7 @@ class ExternalApiInstanceTestCase(ExternalApiTestCase):
         self.assertEqual(400, resp.status_code)
 
     @mock.patch('shakenfist.net.Network._db_get_attribute',
-                return_value={'state': 'created'})
+                return_value={'state': 'created', 'update_time': 2})
     @mock.patch('shakenfist.net.Network.from_db',
                 return_value=FakeNetwork(
                     uuid='87c15186-5f73-4947-a9fb-2183c4951efc',
@@ -987,7 +988,7 @@ class ExternalApiNetworkTestCase(ExternalApiTestCase):
         self.addCleanup(self.config.stop)
 
     @mock.patch('shakenfist.net.Network._db_get_attribute',
-                return_value={'state': 'created'})
+                return_value={'state': 'created', 'update_time': 2})
     @mock.patch('shakenfist.ipmanager.IPManager.from_db')
     @mock.patch('shakenfist.net.Network.from_db',
                 return_value=FakeNetwork(

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -38,14 +38,15 @@ class BaseFakeObject(object):
         else:
             return State(self._state, 1)
 
+    @state.setter
+    def state(self, state):
+        self._state = state
+
     def unique_label(self):
         return ('instance', self.uuid)
 
     def add_event(self, operation, phase, duration=None, msg=None):
         pass
-
-    def update_state(self, state):
-        self._state = state
 
     def delete(self):
         pass

--- a/shakenfist/tests/test_images.py
+++ b/shakenfist/tests/test_images.py
@@ -250,21 +250,20 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
                          images.Image.calc_unique_ref('http://example.com'))
 
     @mock.patch('shakenfist.db.get_lock')
-    @mock.patch('shakenfist.images.Image.state',
-                new_callable=mock.PropertyMock)
+    @mock.patch('shakenfist.images.Image._db_get_attribute',
+                side_effect=[
+                    {'value': None, 'update_time': 0},
+                    {'value': 'initial', 'update_time': 0},
+                    {'value': 'initial', 'update_time': 0},
+                    {'value': 'creating', 'update_time': 0},
+                    {'value': 'created', 'update_time': 0},
+                    {'value': 'error', 'update_time': 0},
+                    {'value': 'deleted', 'update_time': 0},
+                ])
     @mock.patch('shakenfist.images.Image._db_set_attribute')
     @mock.patch('shakenfist.etcd.put')
-    def test_update_state_valid(
+    def test_state_property_valid(
             self, mock_put, mock_attribute_set, mock_state_get, mock_lock):
-        mock_state_get.side_effect = [
-            State(None, 0),
-            State('initial', 0),
-            State('initial', 0),
-            State('creating', 0),
-            State('created', 0),
-            State('error', 0),
-            State('deleted', 0),
-        ]
 
         i = images.Image({
             'ref': 'ref',
@@ -272,16 +271,16 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
             'version': 1,
             'url': 'a'
             })
-        i.update_state('initial')
-        self.assertRaises(exceptions.InvalidStateException,
-                          i.update_state, 'created')
-        self.assertRaises(exceptions.InvalidStateException,
-                          i.update_state, 'created')
-        i.update_state('deleted')
-        i.update_state('error')
-        i.update_state('deleted')
-        self.assertRaises(exceptions.InvalidStateException,
-                          i.update_state, 'created')
+        i.state = 'initial'
+        with testtools.ExpectedException(exceptions.InvalidStateException):
+            i.state = 'created'
+        with testtools.ExpectedException(exceptions.InvalidStateException):
+            i.state = 'created'
+        i.state = 'deleted'
+        i.state = 'error'
+        i.state = 'deleted'
+        with testtools.ExpectedException(exceptions.InvalidStateException):
+            i.state = 'created'
 
     @mock.patch('shakenfist.baseobject.DatabaseBackedObject._db_get',
                 return_value={
@@ -301,7 +300,7 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertEqual([mock.call('latest_checksum', {'checksum': '1abab'})],
                          mock_set_attr.mock_calls)
 
-    @mock.patch('shakenfist.images.Image.update_state')
+    @mock.patch('shakenfist.images.Image.state')
     @mock.patch('shakenfist.baseobject.DatabaseBackedObject._db_get',
                 side_effect=[None,
                              {
@@ -318,7 +317,8 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
                 new_callable=mock.PropertyMock)
     def test_image_persist(
             self, mock_checksum, mock_create, mock_set_attr, mock_mkdirs, mock_get,
-            mock_update_state):
+            mock_state):
+        mock_state.setter.return_value = State(None, 1)
         images.Image.new('http://example.com', '1abab')
         self.assertEqual([
             mock.call('f0e6a6a97042a4f1f1c87f5f7d44315b2d852c2df5c7991cc66241'
@@ -464,7 +464,7 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
         dirty_fields = img._new_image_available(img._open_connection())
         self.assertEqual(('size', 200000, 16338944), dirty_fields)
 
-    @mock.patch('shakenfist.images.Image.update_state')
+    @mock.patch('shakenfist.images.Image.state')
     @mock.patch('requests.get',
                 return_value=FakeResponse(
                     200, '',
@@ -486,8 +486,9 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
                 new_callable=mock.PropertyMock)
     def test_fetch_image_new(
             self, mock_version, mock_checksum, mock_mkdirs, mock_get,
-            mock_request_head, mock_update_state):
+            mock_request_head, mock_state):
         mock_version.return_value = {}
+        mock_state.setter.return_value = State(None, 1)
 
         img = images.Image.new('http://example.com')
         dirty_fields = img._new_image_available(img._open_connection())
@@ -805,7 +806,7 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertFalse(image.correct_checksum(ret))
 
     # Data matches checksum
-    @mock.patch('shakenfist.images.Image.update_state')
+    @mock.patch('shakenfist.images.Image.state')
     @mock.patch('shakenfist.images.Image._add_download_version')
     @mock.patch('shakenfist.images.Image.latest_download_version',
                 new_callable=mock.PropertyMock)
@@ -820,7 +821,8 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
     @mock.patch('shakenfist.db.refresh_locks')
     def test_get(
             self, mock_refresh_locks, mock_put, mock_open, mock_transcode,
-            mock_version, mock_add_version, mock_update_state):
+            mock_version, mock_add_version, mock_state):
+        mock_state.setter.return_value = State(None, 1)
         mock_version.return_value = {
             'size': 200000,
             'modified': 'Tue, 10 Sep 2019 07:24:40 GMT',
@@ -850,7 +852,7 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
             mock_add_version.mock_calls)
 
     # First download attempt corrupted, second download matches checksum
-    @mock.patch('shakenfist.images.Image.update_state')
+    @mock.patch('shakenfist.images.Image.state')
     @mock.patch('shakenfist.images.Image._add_download_version')
     @mock.patch('shakenfist.images.Image.latest_download_version',
                 new_callable=mock.PropertyMock)
@@ -867,7 +869,8 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
     @mock.patch('shakenfist.db.refresh_locks')
     def test_get_one_corrupt(
             self, mock_refresh_locks, mock_put, mock_open, mock_transcode,
-            mock_version, mock_add_version, mock_update_state):
+            mock_version, mock_add_version, mock_state):
+        mock_state.setter.return_value = State(None, 1)
         mock_version.return_value = {
             'size': 200000,
             'modified': 'Tue, 10 Sep 2019 07:24:40 GMT',
@@ -894,8 +897,19 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
 
     # All download attempts not matching checksum
     @mock.patch('shakenfist.images.Image._db_get_attribute',
-                return_value={'state': 'error', 'update_time': 123})
-    @mock.patch('shakenfist.images.Image.update_state')
+                side_effect=[
+                    {'value': 'creating', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    ])
+    @mock.patch('shakenfist.images.Image.get_lock_attr')
     @mock.patch('shakenfist.images.Image._add_download_version')
     @mock.patch('shakenfist.images.Image.latest_download_version',
                 new_callable=mock.PropertyMock)
@@ -912,7 +926,7 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
     @mock.patch('shakenfist.db.refresh_locks')
     def test_get_always_corrupt(
             self, mock_refresh_locks, mock_put, mock_open,
-            mock_version, mock_add_version, mock_update_state,
+            mock_version, mock_add_version, get_lock_attr,
             mock_db_get_attribute):
         mock_version.return_value = {
             'size': 200000,

--- a/shakenfist/tests/test_images.py
+++ b/shakenfist/tests/test_images.py
@@ -893,6 +893,8 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertTrue(image.correct_checksum(ret))
 
     # All download attempts not matching checksum
+    @mock.patch('shakenfist.images.Image._db_get_attribute',
+                return_value={'state': 'error', 'update_time': 123})
     @mock.patch('shakenfist.images.Image.update_state')
     @mock.patch('shakenfist.images.Image._add_download_version')
     @mock.patch('shakenfist.images.Image.latest_download_version',
@@ -910,14 +912,14 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
     @mock.patch('shakenfist.db.refresh_locks')
     def test_get_always_corrupt(
             self, mock_refresh_locks, mock_put, mock_open,
-            mock_version, mock_add_version, mock_update_state):
+            mock_version, mock_add_version, mock_update_state,
+            mock_db_get_attribute):
         mock_version.return_value = {
             'size': 200000,
             'modified': 'Tue, 10 Sep 2019 07:24:40 GMT',
             'fetched_at': 'Tue, 20 Oct 2020 23:02:29 -0000',
             'sequence': 1
         }
-
         test_checksum = '097c42989a9e5d9dcced7b35ec4b0486'
         image = FakeImageChecksum({
             'url': 'testurl',

--- a/shakenfist/tests/test_images.py
+++ b/shakenfist/tests/test_images.py
@@ -10,6 +10,7 @@ from shakenfist import images
 from shakenfist import image_resolver_cirros
 from shakenfist import image_resolver_ubuntu
 from shakenfist import logutil
+from shakenfist.baseobject import State
 from shakenfist.tests import test_shakenfist
 from shakenfist.config import SFConfigBase
 
@@ -256,13 +257,13 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
     def test_update_state_valid(
             self, mock_put, mock_attribute_set, mock_state_get, mock_lock):
         mock_state_get.side_effect = [
-            {'state': None, 'state_updated': 0},
-            {'state': 'initial', 'state_updated': 0},
-            {'state': 'initial', 'state_updated': 0},
-            {'state': 'creating', 'state_updated': 0},
-            {'state': 'created', 'state_updated': 0},
-            {'state': 'error', 'state_updated': 0},
-            {'state': 'deleted', 'state_updated': 0},
+            State(None, 0),
+            State('initial', 0),
+            State('initial', 0),
+            State('creating', 0),
+            State('created', 0),
+            State('error', 0),
+            State('deleted', 0),
         ]
 
         i = images.Image({

--- a/shakenfist/tests/test_net.py
+++ b/shakenfist/tests/test_net.py
@@ -2,6 +2,7 @@ import mock
 
 from shakenfist import exceptions
 from shakenfist import net
+from shakenfist.baseobject import State
 from shakenfist.config import SFConfig
 from shakenfist.tests import test_shakenfist
 
@@ -254,13 +255,13 @@ link/ether 1a:46:97:a1:c2:3a brd ff:ff:ff:ff:ff:ff
     def test_update_state_valid(
             self, mock_put, mock_attribute_set, mock_state_get, mock_lock):
         mock_state_get.side_effect = [
-            {'state': 'created', 'state_updated': 0},
-            {'state': 'created', 'state_updated': 0},
-            {'state': 'created', 'state_updated': 0},
-            {'state': 'deleting', 'state_updated': 0},
-            {'state': 'error', 'state_updated': 0},
-            {'state': 'deleted', 'state_updated': 0},
-            {'state': 'deleted', 'state_updated': 0},
+            State('created', 0),
+            State('created', 0),
+            State('created', 0),
+            State('deleting', 0),
+            State('error', 0),
+            State('deleted', 0),
+            State('deleted', 0),
         ]
 
         n = net.Network({

--- a/shakenfist/tests/test_net.py
+++ b/shakenfist/tests/test_net.py
@@ -3,7 +3,6 @@ import testtools
 
 from shakenfist import exceptions
 from shakenfist import net
-from shakenfist.baseobject import State
 from shakenfist.config import SFConfig
 from shakenfist.tests import test_shakenfist
 

--- a/shakenfist/tests/test_net.py
+++ b/shakenfist/tests/test_net.py
@@ -3,6 +3,7 @@ import testtools
 
 from shakenfist import exceptions
 from shakenfist import net
+from shakenfist.baseobject import State
 from shakenfist.config import SFConfig
 from shakenfist.tests import test_shakenfist
 

--- a/shakenfist/tests/test_scheduler.py
+++ b/shakenfist/tests/test_scheduler.py
@@ -4,6 +4,7 @@ from shakenfist import exceptions
 from shakenfist import images
 from shakenfist import scheduler
 from shakenfist.tests import test_shakenfist
+from shakenfist.baseobject import State
 from shakenfist.config import SFConfig
 from shakenfist.virt import Instance
 
@@ -420,10 +421,7 @@ class FindMostTestCase(SchedulerTestCase):
                 ])
     def test_most_matching_images(
             self, mock_from_db, mock_get_meta_all, mock_state_get):
-        mock_state_get.return_value = {
-            'state': 'created',
-            'state_updated': 0
-        }
+        mock_state_get.return_value = State('created', 0)
 
         req_images = ['req_image1']
         candidates = ['node1_net', 'node2', 'node3', 'node4']
@@ -496,10 +494,7 @@ class FindMostTestCase(SchedulerTestCase):
                 ])
     def test_most_matching_images_big_one(
             self, mock_from_db, mock_get_meta_all, mock_state_get):
-        mock_state_get.return_value = {
-            'state': 'created',
-            'state_updated': 0
-        }
+        mock_state_get.return_value = State('created', 1)
 
         candidates = ['node1_net', 'node2', 'node3', 'node4']
 
@@ -613,10 +608,7 @@ class FindMostTestCase(SchedulerTestCase):
                 ])
     def test_most_matching_images_big_two(
             self, mock_from_db, mock_get_meta_all, mock_state_get):
-        mock_state_get.return_value = {
-            'state': 'created',
-            'state_updated': 0
-        }
+        mock_state_get.return_value = State('created', 1)
 
         candidates = ['node1_net', 'node2', 'node3', 'node4']
 
@@ -688,10 +680,7 @@ class FindMostTestCase(SchedulerTestCase):
                 ])
     def test_most_matching_images_big_three(
             self, mock_from_db, mock_get_meta_all, mock_state_get):
-        mock_state_get.return_value = {
-            'state': 'created',
-            'state_updated': 0
-        }
+        mock_state_get.return_value = State('created', 1)
 
         candidates = ['node1_net', 'node2', 'node3', 'node4']
 

--- a/shakenfist/tests/test_virt.py
+++ b/shakenfist/tests/test_virt.py
@@ -64,7 +64,7 @@ class VirtMetaTestCase(test_shakenfist.ShakenFistTestCase):
     @mock.patch('shakenfist.etcd.put')
     @mock.patch('shakenfist.etcd.create')
     @mock.patch('shakenfist.baseobject.DatabaseBackedObject._db_get_attribute',
-                return_value={'state': None, 'update_time': 0})
+                return_value={'value': None, 'update_time': 0})
     @mock.patch('shakenfist.db.get_lock')
     @mock.patch('time.time', return_value=1234)
     def test_instance_new(self, mock_time, mock_get_lock, mock_get_attribute,
@@ -196,7 +196,7 @@ class InstanceTestCase(test_shakenfist.ShakenFistTestCase):
 
         etcd_write = mock_attribute_set.mock_calls[2]
         self.assertTrue(time.time() - etcd_write[1][1].update_time < 3)
-        self.assertEqual('preflight', etcd_write[1][1].state)
+        self.assertEqual('preflight', etcd_write[1][1].value)
 
     @mock.patch('shakenfist.db.get_lock')
     @mock.patch('shakenfist.virt.Instance.state',
@@ -620,7 +620,7 @@ class InstancesTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertEqual([], uuids)
 
     @mock.patch('shakenfist.virt.Instance._db_get_attribute',
-                return_value={'state': 'created', 'update_time': 1})
+                return_value={'value': 'created', 'update_time': 1})
     @mock.patch('shakenfist.etcd.get', side_effect=JUST_INSTANCES)
     @mock.patch('shakenfist.etcd.get_all', return_value=GET_ALL_INSTANCES)
     def test_state_filter_all(self, mock_get_all, mock_get, mock_attr):
@@ -632,7 +632,7 @@ class InstancesTestCase(test_shakenfist.ShakenFistTestCase):
                           'a7c5ecec-c3a9-4774-ad1b-249d9e90e806'], uuids)
 
     @mock.patch('shakenfist.virt.Instance._db_get_attribute',
-                return_value={'state': 'deleted', 'update_time': 1})
+                return_value={'value': 'deleted', 'update_time': 1})
     @mock.patch('shakenfist.etcd.get', side_effect=JUST_INSTANCES)
     @mock.patch('shakenfist.etcd.get_all', return_value=GET_ALL_INSTANCES)
     def test_state_filter_none(self, mock_get_all, mock_get, mock_attr):
@@ -643,8 +643,8 @@ class InstancesTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertEqual([], uuids)
 
     @mock.patch('shakenfist.virt.Instance._db_get_attribute',
-                side_effect=[{'state': 'deleted', 'update_time': 1},
-                             {'state': 'initial', 'update_time': 1}])
+                side_effect=[{'value': 'deleted', 'update_time': 1},
+                             {'value': 'initial', 'update_time': 1}])
     @mock.patch('shakenfist.etcd.get', side_effect=JUST_INSTANCES)
     @mock.patch('shakenfist.etcd.get_all', return_value=GET_ALL_INSTANCES)
     def test_state_filter_active(self, mock_get_all, mock_get, mock_attr):
@@ -655,8 +655,8 @@ class InstancesTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertEqual(['a7c5ecec-c3a9-4774-ad1b-249d9e90e806'], uuids)
 
     @mock.patch('shakenfist.virt.Instance._db_get_attribute',
-                side_effect=[{'state': 'deleted', 'update_time': 1},
-                             {'state': 'initial', 'update_time': 1}])
+                side_effect=[{'value': 'deleted', 'update_time': 1},
+                             {'value': 'initial', 'update_time': 1}])
     @mock.patch('shakenfist.etcd.get', side_effect=JUST_INSTANCES)
     @mock.patch('shakenfist.etcd.get_all', return_value=GET_ALL_INSTANCES)
     def test_state_filter_inactive(self, mock_get_all, mock_get, mock_attr):
@@ -667,9 +667,9 @@ class InstancesTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertEqual(['373a165e-9720-4e14-bd0e-9612de79ff15'], uuids)
 
     @mock.patch('shakenfist.virt.Instance._db_get_attribute',
-                side_effect=[{'state': 'deleted', 'update_time': time.time()},
-                             {'state': 'deleted', 'update_time': time.time()},
-                             {'state': 'initial', 'update_time': 1}])
+                side_effect=[{'value': 'deleted', 'update_time': time.time()},
+                             {'value': 'deleted', 'update_time': time.time()},
+                             {'value': 'initial', 'update_time': 1}])
     @mock.patch('shakenfist.etcd.get', side_effect=JUST_INSTANCES)
     @mock.patch('shakenfist.etcd.get_all', return_value=GET_ALL_INSTANCES)
     def test_state_hard_delete_later(self, mock_get_all, mock_get, mock_attr):
@@ -682,9 +682,9 @@ class InstancesTestCase(test_shakenfist.ShakenFistTestCase):
 
     @mock.patch('shakenfist.virt.Instance._db_get_attribute',
                 side_effect=[
-                    {'state': 'deleted', 'update_time': time.time() - 1000},
-                    {'state': 'deleted', 'update_time': time.time() - 1000},
-                    {'state': 'initial', 'update_time': 1}])
+                    {'value': 'deleted', 'update_time': time.time() - 1000},
+                    {'value': 'deleted', 'update_time': time.time() - 1000},
+                    {'value': 'initial', 'update_time': 1}])
     @mock.patch('shakenfist.etcd.get', side_effect=JUST_INSTANCES)
     @mock.patch('shakenfist.etcd.get_all', return_value=GET_ALL_INSTANCES)
     def test_state_hard_delete_now(self, mock_get_all, mock_get, mock_attr):

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -201,7 +201,8 @@ class Instance(baseobject.DatabaseBackedObject):
             'state': self.state.value,
             'user_data': self.user_data,
             'video': self.video,
-            'version': self.version
+            'version': self.version,
+            'error_message': self.error_msg,
         }
 
         if self.requested_placement:
@@ -209,7 +210,6 @@ class Instance(baseobject.DatabaseBackedObject):
 
         external_attribute_key_whitelist = [
             'console_port',
-            'error_message',
             'node',
             'power_state',
             'vdi_port'

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -118,7 +118,7 @@ class Instance(baseobject.DatabaseBackedObject):
     object_type = 'instance'
     current_version = 2
     state_targets = {
-        None: ('initial', ),
+        None: ('initial', 'error'),
         'initial': ('preflight', 'deleted', 'error'),
         'preflight': ('creating', 'deleted', 'error'),
         'creating': ('created', 'deleted', 'error'),

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -118,7 +118,7 @@ class Instance(baseobject.DatabaseBackedObject):
     object_type = 'instance'
     current_version = 2
     state_targets = {
-        None: ('initial', ),
+        None: ('initial', 'error'),
         'initial': ('preflight', 'deleted', 'error'),
         'preflight': ('creating', 'deleted', 'error'),
         'creating': ('created', 'deleted', 'error'),
@@ -171,7 +171,7 @@ class Instance(baseobject.DatabaseBackedObject):
                 'version': cls.current_version
             })
         i = Instance.from_db(uuid)
-        i.update_state('initial')
+        i.state = 'initial'
         i._db_set_attribute('power_state', {'power_state': 'initial'})
         i.add_event('db record creation', None)
         return i
@@ -352,7 +352,7 @@ class Instance(baseobject.DatabaseBackedObject):
     # has been transcoded to the right format. This has been done to facilitate
     # moving to a queue and task based creation mechanism.
     def create(self, lock=None):
-        self.update_state('creating')
+        self.state = 'creating'
 
         # Ensure we have state on disk
         os.makedirs(self.instance_path, exist_ok=True)
@@ -379,7 +379,7 @@ class Instance(baseobject.DatabaseBackedObject):
             LOG.withObj(self).info('Instance now powered on')
         else:
             LOG.withObj(self).info('Instance failed to power on')
-        self.update_state('created')
+        self.state = 'created'
 
     def delete(self):
         with util.RecordedOperation('delete domain', self):
@@ -412,7 +412,7 @@ class Instance(baseobject.DatabaseBackedObject):
         self._free_console_port(ports.get('console_port'))
         self._free_console_port(ports.get('vdi_port'))
 
-        self.update_state('deleted')
+        self.state = 'deleted'
 
     def hard_delete(self):
         etcd.delete('instance', None, self.uuid)

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -198,6 +198,7 @@ class Instance(baseobject.DatabaseBackedObject):
             'name': self.name,
             'namespace': self.namespace,
             'ssh_key': self.ssh_key,
+            'state': self.state.value,
             'user_data': self.user_data,
             'video': self.video,
             'version': self.version
@@ -211,7 +212,6 @@ class Instance(baseobject.DatabaseBackedObject):
             'error_message',
             'node',
             'power_state',
-            'state',
             'vdi_port'
         ]
         # Ensure that missing attributes still get reported

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -118,7 +118,7 @@ class Instance(baseobject.DatabaseBackedObject):
     object_type = 'instance'
     current_version = 2
     state_targets = {
-        None: ('initial', 'error'),
+        None: ('initial', ),
         'initial': ('preflight', 'deleted', 'error'),
         'preflight': ('creating', 'deleted', 'error'),
         'creating': ('created', 'deleted', 'error'),

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -118,7 +118,7 @@ class Instance(baseobject.DatabaseBackedObject):
     object_type = 'instance'
     current_version = 2
     state_targets = {
-        None: ('initial', 'error'),
+        None: ('initial', ),
         'initial': ('preflight', 'deleted', 'error'),
         'preflight': ('creating', 'deleted', 'error'),
         'creating': ('created', 'deleted', 'error'),
@@ -171,7 +171,7 @@ class Instance(baseobject.DatabaseBackedObject):
                 'version': cls.current_version
             })
         i = Instance.from_db(uuid)
-        i._db_set_attribute('state', {'state': 'initial'})
+        i.update_state('initial')
         i._db_set_attribute('power_state', {'power_state': 'initial'})
         i.add_event('db record creation', None)
         return i


### PR DESCRIPTION
Lock networks to prevent deletion during creation

Also:
* Only restore networks that are not dead
* Move get_object_lock into DatabaseBackedObject

Resolves #647 