### PR TITLE
Lock networks to prevent deletion during creation

### DIFF
--- a/shakenfist/baseobject.py
+++ b/shakenfist/baseobject.py
@@ -72,6 +72,12 @@ class DatabaseBackedObject(object):
     def _db_set_attribute(self, attribute, value):
         etcd.put('attribute/%s' % self.object_type, self.__uuid, attribute, value)
 
+    def get_lock(self, subtype=None, ttl=60, relatedobjects=None, log_ctx=LOG,
+                 op=None):
+        return db.get_lock(self.object_type, subtype, self.uuid, ttl=ttl,
+                           relatedobjects=relatedobjects, log_ctx=log_ctx,
+                           op=op)
+
     def get_lock_attr(self, name, op):
         return db.get_lock('attribute/%s' % self.object_type,
                            self.__uuid, name, op=op)

--- a/shakenfist/client/upgrade.py
+++ b/shakenfist/client/upgrade.py
@@ -162,13 +162,17 @@ def main():
                             json.dumps(data, indent=4, sort_keys=True))
 
                     state = baseobject.State(instance.get('state'),
-                                             instance.get('state_updated'),
-                                             instance.get('error_message'))
+                                             instance.get('state_updated'))
                     for attr in ['state', 'state_updated', 'error_message']:
                         instance.pop(attr, None)
                     etcd_client.put(
                         '/sf/attribute/instance/%s/state' % instance['uuid'],
                         json.dumps(state.obj_dict(), indent=4, sort_keys=True))
+
+                    err_msg = instance.get('error_message')
+                    etcd_client.put(
+                        '/sf/attribute/instance/%s/error_msg' % instance['uuid'],
+                        json.dumps(err_msg, indent=4, sort_keys=True))
 
                     data = {}
                     for attr in ['power_state', 'power_state_previous',

--- a/shakenfist/daemons/cleaner.py
+++ b/shakenfist/daemons/cleaner.py
@@ -78,7 +78,7 @@ class Monitor(daemon.Daemon):
                 state = util.extract_power_state(libvirt, domain)
                 instance.update_power_state(state)
                 if state == 'crashed':
-                    instance.update_state('error')
+                    instance.state = 'error'
 
             # Inactive VMs just have a name, and are powered off
             # in our state system.
@@ -115,14 +115,14 @@ class Monitor(daemon.Daemon):
 
                     instance.place_instance(config.NODE_NAME)
 
-                    dbpowerstate = instance.power_state
+                    db_power = instance.power_state
                     if not os.path.exists(instance.instance_path):
                         # If we're inactive and our files aren't on disk,
                         # we have a problem.
                         log_ctx.info('Detected error state for instance')
-                        instance.update_state('error')
+                        instance.state = 'error'
 
-                    elif dbpowerstate['power_state'] != 'off':
+                    elif not db_power or db_power['power_state'] != 'off':
                         log_ctx.info('Detected power off for instance')
                         instance.update_power_state('off')
                         instance.add_event('detected poweroff', 'complete')

--- a/shakenfist/daemons/main.py
+++ b/shakenfist/daemons/main.py
@@ -58,9 +58,10 @@ def restore_instances():
         for network in networks:
             try:
                 n = net.Network.from_db(network)
-                LOG.withObj(n).info('Restoring network')
-                n.create_on_hypervisor()
-                n.ensure_mesh()
+                if not n.is_dead():
+                    LOG.withObj(n).info('Restoring network')
+                    n.create_on_hypervisor()
+                    n.ensure_mesh()
             except Exception as e:
                 util.ignore_exception('restore network %s' % network, e)
 

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -84,13 +84,13 @@ def handle(jobname, workitem):
 
             elif isinstance(task, DeleteInstanceTask):
                 try:
-                    instance_delete(instance_uuid, 'deleted')
+                    instance_delete(instance_uuid)
                 except Exception as e:
                     util.ignore_exception(daemon.process_name('queues'), e)
 
             elif isinstance(task, ErrorInstanceTask):
                 try:
-                    instance_delete(instance_uuid, 'error', task.error_msg())
+                    instance_error(instance_uuid, task.error_msg())
                     db.enqueue('%s-metrics' % config.NODE_NAME, {})
                 except Exception as e:
                     util.ignore_exception(daemon.process_name('queues'), e)
@@ -157,7 +157,7 @@ def instance_preflight(instance_uuid, network):
     if not instance:
         raise exceptions.InstanceNotInDBException(instance_uuid)
 
-    instance.update_state('preflight')
+    instance.state = 'preflight'
 
     # Try to place on this node
     s = scheduler.Scheduler()
@@ -243,7 +243,7 @@ def instance_start(instance_uuid, network):
             db.update_network_interface_state(iface['uuid'], 'created')
 
 
-def instance_delete(instance_uuid, new_state, error_msg=None):
+def instance_delete(instance_uuid):
     with db.get_lock('instance', None, instance_uuid, timeout=120,
                      op='Instance delete'):
         db.add_event('instance', instance_uuid, 'queued', 'delete', None, None)
@@ -265,9 +265,6 @@ def instance_delete(instance_uuid, new_state, error_msg=None):
         instance = virt.Instance.from_db(instance_uuid)
         if instance:
             instance.delete()
-            instance.update_state(new_state)
-            if error_msg:
-                instance.error_msg = error_msg
 
         # Check each network used by the deleted instance
         for network in instance_networks:
@@ -282,6 +279,14 @@ def instance_delete(instance_uuid, new_state, error_msg=None):
                     # Network not used by any other instance therefore delete
                     with util.RecordedOperation('remove network', n):
                         n.delete()
+        return instance
+
+
+def instance_error(instance_uuid, error_msg):
+    instance = instance_delete(instance_uuid)
+    if instance:
+        instance.state = 'error'
+        instance.error_msg = error_msg
 
 
 class Monitor(daemon.Daemon):

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -265,7 +265,9 @@ def instance_delete(instance_uuid, new_state, error_msg=None):
         instance = virt.Instance.from_db(instance_uuid)
         if instance:
             instance.delete()
-            instance.update_state(new_state, error_message=error_msg)
+            instance.update_state(new_state)
+            if error_msg:
+                instance.error_msg = error_msg
 
         # Check each network used by the deleted instance
         for network in instance_networks:

--- a/shakenfist/db.py
+++ b/shakenfist/db.py
@@ -11,8 +11,7 @@ from shakenfist import util
 from shakenfist.tasks import DeleteInstanceTask, ErrorInstanceTask
 
 
-# TODO(andy): Change back to 5 once network bugs fixed
-ETCD_ATTEMPT_TIMEOUT = 15
+ETCD_ATTEMPT_TIMEOUT = 60
 
 
 LOG, _ = logutil.setup(__name__)
@@ -67,17 +66,7 @@ def get_network_node():
 def get_lock(objecttype, subtype, name, ttl=60, timeout=ETCD_ATTEMPT_TIMEOUT,
              relatedobjects=None, log_ctx=LOG, op=None):
     return etcd.get_lock(objecttype, subtype, name, ttl=ttl, timeout=timeout,
-                         log_ctx=log_ctx, op=None)
-
-
-def get_object_lock(obj, ttl=60, timeout=ETCD_ATTEMPT_TIMEOUT,
-                    relatedobjects=None, log_ctx=LOG, op=None):
-    obj_type, obj_name = obj.unique_label()
-    if not (obj_type and obj_name):
-        raise exceptions.LockException(
-            'Could not derive lock name from %s' % obj)
-    return get_lock(obj_type, None, obj_name, ttl=ttl, timeout=timeout,
-                    relatedobjects=relatedobjects, log_ctx=log_ctx, op=op)
+                         log_ctx=log_ctx, op=op)
 
 
 def refresh_lock(lock, relatedobjects=None, log_ctx=LOG):

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -116,6 +116,7 @@ class ActualLock(Lock):
                                          'threshold': threshold,
                                          'holder-pid': pid,
                                          'holder-node': node,
+                                         'requesting-op': self.operation,
                                          }).info('Waiting for lock')
                 slow_warned = True
 
@@ -130,6 +131,7 @@ class ActualLock(Lock):
         self.log_ctx.withFields({'duration': duration,
                                  'holder-pid': pid,
                                  'holder-node': node,
+                                 'requesting-op': self.operation,
                                  }).info('Failed to acquire lock')
 
         raise exceptions.LockException(
@@ -138,6 +140,10 @@ class ActualLock(Lock):
 
     def __exit__(self, _exception_type, _exception_value, _traceback):
         if not self.release():
+            locks = list(get_all(LOCK_PREFIX, None))
+            self.log_ctx.withFields({'locks': locks,
+                                     'key': self.name,
+                                     }).error('Cannot release lock')
             raise exceptions.LockException(
                 'Cannot release lock: %s' % self.name)
 

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -1157,16 +1157,14 @@ def _delete_network(network_from_db):
         return error(404, 'network does not exist')
 
     if n.is_dead():
+        # The network has been deleted. No need to attempt further effort.
         LOG.withFields({'network_uuid': n.uuid,
                         'state': n.state.value
                         }).warning('delete_network: network is dead')
         return error(404, 'network is deleted')
 
-    n.state = 'deleting'
     n.add_event('api', 'delete')
-    n.remove_dhcp()
     n.delete()
-    n.state = 'deleted'
 
 
 class Network(Resource):
@@ -1351,15 +1349,14 @@ class NetworkPing(Resource):
         if not n:
             return error(404, 'network %s not found' % network_uuid)
 
-        with db.get_object_lock(n, ttl=120, op='Network ping via API'):
-            out, err = util.execute(
-                None, 'ip netns exec %s ping -c 10 %s' % (
-                    network_uuid, address),
-                check_exit_code=[0, 1])
-            return {
-                'stdout': out,
-                'stderr': err
-            }
+        out, err = util.execute(
+            None, 'ip netns exec %s ping -c 10 %s' % (
+                network_uuid, address),
+            check_exit_code=[0, 1])
+        return {
+            'stdout': out,
+            'stderr': err
+        }
 
 
 class Nodes(Resource):

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -1162,11 +1162,11 @@ def _delete_network(network_from_db):
                         }).warning('delete_network: network is dead')
         return error(404, 'network is deleted')
 
-    n.update_state('deleting')
+    n.state = 'deleting'
     n.add_event('api', 'delete')
     n.remove_dhcp()
     n.delete()
-    n.update_state('deleted')
+    n.state = 'deleted'
 
 
 class Network(Resource):

--- a/shakenfist/images.py
+++ b/shakenfist/images.py
@@ -78,7 +78,7 @@ class Image(baseobject.DatabaseBackedObject):
             'version': cls.current_version
         })
         i = Image.from_db(uuid)
-        i.update_state('initial')
+        i.state = 'initial'
         i.update_checksum(checksum)
         i.add_event('db record creation', None)
         return i
@@ -201,7 +201,7 @@ class Image(baseobject.DatabaseBackedObject):
         # without verifying that no instance is using it, so we just mark the
         # image as deleted in the database and move on without removing things
         # from the cache. We will probably want to revisit this in the future.
-        self.update_state('deleted')
+        self.state = 'deleted'
 
     def get(self, locks, related_object):
         """Wrap three retries around the image get.
@@ -210,15 +210,15 @@ class Image(baseobject.DatabaseBackedObject):
         download, the locks will be refreshed. Any lock error should abort the
         get, since the lock will have been lost.
         """
-        self.update_state('creating')
+        self.state = 'creating'
         for _ in range(3):
             try:
                 image_path = self._get(locks, related_object)
-                self.update_state('created')
+                self.state = 'created'
                 return image_path
             except exceptions.BadCheckSum as e:
                 LOG.warning('Bad checksum while downloading image: %s' % e)
-                self.update_state('error')
+                self.state = 'error'
                 self.error_msg = 'Bad checksum while downloading image: %s' % e
                 exc = e
         raise exc

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -294,107 +294,98 @@ class Network(baseobject.DatabaseBackedObject):
     def _create_common(self):
         subst = self.subst_dict()
 
-        with db.get_object_lock(self, ttl=120, op='Network create'):
-            # Ensure network was not deleted whilst waiting for the lock.
+        if not util.check_for_interface(subst['vx_interface']):
+            with util.RecordedOperation('create vxlan interface', self):
+                util.create_interface(
+                    subst['vx_interface'], 'vxlan',
+                    'id %(vx_id)s dev %(physical_interface)s dstport 0'
+                    % subst)
+                util.execute(None, 'sysctl -w net.ipv4.conf.'
+                                   '%(vx_interface)s.arp_notify=1' % subst)
+
+        if not util.check_for_interface(subst['vx_bridge']):
+            with util.RecordedOperation('create vxlan bridge', self):
+                util.create_interface(subst['vx_bridge'], 'bridge', '')
+                util.execute(None, 'ip link set %(vx_interface)s '
+                                   'master %(vx_bridge)s' % subst)
+                util.execute(None, 'ip link set %(vx_interface)s up' % subst)
+                util.execute(None, 'ip link set %(vx_bridge)s up' % subst)
+                util.execute(None, 'sysctl -w net.ipv4.conf.'
+                                   '%(vx_bridge)s.arp_notify=1' % subst)
+                util.execute(None, 'brctl setfd %(vx_bridge)s 0' % subst)
+                util.execute(None, 'brctl stp %(vx_bridge)s off' % subst)
+                util.execute(None, 'brctl setageing %(vx_bridge)s 0' % subst)
+
+    def create_on_hypervisor(self):
+        with self.get_lock(op='create_on_hypervisor'):
+            if self.is_dead():
+                raise DeadNetwork('network=%s' % self)
+            self._create_common()
+            db.enqueue('networknode', DeployNetworkTask(self.uuid))
+            self.add_event('deploy', 'enqueued')
+
+    def create_on_network_node(self):
+        with self.get_lock(op='create_on_network_node'):
             if self.is_dead():
                 raise DeadNetwork('network=%s' % self)
 
-            if not util.check_for_interface(subst['vx_interface']):
-                with util.RecordedOperation('create vxlan interface', self):
+            self._create_common()
+
+            subst = self.subst_dict()
+            if not os.path.exists('/var/run/netns/%(netns)s' % subst):
+                with util.RecordedOperation('create netns', self):
+                    util.execute(None, 'ip netns add %(netns)s' % subst)
+
+            if not util.check_for_interface(subst['vx_veth_outer']):
+                with util.RecordedOperation('create router veth', self):
                     util.create_interface(
-                        subst['vx_interface'], 'vxlan',
-                        'id %(vx_id)s dev %(physical_interface)s dstport 0'
-                        % subst)
+                        subst['vx_veth_outer'], 'veth',
+                        'peer name %(vx_veth_inner)s' % subst)
+                    util.execute(
+                        None,
+                        'ip link set %(vx_veth_inner)s netns %(netns)s' % subst)
+                    util.execute(
+                        None,
+                        'brctl addif %(vx_bridge)s %(vx_veth_outer)s' % subst)
+                    util.execute(None, 'ip link set %(vx_veth_outer)s up' % subst)
+                    util.execute(
+                        None,
+                        '%(in_netns)s ip link set %(vx_veth_inner)s up' % subst)
+                    util.execute(
+                        None,
+                        '%(in_netns)s ip addr add %(router)s/%(netmask)s '
+                        'dev %(vx_veth_inner)s' % subst)
+
+            if not util.check_for_interface(subst['physical_veth_outer']):
+                with util.RecordedOperation('create physical veth', self):
+                    util.create_interface(
+                        subst['physical_veth_outer'], 'veth',
+                        'peer name %(physical_veth_inner)s' % subst)
                     util.execute(None,
-                                 'sysctl -w net.ipv4.conf.'
-                                 '%(vx_interface)s.arp_notify=1' % subst)
-
-            if not util.check_for_interface(subst['vx_bridge']):
-                with util.RecordedOperation('create vxlan bridge', self):
-                    util.create_interface(subst['vx_bridge'], 'bridge', '')
+                                 'brctl addif %(physical_bridge)s '
+                                 '%(physical_veth_outer)s' % subst)
                     util.execute(None,
-                                 'ip link set %(vx_interface)s '
-                                 'master %(vx_bridge)s' % subst)
+                                 'ip link set %(physical_veth_outer)s up'
+                                 % subst)
                     util.execute(None,
-                                 'ip link set %(vx_interface)s up' % subst)
-                    util.execute(None,
-                                 'ip link set %(vx_bridge)s up' % subst)
-                    util.execute(None,
-                                 'sysctl -w net.ipv4.conf.'
-                                 '%(vx_bridge)s.arp_notify=1' % subst)
-                    util.execute(None,
-                                 'brctl setfd %(vx_bridge)s 0' % subst)
-                    util.execute(None,
-                                 'brctl stp %(vx_bridge)s off' % subst)
-                    util.execute(None,
-                                 'brctl setageing %(vx_bridge)s 0' % subst)
+                                 'ip link set %(physical_veth_inner)s '
+                                 'netns %(netns)s' % subst)
 
-    def create_on_hypervisor(self):
-        self._create_common()
-        db.enqueue('networknode', DeployNetworkTask(self.uuid))
-        self.add_event('deploy', 'enqueued')
+            if self.provide_nat:
+                # We don't always need this lock, but acquiring it here means
+                # we don't need to construct two identical ipmanagers one after
+                # the other.
+                with db.get_lock('ipmanager', None, 'floating', ttl=120,
+                                 op='Network deploy NAT'):
+                    ipm = IPManager.from_db('floating')
+                    if not self.floating_gateway:
+                        self.update_floating_gateway(
+                            ipm.get_random_free_address())
+                        ipm.persist()
 
-    def create_on_network_node(self):
-        self._create_common()
-        subst = self.subst_dict()
-
-        if not os.path.exists('/var/run/netns/%(netns)s' % subst):
-            with util.RecordedOperation('create netns', self):
-                util.execute(None, 'ip netns add %(netns)s' % subst)
-
-        if not util.check_for_interface(subst['vx_veth_outer']):
-            with util.RecordedOperation('create router veth', self):
-                util.create_interface(
-                    subst['vx_veth_outer'], 'veth',
-                    'peer name %(vx_veth_inner)s' % subst)
-                util.execute(
-                    None,
-                    'ip link set %(vx_veth_inner)s netns %(netns)s' % subst)
-                util.execute(
-                    None,
-                    'brctl addif %(vx_bridge)s %(vx_veth_outer)s' % subst)
-                util.execute(None, 'ip link set %(vx_veth_outer)s up' % subst)
-                util.execute(
-                    None,
-                    '%(in_netns)s ip link set %(vx_veth_inner)s up' % subst)
-                util.execute(
-                    None,
-                    '%(in_netns)s ip addr add %(router)s/%(netmask)s '
-                    'dev %(vx_veth_inner)s' % subst)
-
-        if not util.check_for_interface(subst['physical_veth_outer']):
-            with util.RecordedOperation('create physical veth', self):
-                util.create_interface(
-                    subst['physical_veth_outer'], 'veth',
-                    'peer name %(physical_veth_inner)s' % subst)
-                util.execute(None,
-                             'brctl addif %(physical_bridge)s '
-                             '%(physical_veth_outer)s' % subst)
-                util.execute(None,
-                             'ip link set %(physical_veth_outer)s up'
-                             % subst)
-                util.execute(None,
-                             'ip link set %(physical_veth_inner)s '
-                             'netns %(netns)s' % subst)
-
-        if self.provide_nat:
-            # We don't always need this lock, but acquiring it here means we don't
-            # need to construct two idential ipmanagers one after the other.
-            with db.get_lock('ipmanager', None, 'floating', ttl=120,
-                             op='Network deploy NAT'):
-                ipm = IPManager.from_db('floating')
-                if not self.floating_gateway:
-                    self.update_floating_gateway(ipm.get_random_free_address())
-                    ipm.persist()
-
-                subst['floating_router'] = ipm.get_address_at_index(1)
-                subst['floating_gateway'] = self.floating_gateway
-                subst['floating_netmask'] = ipm.netmask
-
-            with db.get_object_lock(self, ttl=120, op='Network deploy NAT'):
-                # Ensure network was not deleted whilst waiting for the lock.
-                if self.is_dead():
-                    raise DeadNetwork('network=%s' % self)
+                    subst['floating_router'] = ipm.get_address_at_index(1)
+                    subst['floating_gateway'] = self.floating_gateway
+                    subst['floating_netmask'] = ipm.netmask
 
                 with util.RecordedOperation('enable virtual routing', self):
                     addresses = util.get_interface_addresses(
@@ -438,52 +429,66 @@ class Network(baseobject.DatabaseBackedObject):
                                      '-s %(ipblock)s/%(netmask)s '
                                      '-o %(physical_veth_inner)s '
                                      '-j MASQUERADE' % subst)
-
+            self.state = 'created'
         self.update_dhcp()
-        self.state = 'created'
 
     def delete(self):
+        with self.get_lock(op='Network delete'):
+            if self.is_dead():
+                LOG.withObj(self).info('Network died whilst waiting for lock')
+                return
+            self._delete_on_node()
+            self.state = 'deleted'
+        self.remove_dhcp()
+
+    def delete_on_node_with_lock(self):
+        with self.get_lock(op='Network delete on node'):
+            if self.is_dead():
+                LOG.withObj(self).info('Network died whilst waiting for lock')
+                return
+            self._delete_on_node()
+
+    def _delete_on_node(self):
         subst = self.subst_dict()
-        LOG.withFields(subst).debug('net.delete()')
+        LOG.withFields(subst).debug('net.delete_on_node()')
 
         # Cleanup local node
-        with db.get_object_lock(self, ttl=120, op='Network delete'):
-            if util.check_for_interface(subst['vx_bridge']):
-                with util.RecordedOperation('delete vxlan bridge', self):
-                    util.execute(None, 'ip link delete %(vx_bridge)s' % subst)
+        if util.check_for_interface(subst['vx_bridge']):
+            with util.RecordedOperation('delete vxlan bridge', self):
+                util.execute(None, 'ip link delete %(vx_bridge)s' % subst)
 
-            if util.check_for_interface(subst['vx_interface']):
-                with util.RecordedOperation('delete vxlan interface', self):
+        if util.check_for_interface(subst['vx_interface']):
+            with util.RecordedOperation('delete vxlan interface', self):
+                util.execute(
+                    None, 'ip link delete %(vx_interface)s' % subst)
+
+        # If this is the network node do additional cleanup
+        if util.is_network_node():
+            if util.check_for_interface(subst['vx_veth_outer']):
+                with util.RecordedOperation('delete router veth', self):
                     util.execute(
-                        None, 'ip link delete %(vx_interface)s' % subst)
+                        None, 'ip link delete %(vx_veth_outer)s' % subst)
 
-            # If this is the network node do additional cleanup
-            if util.is_network_node():
-                if util.check_for_interface(subst['vx_veth_outer']):
-                    with util.RecordedOperation('delete router veth', self):
-                        util.execute(
-                            None, 'ip link delete %(vx_veth_outer)s' % subst)
+            if util.check_for_interface(subst['physical_veth_outer']):
+                with util.RecordedOperation('delete physical veth', self):
+                    util.execute(
+                        None,
+                        'ip link delete %(physical_veth_outer)s' % subst)
 
-                if util.check_for_interface(subst['physical_veth_outer']):
-                    with util.RecordedOperation('delete physical veth', self):
-                        util.execute(
-                            None,
-                            'ip link delete %(physical_veth_outer)s' % subst)
+            if os.path.exists('/var/run/netns/%(netns)s' % subst):
+                with util.RecordedOperation('delete netns', self):
+                    util.execute(None, 'ip netns del %(netns)s' % subst)
 
-                if os.path.exists('/var/run/netns/%(netns)s' % subst):
-                    with util.RecordedOperation('delete netns', self):
-                        util.execute(None, 'ip netns del %(netns)s' % subst)
+            if self.floating_gateway:
+                with db.get_lock('ipmanager', None, 'floating', ttl=120,
+                                 op='Network delete'):
+                    ipm = IPManager.from_db('floating')
+                    ipm.release(self.floating_gateway)
+                    ipm.persist()
+                    self.update_floating_gateway(None)
 
-                if self.floating_gateway:
-                    with db.get_lock('ipmanager', None, 'floating', ttl=120,
-                                     op='Network delete'):
-                        ipm = IPManager.from_db('floating')
-                        ipm.release(self.floating_gateway)
-                        ipm.persist()
-                        self.update_floating_gateway(None)
-
-            Network.deallocate_vxid(self.vxid)
-            IPManager.from_db(self.uuid).delete()
+        Network.deallocate_vxid(self.vxid)
+        IPManager.from_db(self.uuid).delete()
 
     def hard_delete(self):
         etcd.delete('network', None, self.uuid)
@@ -508,7 +513,7 @@ class Network(baseobject.DatabaseBackedObject):
         if util.is_network_node():
             subst = self.subst_dict()
             with util.RecordedOperation('update dhcp', self):
-                with db.get_object_lock(self, ttl=120, op='Network update DHCP'):
+                with self.get_lock(op='Network update DHCP'):
                     d = dhcp.DHCP(self, subst['vx_veth_inner'])
                     d.restart_dhcpd()
         else:
@@ -519,7 +524,7 @@ class Network(baseobject.DatabaseBackedObject):
         if util.is_network_node():
             subst = self.subst_dict()
             with util.RecordedOperation('remove dhcp', self):
-                with db.get_object_lock(self, ttl=120, op='Network remove DHCP'):
+                with self.get_lock(op='Network remove DHCP'):
                     d = dhcp.DHCP(self, subst['vx_veth_inner'])
                     d.remove_dhcpd()
         else:
@@ -538,7 +543,7 @@ class Network(baseobject.DatabaseBackedObject):
                 yield m.group(1)
 
     def ensure_mesh(self):
-        with db.get_object_lock(self, ttl=120, op='Network ensure mesh'):
+        with self.get_lock(op='Network ensure mesh'):
             # Ensure network was not deleted whilst waiting for the lock.
             if self.is_dead():
                 raise DeadNetwork('network=%s' % self)

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -30,12 +30,9 @@ class Network(baseobject.DatabaseBackedObject):
     current_version = 2
     state_targets = {
         None: ('initial', ),
-        'initial': ('created', 'deleting', 'error'),
-        # TODO(andy): Investigate whether networks should created->deleted
-        'created': ('created', 'deleting', 'deleted', 'error'),
-        # TODO(andy): Remove deleting->created. Example occurs during CI.
-        'deleting': ('deleted', 'created', 'error'),
-        'error': ('deleting', 'error'),
+        'initial': ('created', 'deleted', 'error'),
+        'created': ('created', 'deleted', 'error'),
+        'error': ('deleted', 'error'),
         'deleted': (),
     }
 
@@ -321,6 +318,8 @@ class Network(baseobject.DatabaseBackedObject):
             if self.is_dead():
                 raise DeadNetwork('network=%s' % self)
             self._create_common()
+
+            # TODO(andy): Check with mikal: is this task required here?
             db.enqueue('networknode', DeployNetworkTask(self.uuid))
             self.add_event('deploy', 'enqueued')
 

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -100,7 +100,7 @@ class Network(baseobject.DatabaseBackedObject):
         )
 
         n = Network.from_db(uuid)
-        n.update_state('initial')
+        n.state = 'initial'
         n.add_event('db record creation', None)
 
         # Networks should immediately appear on the network node
@@ -440,7 +440,7 @@ class Network(baseobject.DatabaseBackedObject):
                                      '-j MASQUERADE' % subst)
 
         self.update_dhcp()
-        self.update_state('created')
+        self.state = 'created'
 
     def delete(self):
         subst = self.subst_dict()

--- a/shakenfist/tests/test_baseobject.py
+++ b/shakenfist/tests/test_baseobject.py
@@ -1,6 +1,8 @@
 import mock
+import testtools
 
 from shakenfist.baseobject import DatabaseBackedObject, State
+from shakenfist import exceptions
 from shakenfist.tests import test_shakenfist
 
 
@@ -11,27 +13,42 @@ class DatabaseBackedObjectTestCase(test_shakenfist.ShakenFistTestCase):
                     {'value': 'initial', 'update_time': 4},
                     {'value': 'created', 'update_time': 10},
                 ])
-    def test_state_property(self, mock_get_attribute):
+    def test_state(self, mock_get_attribute):
         d = DatabaseBackedObject('uuid')
         self.assertEqual(d.state, State(None, 2))
         self.assertEqual(d.state, State('initial', 4))
         self.assertEqual(d.state, State('created', 10))
 
-
-class StateTestCase(test_shakenfist.ShakenFistTestCase):
-    def test_state_object_full(self):
-        s = State('state1', 3, 'error msg')
+    def test_property_state_object_full(self):
+        s = State('state1', 3)
 
         self.assertEqual(s.value, 'state1')
         self.assertEqual(s.update_time, 3)
-        self.assertEqual(s.error_msg, 'error msg')
 
         self.assertEqual(s.obj_dict(), {
             'value': 'state1',
             'update_time': 3,
         })
 
-        self.assertEqual(s, State('state1', 3, 'error msg'))
-
+        self.assertEqual(s, State('state1', 3))
         self.assertEqual(str(s),
                          "State({'value': 'state1', 'update_time': 3})")
+
+    @mock.patch('shakenfist.baseobject.DatabaseBackedObject._db_set_attribute')
+    @mock.patch('shakenfist.baseobject.DatabaseBackedObject._db_get_attribute',
+                side_effect=[
+                    None,
+                    'bad error',
+                    {'value': 'initial', 'update_time': 4},
+                    {'value': 'error', 'update_time': 4},
+                    'real bad',
+                ])
+    def test_property_error_msg(self, mock_get_attribute, mock_set_attribute):
+        d = DatabaseBackedObject('uuid')
+        self.assertEqual(d.error_msg, None)
+        self.assertEqual(d.error_msg, 'bad error')
+
+        with testtools.ExpectedException(exceptions.InvalidStateException):
+            d.error_msg = 'real bad'
+
+        d.error_msg = 'real bad'

--- a/shakenfist/tests/test_baseobject.py
+++ b/shakenfist/tests/test_baseobject.py
@@ -29,18 +29,9 @@ class StateTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertEqual(s.obj_dict(), {
             'value': 'state1',
             'update_time': 3,
-            'error_msg': 'error msg',
         })
 
         self.assertEqual(s, State('state1', 3, 'error msg'))
 
         self.assertEqual(str(s),
-                         "State({'value': 'state1', 'update_time': 3, "
-                         "'error_msg': 'error msg'})")
-
-    def _test_state_object_def(self):
-        s = State('state1', 4)
-
-        self.assertEqual(s.value, 'state1')
-        self.assertEqual(s.update_time, 4)
-        self.assertEqual(s.error_msg, None)
+                         "State({'value': 'state1', 'update_time': 3})")

--- a/shakenfist/tests/test_daemon_cleaner.py
+++ b/shakenfist/tests/test_daemon_cleaner.py
@@ -92,6 +92,12 @@ def fake_put(objecttype, subtype, name, v):
     FAKE_ETCD_STATE['%s/%s/%s' % (objecttype, subtype, name)] = v
 
 
+def fake_get(objecttype, subtype, name):
+    global FAKE_ETCD_STATE
+    val = FAKE_ETCD_STATE.get('%s/%s/%s' % (objecttype, subtype, name))
+    return val
+
+
 class CleanerTestCase(test_shakenfist.ShakenFistTestCase):
     def setUp(self):
         super(CleanerTestCase, self).setUp()
@@ -110,27 +116,25 @@ class CleanerTestCase(test_shakenfist.ShakenFistTestCase):
         self.mock_config = self.config.start()
         self.addCleanup(self.config.stop)
 
-    @mock.patch('shakenfist.virt.Instance.state',
-                new_callable=mock.PropertyMock)
+    @mock.patch('shakenfist.etcd.get', side_effect=fake_get)
     @mock.patch('shakenfist.db.get_lock')
     @mock.patch('shakenfist.db.see_this_node')
     @mock.patch('shakenfist.db.add_event')
     @mock.patch('shakenfist.virt.Instance._db_get', side_effect=fake_instance_get)
-    @mock.patch('shakenfist.virt.Instance._db_get_attribute', return_value={})
     @mock.patch('shakenfist.etcd.put', side_effect=fake_put)
     @mock.patch('os.path.exists', side_effect=fake_exists)
     @mock.patch('time.time', return_value=7)
     def test_update_power_states(self, mock_time, mock_exists, mock_put,
-                                 mock_get_instance_attribute, mock_get_instance,
-                                 mock_event, mock_see, mock_lock,
-                                 mock_state_get):
-        mock_state_get.return_value = State('initial', 0)
+                                 mock_get_instance, mock_event, mock_see,
+                                 mock_lock, mock_etcd_get):
 
         m = cleaner.Monitor('cleaner')
         m._update_power_states()
 
         result = []
         for c in mock_put.mock_calls:
+            if type(c[1][3]) is dict and 'placement_attempts' in c[1][3]:
+                continue
             if type(c[1][3]) is State:
                 val = c[1][3]
             else:
@@ -140,18 +144,20 @@ class CleanerTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertEqual(
             [
                 ('attribute/instance', 'running',
-                 'placement', {'power_state': 'off'}),
-                ('attribute/instance', 'running',
-                 'power_state', {'power_state': 'off'}),
+                 'power_state', {'power_state': 'on'}),
                 ('attribute/instance', 'shutoff',
                  'power_state', {'power_state': 'off'}),
                 ('attribute/instance', 'crashed',
-                 'power_state', {'power_state': 'off'}),
+                 'power_state', {'power_state': 'crashed'}),
                 ('attribute/instance', 'crashed',
                  'state', State('error', 7)),
                 ('attribute/instance', 'paused',
-                 'power_state', {'power_state': 'off'}),
+                 'power_state', {'power_state': 'paused'}),
+                ('attribute/instance', 'suspended',
+                 'power_state', {'power_state': 'paused'}),
                 ('attribute/instance', 'foo',
+                 'power_state', {'power_state': 'off'}),
+                ('attribute/instance', 'bar',
                  'power_state', {'power_state': 'off'}),
                 ('attribute/instance', 'nofiles',
                  'state', State('error', 7))

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -44,7 +44,7 @@ class BaseFakeObject(object):
     def add_event(self, operation, phase, duration=None, msg=None):
         pass
 
-    def update_state(self, state, error_message=None):
+    def update_state(self, state):
         self._state = state
 
     def delete(self):

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -38,14 +38,15 @@ class BaseFakeObject(object):
         else:
             return State(self._state, 1)
 
+    @state.setter
+    def state(self, state):
+        self._state = state
+
     def unique_label(self):
         return ('instance', self.uuid)
 
     def add_event(self, operation, phase, duration=None, msg=None):
         pass
-
-    def update_state(self, state):
-        self._state = state
 
     def delete(self):
         pass

--- a/shakenfist/tests/test_images.py
+++ b/shakenfist/tests/test_images.py
@@ -250,21 +250,20 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
                          images.Image.calc_unique_ref('http://example.com'))
 
     @mock.patch('shakenfist.db.get_lock')
-    @mock.patch('shakenfist.images.Image.state',
-                new_callable=mock.PropertyMock)
+    @mock.patch('shakenfist.images.Image._db_get_attribute',
+                side_effect=[
+                    {'value': None, 'update_time': 0},
+                    {'value': 'initial', 'update_time': 0},
+                    {'value': 'initial', 'update_time': 0},
+                    {'value': 'creating', 'update_time': 0},
+                    {'value': 'created', 'update_time': 0},
+                    {'value': 'error', 'update_time': 0},
+                    {'value': 'deleted', 'update_time': 0},
+                ])
     @mock.patch('shakenfist.images.Image._db_set_attribute')
     @mock.patch('shakenfist.etcd.put')
-    def test_update_state_valid(
+    def test_state_property_valid(
             self, mock_put, mock_attribute_set, mock_state_get, mock_lock):
-        mock_state_get.side_effect = [
-            State(None, 0),
-            State('initial', 0),
-            State('initial', 0),
-            State('creating', 0),
-            State('created', 0),
-            State('error', 0),
-            State('deleted', 0),
-        ]
 
         i = images.Image({
             'ref': 'ref',
@@ -272,16 +271,16 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
             'version': 1,
             'url': 'a'
             })
-        i.update_state('initial')
-        self.assertRaises(exceptions.InvalidStateException,
-                          i.update_state, 'created')
-        self.assertRaises(exceptions.InvalidStateException,
-                          i.update_state, 'created')
-        i.update_state('deleted')
-        i.update_state('error')
-        i.update_state('deleted')
-        self.assertRaises(exceptions.InvalidStateException,
-                          i.update_state, 'created')
+        i.state = 'initial'
+        with testtools.ExpectedException(exceptions.InvalidStateException):
+            i.state = 'created'
+        with testtools.ExpectedException(exceptions.InvalidStateException):
+            i.state = 'created'
+        i.state = 'deleted'
+        i.state = 'error'
+        i.state = 'deleted'
+        with testtools.ExpectedException(exceptions.InvalidStateException):
+            i.state = 'created'
 
     @mock.patch('shakenfist.baseobject.DatabaseBackedObject._db_get',
                 return_value={
@@ -301,7 +300,7 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertEqual([mock.call('latest_checksum', {'checksum': '1abab'})],
                          mock_set_attr.mock_calls)
 
-    @mock.patch('shakenfist.images.Image.update_state')
+    @mock.patch('shakenfist.images.Image.state')
     @mock.patch('shakenfist.baseobject.DatabaseBackedObject._db_get',
                 side_effect=[None,
                              {
@@ -318,7 +317,8 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
                 new_callable=mock.PropertyMock)
     def test_image_persist(
             self, mock_checksum, mock_create, mock_set_attr, mock_mkdirs, mock_get,
-            mock_update_state):
+            mock_state):
+        mock_state.setter.return_value = State(None, 1)
         images.Image.new('http://example.com', '1abab')
         self.assertEqual([
             mock.call('f0e6a6a97042a4f1f1c87f5f7d44315b2d852c2df5c7991cc66241'
@@ -464,7 +464,7 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
         dirty_fields = img._new_image_available(img._open_connection())
         self.assertEqual(('size', 200000, 16338944), dirty_fields)
 
-    @mock.patch('shakenfist.images.Image.update_state')
+    @mock.patch('shakenfist.images.Image.state')
     @mock.patch('requests.get',
                 return_value=FakeResponse(
                     200, '',
@@ -486,8 +486,9 @@ class ImageObjectTestCase(test_shakenfist.ShakenFistTestCase):
                 new_callable=mock.PropertyMock)
     def test_fetch_image_new(
             self, mock_version, mock_checksum, mock_mkdirs, mock_get,
-            mock_request_head, mock_update_state):
+            mock_request_head, mock_state):
         mock_version.return_value = {}
+        mock_state.setter.return_value = State(None, 1)
 
         img = images.Image.new('http://example.com')
         dirty_fields = img._new_image_available(img._open_connection())
@@ -805,7 +806,7 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertFalse(image.correct_checksum(ret))
 
     # Data matches checksum
-    @mock.patch('shakenfist.images.Image.update_state')
+    @mock.patch('shakenfist.images.Image.state')
     @mock.patch('shakenfist.images.Image._add_download_version')
     @mock.patch('shakenfist.images.Image.latest_download_version',
                 new_callable=mock.PropertyMock)
@@ -820,7 +821,8 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
     @mock.patch('shakenfist.db.refresh_locks')
     def test_get(
             self, mock_refresh_locks, mock_put, mock_open, mock_transcode,
-            mock_version, mock_add_version, mock_update_state):
+            mock_version, mock_add_version, mock_state):
+        mock_state.setter.return_value = State(None, 1)
         mock_version.return_value = {
             'size': 200000,
             'modified': 'Tue, 10 Sep 2019 07:24:40 GMT',
@@ -850,7 +852,7 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
             mock_add_version.mock_calls)
 
     # First download attempt corrupted, second download matches checksum
-    @mock.patch('shakenfist.images.Image.update_state')
+    @mock.patch('shakenfist.images.Image.state')
     @mock.patch('shakenfist.images.Image._add_download_version')
     @mock.patch('shakenfist.images.Image.latest_download_version',
                 new_callable=mock.PropertyMock)
@@ -867,7 +869,8 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
     @mock.patch('shakenfist.db.refresh_locks')
     def test_get_one_corrupt(
             self, mock_refresh_locks, mock_put, mock_open, mock_transcode,
-            mock_version, mock_add_version, mock_update_state):
+            mock_version, mock_add_version, mock_state):
+        mock_state.setter.return_value = State(None, 1)
         mock_version.return_value = {
             'size': 200000,
             'modified': 'Tue, 10 Sep 2019 07:24:40 GMT',
@@ -894,8 +897,19 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
 
     # All download attempts not matching checksum
     @mock.patch('shakenfist.images.Image._db_get_attribute',
-                return_value={'state': 'error', 'update_time': 123})
-    @mock.patch('shakenfist.images.Image.update_state')
+                side_effect=[
+                    {'value': 'creating', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    {'value': 'error', 'update_time': 123},
+                    ])
+    @mock.patch('shakenfist.images.Image.get_lock_attr')
     @mock.patch('shakenfist.images.Image._add_download_version')
     @mock.patch('shakenfist.images.Image.latest_download_version',
                 new_callable=mock.PropertyMock)
@@ -912,7 +926,7 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
     @mock.patch('shakenfist.db.refresh_locks')
     def test_get_always_corrupt(
             self, mock_refresh_locks, mock_put, mock_open,
-            mock_version, mock_add_version, mock_update_state,
+            mock_version, mock_add_version, get_lock_attr,
             mock_db_get_attribute):
         mock_version.return_value = {
             'size': 200000,

--- a/shakenfist/tests/test_images.py
+++ b/shakenfist/tests/test_images.py
@@ -893,6 +893,8 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
         self.assertTrue(image.correct_checksum(ret))
 
     # All download attempts not matching checksum
+    @mock.patch('shakenfist.images.Image._db_get_attribute',
+                return_value={'state': 'error', 'update_time': 123})
     @mock.patch('shakenfist.images.Image.update_state')
     @mock.patch('shakenfist.images.Image._add_download_version')
     @mock.patch('shakenfist.images.Image.latest_download_version',
@@ -910,14 +912,14 @@ class ImageChecksumTestCase(test_shakenfist.ShakenFistTestCase):
     @mock.patch('shakenfist.db.refresh_locks')
     def test_get_always_corrupt(
             self, mock_refresh_locks, mock_put, mock_open,
-            mock_version, mock_add_version, mock_update_state):
+            mock_version, mock_add_version, mock_update_state,
+            mock_db_get_attribute):
         mock_version.return_value = {
             'size': 200000,
             'modified': 'Tue, 10 Sep 2019 07:24:40 GMT',
             'fetched_at': 'Tue, 20 Oct 2020 23:02:29 -0000',
             'sequence': 1
         }
-
         test_checksum = '097c42989a9e5d9dcced7b35ec4b0486'
         image = FakeImageChecksum({
             'url': 'testurl',

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -201,7 +201,8 @@ class Instance(baseobject.DatabaseBackedObject):
             'state': self.state.value,
             'user_data': self.user_data,
             'video': self.video,
-            'version': self.version
+            'version': self.version,
+            'error_message': self.error_msg,
         }
 
         if self.requested_placement:
@@ -209,7 +210,6 @@ class Instance(baseobject.DatabaseBackedObject):
 
         external_attribute_key_whitelist = [
             'console_port',
-            'error_message',
             'node',
             'power_state',
             'vdi_port'

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -118,7 +118,7 @@ class Instance(baseobject.DatabaseBackedObject):
     object_type = 'instance'
     current_version = 2
     state_targets = {
-        None: ('initial', ),
+        None: ('initial', 'error'),
         'initial': ('preflight', 'deleted', 'error'),
         'preflight': ('creating', 'deleted', 'error'),
         'creating': ('created', 'deleted', 'error'),
@@ -171,7 +171,7 @@ class Instance(baseobject.DatabaseBackedObject):
                 'version': cls.current_version
             })
         i = Instance.from_db(uuid)
-        i.update_state('initial')
+        i.state = 'initial'
         i._db_set_attribute('power_state', {'power_state': 'initial'})
         i.add_event('db record creation', None)
         return i
@@ -352,7 +352,7 @@ class Instance(baseobject.DatabaseBackedObject):
     # has been transcoded to the right format. This has been done to facilitate
     # moving to a queue and task based creation mechanism.
     def create(self, lock=None):
-        self.update_state('creating')
+        self.state = 'creating'
 
         # Ensure we have state on disk
         os.makedirs(self.instance_path, exist_ok=True)
@@ -379,7 +379,7 @@ class Instance(baseobject.DatabaseBackedObject):
             LOG.withObj(self).info('Instance now powered on')
         else:
             LOG.withObj(self).info('Instance failed to power on')
-        self.update_state('created')
+        self.state = 'created'
 
     def delete(self):
         with util.RecordedOperation('delete domain', self):
@@ -412,7 +412,7 @@ class Instance(baseobject.DatabaseBackedObject):
         self._free_console_port(ports.get('console_port'))
         self._free_console_port(ports.get('vdi_port'))
 
-        self.update_state('deleted')
+        self.state = 'deleted'
 
     def hard_delete(self):
         etcd.delete('instance', None, self.uuid)


### PR DESCRIPTION
* Lock networks to prevent deletion during creation
* Only restore networks that are not dead
* Move get_object_lock into DatabaseBackedObject

Resolves #647