### PR TITLE
Networks should enter 'created' state once the network node is setup.

### DIFF
--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -176,6 +176,7 @@ class Monitor(daemon.Daemon):
                 try:
                     n.create_on_network_node()
                     n.ensure_mesh()
+                    n.state = 'created'
                     db.add_event('network', workitem.network_uuid(),
                                  'network node', 'deploy', None, None)
                 except exceptions.DeadNetwork as e:


### PR DESCRIPTION
Fixes #669.