### PR TITLE
A new installer.

### DIFF
--- a/Jenkinsfile-ci-ubuntu-2004
+++ b/Jenkinsfile-ci-ubuntu-2004
@@ -19,13 +19,18 @@ pipeline {
                 echo "Updating worker"
                 sudo apt-get update
                 sudo apt-get -y dist-upgrade
-                sudo apt-get -y install pwgen build-essential python3-dev python3-wheel python3-pip curl
+                sudo apt-get -y install ansible tox pwgen build-essential python3-dev python3-wheel \
+                  python3-pip curl ansible vim git pwgen
 
                 sudo pip3 uninstall ansible
                 sudo apt-get remove -y ansible
+
+                sudo pip3 install -U pip
+                sudo apt-get remove -y python3-pip
+
                 sudo pip3 install -U ansible tox
-                ansible-galaxy install andrewrothstein.etcd-cluster andrewrothstein.terraform andrewrothstein.go
-                ansible-galaxy collection install community.general
+                sudo ansible-galaxy install andrewrothstein.etcd-cluster andrewrothstein.terraform andrewrothstein.go
+                sudo ansible-galaxy collection install community.general
 
                 # We create a RAM disk for etcd to work around poor performance on cloud instances
                 sudo mkdir -p /var/lib/etcd
@@ -37,23 +42,35 @@ pipeline {
       steps {
         sh '''
 
-                if [ '%%' == '%%' ]
+                if [ '%master%' == '%%' ]
                 then
                   BRANCH=`git rev-parse --abbrev-ref HEAD`
                 else
-                  BRANCH=""
+                  BRANCH="master"
                 fi
 
-                cd $WORKSPACE/deploy/ansible
+                cd $WORKSPACE
 
 
 
                 # Install the latest 0.3 pypi release
-                export CLOUD="localhost"
-                export FLOATING_IP_BLOCK="10.0.0.0/24"
-                export KSM_ENABLED="0"
-                export RELEASE=`curl -s https://pypi.org/simple/shakenfist/ | grep whl | sed -e 's/.*shakenfist-//' -e 's/-py3.*//' | grep 0.3 | tail -1`
-                ./deployandtest.sh
+                sudo pip install "shakenfist>=0.3,<0.4"
+                sudo pip install "shakenfist_client>=0.3,<0.4"
+                SFVERSION=`pip list | tr -s " " | grep "shakenfist " | sed 's/.dev.*//' | cut -f 2 -d " "`
+
+                if [ -e /usr/local/share/shakenfist/installer/install.sh ]
+                then
+                  sudo CLOUD="localhost" FLOATING_IP_BLOCK="10.0.0.0/24" KSM_ENABLED="0" /usr/local/share/shakenfist/installer/install.sh
+                else
+                  cd deploy/ansible
+
+                  previous=`git branch --show-current`
+                  git remote add github https://github.com/shakenfist/shakenfist
+                  git fetch github
+                  git checkout v$SFVERSION
+                  sudo CLOUD="localhost" FLOATING_IP_BLOCK="10.0.0.0/24" KSM_ENABLED="0" ./deployandtest.sh
+                  git checkout $previous
+                fi
 
                 # Log what versions we are running
                 echo "============================================================"
@@ -131,22 +148,25 @@ pipeline {
         sh '''
 
 
-                if [ '%%' == '%%' ]
+                if [ '%master%' == '%%' ]
                 then
                   BRANCH=`git rev-parse --abbrev-ref HEAD`
                 else
-                  BRANCH=""
+                  BRANCH="master"
                 fi
 
-                cd $WORKSPACE/deploy/ansible
-                export RELEASE="git:master"
+                cd $WORKSPACE
 
-                export CLOUD="localhost"
-                export FLOATING_IP_BLOCK="10.0.0.0/24"
-                export KSM_ENABLED="0"
+                # Make a wheel to install
+                sudo pip install --upgrade readme-renderer
+                sudo pip install --upgrade twine
+                tar czf deploy.tgz deploy
+                tar czf docs.tgz docs
+                python3 setup.py sdist bdist_wheel
+                sudo pip install dist/shakenfist-*whl
 
-                echo "Deploying $RELEASE to cloud $CLOUD"
-                ./deployandtest.sh
+                # Run installer
+                sudo CLOUD="localhost" FLOATING_IP_BLOCK="10.0.0.0/24" KSM_ENABLED="0" /usr/local/share/shakenfist/installer/install.sh
 
                 # Log what versions we are running
                 echo "============================================================"

--- a/deploy/ansible/deploy.sh
+++ b/deploy/ansible/deploy.sh
@@ -160,65 +160,6 @@ fi
 
 set -x
 
-#### Release selection, git or a version from pypi
-if [ -z "$RELEASE" ]
-then
-  # This is the latest version from pypi
-  RELEASE=`curl -s https://pypi.org/simple/shakenfist/ | grep whl | sed -e 's/.*shakenfist-//' -e 's/-py3.*//' | tail -1`
-fi
-
-cwd=`pwd`
-if [ `echo $RELEASE | cut -f 1 -d ":"` == "git" ]
-then
-  for repo in client-python ansible-modules
-  do
-    if [ ! -e ../gitrepos/$repo ]
-    then
-      git clone https://github.com/shakenfist/$repo ../gitrepos/$repo
-    else
-      
-      cd ../gitrepos/$repo
-      git fetch
-    fi
-    cd "$cwd"
-  done
-
-  branch=`echo $RELEASE | cut -f 2 -d ":"`
-  if [ -z "$branch" ]
-  then
-    branch="master"
-  fi
-
-  # And make sure our other repos are using the right branch too
-  for repo in client-python ansible-modules
-  do
-    cd ../gitrepos/$repo
-    git checkout $branch || git checkout master
-    git pull
-    cd "$cwd"
-  done
-
-  RELEASE="git"
-else
-  # NOTE(mikal): this is a hack until we use ansible galaxy for these modules
-  for repo in ansible-modules
-  do
-    echo "Priming $repo"
-
-    if [ ! -e ../gitrepos/$repo ]
-    then
-      git clone https://github.com/shakenfist/$repo ../gitrepos/$repo
-    else
-      cd ../gitrepos/$repo
-      git fetch
-      git checkout master
-      git pull
-    fi
-    cd "$cwd"
-  done
-fi
-VARIABLES="$VARIABLES,release=$RELEASE"
-
 #### Mode selection, deploy or hotfix at this time
 if [ -z "$MODE" ]
 then

--- a/deploy/ansible/deploy.yml
+++ b/deploy/ansible/deploy.yml
@@ -4,7 +4,6 @@
   gather_facts: yes
   connection: ssh
   vars:
-    release: git
     mode: deploy
     ram_system_reservation: 5.0
 
@@ -20,23 +19,6 @@
 
     - name: Load default vars
       include_vars: main.yml
-
-    - include: tasks/build-wheel.yml
-        repo_path="../.."
-        package="shakenfist"
-      when: release == "git"
-
-    - include: tasks/build-wheel.yml
-        repo_path="../gitrepos/client-python"
-        package="shakenfist_client"
-      when: release == "git"
-
-    - name: Log wheel details
-      debug:
-        msg:
-          - "Shakenfist wheel is: {{hostvars['localhost']['shakenfist_wheel_path']}}"
-          - "Shakenfist client wheel is: {{hostvars['localhost']['shakenfist_client_wheel_path']}}"
-      when: release == "git"
 
     - name: Generate a random auth secret
       set_fact:
@@ -58,7 +40,6 @@
   gather_facts: no
   connection: ssh
   vars:
-    release: git
     mode: deploy
 
   tasks:
@@ -71,7 +52,6 @@
   gather_facts: no
   connection: ssh
   vars:
-    release: git
     mode: deploy
 
   tasks:
@@ -255,64 +235,13 @@
   gather_facts: yes
   connection: ssh
   vars:
-    release: git
     mode: deploy
 
   tasks:
-    - include: includes/python3.yml
-      when: mode == "deploy"
-
-    - name: Ensure the source directory is absent
-      file:
-        path: /srv/shakenfist/src/
-        state: absent
-      when: mode == "deploy"
-
-    - name: Remove old wheels
-      file:
-        path: /srv/shakenfist/shakenfist*-py3-none-any.whl
-        state: absent
-
     # We use a shell command here because the service might not exist and
     # that's ok.
     - name: Stop the SF daemon
       shell: systemctl stop sf || true
-
-    - name: Copy shakenfist
-      synchronize:
-        src: ../../dist/{{hostvars['localhost']['shakenfist_wheel_path']}}
-        dest: /srv/shakenfist/
-      when: release == "git"
-
-    - name: Copy shakenfist client
-      synchronize:
-        src: ../gitrepos/client-python/dist/{{hostvars['localhost']['shakenfist_client_wheel_path']}}
-        dest: /srv/shakenfist/
-      when: release == "git"
-
-    - name: Uninstall shakenfist, if present
-      command: pip3 uninstall -y shakenfist shakenfist-client
-      ignore_errors: True
-
-    - name: Install shakenfist
-      command: pip3 install {{hostvars['localhost']['shakenfist_wheel_path']}}
-      args:
-        chdir: /srv/shakenfist/
-      when: release == "git"
-
-    - name: Install shakenfist client
-      command: pip3 install {{hostvars['localhost']['shakenfist_client_wheel_path']}}
-      args:
-        chdir: /srv/shakenfist/
-      when: release == "git"
-
-    - name: Install shakenfist from pypi
-      command: pip3 install shakenfist=={{release}}
-      when: release != "git"
-
-    - name: Install shakenfist client from pypi
-      command: pip3 install shakenfist-client=={{release}}
-      when: release != "git"
 
 - hosts: primary
   any_errors_fatal: true
@@ -321,7 +250,6 @@
   gather_facts: no
   connection: ssh
   vars:
-    release: git
     mode: deploy
 
   tasks:
@@ -508,7 +436,6 @@
   gather_facts: no
   connection: ssh
   vars:
-    release: git
     mode: deploy
 
   tasks:
@@ -521,7 +448,8 @@
 
     - name: Copy libvirt template
       copy:
-        src: files/libvirt.tmpl
+        src: /usr/local/share/shakenfist/templates/libvirt.tmpl
+        remote_src: yes
         dest: /srv/shakenfist/libvirt.tmpl
         owner: root
         group: root
@@ -535,7 +463,8 @@
 
     - name: Copy dhcp config template
       copy:
-        src: files/dhcp.tmpl
+        src: /usr/local/share/shakenfist/templates/dhcp.tmpl
+        remote_src: yes
         dest: /srv/shakenfist/dhcp.tmpl
         owner: root
         group: root
@@ -543,7 +472,8 @@
 
     - name: Copy dhcp hosts template
       copy:
-        src: files/dhcphosts.tmpl
+        src: /usr/local/share/shakenfist/templates/dhcphosts.tmpl
+        remote_src: yes
         dest: /srv/shakenfist/dhcphosts.tmpl
         owner: root
         group: root
@@ -561,7 +491,8 @@
 
     - name: Write systemd unit
       template:
-        src: files/sf.service
+        src: /usr/local/share/shakenfist/templates/sf.service
+        remote_src: yes
         dest: /lib/systemd/system
         owner: root
         group: root
@@ -600,7 +531,6 @@
   gather_facts: no
   connection: ssh
   vars:
-    release: git
     mode: deploy
 
   tasks:
@@ -622,7 +552,7 @@
         chdir: /srv/shakenfist/terraform-provider-shakenfist
       when: mode == "deploy"
 
-    - name: Make /srv/shakenfist/
+    - name: Make /usr/local/bin/terraform_install/
       file:
         path: /usr/local/bin/terraform_install/
         state: directory

--- a/deploy/ansible/library
+++ b/deploy/ansible/library
@@ -1,1 +1,0 @@
-../gitrepos/ansible-modules

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# A simple script to extract the installer and run it.
+
+CWD=`pwd`
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+mkdir -p /tmp/shakenfist_install_$$
+cd /tmp/shakenfist_install_$$
+tar xzf $DIR/deploy.tgz --directory .
+cd deploy/ansible/
+./deploy.sh
+
+cd "$CWD"
+rm -rf /tmp/shakenfist_install_$$
+

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,43 +7,43 @@ This guide will assume that you want to install Shaken Fist on a single local ma
 
 Shaken Fist only supports Ubuntu 18.04 or later but we strongly recommend 20.04 or higher, so if you're running on localhost that implies that you must be running a recent Ubuntu on your development machine. Note as well that the deployer installs software and changes the configuration of your networking, so be careful when running it on machines you are fond of.
 
-Create a directory for Shaken Fist, and then checkout the Shaken Fist git repository there:
+Note that we used to recommend deployers run the installer from git, but we've outgrown that approach. If you
+see that mentioned in the documentation, you are likely reading outdated guides.
 
-```bash
-git clone https://github.com/shakenfist/shakenfist
-cd shakenfist/deploy/ansible
-```
-
-And install some dependancies:
+First install some dependancies:
 
 ```bash
 sudo apt-get update
 sudo apt-get -y dist-upgrade
 sudo apt-get -y install ansible tox pwgen build-essential python3-dev python3-wheel \
-    python3-pip curl ansible
-ansible-galaxy install andrewrothstein.etcd-cluster andrewrothstein.terraform \
+    python3-pip curl ansible vim git pwgen
+sudo ansible-galaxy install andrewrothstein.etcd-cluster andrewrothstein.terraform \
     andrewrothstein.go
 ```
 
+And then manually upgrade pip:
+
+```
+sudo pip3 install -U pip
+sudo apt-get remove -y python3-pip
+```
+
+Next install your desired Shaken Fist pip package. The default should be the latest release.
+
+```
+sudo pip install -U shakenfist shakenfist_client
+```
+
+And then run the installer. We describe the correct invocation for a local development environment in the section below.
 ## Local Development
 
-Shaken Fist uses ansible as its installer, with terraform to bring up cloud resources. Because we're going to install Shaken Fist on localhost, there isn't much terraform in this example.Installation is run by a simple wrapper called "deployandtest.sh". This wrapper checks out required git repositories, runs ansible plays, and then performs CI testing of the installation.
-!!! warning
-    CI testing is currently destructive (don't run it against production!), and not supported for installs with fewer than three machines. It is skipped for a localhost install.
+Shaken Fist uses ansible as its installer, with terraform to bring up cloud resources. Because we're going to install Shaken Fist on localhost, there isn't much terraform in this example. Installation is run by a simple wrapper called "install.sh".
 
 We also make the assumption that developer laptops move around more than servers. In a traditional install we detect the primary NIC of the machine and then use that to build VXLAN meshes. For localhost single node deploys we instead create a bridge called "brsf" and then use that as our primary NIC. This means your machine can move around and have different routes to the internet over time, but it also means its fiddly to convert a localhost install into a real production cluster. Please only use localhost installs for development purposes.
 
-```bash 
-CLOUD=localhost RELEASE="git:master" ./deployandtest.sh
 ```
-
-<aside>The deployer clones a number of git repositories that it needs to build a working Shaken Fist installation. As a developer, you might want to move these out of shakenfist/deploy/gitrepos to somewhere more obvious once the installer has finished running. You can just symlink the repositories to the location that the deployer users and things will work as expected. Note that the deloyer does not clone all repositories, just those it needs, so you might still need to clone other repositories.</aside>
-
-If you want to install a specific release, you can set the RELEASE environment variable. Possible options are:
-
-* Any [valid pypi release](https://pypi.org/project/shakenfist/#history) version number. This is the default and you get the most recent pypi release if you do not specify a value.
-* "git:master" for the current master branch of each repository.
-* "git:branch" for a specific branch. If that branch does not exist in a given repository, master is used instead.
+sudo CLOUD=localhost /usr/local/share/shakenfist/installer/install.sh
+```
 
 ## Your first instance
 

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -e
+
+# Release a specified version of Shaken Fist
+
+echo "--- Determine verison number ---"
+PREVIOUS=`git tag | egrep "^v" | sort -n | tail -1 | sed 's/^v//'`
+
+echo
+echo -n "What is the version number (previous was $PREVIOUS)? "
+read VERSION
+
+echo
+echo "--- Preparing deployer ---"
+set -x
+rm -rf deploy/shakenfist_ci.egg-info deploy/gitrepos deploy/.tox
+find deploy/ansible/terraform -type f -name "*tfstate*" -exec rm {} \;
+find deploy/ansible/terraform -type d  -name ".terraform" -exec rm -rf {} \;
+
+rm -f deploy.tgz
+tar cvzf deploy.tgz deploy
+
+rm -f docs.tgz
+tar cvzf docs.tgz docs
+set +x
+
+echo
+echo "--- Building ---"
+set -x
+pip install --upgrade readme-renderer
+pip install --upgrade twine
+rm -rf build dist *.egg-info
+git pull
+python3 setup.py sdist bdist_wheel
+twine check dist/*
+set +x
+
+echo
+echo "--- Uploading ---"
+echo "This is the point where we push files to pypi. Hit ctrl-c to abort."
+read DUMMY
+
+set -x
+git tag -s "v$VERSION" -m "Release v$VERSION"
+git push origin "v$VERSION"
+twine upload dist/*
+set +x

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,22 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     data_files=[
         (
-            '/srv/shakenfist/templates', [
+            'share/shakenfist/templates', [
                 'deploy/ansible/files/libvirt.tmpl',
-                'deploy/ansible/files/dhcp.tmpl'
+                'deploy/ansible/files/dhcp.tmpl',
+                'deploy/ansible/files/dhcphosts.tmpl',
+                'deploy/ansible/files/sf.service'
+            ]
+        ),
+        (
+            'share/shakenfist/installer', [
+                'deploy.tgz',
+                'deploy/install.sh'
+            ]
+        ),
+        (
+            'share/shakenfist/docs', [
+                'docs.tgz'
             ]
         )
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py38,flake8,cover
+skipsdist=true
 
 [testenv]
 deps =
@@ -14,6 +15,7 @@ whitelist_externals =
   find
   rm
   env
+  tar
 setenv =
   VIRTUAL_ENV={envdir}
   LANGUAGE=en_US


### PR DESCRIPTION
I've realised while doing the glusterfs work that the current installation
system is broken. Specifically, we currently use the configuration files and
ansible plays from the most recent version for all installs, which means that
when someone installs an older more stable version they can end up out of
alignment. This is especially obvious with the gluster work because we need
to tweak the libvirt template.

So instead, we now package the configuration samples and installer into the
python package, and use those to do the install. This means we need to
install the pip packages _before_ we install, instead of as part of the
install like before.