### PR TITLE
Allow netspecs to request an interface float once created.

### DIFF
--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -1,6 +1,5 @@
 import copy
 import multiprocessing
-import re
 import requests
 import setproctitle
 import time

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -22,6 +22,7 @@ from shakenfist.tasks import (QueueTask,
                               InstanceTask,
                               PreflightInstanceTask,
                               StartInstanceTask,
+                              FloatNetworkInterfaceTask,
                               DefloatNetworkInterfaceTask
                               )
 
@@ -93,6 +94,10 @@ def handle(jobname, workitem):
                     db.enqueue('%s-metrics' % config.NODE_NAME, {})
                 except Exception as e:
                     util.ignore_exception(daemon.process_name('queues'), e)
+
+            elif isinstance(task, FloatNetworkInterfaceTask):
+                # Just punt it to the network node now that the interface is ready
+                db.enqueue('networknode', task)
 
             else:
                 log_i.with_field('task', task).error(

--- a/shakenfist/tasks.py
+++ b/shakenfist/tasks.py
@@ -84,10 +84,11 @@ class StartInstanceTask(InstanceTask):
 class DeleteInstanceTask(InstanceTask):
     _name = 'instance_delete'
 
-
 #
 # Network Tasks
 #
+
+
 class NetworkTask(QueueTask):
     def __init__(self, network_uuid):
         super(NetworkTask, self).__init__()
@@ -166,10 +167,11 @@ class FloatNetworkInterfaceTask(NetworkInterfaceTask):
 class DefloatNetworkInterfaceTask(NetworkInterfaceTask):
     _name = 'network_interface_defloat'
 
-
 #
 # Image Tasks
 #
+
+
 class ImageTask(QueueTask):
     def __init__(self, url):
         super(ImageTask, self).__init__()


### PR DESCRIPTION
This means you can float an interface at instance creation time,
instead of a two step process where you create the instance and
then request the float. Fixes #746.