### PR TITLE
Fix network metadata.

### DIFF
--- a/deploy/ansible/files/sf.service
+++ b/deploy/ansible/files/sf.service
@@ -19,6 +19,7 @@ Environment=SHAKENFIST_DISK_FORMAT=qcow
 # Cluster tuning.
 Environment=SHAKENFIST_RAM_SYSTEM_RESERVATION={{hostvars['localhost']['ram_system_reservation']}}
 Environment=SHAKENFIST_MAX_HYPERVISOR_MTU={{hostvars['localhost']['lowest_mtu']}}
+Environment=SHAKENFIST_DNS_SERVER="{{dns_server}}"
 
 # Whether we have a local cloud image mirror is controlled by the
 # HAS_MIRROR ansible variable. Define HAS_MIRROR with any value to use

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -787,6 +787,7 @@ class Instances(Resource):
                 }).info('Interface allocated')
                 db.create_network_interface(
                     iface_uuid, netdesc, instance.uuid, order)
+                order += 1
 
                 if 'float' in netdesc and netdesc['float']:
                     err = _assign_floating_ip(iface_uuid)

--- a/shakenfist/tests/test_virt.py
+++ b/shakenfist/tests/test_virt.py
@@ -442,7 +442,7 @@ class InstanceTestCase(test_shakenfist.ShakenFistTestCase):
                                 {
                                     "ethernet_mac_address": "1a:91:64:d2:15:39",
                                     "id": "eth0",
-                                    "mtu": 1450,
+                                    "mtu": 7950,
                                     "name": "eth0",
                                     "type": "vif",
                                     "vif_id": "ifaceuuid"
@@ -450,7 +450,7 @@ class InstanceTestCase(test_shakenfist.ShakenFistTestCase):
                                 {
                                     "ethernet_mac_address": "1a:91:64:d2:15:40",
                                     "id": "eth1",
-                                    "mtu": 1450,
+                                    "mtu": 7950,
                                     "name": "eth1",
                                     "type": "vif",
                                     "vif_id": "ifaceuuid2"

--- a/shakenfist/virt.py
+++ b/shakenfist/virt.py
@@ -652,7 +652,7 @@ class Instance(baseobject.DatabaseBackedObject):
                     'ethernet_mac_address': iface['macaddr'],
                     'id': devname,
                     'name': devname,
-                    'mtu': 1450,
+                    'mtu': config.get('MAX_HYPERVISOR_MTU') - 50,
                     'type': 'vif',
                     'vif_id': iface['uuid']
                 }


### PR DESCRIPTION
- Use discovered MTU in metadata as well as DHCP.
- Use configured DNS server at all.
- Increment interface index when there is more than one interface.

Fixes #767.