### PR TITLE
Preserve the requested disk base by storing blob lookups elsewhere.

### DIFF
--- a/shakenfist/artifact.py
+++ b/shakenfist/artifact.py
@@ -14,6 +14,12 @@ from shakenfist import logutil
 LOG, _ = logutil.setup(__name__)
 
 
+BLOB_URL = 'sf://blob/'
+INSTANCE_URL = 'sf://instance/'
+LABEL_URL = 'sf://label/'
+SNAPSHOT_URL = 'sf://snapshot/'
+
+
 class Artifact(dbo):
     object_type = 'artifact'
     current_version = 2
@@ -160,4 +166,4 @@ def type_filter(artifact_type, a):
 def instance_snapshot_filter(instance_uuid, a):
     if a.artifact_type != Artifact.TYPE_SNAPSHOT:
         return False
-    return a.source_url.startswith('sf://instance/%s' % instance_uuid)
+    return a.source_url.startswith('%s%s' % (INSTANCE_URL, instance_uuid))

--- a/shakenfist/external_api/label.py
+++ b/shakenfist/external_api/label.py
@@ -1,7 +1,7 @@
 from flask_jwt_extended import get_jwt_identity
 from flask_jwt_extended import jwt_required
 
-from shakenfist.artifact import Artifact
+from shakenfist.artifact import Artifact, LABEL_URL
 from shakenfist.baseobject import DatabaseBackedObject as dbo
 from shakenfist.external_api import base as api_base
 
@@ -10,10 +10,10 @@ class LabelEndpoint(api_base.Resource):
     @jwt_required
     def post(self, label_name=None, blob_uuid=None):
         a = Artifact.from_url(
-            Artifact.TYPE_LABEL, 'sf://label/%s/%s' % (get_jwt_identity(), label_name))
+            Artifact.TYPE_LABEL, '%s%s/%s' % (LABEL_URL, get_jwt_identity(), label_name))
         if not a:
             a = Artifact.new(
-                Artifact.TYPE_LABEL, 'sf://label/%s/%s' % (get_jwt_identity(), label_name))
+                Artifact.TYPE_LABEL, '%s%s/%s' % (LABEL_URL, get_jwt_identity(), label_name))
 
         a.add_index(blob_uuid)
         a.state = dbo.STATE_CREATED
@@ -22,7 +22,7 @@ class LabelEndpoint(api_base.Resource):
     @jwt_required
     def get(self, label_name=None):
         a = Artifact.from_url(
-            Artifact.TYPE_LABEL, 'sf://label/%s/%s' % (get_jwt_identity(), label_name))
+            Artifact.TYPE_LABEL, '%s%s/%s' % (LABEL_URL, get_jwt_identity(), label_name))
         if not a:
             api_base.error(404, 'label %s not found' % label_name)
 
@@ -31,7 +31,7 @@ class LabelEndpoint(api_base.Resource):
     @jwt_required
     def delete(self, label_name=None):
         a = Artifact.from_url(
-            Artifact.TYPE_LABEL, 'sf://label/%s/%s' % (get_jwt_identity(), label_name))
+            Artifact.TYPE_LABEL, '%s%s/%s' % (LABEL_URL, get_jwt_identity(), label_name))
         if not a:
             api_base.error(404, 'label %s not found' % label_name)
 

--- a/shakenfist/external_api/snapshot.py
+++ b/shakenfist/external_api/snapshot.py
@@ -38,7 +38,7 @@ class InstanceSnapshotEndpoint(api_base.Resource):
 
             a = Artifact.from_url(
                 Artifact.TYPE_SNAPSHOT,
-                'sf://instance/%s/%s' % (instance_uuid, disk['device']))
+                '%s%s/%s' % (artifact.INSTANCE_URL, instance_uuid, disk['device']))
 
             blob_uuid = str(uuid.uuid4())
             entry = a.add_index(blob_uuid)

--- a/shakenfist/images.py
+++ b/shakenfist/images.py
@@ -9,7 +9,7 @@ import requests
 import shutil
 import time
 
-from shakenfist.artifact import Artifact
+from shakenfist.artifact import Artifact, BLOB_URL, SNAPSHOT_URL
 from shakenfist.baseobject import (
     DatabaseBackedObject as dbo,
     DatabaseBackedObjectIterator as dbo_iter)
@@ -211,13 +211,13 @@ class Image(dbo):
         self.state = self.STATE_DELETED
 
     def get(self, locks, related_object):
-        if self.url.startswith('sf://blob/'):
+        if self.url.startswith(BLOB_URL):
             return self._blob_get(self.url, locks, related_object)
-        elif self.url.startswith('sf://snapshot/'):
-            snapshot_uuid = self.url[len('sf://snapshot/'):]
+        elif self.url.startswith(SNAPSHOT_URL):
+            snapshot_uuid = self.url[len(SNAPSHOT_URL):]
             snap = Artifact.from_db(snapshot_uuid)
             blob_uuid = snap.most_recent_index['blob_uuid']
-            url = 'sf://blob/%s' % blob_uuid
+            url = '%s%s' % (BLOB_URL, blob_uuid)
             return self._blob_get(url, locks, related_object)
         else:
             return self._http_get(self.url, locks, related_object)
@@ -226,7 +226,7 @@ class Image(dbo):
         """Fetch a blob from the cluster."""
 
         actual_image = self.version_image_path()
-        blob_uuid = url[len('sf://blob/'):]
+        blob_uuid = url[len(BLOB_URL):]
         blob_path = os.path.join(config.get(
             'STORAGE_PATH'), 'blobs', blob_uuid)
         os.makedirs(os.path.join(config.get(

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -13,6 +13,7 @@ import socket
 import time
 from uuid import uuid4
 
+from shakenfist.artifact import BLOB_URL
 from shakenfist import baseobject
 from shakenfist.baseobject import (
     DatabaseBackedObject as dbo,
@@ -515,7 +516,7 @@ class Instance(dbo):
 
                     disk_base = disk.get('base')
                     if disk.get('blob_uuid'):
-                        disk_base = 'sf://blob/%s' % disk['blob_uuid']
+                        disk_base = '%s%s' % (BLOB_URL, disk['blob_uuid'])
 
                     if disk_base:
                         img = images.Image.new(disk_base)

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -81,6 +81,7 @@ def _initialize_block_devices(instance_path, disk_spec):
                 'bus': bus,
                 'path': os.path.join(instance_path, root_device),
                 'base': disk_spec[0].get('base'),
+                'blob_uuid': disk_spec[0].get('blob_uuid'),
                 'present_as': _get_defaulted_disk_type(disk_spec[0]),
                 'snapshot_ignores': False
             },
@@ -106,6 +107,7 @@ def _initialize_block_devices(instance_path, disk_spec):
             'bus': bus,
             'path': os.path.join(instance_path, device),
             'base': d.get('base'),
+            'blob_uuid': d.get('blob_uuid'),
             'present_as': _get_defaulted_disk_type(d),
             'snapshot_ignores': False
         })
@@ -511,8 +513,12 @@ class Instance(dbo):
                     disk['source'] = "<source file='%s'/>" % disk['path']
                     disk['source_type'] = 'file'
 
-                    if disk.get('base'):
-                        img = images.Image.new(disk['base'])
+                    disk_base = disk.get('base')
+                    if disk.get('blob_uuid'):
+                        disk_base = 'sf://blob/%s' % disk['blob_uuid']
+
+                    if disk_base:
+                        img = images.Image.new(disk_base)
                         hashed_image_path = img.version_image_path()
 
                         with util.RecordedOperation('detect cdrom images', self):


### PR DESCRIPTION
I realised that clobbering the original disk base from the user is a bad idea, instead store the looked up blob in a separate field.