### PR TITLE
Include SF version in process title.

### DIFF
--- a/shakenfist/daemons/main.py
+++ b/shakenfist/daemons/main.py
@@ -101,7 +101,8 @@ def main():
     global DAEMON_IMPLEMENTATIONS
     global DAEMON_PIDS
 
-    setproctitle.setproctitle(daemon.process_name('main'))
+    setproctitle.setproctitle(daemon.process_name(
+        'main') + '-v%s' % util.get_version())
 
     # Log configuration on startup
     for key, value in config.dict().items():


### PR DESCRIPTION
This change includes the currently running version string in the process title of the "main" process so that operators can quickly tell what's running.