### PR TITLE
Refresh locks during blob transfers.

### DIFF
--- a/shakenfist/baseobject.py
+++ b/shakenfist/baseobject.py
@@ -84,12 +84,12 @@ class DatabaseBackedObject(object):
         etcd.delete('attribute/%s' % self.object_type, self.__uuid, attribute)
 
     def get_lock(self, subtype=None, ttl=60, relatedobjects=None, log_ctx=None,
-                 op=None):
+                 op=None, timeout=None):
         if not log_ctx:
             log_ctx = self.log
         return db.get_lock(self.object_type, subtype, self.uuid, ttl=ttl,
                            relatedobjects=relatedobjects, log_ctx=log_ctx,
-                           op=op)
+                           op=op, timeout=db.ETCD_ATTEMPT_TIMEOUT)
 
     def get_lock_attr(self, name, op):
         return db.get_lock('attribute/%s' % self.object_type,

--- a/shakenfist/blob.py
+++ b/shakenfist/blob.py
@@ -15,6 +15,9 @@ from shakenfist import util
 LOG, _ = logutil.setup(__name__)
 
 
+LOCK_REFRESH_SECONDS = 5
+
+
 class Blob(dbo):
     object_type = 'blob'
     current_version = 2
@@ -158,7 +161,7 @@ def http_fetch(resp, blob_uuid, locks, logs):
                     'Fetch %.02f percent complete' % percentage)
                 previous_percentage = percentage
 
-            if time.time() - last_refresh > 5:
+            if time.time() - last_refresh > LOCK_REFRESH_SECONDS:
                 db.refresh_locks(locks)
                 last_refresh = time.time()
 


### PR DESCRIPTION
Otherwise large blob transfers result in the lock expiring and then a stack trace when we try to release it.