### PR TITLE
Store network interfaces in instances.

### DIFF
--- a/shakenfist/daemons/main.py
+++ b/shakenfist/daemons/main.py
@@ -1,10 +1,12 @@
 # Copyright 2019 Michael Still
 
+from functools import partial
 import setproctitle
 import time
 import os
 import psutil
 
+from shakenfist import baseobject
 from shakenfist.config import config
 from shakenfist.daemons import daemon
 from shakenfist.daemons import external_api as external_api_daemon
@@ -15,10 +17,11 @@ from shakenfist.daemons import resources as resource_daemon
 from shakenfist.daemons import triggers as trigger_daemon
 from shakenfist import db
 from shakenfist import instance
+from shakenfist.networkinterface import instance_filter as ni_instance_filter
 from shakenfist.ipmanager import IPManager
 from shakenfist import logutil
 from shakenfist import net
-from shakenfist import networkinterface
+from shakenfist.networkinterface import NetworkInterfaces
 from shakenfist.node import Node
 from shakenfist import util
 
@@ -26,15 +29,30 @@ from shakenfist import util
 LOG, HANDLER = logutil.setup('main')
 
 
+def interfaces_for_instance(instance):
+    nis = {}
+    loggable_nis = {}
+    for ni in NetworkInterfaces([baseobject.active_states_filter,
+                                 partial(ni_instance_filter, instance)]):
+        nis[ni.order] = ni
+        loggable_nis[ni.order] = str(ni)
+
+    for order in sorted(nis.keys()):
+        yield nis[order]
+
+
 def restore_instances():
-    # Ensure all instances for this node are defined
+    # Ensure all instances for this node are defined and have up to date data.
     networks = []
     instances = []
-    for inst in instance.Instances([instance.this_node_filter, instance.healthy_states_filter]):
+    for inst in instance.Instances([instance.this_node_filter,
+                                    instance.healthy_states_filter]):
         instance_problems = []
-        for ni in networkinterface.interfaces_for_instance(inst):
+        for ni in interfaces_for_instance(inst):
             if ni.network_uuid not in networks:
                 networks.append(ni.network_uuid)
+            if ni.network_uuid not in inst.interfaces:
+                inst.interfaces += ni.network_uuid
 
         # TODO(mikal): do better here.
         # for disk in inst.disk_spec:

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -46,7 +46,8 @@ class Monitor(daemon.Daemon):
         if not util.is_network_node():
             # For normal nodes, just the ones we have instances for
             for inst in instance.Instances([instance.this_node_filter, instance.active_states_filter]):
-                for ni in networkinterface.interfaces_for_instance(inst):
+                for iface_uuid in inst.interfaces:
+                    ni = networkinterface.NetworkInterface.from_db(iface_uuid)
                     if ni.network_uuid not in host_networks:
                         host_networks.append(ni.network_uuid)
         else:

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -257,7 +257,8 @@ class Instance(dbo):
         # Mix in details of the instance's interfaces to reduce API round trips
         # for clients.
         i['interfaces'] = []
-        for ni in networkinterface.interfaces_for_instance(self):
+        for iface_uuid in self.interfaces:
+            ni = networkinterface.NetworkInterface.from_db(iface_uuid)
             i['interfaces'].append(ni.external_view())
 
         return i
@@ -332,6 +333,14 @@ class Instance(dbo):
     def block_devices(self):
         return self._db_get_attribute('block_devices')
 
+    @property
+    def interfaces(self):
+        return self._db_get_attribute('interfaces')
+
+    @interfaces.setter
+    def interfaces(self, interfaces):
+        self._db_set_attribute('interfaces', interfaces)
+
     # Implementation
     def place_instance(self, location):
         with self.get_lock_attr('placement', 'Instance placement'):
@@ -381,8 +390,9 @@ class Instance(dbo):
     # creation. It is assumed that the image sits in local cache already, and
     # has been transcoded to the right format. This has been done to facilitate
     # moving to a queue and task based creation mechanism.
-    def create(self, lock=None):
+    def create(self, iface_uuids, lock=None):
         self.state = self.STATE_CREATING
+        self.interfaces = iface_uuids
 
         # Ensure we have state on disk
         os.makedirs(self.instance_path, exist_ok=True)
@@ -655,7 +665,8 @@ class Instance(dbo):
         }
 
         have_default_route = False
-        for iface in networkinterface.interfaces_for_instance(self):
+        for iface_uuid in self.interfaces:
+            iface = networkinterface.NetworkInterface.from_db(iface_uuid)
             if iface.ipv4:
                 devname = 'eth%d' % iface.order
                 nd['links'].append(
@@ -738,7 +749,8 @@ class Instance(dbo):
             t = jinja2.Template(f.read())
 
         networks = []
-        for ni in networkinterface.interfaces_for_instance(self):
+        for iface_uuid in self.interfaces:
+            ni = networkinterface.NetworkInterface.from_db(iface_uuid)
             n = net.Network.from_db(ni.network_uuid)
             networks.append(
                 {

--- a/shakenfist/networkinterface.py
+++ b/shakenfist/networkinterface.py
@@ -195,18 +195,6 @@ def network_filter(network, ni):
 
 
 # Convenience helpers
-def interfaces_for_instance(instance):
-    nis = {}
-    loggable_nis = {}
-    for ni in NetworkInterfaces([baseobject.active_states_filter,
-                                 partial(instance_filter, instance)]):
-        nis[ni.order] = ni
-        loggable_nis[ni.order] = str(ni)
-
-    for order in sorted(nis.keys()):
-        yield nis[order]
-
-
 def interfaces_for_network(network):
     return NetworkInterfaces([baseobject.active_states_filter,
                               partial(network_filter, network)])

--- a/shakenfist/scheduler.py
+++ b/shakenfist/scheduler.py
@@ -171,7 +171,8 @@ class Scheduler(object):
             # Make a list of networks for the node
             present_networks = []
             for inst in per_node.get(n, []):
-                for ni in networkinterface.interfaces_for_instance(inst):
+                for iface_uuid in inst.interfaces:
+                    ni = networkinterface.NetworkInterface.from_db(iface_uuid)
                     if ni.network_uuid not in present_networks:
                         present_networks.append(ni.network_uuid)
 

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -67,6 +67,7 @@ class FakeInstance(BaseFakeObject):
         self.power_state = {'power_state': power_state}
         self.placement = {'node': placement}
         self.version = 2
+        self.interfaces = []
 
 
 class FakeNetwork(BaseFakeObject):
@@ -520,7 +521,7 @@ class ExternalApiGeneralTestCase(ExternalApiTestCase):
         self.assertEqual(404, resp.status_code)
 
     # TODO(mikal): do better with covering interfaces here
-    @mock.patch('shakenfist.networkinterface.interfaces_for_instance')
+    @mock.patch('shakenfist.networkinterface.NetworkInterface.from_db')
     @mock.patch('shakenfist.instance.Instance._db_get',
                 return_value={
                     'cpus': 1,
@@ -539,7 +540,7 @@ class ExternalApiGeneralTestCase(ExternalApiTestCase):
     @mock.patch('shakenfist.instance.Instance._db_get_attribute',
                 return_value={})
     def test_get_instance(self, mock_get_instance_attribute, mock_get_instance,
-                          mock_get_interfaces):
+                          mock_get_interface):
         resp = self.client.get(
             '/instances/foo', headers={'Authorization': self.auth_header})
         self.assertEqual({

--- a/shakenfist/tests/test_instance.py
+++ b/shakenfist/tests/test_instance.py
@@ -374,8 +374,10 @@ class InstanceTestCase(test_shakenfist.ShakenFistTestCase):
 
     # create, delete
 
-    @mock.patch('shakenfist.networkinterface.NetworkInterfaces',
-                return_value=[
+    @mock.patch('shakenfist.instance.Instance._db_get_attribute',
+                return_value=['ifaceuuid', 'ifaceuuid2'])
+    @mock.patch('shakenfist.networkinterface.NetworkInterface.from_db',
+                side_effect=[
                     FakeNetworkInterface({
                         'uuid': 'ifaceuuid',
                         'instance_uuid': 'instuuid',
@@ -398,7 +400,7 @@ class InstanceTestCase(test_shakenfist.ShakenFistTestCase):
     @mock.patch('shakenfist.baseobject.DatabaseBackedObject.state',
                 new_callable=mock.PropertyMock)
     def test_make_config_drive(self, mock_update, mock_net_from_db,
-                               mock_interfaces):
+                               mock_interfaces, mock_get_attribute):
         i = self._make_instance()
 
         (fd, cd_file) = tempfile.mkstemp()

--- a/shakenfist/tests/test_scheduler.py
+++ b/shakenfist/tests/test_scheduler.py
@@ -353,8 +353,8 @@ class CorrectAllocationTestCase(SchedulerTestCase):
         self.assertSetEqual(set(self.fake_db.nodes)-{'node1_net', },
                             set(nodes))
 
-    @mock.patch('shakenfist.networkinterface.interfaces_for_instance',
-                return_value=[FakeInterface('uuid-net1')])
+    @mock.patch('shakenfist.networkinterface.NetworkInterface.from_db',
+                return_value=FakeInterface('uuid-net1'))
     @mock.patch('shakenfist.instance.Instance._db_get_attribute',
                 return_value={
                     'node': 'node3'
@@ -377,7 +377,7 @@ class CorrectAllocationTestCase(SchedulerTestCase):
     def test_single_node_that_has_network(
             self, mock_get_artifacts, mock_get_instances,
             mock_get_instance, mock_instance_attribute,
-            mock_instance_interfaces):
+            mock_get_interface):
         self.fake_db.set_node_metrics_same({
             'cpu_max_per_instance': 16,
             'cpu_max': 4,


### PR DESCRIPTION
A counter proposal to https://github.com/shakenfist/shakenfist/pull/875 -- we know what interfaces an instance has because we create them before we create the instance, so let's just store them in the instance as well.