### PR TITLE
Remove locking from Artifact.from_url.

### DIFF
--- a/shakenfist/artifact.py
+++ b/shakenfist/artifact.py
@@ -6,9 +6,6 @@ from uuid import uuid4
 from shakenfist.baseobject import (
     DatabaseBackedObject as dbo,
     DatabaseBackedObjectIterator as dbo_iter)
-from shakenfist.config import config
-from shakenfist import constants
-from shakenfist import db
 from shakenfist import etcd
 from shakenfist import exceptions
 from shakenfist import logutil
@@ -85,16 +82,13 @@ class Artifact(dbo):
 
     @staticmethod
     def from_url(artifact_type, url):
-        with db.get_lock('artifact', artifact_type, url,
-                         ttl=(12 * constants.LOCK_REFRESH_SECONDS),
-                         timeout=config.MAX_IMAGE_TRANSFER_SECONDS):
-            artifacts = list(Artifacts([partial(url_filter, url),
-                                        partial(type_filter, artifact_type)]))
-            if len(artifacts) == 0:
-                return Artifact.new(artifact_type, url)
-            if len(artifacts) == 1:
-                return artifacts[0]
-            raise exceptions.TooManyMatches()
+        artifacts = list(Artifacts([partial(url_filter, url),
+                                    partial(type_filter, artifact_type)]))
+        if len(artifacts) == 0:
+            return Artifact.new(artifact_type, url)
+        if len(artifacts) == 1:
+            return artifacts[0]
+        raise exceptions.TooManyMatches()
 
     @property
     def most_recent_index(self):

--- a/shakenfist/baseobject.py
+++ b/shakenfist/baseobject.py
@@ -89,7 +89,7 @@ class DatabaseBackedObject(object):
             log_ctx = self.log
         return db.get_lock(self.object_type, subtype, self.uuid, ttl=ttl,
                            relatedobjects=relatedobjects, log_ctx=log_ctx,
-                           op=op, timeout=db.ETCD_ATTEMPT_TIMEOUT)
+                           op=op, timeout=timeout)
 
     def get_lock_attr(self, name, op):
         return db.get_lock('attribute/%s' % self.object_type,

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -151,7 +151,7 @@ class ActualLock(Lock):
 
         raise exceptions.LockException(
             'Cannot acquire lock %s, timed out after %.02f seconds'
-            % (self.name, duration))
+            % (self.name, self.timeout))
 
     def __exit__(self, _exception_type, _exception_value, _traceback):
         if not self.release():


### PR DESCRIPTION
Locking here doesn't make sense in hindsight, and causes blockages
if another thread is fetching a large image and we're just trying
to refer to it (a second usage for example).