### PR TITLE
Pass MTU through to libvirt.

### DIFF
--- a/deploy/ansible/files/libvirt.tmpl
+++ b/deploy/ansible/files/libvirt.tmpl
@@ -70,6 +70,7 @@
       <mac address='{{net.macaddr}}'/>
       <source bridge='{{net.bridge}}'/>
       <model type='{{net.model}}'/>
+      <mtu size='{{net.mtu}}'/>
     </interface>
     {% endfor %}
 

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -758,7 +758,8 @@ class Instance(dbo):
                 {
                     'macaddr': ni.macaddr,
                     'bridge': n.subst_dict()['vx_bridge'],
-                    'model': ni.model
+                    'model': ni.model,
+                    'mtu': config.MAX_HYPERVISOR_MTU - 50
                 }
             )
 


### PR DESCRIPTION
libvirt seems to sometimes get confused about what MTU to set on vnet devices, so let's just tell it what to do.