### PR TITLE
Delete the correct path.

### DIFF
--- a/shakenfist/daemons/cleaner.py
+++ b/shakenfist/daemons/cleaner.py
@@ -221,7 +221,7 @@ class Monitor(daemon.Daemon):
                         LOG.with_fields({
                             'blob': blob_uuid,
                             'entity': ent}).warning('Deleting orphaned blob')
-                        os.unlink(ent)
+                        os.unlink(entpath)
 
             # Perform etcd maintenance, if we are an etcd master
             if config.NODE_IS_ETCD_MASTER:


### PR DESCRIPTION
Not caught in CI because we don't have stray blobs there, caught on my test cluster post merge.