### PR TITLE
Ensure we don't attempt to create a dead network.

### DIFF
--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -450,6 +450,10 @@ class Network(dbo):
                 self.enable_nat()
 
         self.update_dhcp()
+
+        # A final check to ensure we haven't raced with a delete
+        if self.is_dead():
+            raise DeadNetwork('network=%s' % self)
         self.state = self.STATE_CREATED
 
     def delete_on_hypervisor(self):


### PR DESCRIPTION
I wouldn't think this would be all that common, but I can see at least
ten examples a day of us deleting a network while it is being created
and thefore attempting to transition from DELETE_WAITING to CREATED
state. Add a final check before the state change to catch this more
gracefully.