### PR TITLE
Use create_interface() for floating IP veths.

### DIFF
--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -698,10 +698,9 @@ class Network(dbo):
             ipaddress.IPv4Address(floating_address))
         subst['inner_address'] = inner_address
 
-        util_process.execute(None,
-                             'ip link add flt-%(floating_address_as_hex)s-o type veth '
-                             'peer name flt-%(floating_address_as_hex)s-i'
-                             % subst)
+        util_network.create_interface(
+            'flt-%(floating_address_as_hex)s-o' % subst, 'veth',
+            'peer name flt-%(floating_address_as_hex)s-i' % subst)
         util_process.execute(None,
                              'ip link set flt-%(floating_address_as_hex)s-i netns %(netns)s'
                              % subst)


### PR DESCRIPTION
This means they'll pick up MTUs like other interfaces we manage.