### PR TITLE
Do not install terraform.

### DIFF
--- a/deploy/ansible/ci.yml
+++ b/deploy/ansible/ci.yml
@@ -366,7 +366,7 @@
         autoremove: yes
 
     - name: Install ansible roles
-      shell: ansible-galaxy install andrewrothstein.etcd-cluster andrewrothstein.terraform andrewrothstein.go
+      shell: ansible-galaxy install andrewrothstein.etcd-cluster
 
     - name: Copy client wheel file
       copy:

--- a/deploy/ansible/deploy.yml
+++ b/deploy/ansible/deploy.yml
@@ -226,11 +226,11 @@
   tasks:
     - name: Find hypervisor with lowest MTU
       set_fact:
-       lowest_mtu_hypervisor: "{{ groups['hypervisors'] | sort('node_mtu' | int) | first }}"
+        lowest_mtu_hypervisor: "{{ groups['hypervisors'] | sort('node_mtu' | int) | first }}"
 
     - name: Find lowest MTU
       set_fact:
-       lowest_mtu: "{{ hostvars[lowest_mtu_hypervisor]['node_mtu'] }}"
+        lowest_mtu: "{{ hostvars[lowest_mtu_hypervisor]['node_mtu'] }}"
 
     - name: Write syslog file
       template:
@@ -643,14 +643,6 @@
         enabled: yes
         state: restarted
         daemon_reload: yes
-
-- hosts: localhost
-  roles:
-    - role: andrewrothstein.terraform
-      vars:
-        terraform_binary_dir: /usr/local/bin/terraform_install
-
-    - role: andrewrothstein.go
 
 - hosts: localhost
   any_errors_fatal: true


### PR DESCRIPTION
Skipping terraform install (but not the provider install) saves ten minutes on a CI run at night when my network link is busy, and most users don't use terraform anyways. We still install the provider, so they just have to do the terraform bit themselves.