### PR TITLE
Use random ids for queue items, instead of sequential counters.

### DIFF
--- a/shakenfist/daemons/main.py
+++ b/shakenfist/daemons/main.py
@@ -121,8 +121,9 @@ def main():
     global DAEMON_IMPLEMENTATIONS
     global DAEMON_PIDS
 
-    setproctitle.setproctitle(daemon.process_name(
-        'main') + '-v%s' % util_general.get_version())
+    LOG.info('Starting...')
+    setproctitle.setproctitle(
+        daemon.process_name('main') + '-v%s' % util_general.get_version())
 
     # Log configuration on startup
     for key, value in config.dict().items():
@@ -131,7 +132,7 @@ def main():
     daemon.set_log_level(LOG, 'main')
 
     # Check in early and often, also reset processing queue items.
-    db.clear_stale_locks()
+    etcd.clear_stale_locks()
     Node.observe_this_node()
     etcd.restart_queues()
 

--- a/shakenfist/db.py
+++ b/shakenfist/db.py
@@ -33,10 +33,6 @@ def refresh_locks(locks, relatedobjects=None, log_ctx=LOG):
             refresh_lock(lock, log_ctx=log_ctx)
 
 
-def clear_stale_locks():
-    etcd.clear_stale_locks()
-
-
 def get_existing_locks():
     return etcd.get_existing_locks()
 

--- a/shakenfist/util/random.py
+++ b/shakenfist/util/random.py
@@ -1,0 +1,7 @@
+import random
+import string
+
+
+def random_id():
+    """ Returns a short random string for queue entries. """
+    return ''.join(random.choices(string.ascii_letters + string.digits, k=16))


### PR DESCRIPTION
This should reduce etcd load when adding a queue item.