### PR TITLE
Do not persist blob reference images.

### DIFF
--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -328,7 +328,7 @@ def _construct_key(objecttype, subtype, name):
     return '/sf/%s/' % objecttype
 
 
-class JSONEncoderTasks(json.JSONEncoder):
+class JSONEncoderCustomTypes(json.JSONEncoder):
     def default(self, obj):
         if QueueTask.__subclasscheck__(type(obj)):
             return obj.obj_dict()
@@ -345,7 +345,7 @@ def put(objecttype, subtype, name, data, ttl=None):
 
     path = _construct_key(objecttype, subtype, name)
     encoded = json.dumps(data, indent=4, sort_keys=True,
-                         cls=JSONEncoderTasks)
+                         cls=JSONEncoderCustomTypes)
     WrappedEtcdClient().put(path, encoded, lease=None)
 
 
@@ -357,7 +357,7 @@ def create(objecttype, subtype, name, data, ttle=None):
 
     path = _construct_key(objecttype, subtype, name)
     encoded = json.dumps(data, indent=4, sort_keys=True,
-                         cls=JSONEncoderTasks)
+                         cls=JSONEncoderCustomTypes)
     return WrappedEtcdClient().create(path, encoded, lease=None)
 
 


### PR DESCRIPTION
At the moment we create artifacts of type image when we need to
refer to a specific blob -- for example starting an instance. This
is actually pretty annoying as a user because you end up seeing a
lot of artifacts like this in the artifact list:

   sf://blob/6c3aa525-5af5-4c9e-8371-3549e88e2de8

On the other hand its nice as a developer, because it means I can
treat a blob as just another artifact when starting an instance.

So instead of making someone unhappy, let's just have the concept
of an artifact which isn't persisted to the database. I get my nice
abstraction, and the database stays cleaner.