### PR TITLE
Ensure cluster wide maintenance is only happening once.

### DIFF
--- a/shakenfist/artifact.py
+++ b/shakenfist/artifact.py
@@ -47,8 +47,6 @@ class Artifact(dbo):
 
         self.__artifact_type = static_values['artifact_type']
         self.__source_url = static_values['source_url']
-        self.__max_versions = static_values.get(
-            'max_versions', config.ARTIFACT_MAX_VERSIONS_DEFAULT)
 
     @classmethod
     def new(cls, artifact_type, source_url, max_versions=0):

--- a/shakenfist/constants.py
+++ b/shakenfist/constants.py
@@ -7,6 +7,11 @@ LOCK_REFRESH_SECONDS = 5
 ETCD_ATTEMPT_TIMEOUT = 60
 
 
+# A list of object names which deserve hard delete and event tracking
+OBJECT_NAMES = ['artifact', 'blob', 'instance', 'network', 'networkinterface',
+                'node']
+
+
 # Disk caching mode. Refer to docs/development/io_performance_tuning.md for
 # more details than you really want.
 #

--- a/shakenfist/daemons/cleaner.py
+++ b/shakenfist/daemons/cleaner.py
@@ -6,19 +6,12 @@ import pathlib
 import random
 import time
 
-from shakenfist import artifact
 from shakenfist.baseobject import DatabaseBackedObject as dbo
 from shakenfist.blob import Blob
 from shakenfist.config import config
 from shakenfist.daemons import daemon
 from shakenfist import logutil
 from shakenfist import instance
-from shakenfist import net
-from shakenfist import networkinterface
-from shakenfist.node import (
-    Node, Nodes,
-    active_states_filter as node_active_states_filter,
-    inactive_states_filter as node_inactive_states_filter)
 from shakenfist.util import general as util_general
 from shakenfist.util import libvirt as util_libvirt
 from shakenfist.util import process as util_process
@@ -168,56 +161,10 @@ class Monitor(daemon.Daemon):
         # Delay first compaction until system startup load has reduced
         last_compaction = time.time() - random.randint(1, 20*60)
 
-        last_loop_run = time.time()
         while True:
             # Update power state of all instances on this hypervisor
             LOG.info('Updating power states')
             self._update_power_states()
-
-            # Cleanup soft deleted instances and networks
-            for i in instance.inactive_instances():
-                LOG.with_object(i).info('Hard deleting instance')
-                i.hard_delete()
-
-            for n in net.inactive_networks():
-                LOG.with_network(n).info('Hard deleting network')
-                n.hard_delete()
-
-            for ni in networkinterface.inactive_network_interfaces():
-                LOG.with_networkinterface(
-                    ni).info('Hard deleting network interface')
-                ni.hard_delete()
-
-            # Prune artifacts which might have too many versions
-            for a in artifact.Artifacts([]):
-                a.delete_old_versions()
-
-            for n in Nodes([node_inactive_states_filter]):
-                age = time.time() - n.last_seen
-
-                # Find nodes which have returned from being missing
-                if age < config.NODE_CHECKIN_MAXIMUM:
-                    n.state = Node.STATE_CREATED
-                    LOG.with_object(n).info('Node returned from being missing')
-
-                # Find nodes which have been offline for a long time, unless
-                # this machine has been asleep for a long time (think developer
-                # laptop).
-                if (time.time() - last_loop_run < config.NODE_CHECKIN_MAXIMUM
-                        and age > config.NODE_CHECKIN_MAXIMUM * 10):
-                    n.state = Node.STATE_ERROR
-                    for i in instance.healthy_instances_on_node(n):
-                        LOG.with_object(i).with_object(n).info(
-                            'Node in error state, erroring instance')
-                        # Note, this queue job is just in case the node comes
-                        # back.
-                        i.enqueue_delete_due_error('Node in error state')
-
-            # Find nodes which haven't checked in recently
-            for n in Nodes([node_active_states_filter]):
-                age = time.time() - n.last_seen
-                if age > config.NODE_CHECKIN_MAXIMUM:
-                    n.state = Node.STATE_MISSING
 
             # Find orphaned and deleted blobs still on disk
             blob_path = os.path.join(config.STORAGE_PATH, 'blobs')
@@ -312,5 +259,4 @@ class Monitor(daemon.Daemon):
                     self._compact_etcd()
                     last_compaction = time.time()
 
-            last_loop_run = time.time()
             time.sleep(60)

--- a/shakenfist/daemons/cluster.py
+++ b/shakenfist/daemons/cluster.py
@@ -1,0 +1,103 @@
+# The cluster daemon is for cluster level maintenance tasks which are not
+# urgent. Hard deleting data for example. Its therefore pretty relaxed about
+# obtaining the lock to do work et cetera. There is only one active cluster
+# maintenance daemon per cluster.
+
+import setproctitle
+import time
+
+from shakenfist import artifact
+from shakenfist.config import config
+from shakenfist.daemons import daemon
+from shakenfist import etcd
+from shakenfist import instance
+from shakenfist import logutil
+from shakenfist import net
+from shakenfist import networkinterface
+from shakenfist.node import (
+    Node, Nodes,
+    active_states_filter as node_active_states_filter,
+    inactive_states_filter as node_inactive_states_filter)
+
+
+LOG, _ = logutil.setup(__name__)
+
+
+class Monitor(daemon.Daemon):
+    def __init__(self, name):
+        super(Monitor, self).__init__(name)
+        self.lock = None
+        self.is_elected = False
+
+    def _await_election(self):
+        # Attempt to acquire the cluster maintenance lock forever. We never
+        # release the lock, it gets cleared on a crash. This is so that only
+        # one node at a time is performing cluster maintenance.
+        while True:
+            self.lock = etcd.get_lock('cluster', None, None, ttl=900, timeout=10,
+                                      op='Cluster maintenance')
+            result = self.lock.acquire()
+            if result:
+                self.is_elected = True
+                return
+            time.sleep(300)
+
+    def _cluster_wide_cleanup(self, last_loop_run):
+        # Cleanup soft deleted instances and networks
+        for i in instance.inactive_instances():
+            LOG.with_object(i).info('Hard deleting instance')
+            i.hard_delete()
+
+        for n in net.inactive_networks():
+            LOG.with_network(n).info('Hard deleting network')
+            n.hard_delete()
+
+        for ni in networkinterface.inactive_network_interfaces():
+            LOG.with_networkinterface(
+                ni).info('Hard deleting network interface')
+            ni.hard_delete()
+
+        # Prune artifacts which might have too many versions
+        for a in artifact.Artifacts([]):
+            a.delete_old_versions()
+
+        for n in Nodes([node_inactive_states_filter]):
+            age = time.time() - n.last_seen
+
+            # Find nodes which have returned from being missing
+            if age < config.NODE_CHECKIN_MAXIMUM:
+                n.state = Node.STATE_CREATED
+                LOG.with_object(n).info('Node returned from being missing')
+
+            # Find nodes which have been offline for a long time, unless
+            # this machine has been asleep for a long time (think developer
+            # laptop).
+            if (time.time() - last_loop_run < config.NODE_CHECKIN_MAXIMUM
+                    and age > config.NODE_CHECKIN_MAXIMUM * 10):
+                n.state = Node.STATE_ERROR
+                for i in instance.healthy_instances_on_node(n):
+                    LOG.with_object(i).with_object(n).info(
+                        'Node in error state, erroring instance')
+                    # Note, this queue job is just in case the node comes
+                    # back.
+                    i.enqueue_delete_due_error('Node in error state')
+
+        # Find nodes which haven't checked in recently
+        for n in Nodes([node_active_states_filter]):
+            age = time.time() - n.last_seen
+            if age > config.NODE_CHECKIN_MAXIMUM:
+                n.state = Node.STATE_MISSING
+
+    def run(self):
+        LOG.info('Starting')
+        setproctitle.setproctitle(daemon.process_name('cluster') + ' idle')
+        self._await_election()
+        setproctitle.setproctitle(daemon.process_name('cluster') + ' active')
+
+        last_loop_run = 0
+        while True:
+            self.lock.refresh()
+            self._cluster_wide_cleanup(last_loop_run)
+            last_loop_run = time.time()
+            self.lock.refresh()
+            time.sleep(300)

--- a/shakenfist/daemons/daemon.py
+++ b/shakenfist/daemons/daemon.py
@@ -12,6 +12,7 @@ from shakenfist.util import libvirt as util_libvirt
 DAEMON_NAMES = {
     'api': 'sf-api',
     'cleaner': 'sf-cleaner',
+    'cluster': 'sf-cluster',
     'main': 'sf-main',
     'net': 'sf-net',
     'queues': 'sf-queues',

--- a/shakenfist/daemons/main.py
+++ b/shakenfist/daemons/main.py
@@ -9,6 +9,7 @@ from shakenfist.config import config
 from shakenfist.daemons import daemon
 from shakenfist.daemons import external_api as external_api_daemon
 from shakenfist.daemons import cleaner as cleaner_daemon
+from shakenfist.daemons import cluster as cluster_daemon
 from shakenfist.daemons import queues as queues_daemon
 from shakenfist.daemons import net as net_daemon
 from shakenfist.daemons import resources as resource_daemon
@@ -107,6 +108,7 @@ def restore_instances():
 DAEMON_IMPLEMENTATIONS = {
     'api': external_api_daemon,
     'cleaner': cleaner_daemon,
+    'cluster': cluster_daemon,
     'net': net_daemon,
     'queues': queues_daemon,
     'resources': resource_daemon,


### PR DESCRIPTION
At the moment every node attempts to perform the cluster wide
maintenance tasks as part of its cleaner loop. This is ok with smaller
clusters, but on bigger clusters it means that we're running cleanup
N times more often than needed, where N is the number of nodes in the
cluster.

Implement a simple election scheme using a lock to ensure that only
one daemon is doing cleanup at a time.