### PR TITLE
Reduce API timeout time.

### DIFF
--- a/shakenfist/config.py
+++ b/shakenfist/config.py
@@ -22,11 +22,11 @@ class SFConfig(BaseSettings):
     # API Options
     API_PORT: int = Field(13000, description='Port for the REST API')
     API_TIMEOUT: int = Field(
-        900,
+        30,
         description='How long gunicorn processes can use for a single request'
     )
     API_ASYNC_WAIT: int = Field(
-        30,
+        15,
         description='How long we wait for an async operation to complete '
                     'before returning to the user'
     )

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -383,9 +383,14 @@ def instance_delete(inst):
 
 def snapshot(inst, disk, artifact_uuid, blob_uuid):
     b = blob.snapshot_disk(disk, blob_uuid)
-    b.ref_count_inc()
     a = Artifact.from_db(artifact_uuid)
-    a.state = dbo.STATE_CREATED
+
+    if b.state.value == blob.Blob.STATE_DELETED:
+        # The blob was deleted while it was being created
+        a.state = Artifact.STATE_ERROR
+    else:
+        b.ref_count_inc()
+        a.state = Artifact.STATE_CREATED
 
 
 class Monitor(daemon.WorkerPoolDaemon):

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -59,15 +59,18 @@ def log_request_info():
 
 @app.after_request
 def log_response_info(response):
+    # Unfortunately the response body is too long to log here, but may be
+    # obtained with flask.response.get_data() if we ever want to grow a more
+    # complete tracing system.
     log = LOG.with_fields(
         {
             'request-id': flask.request.environ.get('FLASK_REQUEST_ID', 'none'),
-            'headers': response.headers,
-            'body': response.get_data()
+            'headers': response.headers
         })
     if config.EXCESSIVE_ETCD_CACHE_LOGGING:
-        log.with_fields(etcd.get_statistics())
-    log.debug('API response sent')
+        log.with_fields(etcd.get_statistics()).info('API response sent')
+    else:
+        log.debug('API response sent')
     etcd.reset_statistics()
     return response
 


### PR DESCRIPTION
Now that all long lived tasks are queue jobs, we should reduce the
maximum amount of time an API request can take. This might help us
debug API lockups as well.