### PR TITLE
Speed up building infrastructure.

### DIFF
--- a/deploy/ansible/ci-image.yml
+++ b/deploy/ansible/ci-image.yml
@@ -88,6 +88,7 @@
       apt:
         name:
           [
+            ansible,
             git,
             python3-dev,
             python3-grpcio,
@@ -99,6 +100,48 @@
             tox,
           ]
         state: latest
+
+    - name: Copy ansible config
+      copy:
+        src: /etc/ansible/ansible.cfg
+        dest: /etc/ansible/ansible.cfg
+        owner: root
+        group: root
+        mode: u=r,g=r,o=r
+
+    - name: Copy SF installer ansible requirements
+      copy:
+        src: ../requirements.yml
+        dest: /tmp/ansible-requirements.yml
+        owner: root
+        group: root
+        mode: u=r,g=r,o=r
+
+    - name: Install ansible galaxy roles
+      shell: ansible-galaxy install -r /tmp/ansible-requirements.yml
+
+    - name: Copy SF requirements.txt
+      copy:
+        src: ../../requirements.txt
+        dest: /tmp/sf-requirements.txt
+        owner: root
+        group: root
+        mode: u=r,g=r,o=r
+
+    - name: Copy SF client requirements.txt
+      copy:
+        src: ../../../client-python/client-requirements.txt
+        dest: /tmp/sf-requirements.txt
+        owner: root
+        group: root
+        mode: u=r,g=r,o=r
+
+    - name: Make venv and install server wheel
+      shell: |
+        python3 -m venv --system-site-packages /srv/shakenfist/venv
+        /srv/shakenfist/venv/bin/pip install -U pip
+        /srv/shakenfist/venv/bin/pip install -U -i /tmp/sf-requirements.txt
+        /srv/shakenfist/venv/bin/pip install -U -i /tmp/client-requirements.txt
 
     - name: Try and avoid the disk being corrupt when snapshot
       shell: |

--- a/deploy/ansible/ci-include-common-sfnodes.yml
+++ b/deploy/ansible/ci-include-common-sfnodes.yml
@@ -49,6 +49,8 @@
 
 - name: Make venv and install server wheel
   shell: |
-    python3 -m venv --system-site-packages /srv/shakenfist/venv
+    if [ ! -e /srv/shakenfist/venv ]; then
+      python3 -m venv --system-site-packages /srv/shakenfist/venv
+    fi
     /srv/shakenfist/venv/bin/pip install -U pip
     /srv/shakenfist/venv/bin/pip install /tmp/shakenfist*whl


### PR DESCRIPTION
Specifically targetting:

Make venv and install server wheel ------------------------------------ 218.56s
Enable eth1 (Debian) -------------------------------------------------- 126.40s
Install client wheel into shakenfist venv (in addition to system above) -- 98.73s

By:

 - pre-creating the venv and pre-installing requirements for the server and
   client
 - pre-installing ansible galaxy requirements
 - configuring ansible on the primary to record task timing information