### PR TITLE
Manage blob replication levels

### DIFF
--- a/shakenfist/blob.py
+++ b/shakenfist/blob.py
@@ -12,7 +12,7 @@ from shakenfist.baseobject import (
     DatabaseBackedObject as dbo,
     DatabaseBackedObjectIterator as dbo_iter)
 from shakenfist.config import config
-from shakenfist.constants import ETCD_ATTEMPT_TIMEOUT, LOCK_REFRESH_SECONDS, GiB
+from shakenfist.constants import LOCK_REFRESH_SECONDS, GiB
 from shakenfist import db
 from shakenfist import etcd
 from shakenfist.exceptions import BlobDeleted, BlobFetchFailed
@@ -303,7 +303,8 @@ class Blob(dbo):
             if targets > 0:
                 blob_size_gb = int(int(self.size) / GiB)
                 nodes = nodes_by_free_disk_descending(
-                    minimum=blob_size_gb + config.MINIMUM_FREE_DISK)
+                    minimum=blob_size_gb + config.MINIMUM_FREE_DISK,
+                    intention='blobs')
 
                 # Don't copy to locations which already have the blob
                 for n in self.locations:

--- a/shakenfist/blob.py
+++ b/shakenfist/blob.py
@@ -261,6 +261,7 @@ class Blob(dbo):
 
         os.rename(blob_path + '.partial', blob_path)
         self.observe()
+        return total_bytes_received
 
     def request_replication(self, allow_excess=0):
         replica_count = len(self.locations)

--- a/shakenfist/daemons/cluster.py
+++ b/shakenfist/daemons/cluster.py
@@ -83,7 +83,8 @@ class Monitor(daemon.Daemon):
         overreplicated = {}
         underreplicated = []
         low_disk_nodes = nodes_by_free_disk_descending(
-            maximum=config.MINIMUM_FREE_DISK)
+            minimum=0, maximum=config.MINIMUM_FREE_DISK,
+            intention='blobs')
         absent_nodes = [n.fqdn for n in Nodes([node_inactive_states_filter])]
 
         current_fetches = {}

--- a/shakenfist/daemons/cluster.py
+++ b/shakenfist/daemons/cluster.py
@@ -3,6 +3,7 @@
 # obtaining the lock to do work et cetera. There is only one active cluster
 # maintenance daemon per cluster.
 
+from collections import defaultdict
 import setproctitle
 import time
 
@@ -87,7 +88,7 @@ class Monitor(daemon.Daemon):
             intention='blobs')
         absent_nodes = [n.fqdn for n in Nodes([node_inactive_states_filter])]
 
-        current_fetches = {}
+        current_fetches = defaultdict(list)
         for workname, workitem in etcd.get_outstanding_jobs():
             # A workname looks like: /sf/queue/sf-3/jobname
             _, _, phase, node, _ = workname.split('/')
@@ -109,7 +110,6 @@ class Monitor(daemon.Daemon):
                             'phase': phase
                         }).warning('Node is absent, ignoring fetch')
                     else:
-                        current_fetches.setdefault(task.blob_uuid, [])
                         current_fetches[task.blob_uuid].append(node)
 
         with etcd.ThreadLocalReadOnlyCache():

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -170,7 +170,8 @@ def handle(jobname, workitem):
                         'blob': task.blob_uuid()
                     }).info('Cannot replicate blob, not found')
 
-                elif metrics.get('disk_free_blobs', 0) - b.size < config.MINIMUM_FREE_DISK:
+                elif (int(metrics.get('disk_free_blobs', 0)) - int(b.size) <
+                      config.MINIMUM_FREE_DISK):
                     log.with_fields({
                         'blob': task.blob_uuid()
                     }).info('Cannot replicate blob, insufficient space')

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -164,8 +164,11 @@ def handle(jobname, workitem):
 
             elif isinstance(task, FetchBlobTask):
                 b = blob.Blob.from_db(task.blob_uuid())
-                log.with_object(b).info('Replicating blob')
-                b.ensure_local([])
+                size = b.ensure_local([])
+                log.with_object(b).with_fields({
+                    'transferred': size,
+                    'expected': b.size
+                }).info('Replicating blob complete')
 
             else:
                 log_i.with_field('task', task).error(

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -551,6 +551,13 @@ def _restart_queue(queuename):
                              }).warning('Reset workitem')
 
 
+def get_outstanding_jobs():
+    for data, metadata in WrappedEtcdClient().get_prefix('/sf/processing'):
+        yield metadata['key'].decode('utf-8'), json.loads(data, object_hook=decodeTasks)
+    for data, metadata in WrappedEtcdClient().get_prefix('/sf/queued'):
+        yield metadata['key'].decode('utf-8'), json.loads(data, object_hook=decodeTasks)
+
+
 def restart_queues():
     # Move things which were in processing back to the queue because
     # we didn't complete them before crashing.

--- a/shakenfist/exceptions.py
+++ b/shakenfist/exceptions.py
@@ -200,3 +200,7 @@ class BlobMissing(ArtifactException):
 
 class BlobDeleted(ArtifactException):
     pass
+
+
+class BlobFetchFailed(Exception):
+    pass

--- a/shakenfist/external_api/artifact.py
+++ b/shakenfist/external_api/artifact.py
@@ -73,9 +73,10 @@ class ArtifactEndpoint(api_base.Resource):
         sole_ref_in_use = []
         for blob_index in artifact_from_db.get_all_indexes():
             b = Blob.from_db(blob_index['blob_uuid'])
-            blobs.append(b)
-            if b.ref_count == 1:
-                sole_ref_in_use += b.instances
+            if b:
+                blobs.append(b)
+                if b.ref_count == 1:
+                    sole_ref_in_use += b.instances
         if sole_ref_in_use:
             return api_base.error(
                 400, 'Cannot delete last reference to blob in use by instance (%s)' % (

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -200,7 +200,7 @@ class InstancesEndpoint(api_base.Resource):
                 if not a:
                     return api_base.error(404, 'artifact %s not found' % disk_base)
                 if a.state.value != Artifact.STATE_CREATED:
-                    return api_base.error(404, 'artifact %s is not ready (state=%s)'
+                    return api_base.error(404, 'disk base %s is not ready (state=%s)'
                                           % (disk_base, a.state.value))
 
                 blob_uuid = a.most_recent_index.get('blob_uuid')

--- a/shakenfist/node.py
+++ b/shakenfist/node.py
@@ -150,7 +150,8 @@ def nodes_by_free_disk_descending(minimum=0, maximum=-1, intention=None):
 
     for n in Nodes([active_states_filter]):
         metrics = db.get_metrics(n.fqdn)
-        disk_free_gb = int(metrics.get('disk_free%s' % intention, '0') / GiB)
+        disk_free_gb = int(
+            int(metrics.get('disk_free%s' % intention, '0')) / GiB)
 
         if disk_free_gb < minimum:
             continue

--- a/shakenfist/node.py
+++ b/shakenfist/node.py
@@ -132,7 +132,7 @@ class Nodes(dbo_iter):
 active_states_filter = partial(
     baseobject.state_filter, [dbo.STATE_CREATED])
 inactive_states_filter = partial(
-    baseobject.state_filter, [dbo.STATE_DELETED, dbo.STATE_ERROR, 'missing'])
+    baseobject.state_filter, [dbo.STATE_DELETED, dbo.STATE_ERROR, Node.STATE_MISSING])
 
 
 def _sort_by_key(d):

--- a/shakenfist/node.py
+++ b/shakenfist/node.py
@@ -142,7 +142,7 @@ def _sort_by_key(d):
 
 
 def nodes_by_free_disk_descending(minimum=0, maximum=-1, intention=None):
-    by_disk = {}
+    by_disk = defaultdict(list)
     if not intention:
         intention = ''
     else:

--- a/shakenfist/node.py
+++ b/shakenfist/node.py
@@ -141,12 +141,16 @@ def _sort_by_key(d):
             yield v
 
 
-def nodes_by_free_disk_descending(minimum=0, maximum=-1):
-    by_disk = defaultdict(list)
+def nodes_by_free_disk_descending(minimum=0, maximum=-1, intention=None):
+    by_disk = {}
+    if not intention:
+        intention = ''
+    else:
+        intention = '_%s' % intention
 
     for n in Nodes([active_states_filter]):
         metrics = db.get_metrics(n.fqdn)
-        disk_free_gb = int(int(metrics.get('disk_free', '0')) / GiB)
+        disk_free_gb = int(metrics.get('disk_free%s' % intention, '0') / GiB)
 
         if disk_free_gb < minimum:
             continue


### PR DESCRIPTION
Some light refactoring, and then adding two queue tasks. One replicates a blob to the target, and the other removes the blob from a target. Use the first to replicate blobs whenever they are created to config.BLOB_REPLICATION_FACTOR nodes. The deletion task isn't used yet.