### PR TITLE
Install stestr explicitly.

### DIFF
--- a/deploy/test-requirements.txt
+++ b/deploy/test-requirements.txt
@@ -1,2 +1,2 @@
 testtools           # mit
-stestr              # apache2
+stestr==3.2.0       # apache2


### PR DESCRIPTION
This is part of chasing stalled jobs in CI which die after two hours,
which seems to be a problem with tox / stestr.