### PR TITLE
Arguing with secure boot.

### DIFF
--- a/deploy/ansible/files/libvirt.tmpl
+++ b/deploy/ansible/files/libvirt.tmpl
@@ -5,19 +5,28 @@
   <currentMemory unit='KiB'>{{memory}}</currentMemory>
   <vcpu placement='static'>{{vcpus}}</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-i440fx-2.8'>hvm</type>
+    <type arch='x86_64' machine='{{machine_type}}'>hvm</type>
     <boot dev='hd'/>
     <boot dev='cdrom'/>
     <bootmenu enable='yes' timeout='3000'/>
 
     {%- if uefi -%}
+    {%- if secure_boot -%}
+    <loader readonly='yes' secure='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE.secboot.fd</loader>
+    {%- else -%}
     <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE.fd</loader>
+    {%- endif -%}
     <nvram {{nvram_template_attribute}}>{{instance_path}}/nvram</nvram>
     {%- endif -%}
   </os>
   <features>
     <acpi/>
     <apic/>
+    {%- if secure_boot -%}
+    <smm state='on'>
+      <tseg unit='MiB'>48</tseg>
+    </smm>
+    {%- endif -%}
   </features>
   <cpu mode='host-passthrough'>
   </cpu>
@@ -47,6 +56,52 @@
     {%- endif %}
     {%- endfor %}
 
+    {%- if machine_type == 'q35' -%}
+    <!-- NOTE(mikal): q35 is pcie -->
+    <controller type='pci' index='0' model='pcie-root'/>
+    <controller type='pci' index='1' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='1' port='0x10'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0' multifunction='on'/>
+    </controller>
+    <controller type='pci' index='2' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='2' port='0x11'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x1'/>
+    </controller>
+    <controller type='pci' index='3' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='3' port='0x12'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x2'/>
+    </controller>
+    <controller type='pci' index='4' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='4' port='0x13'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x3'/>
+    </controller>
+    <controller type='pci' index='5' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='5' port='0x14'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x4'/>
+    </controller>
+    <controller type='pci' index='6' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='6' port='0x15'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x5'/>
+    </controller>
+    <controller type='pci' index='7' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='7' port='0x16'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x6'/>
+    </controller>
+    <controller type='usb' index='0' model='qemu-xhci' ports='15'>
+      <address type='pci' domain='0x0000' bus='0x03' slot='0x02' function='0x0'/>
+    </controller>
+    <controller type='sata' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x1f' function='0x2'/>
+    </controller>
+    {%- else -%}
+    <!-- NOTE(mikal): i440fx is pci -->
     <controller type='usb' index='0' model='ich9-ehci1'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x7'/>
     </controller>
@@ -66,6 +121,7 @@
     <controller type='ide' index='0'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>
     </controller>
+    {%- endif -%}
 
     {% for net in networks %}
     <interface type='bridge'>
@@ -100,15 +156,22 @@
     <input type='keyboard' bus='ps2'/>
     <video>
       <model type='{{video_model}}' vram='{{video_memory}}' heads='1' primary='yes'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
     </video>
     <memballoon model='virtio'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
     </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+      <address type='pci' domain='0x0000' bus='0x06' slot='0x02' function='0x0'/>
+    </rng>
   </devices>
 
   <!-- NOTE(mikal): this is required to support things like NVME disks. -->
   <qemu:commandline>
+  {%- if secure_boot -%}
+    <qemu:arg value='-global'/><qemu:arg value='ICH9-LPC.disable_s3=1'/>
+  {%- endif -%}
   {%- for extra in extracommands %}
     <qemu:arg value='{{extra}}'/>
   {%- endfor %}

--- a/shakenfist/client/upgrade.py
+++ b/shakenfist/client/upgrade.py
@@ -98,6 +98,12 @@ def main():
                     i['version'] = 5
                     changed = True
 
+                # Find version 5 instances and migrate them to version 6
+                if i.get('version') == 5:
+                    i['machine_type'] = 'pc'
+                    i['version'] = 6
+                    changed = True
+
                 if changed:
                     print('--> Upgraded instance %s to version %d'
                           % (i['uuid'], i['version']))

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -548,6 +548,7 @@ class ExternalApiGeneralTestCase(ExternalApiTestCase):
                 return_value={
                     'cpus': 1,
                     'disk_spec': [{}],
+                    'machine_type': 'pc',
                     'memory': 2048,
                     'name': 'barry',
                     'namespace': 'namespace',
@@ -555,7 +556,7 @@ class ExternalApiGeneralTestCase(ExternalApiTestCase):
                     'ssh_key': 'sshkey',
                     'user_data': 'userdata',
                     'uuid': 'uuid42',
-                    'version': 5,
+                    'version': 6,
                     'video': {'memory': 16384, 'model': 'cirrus'},
                     'uefi': False,
                     'configdrive': 'openstack-disk',
@@ -574,6 +575,7 @@ class ExternalApiGeneralTestCase(ExternalApiTestCase):
             'disk_spec': [{}],
             'error_message': None,
             'interfaces': [],
+            'machine_type': 'pc',
             'memory': 2048,
             'name': 'barry',
             'namespace': 'namespace',
@@ -586,7 +588,7 @@ class ExternalApiGeneralTestCase(ExternalApiTestCase):
             'user_data': 'userdata',
             'uuid': 'uuid42',
             'vdi_port': None,
-            'version': 5,
+            'version': 6,
             'video': {'memory': 16384, 'model': 'cirrus'},
             'nvram_template': None,
             'secure_boot': False

--- a/shakenfist/tests/test_instance.py
+++ b/shakenfist/tests/test_instance.py
@@ -76,7 +76,7 @@ class VirtMetaTestCase(base.ShakenFistTestCase):
                     'video': {'model': 'cirrus', 'memory': 16384},
                     'uefi': False,
                     'configdrive': 'openstack-disk',
-                    'version': 5,
+                    'version': 6,
                     'nvram_template': None,
                     'secure_boot': False
                 })
@@ -110,6 +110,7 @@ class VirtMetaTestCase(base.ShakenFistTestCase):
              {
                  'cpus': 1,
                  'disk_spec': [{}],
+                 'machine_type': 'pc',
                  'memory': 2048,
                  'name': 'barry',
                  'namespace': 'namespace',
@@ -117,7 +118,7 @@ class VirtMetaTestCase(base.ShakenFistTestCase):
                  'ssh_key': 'sshkey',
                  'user_data': 'userdata',
                  'uuid': 'uuid42',
-                 'version': 5,
+                 'version': 6,
                  'video': {'memory': 16384, 'model': 'cirrus'},
                  'uefi': False,
                  'configdrive': 'openstack-disk',
@@ -137,7 +138,7 @@ class VirtMetaTestCase(base.ShakenFistTestCase):
                     'ssh_key': 'sshkey',
                     'user_data': 'userdata',
                     'uuid': 'uuid42',
-                    'version': 5,
+                    'version': 6,
                     'video': {'memory': 16384, 'model': 'cirrus'},
                     'uefi': False,
                     'configdrive': 'openstack-disk',
@@ -155,7 +156,7 @@ class VirtMetaTestCase(base.ShakenFistTestCase):
         self.assertEqual('sshkey', inst.ssh_key)
         self.assertEqual('userdata', inst.user_data)
         self.assertEqual('uuid42', inst.uuid)
-        self.assertEqual(5, inst.version)
+        self.assertEqual(6, inst.version)
         self.assertEqual('openstack-disk', inst.configdrive)
         self.assertEqual(None, inst.nvram_template)
         self.assertEqual(False, inst.secure_boot)
@@ -204,7 +205,7 @@ class InstanceTestCase(base.ShakenFistTestCase):
                     'video': {'model': 'cirrus', 'memory': 16384},
                     'uefi': False,
                     'configdrive': 'openstack-disk',
-                    'version': 5,
+                    'version': 6,
                     'nvram_template': None,
                     'secure_boot': False
                 })
@@ -552,7 +553,7 @@ GET_ALL_INSTANCES = [
         'video': {'model': 'cirrus', 'memory': 16384},
         'uefi': False,
         'configdrive': 'openstack-disk',
-        'version': 5,
+        'version': 6,
         'nvram_template': None,
         'secure_boot': False
     }),
@@ -573,7 +574,7 @@ GET_ALL_INSTANCES = [
         'video': {'model': 'cirrus', 'memory': 16384},
         'uefi': False,
         'configdrive': 'openstack-disk',
-        'version': 5,
+        'version': 6,
         'nvram_template': None,
         'secure_boot': False
     }),
@@ -593,7 +594,7 @@ GET_ALL_INSTANCES = [
         'video': {'model': 'cirrus', 'memory': 16384},
         'uefi': False,
         'configdrive': 'openstack-disk',
-        'version': 5,
+        'version': 6,
         'nvram_template': None,
         'secure_boot': False
     })


### PR DESCRIPTION
This one is still definitely a draft, but add support for secure boot. Things I still need to do:

- determine if we should always change the machine type, I suspect we should. Is it ok to lose IDE support?
- add some logic around adding the other bits like secure="yes" and smm only when secure boot is enabled
- add an arguement to instances requesting secure boot