### PR TITLE
Treat nvram (if it exists) as a block device for snapshots.

### DIFF
--- a/deploy/ansible/files/libvirt.tmpl
+++ b/deploy/ansible/files/libvirt.tmpl
@@ -12,7 +12,7 @@
 
     {%- if uefi -%}
     <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE.fd</loader>
-    <nvram>{{instance_path}}/nvram</nvram>
+    <nvram {{nvram_template_attribute}}>{{instance_path}}/nvram</nvram>
     {%- endif -%}
   </os>
   <features>

--- a/deploy/shakenfist_ci/base.py
+++ b/deploy/shakenfist_ci/base.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import random
+import re
 from socket import error as socket_error
 import string
 import sys
@@ -256,25 +257,36 @@ class BaseTestCase(testtools.TestCase):
             self.system_client.get_artifact, artifact_uuids)
 
     def _test_ping(self, instance_uuid, network_uuid, ip, expected, attempts=1):
+        packet_loss_re = re.compile(r'.* ([0-9\.]+)% packet loss.*')
+
+        packet_loss = None
         while attempts:
             sys.stderr.write('    _test_ping()  attempts=%s\n' % attempts)
             attempts -= 1
-            output = self.system_client.ping(network_uuid, ip)
 
-            actual = output.get('stdout').find(' 0% packet loss') != -1
-            if actual == expected:
-                break
+            output = self.system_client.ping(network_uuid, ip)
+            for line in output.get('stdout', '').split('\n'):
+                m = packet_loss_re.match(line)
+                if m:
+                    packet_loss = int(m.group(1))
+                    break
 
             # Almost unnecessary due to the slowness of execute()
             time.sleep(1)
 
-        if expected != actual:
+        failed = False
+        if expected == 0 and packet_loss > 10:
+            failed = True
+        elif expected == 100 and packet_loss != 100:
+            failed = True
+
+        if failed:
             self._log_console(instance_uuid)
             self._log_instance_events(instance_uuid)
             self._log_netns()
             sys.stderr.write('Current time: '+time.ctime()+'\n')
             self.fail('Ping test failed. Expected %s != actual %s.\nout: %s\nerr: %s\n'
-                      % (expected, actual, output['stdout'], output['stderr']))
+                      % (expected, packet_loss, output['stdout'], output['stderr']))
 
     def assertInstanceOk(self, instance_uuid):
         inst = self.system_client.get_instance(instance_uuid)
@@ -405,7 +417,7 @@ class TestDistroBoots(BaseNamespacedTestCase):
         self._await_login_prompt(inst['uuid'])
 
         ip = self.test_client.get_instance_interfaces(inst['uuid'])[0]['ipv4']
-        self._test_ping(inst['uuid'], self.net['uuid'], ip, True)
+        self._test_ping(inst['uuid'], self.net['uuid'], ip, 0)
 
         self.test_client.delete_instance(inst['uuid'])
         inst_uuids = []

--- a/deploy/shakenfist_ci/tests/test_multiple_nics.py
+++ b/deploy/shakenfist_ci/tests/test_multiple_nics.py
@@ -57,4 +57,4 @@ sudo /etc/init.d/S40network restart"""
 
         for iface in ifaces:
             self._test_ping(
-                inst['uuid'], iface['network_uuid'], iface['ipv4'], True)
+                inst['uuid'], iface['network_uuid'], iface['ipv4'], 0)

--- a/deploy/shakenfist_ci/tests/test_placement.py
+++ b/deploy/shakenfist_ci/tests/test_placement.py
@@ -62,7 +62,7 @@ class TestPlacement(base.BaseNamespacedTestCase):
         # cloud image. This is ok though, because we should be using the config drive
         # style interface information anyway.
         ip = self.test_client.get_instance_interfaces(inst['uuid'])[0]['ipv4']
-        self._test_ping(inst['uuid'], self.net['uuid'], ip, True)
+        self._test_ping(inst['uuid'], self.net['uuid'], ip, 0)
 
         # Ensure that deleting a local instance works
         self.test_client.delete_instance(inst['uuid'])
@@ -98,7 +98,7 @@ class TestPlacement(base.BaseNamespacedTestCase):
         # cloud image. This is ok though, because we should be using the config drive
         # style interface information anyway.
         ip = self.test_client.get_instance_interfaces(inst['uuid'])[0]['ipv4']
-        self._test_ping(inst['uuid'], self.net['uuid'], ip, True)
+        self._test_ping(inst['uuid'], self.net['uuid'], ip, 0)
 
         # Ensure that deleting a remote instance works
         self.test_client.delete_instance(inst['uuid'])

--- a/deploy/shakenfist_ci/tests/test_state_changes.py
+++ b/deploy/shakenfist_ci/tests/test_state_changes.py
@@ -67,7 +67,7 @@ class TestStateChanges(base.BaseNamespacedTestCase):
         # instance "login prompt" event. We are willing to forgive a few fails
         # while the network starts.
         LOG.info('  ping test...')
-        self._test_ping(inst['uuid'], self.net['uuid'], ip, True, 10)
+        self._test_ping(inst['uuid'], self.net['uuid'], ip, 0, 10)
 
         # Soft reboot
         LOG.info('Instance Soft reboot')
@@ -75,7 +75,7 @@ class TestStateChanges(base.BaseNamespacedTestCase):
         self.test_client.reboot_instance(inst['uuid'])
         self.assertInstanceConsoleAfterBoot(inst['uuid'], 'System booted ok')
         LOG.info('  ping test...')
-        self._test_ping(inst['uuid'], self.net['uuid'], ip, True, 10)
+        self._test_ping(inst['uuid'], self.net['uuid'], ip, 0, 10)
 
         # Hard reboot
         LOG.info('Instance Hard reboot')
@@ -83,7 +83,7 @@ class TestStateChanges(base.BaseNamespacedTestCase):
         self.test_client.reboot_instance(inst['uuid'], hard=True)
         self.assertInstanceConsoleAfterBoot(inst['uuid'], 'System booted ok')
         LOG.info('  ping test...')
-        self._test_ping(inst['uuid'], self.net['uuid'], ip, True, 10)
+        self._test_ping(inst['uuid'], self.net['uuid'], ip, 0, 10)
 
         # Power off
         LOG.info('Power off')
@@ -91,7 +91,7 @@ class TestStateChanges(base.BaseNamespacedTestCase):
         # Once the API returns the libvirt has powered off the instance or an
         # error has occurred (which CI will catch).
         LOG.info('  ping test...')
-        self._test_ping(inst['uuid'], self.net['uuid'], ip, False)
+        self._test_ping(inst['uuid'], self.net['uuid'], ip, 100)
 
         # Power on
         LOG.info('Instance Power on')
@@ -99,13 +99,13 @@ class TestStateChanges(base.BaseNamespacedTestCase):
         self.test_client.power_on_instance(inst['uuid'])
         self.assertInstanceConsoleAfterBoot(inst['uuid'], 'System booted ok')
         LOG.info('  ping test...')
-        self._test_ping(inst['uuid'], self.net['uuid'], ip, True, 10)
+        self._test_ping(inst['uuid'], self.net['uuid'], ip, 0, 10)
 
         # Pause
         LOG.info('Instance Pause')
         self.test_client.pause_instance(inst['uuid'])
         LOG.info('  ping test...')
-        self._test_ping(inst['uuid'], self.net['uuid'], ip, False, 10)
+        self._test_ping(inst['uuid'], self.net['uuid'], ip, 100, 10)
 
         # Unpause
         LOG.info('Instance Unpause')
@@ -113,4 +113,4 @@ class TestStateChanges(base.BaseNamespacedTestCase):
         # No new login prompt after unpause, so just forgive a few fails while
         # the instance is un-paused.
         LOG.info('  ping test...')
-        self._test_ping(inst['uuid'], self.net['uuid'], ip, True, 10)
+        self._test_ping(inst['uuid'], self.net['uuid'], ip, 0, 10)

--- a/deploy/shakenfist_ci/tests/test_ubuntu.py
+++ b/deploy/shakenfist_ci/tests/test_ubuntu.py
@@ -34,7 +34,7 @@ class TestUbuntu(base.BaseNamespacedTestCase):
         # cloud image. This is ok though, because we should be using the config drive
         # style interface information anyway.
         ip = self.test_client.get_instance_interfaces(inst['uuid'])[0]['ipv4']
-        self._test_ping(inst['uuid'], self.net['uuid'], ip, True)
+        self._test_ping(inst['uuid'], self.net['uuid'], ip, 0)
 
         self.test_client.delete_instance(inst['uuid'])
         inst_uuids = []

--- a/deploy/shakenfist_ci/tests/test_upgrades.py
+++ b/deploy/shakenfist_ci/tests/test_upgrades.py
@@ -49,20 +49,20 @@ class TestUpgrades(base.BaseTestCase):
             instances['upgrade/fe']['uuid'],
             networks_by_name['upgrade/upgrade-fe']['uuid'],
             addresses['upgrade/fe/upgrade-fe'],
-            True, 10)
+            0, 10)
         self._test_ping(
             instances['upgrade/fe']['uuid'],
             networks_by_name['upgrade/upgrade-be']['uuid'],
             addresses['upgrade/fe/upgrade-be'],
-            True, 10)
+            0, 10)
 
         self._test_ping(
             instances['upgrade/be-1']['uuid'],
             networks_by_name['upgrade/upgrade-be']['uuid'],
             addresses['upgrade/be-1/upgrade-be'],
-            True, 10)
+            0, 10)
         self._test_ping(
             instances['upgrade/be-2']['uuid'],
             networks_by_name['upgrade/upgrade-be']['uuid'],
             addresses['upgrade/be-2/upgrade-be'],
-            True, 10)
+            0, 10)

--- a/shakenfist/blob.py
+++ b/shakenfist/blob.py
@@ -301,7 +301,7 @@ class Blob(dbo):
         return os.path.join(config.STORAGE_PATH, 'blobs', blob_uuid)
 
 
-def _ensure_blob_path():
+def ensure_blob_path():
     blobs_path = os.path.join(config.STORAGE_PATH, 'blobs')
     os.makedirs(blobs_path, exist_ok=True)
 
@@ -309,7 +309,7 @@ def _ensure_blob_path():
 def snapshot_disk(disk, blob_uuid, related_object=None):
     if not os.path.exists(disk['path']):
         return
-    _ensure_blob_path()
+    ensure_blob_path()
     dest_path = Blob.filepath(blob_uuid)
 
     # Actually make the snapshot
@@ -325,7 +325,7 @@ def snapshot_disk(disk, blob_uuid, related_object=None):
 
 
 def http_fetch(resp, blob_uuid, locks, logs):
-    _ensure_blob_path()
+    ensure_blob_path()
 
     fetched = 0
     if resp.headers.get('Content-Length'):

--- a/shakenfist/exceptions.py
+++ b/shakenfist/exceptions.py
@@ -37,6 +37,11 @@ class InstanceBadDiskSpecification(InstanceException):
     pass
 
 
+class NVRAMTemplateMissing(InstanceException):
+    pass
+
+
+# Scheduler
 class SchedulerException(Exception):
     pass
 

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -92,8 +92,10 @@ class InstancesEndpoint(api_base.Resource):
     @api_base.requires_namespace_exist
     def post(self, name=None, cpus=None, memory=None, network=None, disk=None,
              ssh_key=None, user_data=None, placed_on=None, namespace=None,
-             video=None, uefi=False, configdrive=None, metadata=None):
+             video=None, uefi=False, configdrive=None, metadata=None,
+             nvram_template=None):
         global SCHEDULER
+        secure_boot = False
 
         if not namespace:
             namespace = get_jwt_identity()[0]
@@ -109,6 +111,10 @@ class InstancesEndpoint(api_base.Resource):
                 400, ('instance name %s is not useable as a DNS and Linux host name. '
                       'That is, less than 63 characters and in the character set: '
                       'a-z, A-Z, 0-9, or hyphen (-).' % name))
+
+        # Secure boot requires UEFI
+        if secure_boot and not uefi:
+            return api_base.error(400, 'secure boot requires UEFI be enabled')
 
         # If we are placed, make sure that node exists
         if placed_on:
@@ -257,6 +263,8 @@ class InstancesEndpoint(api_base.Resource):
             uefi=uefi,
             configdrive=configdrive,
             requested_placement=placed_on,
+            nvram_template=nvram_template,
+            secure_boot=secure_boot
         )
 
         # Initialise metadata

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -555,10 +555,12 @@ class ExternalApiGeneralTestCase(ExternalApiTestCase):
                     'ssh_key': 'sshkey',
                     'user_data': 'userdata',
                     'uuid': 'uuid42',
-                    'version': 4,
+                    'version': 5,
                     'video': {'memory': 16384, 'model': 'cirrus'},
                     'uefi': False,
                     'configdrive': 'openstack-disk',
+                    'nvram_template': None,
+                    'secure_boot': False
                 })
     @mock.patch('shakenfist.instance.Instance._db_get_attribute',
                 return_value={})
@@ -584,8 +586,10 @@ class ExternalApiGeneralTestCase(ExternalApiTestCase):
             'user_data': 'userdata',
             'uuid': 'uuid42',
             'vdi_port': None,
-            'version': 4,
-            'video': {'memory': 16384, 'model': 'cirrus'}
+            'version': 5,
+            'video': {'memory': 16384, 'model': 'cirrus'},
+            'nvram_template': None,
+            'secure_boot': False
         }, resp.get_json())
         self.assertEqual(200, resp.status_code)
         self.assertEqual('application/json', resp.content_type)

--- a/shakenfist/tests/test_instance.py
+++ b/shakenfist/tests/test_instance.py
@@ -76,7 +76,9 @@ class VirtMetaTestCase(base.ShakenFistTestCase):
                     'video': {'model': 'cirrus', 'memory': 16384},
                     'uefi': False,
                     'configdrive': 'openstack-disk',
-                    'version': 4
+                    'version': 5,
+                    'nvram_template': None,
+                    'secure_boot': False
                 })
     @mock.patch('shakenfist.etcd.put')
     @mock.patch('shakenfist.etcd.create')
@@ -115,10 +117,12 @@ class VirtMetaTestCase(base.ShakenFistTestCase):
                  'ssh_key': 'sshkey',
                  'user_data': 'userdata',
                  'uuid': 'uuid42',
-                 'version': 4,
+                 'version': 5,
                  'video': {'memory': 16384, 'model': 'cirrus'},
                  'uefi': False,
-                 'configdrive': 'openstack-disk'
+                 'configdrive': 'openstack-disk',
+                 'nvram_template': None,
+                 'secure_boot': False
              }),
             mock_create.mock_calls[0][1])
 
@@ -133,10 +137,12 @@ class VirtMetaTestCase(base.ShakenFistTestCase):
                     'ssh_key': 'sshkey',
                     'user_data': 'userdata',
                     'uuid': 'uuid42',
-                    'version': 4,
+                    'version': 5,
                     'video': {'memory': 16384, 'model': 'cirrus'},
                     'uefi': False,
-                    'configdrive': 'openstack-disk'
+                    'configdrive': 'openstack-disk',
+                    'nvram_template': None,
+                    'secure_boot': False
                 })
     def test_from_db(self, mock_get):
         inst = instance.Instance.from_db('uuid42')
@@ -149,7 +155,10 @@ class VirtMetaTestCase(base.ShakenFistTestCase):
         self.assertEqual('sshkey', inst.ssh_key)
         self.assertEqual('userdata', inst.user_data)
         self.assertEqual('uuid42', inst.uuid)
-        self.assertEqual(4, inst.version)
+        self.assertEqual(5, inst.version)
+        self.assertEqual('openstack-disk', inst.configdrive)
+        self.assertEqual(None, inst.nvram_template)
+        self.assertEqual(False, inst.secure_boot)
         self.assertEqual({'memory': 16384, 'model': 'cirrus'}, inst.video)
         self.assertEqual('/a/b/c/instances/uuid42', inst.instance_path)
 
@@ -195,7 +204,9 @@ class InstanceTestCase(base.ShakenFistTestCase):
                     'video': {'model': 'cirrus', 'memory': 16384},
                     'uefi': False,
                     'configdrive': 'openstack-disk',
-                    'version': 4
+                    'version': 5,
+                    'nvram_template': None,
+                    'secure_boot': False
                 })
     def _make_instance(self, mock_get_instance, mock_create_instance):
         return instance.Instance.new(
@@ -541,7 +552,9 @@ GET_ALL_INSTANCES = [
         'video': {'model': 'cirrus', 'memory': 16384},
         'uefi': False,
         'configdrive': 'openstack-disk',
-        'version': 4
+        'version': 5,
+        'nvram_template': None,
+        'secure_boot': False
     }),
     # Present here, but not in the get (a race?)
     (None, {
@@ -560,7 +573,9 @@ GET_ALL_INSTANCES = [
         'video': {'model': 'cirrus', 'memory': 16384},
         'uefi': False,
         'configdrive': 'openstack-disk',
-        'version': 4
+        'version': 5,
+        'nvram_template': None,
+        'secure_boot': False
     }),
     (None, {
         'uuid': 'a7c5ecec-c3a9-4774-ad1b-249d9e90e806',
@@ -578,7 +593,9 @@ GET_ALL_INSTANCES = [
         'video': {'model': 'cirrus', 'memory': 16384},
         'uefi': False,
         'configdrive': 'openstack-disk',
-        'version': 4
+        'version': 5,
+        'nvram_template': None,
+        'secure_boot': False
     })
 ]
 


### PR DESCRIPTION
The contents of nvram for UEFI and UEFI Secure Boot instances is
something you might want to persist between instances -- it contains
things like the boot order and any enrolled system keys. Therefore
snapshot it if it exists.