### PR TITLE
Reduce daemon shutdown time by avoiding sleeps

### DIFF
--- a/shakenfist/daemons/cleaner.py
+++ b/shakenfist/daemons/cleaner.py
@@ -297,7 +297,7 @@ class Monitor(daemon.Daemon):
         # Delay first compaction until system startup load has reduced
         last_compaction = time.time() - random.randint(1, 20*60)
 
-        while self.running:
+        while not self.exit.is_set():
             # Update power state of all instances on this hypervisor
             LOG.info('Updating power states')
             self._update_power_states()
@@ -312,4 +312,4 @@ class Monitor(daemon.Daemon):
                     self._compact_etcd()
                     last_compaction = time.time()
 
-            time.sleep(60)
+            self.exit.wait(60)

--- a/shakenfist/daemons/daemon.py
+++ b/shakenfist/daemons/daemon.py
@@ -2,6 +2,7 @@ import logging
 import multiprocessing
 import setproctitle
 import signal
+from threading import Event
 
 from shakenfist.config import config
 from shakenfist import etcd
@@ -49,13 +50,13 @@ class Daemon(object):
         self.log, _ = logutil.setup(name)
         set_log_level(self.log, name)
 
-        self.running = True
+        self.exit = Event()
         signal.signal(signal.SIGTERM, self.exit_gracefully)
 
     def exit_gracefully(self, sig, _frame):
         if sig == signal.SIGTERM:
-            self.running = False
             self.log.info('Caught SIGTERM, commencing shutdown')
+            self.exit.set()
 
 
 class WorkerPoolDaemon(Daemon):

--- a/shakenfist/daemons/external_api.py
+++ b/shakenfist/daemons/external_api.py
@@ -32,8 +32,6 @@ class Monitor(daemon.Daemon):
 
     def exit_gracefully(self, sig, _frame):
         if sig == signal.SIGTERM:
-            self.running = False
-
             if os.path.exists('/var/run/sf/gunicorn.pid'):
                 with open('/var/run/sf/gunicorn.pid') as f:
                     pid = int(f.read())

--- a/shakenfist/daemons/main.py
+++ b/shakenfist/daemons/main.py
@@ -230,7 +230,7 @@ def main():
 
     running = True
     while True:
-        time.sleep(10)
+        time.sleep(5)
 
         try:
             wpid, _ = os.waitpid(-1, os.WNOHANG)

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -1,6 +1,5 @@
 import requests
 import setproctitle
-import time
 
 from shakenfist.artifact import Artifact
 from shakenfist import blob
@@ -429,13 +428,13 @@ class Monitor(daemon.WorkerPoolDaemon):
             try:
                 self.reap_workers()
 
-                if self.running:
+                if not self.exit.is_set():
                     if not self.dequeue_work_item(config.NODE_NAME, handle):
-                        time.sleep(0.2)
+                        self.exit.wait(0.2)
                 elif len(self.workers) > 0:
                     LOG.info('Waiting for %d workers to finish'
                              % len(self.workers))
-                    time.sleep(0.2)
+                    self.exit.wait(0.2)
                 else:
                     return
 

--- a/shakenfist/daemons/resources.py
+++ b/shakenfist/daemons/resources.py
@@ -204,7 +204,7 @@ class Monitor(daemon.Daemon):
                 ttl=120)
             gauges['updated_at'].set_to_current_time()
 
-        while self.running:
+        while not self.exit.is_set():
             try:
                 jobname, _ = etcd.dequeue('%s-metrics' % config.NODE_NAME)
                 if jobname:
@@ -213,7 +213,7 @@ class Monitor(daemon.Daemon):
                         last_metrics = time.time()
                     etcd.resolve('%s-metrics' % config.NODE_NAME, jobname)
                 else:
-                    time.sleep(0.2)
+                    self.exit.wait(0.2)
 
                 timer = time.time() - last_metrics
                 if timer > config.SCHEDULER_CACHE_TIMEOUT:

--- a/shakenfist/daemons/triggers.py
+++ b/shakenfist/daemons/triggers.py
@@ -48,7 +48,7 @@ def observe(path, instance_uuid):
 
     buffer = ''
     while True:
-        # Detect file trunctations, and die if we see one. We will be restarted
+        # Detect file truncations, and die if we see one. We will be restarted
         # by the monitor process.
         if not os.path.exists(path):
             return
@@ -83,7 +83,7 @@ class Monitor(daemon.Daemon):
         LOG.info('Starting')
         observers = {}
 
-        while self.running:
+        while not self.exit.is_set():
             # Cleanup terminated observers
             all_observers = list(observers.keys())
             for instance_uuid in all_observers:
@@ -141,7 +141,7 @@ class Monitor(daemon.Daemon):
                 db.add_event(
                     'instance', instance_uuid, 'trigger monitor', 'finished', None, None)
 
-            time.sleep(1)
+            self.exit.wait(1)
 
         # No longer running, clean up all trigger deaemons
         for instance_uuid in observers:


### PR DESCRIPTION
Using time.sleep() results in the cleaner only checking 
shutdown requests once per minute.
Waiting on a threading.Event results in an immediate
response.