### PR TITLE
Specify instance or network by name in API calls

### DIFF
--- a/deploy/shakenfist_ci/tests/test_object_names.py
+++ b/deploy/shakenfist_ci/tests/test_object_names.py
@@ -21,7 +21,7 @@ class TestObjectNames(base.BaseNamespacedTestCase):
                 '192.168.242.0/24', True, True, i+'_net')
             nets[i+'_net'] = n['uuid']
 
-        for name, uuid in nets:
+        for name, uuid in nets.items():
             n = self.system_client.get_network(name)
             self.assertEqual(uuid, n['uuid'])
 

--- a/deploy/shakenfist_ci/tests/test_object_names.py
+++ b/deploy/shakenfist_ci/tests/test_object_names.py
@@ -1,0 +1,52 @@
+from shakenfist_ci import base
+
+
+class TestObjectNames(base.BaseNamespacedTestCase):
+    """Make sure instances boot under various configurations."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs['namespace_prefix'] = 'namespace_test'
+        super().__init__(*args, **kwargs)
+
+    def test_object_names(self):
+        """Check instances and networks names
+
+        Testing API create_instance() using network name and instance/network
+        retrieval by name.
+        """
+
+        nets = {}
+        for i in ['barry', 'dave', 'alice']:
+            n = self.test_client.allocate_network(
+                '192.168.242.0/24', True, True, i+'_net')
+            nets[i+'_net'] = n['uuid']
+
+        for name, uuid in nets:
+            n = self.system_client.get_network(name)
+            self.assertEqual(uuid, n['uuid'])
+
+        self._await_networks_ready(['barry_net'])
+
+        inst_uuids = {}
+        for i in ['barry', 'dave']:
+            new_inst = self.test_client.create_instance(
+                'test-cirros-%s' % i, 1, 1024,
+                [
+                    {
+                        'network_uuid': 'barry_net'
+                    }
+                ],
+                [
+                    {
+                        'size': 8,
+                        'base': 'sf://upload/system/cirros',
+                        'type': 'disk'
+                    }
+                ], None, None,
+                namespace=self.namespace)
+            inst_uuids[i] = new_inst['uuid']
+
+        # Get instance by name
+        for name, uuid in inst_uuids.items():
+            inst = self.system_client.get_instance(name)
+            self.assertEqual(uuid, inst['uuid'])

--- a/deploy/shakenfist_ci/tests/test_object_names.py
+++ b/deploy/shakenfist_ci/tests/test_object_names.py
@@ -28,9 +28,9 @@ class TestObjectNames(base.BaseNamespacedTestCase):
         self._await_networks_ready(['barry_net'])
 
         inst_uuids = {}
-        for i in ['barry', 'dave']:
+        for name in ['barry', 'dave', 'trouble-writing-tests']:
             new_inst = self.test_client.create_instance(
-                'test-cirros-%s' % i, 1, 1024,
+                name, 1, 1024,
                 [
                     {
                         'network_uuid': 'barry_net'
@@ -44,7 +44,7 @@ class TestObjectNames(base.BaseNamespacedTestCase):
                     }
                 ], None, None,
                 namespace=self.namespace)
-            inst_uuids[i] = new_inst['uuid']
+            inst_uuids[name] = new_inst['uuid']
 
         # Get instance by name
         for name, uuid in inst_uuids.items():

--- a/shakenfist/artifact.py
+++ b/shakenfist/artifact.py
@@ -78,17 +78,6 @@ class Artifact(dbo):
         return a
 
     @staticmethod
-    def from_db(artifact_uuid):
-        if not artifact_uuid:
-            return None
-
-        static_values = Artifact._db_get(artifact_uuid)
-        if not static_values:
-            return None
-
-        return Artifact(static_values)
-
-    @staticmethod
     def from_url(artifact_type, url, max_versions=0):
         artifacts = list(Artifacts([partial(url_filter, url),
                                     partial(type_filter, artifact_type),

--- a/shakenfist/blob.py
+++ b/shakenfist/blob.py
@@ -64,17 +64,6 @@ class Blob(dbo):
         b.state = Blob.STATE_INITIAL
         return b
 
-    @staticmethod
-    def from_db(blob_uuid):
-        if not blob_uuid:
-            return None
-
-        static_values = Blob._db_get(blob_uuid)
-        if not static_values:
-            return None
-
-        return Blob(static_values)
-
     def external_view(self):
         # If this is an external view, then mix back in attributes that users
         # expect

--- a/shakenfist/exceptions.py
+++ b/shakenfist/exceptions.py
@@ -24,6 +24,10 @@ class NoStateTransitionsDefined(ObjectException):
     pass
 
 
+class MultipleObjects(ObjectException):
+    pass
+
+
 # Instance
 class InstanceException(Exception):
     pass

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -108,31 +108,31 @@ api.add_resource(api_blob.BlobsEndpoint, '/blob')
 api.add_resource(api_blob.BlobEndpoint, '/blob/<blob_uuid>')
 
 api.add_resource(api_instance.InstancesEndpoint, '/instances')
-api.add_resource(api_instance.InstanceEndpoint, '/instances/<instance_uuid>')
+api.add_resource(api_instance.InstanceEndpoint, '/instances/<instance_ref>')
 api.add_resource(api_instance.InstanceEventsEndpoint,
-                 '/instances/<instance_uuid>/events')
+                 '/instances/<instance_ref>/events')
 api.add_resource(api_instance.InstanceInterfacesEndpoint,
-                 '/instances/<instance_uuid>/interfaces')
+                 '/instances/<instance_ref>/interfaces')
 api.add_resource(api_snapshot.InstanceSnapshotEndpoint,
-                 '/instances/<instance_uuid>/snapshot')
+                 '/instances/<instance_ref>/snapshot')
 api.add_resource(api_instance.InstanceRebootSoftEndpoint,
-                 '/instances/<instance_uuid>/rebootsoft')
+                 '/instances/<instance_ref>/rebootsoft')
 api.add_resource(api_instance.InstanceRebootHardEndpoint,
-                 '/instances/<instance_uuid>/reboothard')
+                 '/instances/<instance_ref>/reboothard')
 api.add_resource(api_instance.InstancePowerOffEndpoint,
-                 '/instances/<instance_uuid>/poweroff')
+                 '/instances/<instance_ref>/poweroff')
 api.add_resource(api_instance.InstancePowerOnEndpoint,
-                 '/instances/<instance_uuid>/poweron')
+                 '/instances/<instance_ref>/poweron')
 api.add_resource(api_instance.InstancePauseEndpoint,
-                 '/instances/<instance_uuid>/pause')
+                 '/instances/<instance_ref>/pause')
 api.add_resource(api_instance.InstanceUnpauseEndpoint,
-                 '/instances/<instance_uuid>/unpause')
+                 '/instances/<instance_ref>/unpause')
 api.add_resource(api_instance.InstanceMetadatasEndpoint,
-                 '/instances/<instance_uuid>/metadata')
+                 '/instances/<instance_ref>/metadata')
 api.add_resource(api_instance.InstanceMetadataEndpoint,
-                 '/instances/<instance_uuid>/metadata/<key>')
+                 '/instances/<instance_ref>/metadata/<key>')
 api.add_resource(api_instance.InstanceConsoleDataEndpoint,
-                 '/instances/<instance_uuid>/consoledata')
+                 '/instances/<instance_ref>/consoledata')
 
 api.add_resource(api_interface.InterfaceEndpoint,
                  '/interfaces/<interface_uuid>')
@@ -155,17 +155,17 @@ api.add_resource(api_artifact.ArtifactVersionEndpoint,
 api.add_resource(api_label.LabelEndpoint, '/label/<label_name>')
 
 api.add_resource(api_network.NetworksEndpoint, '/networks')
-api.add_resource(api_network.NetworkEndpoint, '/networks/<network_uuid>')
+api.add_resource(api_network.NetworkEndpoint, '/networks/<network_ref>')
 api.add_resource(api_network.NetworkEventsEndpoint,
-                 '/networks/<network_uuid>/events')
+                 '/networks/<network_ref>/events')
 api.add_resource(api_network.NetworkInterfacesEndpoint,
-                 '/networks/<network_uuid>/interfaces')
+                 '/networks/<network_ref>/interfaces')
 api.add_resource(api_network.NetworkMetadatasEndpoint,
-                 '/networks/<network_uuid>/metadata')
+                 '/networks/<network_ref>/metadata')
 api.add_resource(api_network.NetworkMetadataEndpoint,
-                 '/networks/<network_uuid>/metadata/<key>')
+                 '/networks/<network_ref>/metadata/<key>')
 api.add_resource(api_network.NetworkPingEndpoint,
-                 '/networks/<network_uuid>/ping/<address>')
+                 '/networks/<network_ref>/ping/<address>')
 
 api.add_resource(api_node.NodesEndpoint, '/nodes')
 

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -70,18 +70,18 @@ def caller_is_admin(func):
     return wrapper
 
 
-def arg_is_instance_uuid(func):
+def arg_is_instance_ref(func):
     # Method uses the instance from the db
     def wrapper(*args, **kwargs):
         with ThreadLocalReadOnlyCache():
             try:
-                inst = Instance.from_db_by_ref(kwargs.get('instance_uuid'),
+                inst = Instance.from_db_by_ref(kwargs.get('instance_ref'),
                                                get_jwt_identity()[0])
             except exceptions.MultipleObjects as e:
                 return error(400, str(e))
 
             if not inst:
-                LOG.with_field('instance', kwargs.get('instance_uuid')).info(
+                LOG.with_field('instance', kwargs.get('instance_ref')).info(
                     'Instance not found, missing or deleted')
                 return error(404, 'instance not found')
 
@@ -128,10 +128,10 @@ def redirect_instance_request(func):
 
 
 def requires_instance_ownership(func):
-    # Requires that @arg_is_instance_uuid has already run
+    # Requires that @arg_is_instance_ref has already run
     def wrapper(*args, **kwargs):
         if not kwargs.get('instance_from_db'):
-            LOG.with_field('instance', kwargs['instance_uuid']).info(
+            LOG.with_field('instance', kwargs['instance_ref']).info(
                 'Instance not found, kwarg missing')
             return error(404, 'instance not found')
 
@@ -146,10 +146,10 @@ def requires_instance_ownership(func):
 
 
 def requires_instance_active(func):
-    # Requires that @arg_is_instance_uuid has already run
+    # Requires that @arg_is_instance_ref has already run
     def wrapper(*args, **kwargs):
         if not kwargs.get('instance_from_db'):
-            LOG.with_field('instance', kwargs['instance_uuid']).info(
+            LOG.with_field('instance', kwargs['instance_ref']).info(
                 'Instance not found, kwarg missing')
             return error(404, 'instance not found')
 
@@ -163,18 +163,18 @@ def requires_instance_active(func):
     return wrapper
 
 
-def arg_is_network_uuid(func):
+def arg_is_network_ref(func):
     # Method uses the network from the db
     def wrapper(*args, **kwargs):
         with ThreadLocalReadOnlyCache():
             try:
-                network = net.Network.from_db_by_ref(kwargs.get('network_uuid'),
+                network = net.Network.from_db_by_ref(kwargs.get('network_ref'),
                                                      get_jwt_identity()[0])
             except exceptions.MultipleObjects as e:
                 return error(400, str(e))
 
             if not network:
-                LOG.with_field('network', kwargs.get('network_uuid')).info(
+                LOG.with_field('network', kwargs.get('network_ref')).info(
                     'Network not found, missing or deleted')
                 return error(404, 'network not found')
 
@@ -210,9 +210,9 @@ def redirect_to_network_node(func):
 
 
 def requires_network_ownership(func):
-    # Requires that @arg_is_network_uuid has already run
+    # Requires that @arg_is_network_ref has already run
     def wrapper(*args, **kwargs):
-        log = LOG.with_field('network', kwargs['network_uuid'])
+        log = LOG.with_field('network', kwargs['network_ref'])
 
         if not kwargs.get('network_from_db'):
             log.info('Network not found, kwarg missing')
@@ -227,9 +227,9 @@ def requires_network_ownership(func):
 
 
 def requires_network_active(func):
-    # Requires that @arg_is_network_uuid has already run
+    # Requires that @arg_is_network_ref has already run
     def wrapper(*args, **kwargs):
-        log = LOG.with_field('network', kwargs['network_uuid'])
+        log = LOG.with_field('network', kwargs['network_ref'])
 
         if not kwargs.get('network_from_db'):
             log.info('Network not found, kwarg missing')

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -93,14 +93,13 @@ def arg_is_instance_uuid(func):
                 ]
                 for i in instance.Instances(filters):
                     if i.name == inst_uuid:
-                        inst_uuid = i.uuid
+                        kwargs['instance_from_db'] = i
                         break
-            if inst_uuid:
-                # Retrieve the actual instance via it's UUID
+            else:
                 kwargs['instance_from_db'] = instance.Instance.from_db(inst_uuid)
 
             if not kwargs.get('instance_from_db'):
-                LOG.with_instance(kwargs['instance_uuid']).info(
+                LOG.with_field('instance', kwargs.get('instance_uuid')).info(
                     'Instance not found, missing or deleted')
                 return error(404, 'instance not found')
 
@@ -208,7 +207,7 @@ def arg_is_network_uuid(func):
                 kwargs['network_from_db'] = net.Network.from_db(net_uuid)
 
             if not kwargs.get('network_from_db'):
-                LOG.with_network(net_uuid).info(
+                LOG.with_field('network', kwargs.get('network_uuid')).info(
                     'Network not found, missing or deleted')
                 return error(404, 'network not found')
 

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -270,7 +270,11 @@ class InstancesEndpoint(api_base.Resource):
 
                 # Allow network to be specified by name or UUID (and error early
                 # if not found)
-                n = net.Network.from_db_by_ref(netdesc['network_uuid'])
+                try:
+                    n = net.Network.from_db_by_ref(netdesc['network_uuid'])
+                except exceptions.MultipleObjects as e:
+                    return api_base.error(400, str(e))
+
                 if not n:
                     return api_base.error(
                         404, 'network %s not found' % netdesc['network_uuid'])
@@ -279,7 +283,7 @@ class InstancesEndpoint(api_base.Resource):
                 if netdesc.get('address') and not util_general.noneish(netdesc.get('address')):
                     # The requested address must be within the ip range specified
                     # for that virtual network, unless it is equivalent to "none".
-                    ipm = IPManager.from_db(network.uuid)
+                    ipm = IPManager.from_db(n.uuid)
                     if not ipm.is_in_range(netdesc['address']):
                         return api_base.error(400,
                                               'network specification requests an address outside the '

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -43,16 +43,16 @@ SCHEDULER = None
 
 class InstanceEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
-    def get(self, instance_uuid=None, instance_from_db=None):
+    def get(self, instance_ref=None, instance_from_db=None):
         return instance_from_db.external_view()
 
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
     @api_base.requires_namespace_exist
-    def delete(self, instance_uuid=None, instance_from_db=None, namespace=None):
+    def delete(self, instance_ref=None, instance_from_db=None, namespace=None):
         # Check if instance has already been deleted
         if instance_from_db.state.value == dbo.STATE_DELETED:
             return api_base.error(404, 'instance not found')
@@ -487,9 +487,9 @@ class InstancesEndpoint(api_base.Resource):
 
 class InstanceInterfacesEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
-    def get(self, instance_uuid=None, instance_from_db=None):
+    def get(self, instance_ref=None, instance_from_db=None):
         out = []
         for iface_uuid in instance_from_db.interfaces:
             ni, _, err = api_util.safe_get_network_interface(iface_uuid)
@@ -501,21 +501,21 @@ class InstanceInterfacesEndpoint(api_base.Resource):
 
 class InstanceEventsEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
-    def get(self, instance_uuid=None, instance_from_db=None):
-        return list(db.get_events('instance', instance_uuid))
+    def get(self, instance_ref=None, instance_from_db=None):
+        return list(db.get_events('instance', instance_from_db.uuid))
 
 
 class InstanceRebootSoftEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
     @api_base.redirect_instance_request
     @api_base.requires_instance_active
-    def post(self, instance_uuid=None, instance_from_db=None):
+    def post(self, instance_ref=None, instance_from_db=None):
         with db.get_lock(
-                'instance', None, instance_uuid, ttl=120, timeout=120,
+                'instance', None, instance_from_db.uuid, ttl=120, timeout=120,
                 op='Instance reboot soft'):
             instance_from_db.add_event('api', 'soft reboot')
             return instance_from_db.reboot(hard=False)
@@ -523,13 +523,13 @@ class InstanceRebootSoftEndpoint(api_base.Resource):
 
 class InstanceRebootHardEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
     @api_base.redirect_instance_request
     @api_base.requires_instance_active
-    def post(self, instance_uuid=None, instance_from_db=None):
+    def post(self, instance_ref=None, instance_from_db=None):
         with db.get_lock(
-                'instance', None, instance_uuid, ttl=120, timeout=120,
+                'instance', None, instance_from_db.uuid, ttl=120, timeout=120,
                 op='Instance reboot hard'):
             instance_from_db.add_event('api', 'hard reboot')
             return instance_from_db.reboot(hard=True)
@@ -537,13 +537,13 @@ class InstanceRebootHardEndpoint(api_base.Resource):
 
 class InstancePowerOffEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
     @api_base.redirect_instance_request
     @api_base.requires_instance_active
-    def post(self, instance_uuid=None, instance_from_db=None):
+    def post(self, instance_ref=None, instance_from_db=None):
         with db.get_lock(
-                'instance', None, instance_uuid, ttl=120, timeout=120,
+                'instance', None, instance_from_db.uuid, ttl=120, timeout=120,
                 op='Instance power off'):
             instance_from_db.add_event('api', 'poweroff')
             return instance_from_db.power_off()
@@ -551,13 +551,13 @@ class InstancePowerOffEndpoint(api_base.Resource):
 
 class InstancePowerOnEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
     @api_base.redirect_instance_request
     @api_base.requires_instance_active
-    def post(self, instance_uuid=None, instance_from_db=None):
+    def post(self, instance_ref=None, instance_from_db=None):
         with db.get_lock(
-                'instance', None, instance_uuid, ttl=120, timeout=120,
+                'instance', None, instance_from_db.uuid, ttl=120, timeout=120,
                 op='Instance power on'):
             instance_from_db.add_event('api', 'poweron')
             return instance_from_db.power_on()
@@ -565,13 +565,13 @@ class InstancePowerOnEndpoint(api_base.Resource):
 
 class InstancePauseEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
     @api_base.redirect_instance_request
     @api_base.requires_instance_active
-    def post(self, instance_uuid=None, instance_from_db=None):
+    def post(self, instance_ref=None, instance_from_db=None):
         with db.get_lock(
-                'instance', None, instance_uuid, ttl=120, timeout=120,
+                'instance', None, instance_from_db.uuid, ttl=120, timeout=120,
                 op='Instance pause'):
             instance_from_db.add_event('api', 'pause')
             return instance_from_db.pause()
@@ -579,13 +579,13 @@ class InstancePauseEndpoint(api_base.Resource):
 
 class InstanceUnpauseEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
     @api_base.redirect_instance_request
     @api_base.requires_instance_active
-    def post(self, instance_uuid=None, instance_from_db=None):
+    def post(self, instance_ref=None, instance_from_db=None):
         with db.get_lock(
-                'instance', None, instance_uuid, ttl=120, timeout=120,
+                'instance', None, instance_from_db.uuid, ttl=120, timeout=120,
                 op='Instance unpause'):
             instance_from_db.add_event('api', 'unpause')
             return instance_from_db.unpause()
@@ -593,22 +593,22 @@ class InstanceUnpauseEndpoint(api_base.Resource):
 
 class InstanceMetadatasEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
-    def get(self, instance_uuid=None, instance_from_db=None):
-        md = db.get_metadata('instance', instance_uuid)
+    def get(self, instance_ref=None, instance_from_db=None):
+        md = db.get_metadata('instance', instance_from_db.uuid)
         if not md:
             return {}
         return md
 
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
-    def post(self, instance_uuid=None, key=None, value=None, instance_from_db=None):
+    def post(self, instance_ref=None, key=None, value=None, instance_from_db=None):
         err = _validate_instance_metadata(key, value)
         if err:
             return err
-        return api_util.metadata_putpost('instance', instance_uuid, key, value)
+        return api_util.metadata_putpost('instance', instance_from_db.uuid, key, value)
 
 
 def _validate_instance_metadata(key, value):
@@ -642,35 +642,37 @@ def _validate_instance_metadata(key, value):
 
 class InstanceMetadataEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
-    def put(self, instance_uuid=None, key=None, value=None, instance_from_db=None):
+    def put(self, instance_ref=None, key=None, value=None, instance_from_db=None):
         err = _validate_instance_metadata(key, value)
         if err:
             return err
-        return api_util.metadata_putpost('instance', instance_uuid, key, value)
+        return api_util.metadata_putpost(
+            'instance', instance_from_db.uuid, key, value)
 
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
-    def delete(self, instance_uuid=None, key=None, instance_from_db=None):
+    def delete(self, instance_ref=None, key=None, instance_from_db=None):
         if not key:
             return api_base.error(400, 'no key specified')
 
-        with db.get_lock('metadata', 'instance', instance_uuid, op='Instance metadata delete'):
-            md = db.get_metadata('instance', instance_uuid)
+        with db.get_lock('metadata', 'instance', instance_from_db.uuid,
+                         op='Instance metadata delete'):
+            md = db.get_metadata('instance', instance_from_db.uuid)
             if md is None or key not in md:
                 return api_base.error(404, 'key not found')
             del md[key]
-            db.persist_metadata('instance', instance_uuid, md)
+            db.persist_metadata('instance', instance_from_db.uuid, md)
 
 
 class InstanceConsoleDataEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
     @api_base.redirect_instance_request
-    def get(self, instance_uuid=None, length=None, instance_from_db=None):
+    def get(self, instance_ref=None, length=None, instance_from_db=None):
         parsed_length = None
 
         if not length:
@@ -693,8 +695,8 @@ class InstanceConsoleDataEndpoint(api_base.Resource):
         return resp
 
     @jwt_required
-    @api_base.arg_is_instance_uuid
+    @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
     @api_base.redirect_instance_request
-    def delete(self, instance_uuid=None, instance_from_db=None):
+    def delete(self, instance_ref=None, instance_from_db=None):
         instance_from_db.delete_console_data()

--- a/shakenfist/external_api/network.py
+++ b/shakenfist/external_api/network.py
@@ -91,6 +91,9 @@ class NetworkEndpoint(api_base.Resource):
 
         _delete_network(network_from_db)
 
+        # Return UUID in case API call was made using object name
+        return {'uuid': network_from_db.uuid}
+
 
 class NetworksEndpoint(api_base.Resource):
     @marshal_with({

--- a/shakenfist/external_api/network.py
+++ b/shakenfist/external_api/network.py
@@ -52,18 +52,18 @@ def _delete_network(network_from_db, wait_interfaces=None):
 
 class NetworkEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_network_uuid
+    @api_base.arg_is_network_ref
     @api_base.requires_network_ownership
-    def get(self, network_uuid=None, network_from_db=None):
+    def get(self, network_ref=None, network_from_db=None):
         return network_from_db.external_view()
 
     @jwt_required
-    @api_base.arg_is_network_uuid
+    @api_base.arg_is_network_ref
     @api_base.requires_network_ownership
     @api_base.requires_namespace_exist
     @api_base.redirect_to_network_node
-    def delete(self, network_uuid=None, network_from_db=None, namespace=None):
-        if network_uuid == 'floating':
+    def delete(self, network_ref=None, network_from_db=None, namespace=None):
+        if network_ref == 'floating':
             return api_base.error(403, 'you cannot delete the floating network')
 
         n = net.Network.from_db(network_from_db.uuid)
@@ -195,17 +195,17 @@ class NetworksEndpoint(api_base.Resource):
 
 class NetworkEventsEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_network_uuid
+    @api_base.arg_is_network_ref
     @api_base.requires_network_ownership
-    def get(self, network_uuid=None, network_from_db=None):
-        return list(db.get_events('network', network_uuid))
+    def get(self, network_ref=None, network_from_db=None):
+        return list(db.get_events('network', network_from_db.uuid))
 
 
 class NetworkInterfacesEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_network_uuid
+    @api_base.arg_is_network_ref
     @api_base.requires_network_ownership
-    def get(self, network_uuid=None, network_from_db=None):
+    def get(self, network_ref=None, network_from_db=None):
         out = []
         for ni in networkinterface.interfaces_for_network(self.network):
             out.append(ni.external_view())
@@ -214,61 +214,57 @@ class NetworkInterfacesEndpoint(api_base.Resource):
 
 class NetworkMetadatasEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_network_uuid
+    @api_base.arg_is_network_ref
     @api_base.requires_network_ownership
-    def get(self, network_uuid=None, network_from_db=None):
-        md = db.get_metadata('network', network_uuid)
+    def get(self, network_ref=None, network_from_db=None):
+        md = db.get_metadata('network', network_from_db.uuid)
         if not md:
             return {}
         return md
 
     @jwt_required
-    @api_base.arg_is_network_uuid
+    @api_base.arg_is_network_ref
     @api_base.requires_network_ownership
-    def post(self, network_uuid=None, key=None, value=None, network_from_db=None):
-        return api_util.metadata_putpost('network', network_uuid, key, value)
+    def post(self, network_ref=None, key=None, value=None, network_from_db=None):
+        return api_util.metadata_putpost('network', network_from_db.uuid, key, value)
 
 
 class NetworkMetadataEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_network_uuid
+    @api_base.arg_is_network_ref
     @api_base.requires_network_ownership
-    def put(self, network_uuid=None, key=None, value=None, network_from_db=None):
-        return api_util.metadata_putpost('network', network_uuid, key, value)
+    def put(self, network_ref=None, key=None, value=None, network_from_db=None):
+        return api_util.metadata_putpost('network', network_from_db.uuid, key, value)
 
     @jwt_required
-    @api_base.arg_is_network_uuid
+    @api_base.arg_is_network_ref
     @api_base.requires_network_ownership
-    def delete(self, network_uuid=None, key=None, network_from_db=None):
+    def delete(self, network_ref=None, key=None, network_from_db=None):
         if not key:
             return api_base.error(400, 'no key specified')
 
-        with db.get_lock('metadata', 'network', network_uuid, op='Network metadata delete'):
-            md = db.get_metadata('network', network_uuid)
+        with db.get_lock('metadata', 'network', network_from_db.uuid, op='Network metadata delete'):
+            md = db.get_metadata('network', network_from_db.uuid)
             if md is None or key not in md:
                 return api_base.error(404, 'key not found')
             del md[key]
-            db.persist_metadata('network', network_uuid, md)
+            db.persist_metadata('network', network_from_db.uuid, md)
 
 
 class NetworkPingEndpoint(api_base.Resource):
     @jwt_required
-    @api_base.arg_is_network_uuid
+    @api_base.arg_is_network_ref
     @api_base.requires_network_ownership
     @api_base.redirect_to_network_node
     @api_base.requires_network_active
-    def get(self, network_uuid=None, address=None, network_from_db=None):
-        ipm = IPManager.from_db(network_uuid)
+    def get(self, network_ref=None, address=None, network_from_db=None):
+        ipm = IPManager.from_db(network_from_db.uuid)
         if not ipm.is_in_range(address):
             return api_base.error(400, 'ping request for address outside network block')
 
-        n = net.Network.from_db(network_uuid)
-        if not n:
-            return api_base.error(404, 'network %s not found' % network_uuid)
-
         out, err = util_process.execute(
             None, 'ip netns exec %s ping -c 10 %s' % (
-                network_uuid, address),
+                network_from_db.uuid, address),
             check_exit_code=[0, 1])
         return {
             'stdout': out,

--- a/shakenfist/external_api/network.py
+++ b/shakenfist/external_api/network.py
@@ -105,8 +105,7 @@ class NetworksEndpoint(api_base.Resource):
     })
     @jwt_required
     def get(self, all=False):
-        filters = [partial(baseobject.namespace_filter,
-                           get_jwt_identity()[0])]
+        filters = [partial(baseobject.namespace_filter, get_jwt_identity()[0])]
         if not all:
             filters.append(baseobject.active_states_filter)
 

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -85,6 +85,17 @@ class Instance(dbo):
     STATE_CREATED_ERROR = 'created-error'
     STATE_DELETE_WAIT_ERROR = 'delete-wait-error'
 
+    ACTIVE_STATES = set([dbo.STATE_INITIAL,
+                         STATE_INITIAL_ERROR,
+                         STATE_PREFLIGHT,
+                         STATE_PREFLIGHT_ERROR,
+                         dbo.STATE_CREATING,
+                         STATE_CREATING_ERROR,
+                         dbo.STATE_CREATED,
+                         STATE_CREATED_ERROR,
+                         dbo.STATE_ERROR
+                         ])
+
     state_targets = {
         None: (dbo.STATE_INITIAL, dbo.STATE_ERROR),
         dbo.STATE_INITIAL: (STATE_PREFLIGHT, dbo.STATE_DELETE_WAIT,
@@ -169,17 +180,6 @@ class Instance(dbo):
         i._db_set_attribute(
             'power_state', {'power_state': cls.STATE_INITIAL})
         return i
-
-    @staticmethod
-    def from_db(instance_uuid):
-        if not instance_uuid:
-            return None
-
-        static_values = Instance._db_get(instance_uuid)
-        if not static_values:
-            return None
-
-        return Instance(static_values)
 
     def external_view(self):
         # If this is an external view, then mix back in attributes that users
@@ -1100,12 +1100,7 @@ def placement_filter(node, inst):
 this_node_filter = partial(placement_filter, config.NODE_NAME)
 
 
-active_states_filter = partial(
-    baseobject.state_filter, [Instance.STATE_INITIAL, Instance.STATE_INITIAL_ERROR,
-                              Instance.STATE_PREFLIGHT, Instance.STATE_PREFLIGHT_ERROR,
-                              Instance.STATE_CREATING, Instance.STATE_CREATING_ERROR,
-                              Instance.STATE_CREATED, Instance.STATE_CREATED_ERROR,
-                              Instance.STATE_ERROR])
+active_states_filter = partial(baseobject.state_filter, Instance.ACTIVE_STATES)
 
 healthy_states_filter = partial(
     baseobject.state_filter, [Instance.STATE_INITIAL, Instance.STATE_PREFLIGHT,

--- a/shakenfist/net.py
+++ b/shakenfist/net.py
@@ -123,20 +123,6 @@ class Network(dbo):
 
         return n
 
-    @staticmethod
-    def from_db(uuid):
-        if not uuid:
-            return None
-
-        # NOTE(mikal): we used to lock around this fetch from the database,
-        # but I am hoping that moving state into an attribute means that's
-        # not necessary any more.
-        static_values = Network._db_get(uuid)
-        if not static_values:
-            return None
-
-        return Network(static_values)
-
     def external_view(self):
         # If this is an external view, then mix back in attributes that users
         # expect

--- a/shakenfist/networkinterface.py
+++ b/shakenfist/networkinterface.py
@@ -78,17 +78,6 @@ class NetworkInterface(dbo):
 
         return ni
 
-    @staticmethod
-    def from_db(interface_uuid):
-        if not interface_uuid:
-            return None
-
-        static_values = NetworkInterface._db_get(interface_uuid)
-        if not static_values:
-            return None
-
-        return NetworkInterface(static_values)
-
     def external_view(self):
         # If this is an external view, then mix back in attributes that users
         # expect

--- a/shakenfist/node.py
+++ b/shakenfist/node.py
@@ -25,6 +25,8 @@ class Node(dbo):
     STATE_STOPPING = 'stopping'
     STATE_STOPPED = 'stopped'
 
+    ACTIVE_STATES = set([dbo.STATE_CREATED])
+
     state_targets = {
         None: (dbo.STATE_CREATED, dbo.STATE_ERROR, STATE_MISSING),
         dbo.STATE_CREATED: (dbo.STATE_DELETED, dbo.STATE_ERROR, STATE_MISSING,
@@ -74,17 +76,6 @@ class Node(dbo):
                                 'release': util_general.get_version()
                             })
 
-    @staticmethod
-    def from_db(fqdn):
-        if not fqdn:
-            return None
-
-        static_values = Node._db_get(fqdn)
-        if not static_values:
-            return None
-
-        return Node(static_values)
-
     def external_view(self):
         # If this is an external view, then mix back in attributes that users
         # expect
@@ -128,8 +119,7 @@ class Nodes(dbo_iter):
                 yield out
 
 
-active_states_filter = partial(
-    baseobject.state_filter, [dbo.STATE_CREATED])
+active_states_filter = partial(baseobject.state_filter, Node.ACTIVE_STATES)
 inactive_states_filter = partial(
     baseobject.state_filter, [dbo.STATE_DELETED, dbo.STATE_ERROR, Node.STATE_MISSING])
 

--- a/shakenfist/tests/mock_etcd.py
+++ b/shakenfist/tests/mock_etcd.py
@@ -4,6 +4,8 @@
 # Mock the Etcd store with a Python dict.
 #
 
+import base64
+import bcrypt
 from collections import defaultdict
 import json
 import mock
@@ -12,6 +14,7 @@ import time
 from shakenfist import db
 from shakenfist.baseobject import DatabaseBackedObject
 from shakenfist.instance import Instance
+from shakenfist.net import Network
 from shakenfist.node import Node
 
 
@@ -79,6 +82,7 @@ class MockEtcd():
     def create(self, path, encoded, lease=None):
         self.db[path] = encoded
         print('MockEtcd.create() %s: %s' % (path, encoded))
+        return True
 
     def get(self, path, metadata=False, sort_order=None, sort_target=None):
         d = self.db.get(path)
@@ -87,7 +91,7 @@ class MockEtcd():
             return None
         return [[d]]
 
-    def get_prefix(self, path, sort_order, sort_target):
+    def get_prefix(self, path, sort_order=None, sort_target=None):
         ret = []
         for k in sorted(self.db):
             if k.startswith(path):
@@ -135,21 +139,34 @@ class MockEtcd():
     # Database backed objects
     #
 
-    def createInstance(self, name, instance_uuid,
-                       cpus=1,
-                       disk_spec=[{'base': 'cirros', 'size': 21}],
-                       memory=1024,
-                       namespace='unittest',
-                       requested_placement='',
-                       ssh_key='ssh-rsa AAAAB3Nabc unit@test',
-                       user_data='',
-                       video='cirrus',
-                       uefi=False,
-                       configdrive='openstack-disk',
-                       metadata={},
-                       set_state=Instance.STATE_CREATED,
-                       place_on_node='',
-                       ):
+    def create_namespace(self, namespace, key_name, key):
+        encoded = str(base64.b64encode(bcrypt.hashpw(
+                      key.encode('utf-8'), bcrypt.gensalt())), 'utf-8')
+        rec = {
+                'name': namespace,
+                'keys': {
+                    key_name: encoded
+                }
+            }
+        db.persist_metadata('namespace', namespace, {})
+        db.persist_namespace(namespace, rec)
+
+    def create_instance(self, name,
+                        uuid='12345678-1234-4321-1234-123456789012',
+                        cpus=1,
+                        disk_spec=[{'base': 'cirros', 'size': 21}],
+                        memory=1024,
+                        namespace='unittest',
+                        requested_placement='',
+                        ssh_key='ssh-rsa AAAAB3Nabc unit@test',
+                        user_data='',
+                        video='cirrus',
+                        uefi=False,
+                        configdrive='openstack-disk',
+                        metadata={},
+                        set_state=Instance.STATE_CREATED,
+                        place_on_node='',
+                        ):
 
         inst = Instance.new(name=name,
                             cpus=cpus,
@@ -160,7 +177,7 @@ class MockEtcd():
                             user_data=user_data,
                             video=video,
                             requested_placement=requested_placement,
-                            instance_uuid=instance_uuid,
+                            instance_uuid=uuid,
                             uefi=uefi,
                             configdrive=configdrive,
                             )
@@ -187,3 +204,44 @@ class MockEtcd():
             inst.place_instance(place_on_node)
 
         return inst
+
+    def create_network(self, name,
+                       uuid='12345678-1234-4321-1234-123456789012',
+                       namespace='unittest',
+                       netblock='10.9.8.0/24',
+                       provide_dhcp=False,
+                       provide_nat=False,
+                       vxid=None,
+                       metadata={},
+                       set_state=Network.STATE_CREATED,
+                       ):
+
+        network = Network.new(name=name,
+                              namespace=namespace,
+                              netblock=netblock,
+                              provide_dhcp=provide_dhcp,
+                              provide_nat=provide_nat,
+                              uuid=uuid,
+                              vxid=vxid,
+                              )
+
+        self.persist_metadata(Network, network.uuid, metadata)
+
+        state_path = defaultdict(set)
+        for initial, allowed in Network.state_targets.items():
+            if allowed:
+                for a in allowed:
+                    state_path[a].add(initial)
+
+        def find_start(initial, dest):
+            for s in state_path[dest]:
+                if initial == s:
+                    return True
+                if find_start(initial, s):
+                    network.state = s
+                    return True
+            return False
+        find_start(Network.STATE_INITIAL, set_state)
+        network.state = set_state
+
+        return network

--- a/shakenfist/tests/mock_etcd.py
+++ b/shakenfist/tests/mock_etcd.py
@@ -7,6 +7,7 @@
 import base64
 import bcrypt
 from collections import defaultdict
+from itertools import count
 import json
 import mock
 import time
@@ -29,6 +30,7 @@ class MockEtcd():
     def __init__(self, test_obj, nodes=None, node_count=0):
         self.test_obj = test_obj
         self.db = {}
+        self.obj_counter = count(1)
 
         # Define ShakenFist Nodes
         if nodes is not None:
@@ -74,6 +76,10 @@ class MockEtcd():
         # Setup basic DB data
         for n in self.nodes:
             Node.new(n[0], n[1])
+
+    def next_uuid(self):
+        """Generate predictable UUIDs that are unique during the testcase"""
+        return '12345678-1234-4321-1234-%012i' % next(self.obj_counter)
 
     #
     # DB operations - Low level
@@ -152,7 +158,7 @@ class MockEtcd():
         db.persist_namespace(namespace, rec)
 
     def create_instance(self, name,
-                        uuid='12345678-1234-4321-1234-123456789012',
+                        uuid=None,
                         cpus=1,
                         disk_spec=[{'base': 'cirros', 'size': 21}],
                         memory=1024,
@@ -167,6 +173,9 @@ class MockEtcd():
                         set_state=Instance.STATE_CREATED,
                         place_on_node='',
                         ):
+
+        if not uuid:
+            uuid = self.next_uuid()
 
         inst = Instance.new(name=name,
                             cpus=cpus,
@@ -206,7 +215,7 @@ class MockEtcd():
         return inst
 
     def create_network(self, name,
-                       uuid='12345678-1234-4321-1234-123456789012',
+                       uuid=None,
                        namespace='unittest',
                        netblock='10.9.8.0/24',
                        provide_dhcp=False,
@@ -215,6 +224,9 @@ class MockEtcd():
                        metadata={},
                        set_state=Network.STATE_CREATED,
                        ):
+
+        if not uuid:
+            uuid = self.next_uuid()
 
         network = Network.new(name=name,
                               namespace=namespace,

--- a/shakenfist/tests/test_scheduler.py
+++ b/shakenfist/tests/test_scheduler.py
@@ -42,7 +42,7 @@ class LowResourceTestCase(SchedulerTestCase):
     """Test low resource exceptions."""
 
     def test_no_metrics(self):
-        fake_inst = self.mock_etcd.createInstance('fake-inst', 'fakeuuid')
+        fake_inst = self.mock_etcd.create_instance('fake-inst', 'fakeuuid')
         exc = self.assertRaises(exceptions.LowResourceException,
                                 scheduler.Scheduler().place_instance,
                                 fake_inst,
@@ -56,7 +56,7 @@ class LowResourceTestCase(SchedulerTestCase):
             'cpu_available': 12
         })
 
-        fake_inst = self.mock_etcd.createInstance('fake-inst', 'fakeuuid', cpus=6)
+        fake_inst = self.mock_etcd.create_instance('fake-inst', 'fakeuuid', cpus=6)
         exc = self.assertRaises(exceptions.LowResourceException,
                                 scheduler.Scheduler().place_instance,
                                 fake_inst,
@@ -74,7 +74,7 @@ class LowResourceTestCase(SchedulerTestCase):
             'cpu_available': 4
         })
 
-        fake_inst = self.mock_etcd.createInstance('fake-inst', 'fakeuuid')
+        fake_inst = self.mock_etcd.create_instance('fake-inst', 'fakeuuid')
         exc = self.assertRaises(exceptions.LowResourceException,
                                 scheduler.Scheduler().place_instance,
                                 fake_inst,
@@ -92,7 +92,7 @@ class LowResourceTestCase(SchedulerTestCase):
             'cpu_available': 12
         })
 
-        fake_inst = self.mock_etcd.createInstance('fake-inst', 'fakeuuid')
+        fake_inst = self.mock_etcd.create_instance('fake-inst', 'fakeuuid')
         exc = self.assertRaises(exceptions.LowResourceException,
                                 scheduler.Scheduler().place_instance,
                                 fake_inst,
@@ -111,7 +111,7 @@ class LowResourceTestCase(SchedulerTestCase):
             'cpu_available': 12
         })
 
-        fake_inst = self.mock_etcd.createInstance('fake-inst', 'fakeuuid')
+        fake_inst = self.mock_etcd.create_instance('fake-inst', 'fakeuuid')
         exc = self.assertRaises(exceptions.LowResourceException,
                                 scheduler.Scheduler().place_instance,
                                 fake_inst,
@@ -129,7 +129,7 @@ class LowResourceTestCase(SchedulerTestCase):
             'cpu_available': 12
         })
 
-        fake_inst = self.mock_etcd.createInstance(
+        fake_inst = self.mock_etcd.create_instance(
             'fake-inst', 'fakeuuid', disk_spec=[{
                     'base': 'cirros',
                             'size': 21
@@ -144,7 +144,7 @@ class LowResourceTestCase(SchedulerTestCase):
     def test_ok(self):
         self.mock_etcd.set_node_metrics_same()
 
-        fake_inst = self.mock_etcd.createInstance('fake-inst', 'fakeuuid')
+        fake_inst = self.mock_etcd.create_instance('fake-inst', 'fakeuuid')
 
         nodes = scheduler.Scheduler().place_instance(fake_inst, [])
         self.assertSetEqual(set(self.mock_etcd.node_names)-{'node1_net', },
@@ -155,11 +155,11 @@ class CorrectAllocationTestCase(SchedulerTestCase):
     """Test correct node allocation."""
 
     def test_any_node_but_not_network_node(self):
-        self.mock_etcd.createInstance('instance-1', 'uuid-inst-1',
-                                      place_on_node='node3')
+        self.mock_etcd.create_instance('instance-1', 'uuid-inst-1',
+                                       place_on_node='node3')
         self.mock_etcd.set_node_metrics_same()
 
-        fake_inst = self.mock_etcd.createInstance('fake-inst', 'fakeuuid')
+        fake_inst = self.mock_etcd.create_instance('fake-inst', 'fakeuuid')
         nets = [{'network_uuid': 'uuid-net2'}]
 
         nodes = scheduler.Scheduler().place_instance(fake_inst, nets)
@@ -175,13 +175,13 @@ class ForcedCandidatesTestCase(SchedulerTestCase):
         self.mock_etcd.set_node_metrics_same()
 
     def test_only_two(self):
-        fake_inst = self.mock_etcd.createInstance('fake-inst', 'fakeuuid')
+        fake_inst = self.mock_etcd.create_instance('fake-inst', 'fakeuuid')
         nodes = scheduler.Scheduler().place_instance(
             fake_inst, [], candidates=['node1_net', 'node2'])
         self.assertSetEqual({'node2', }, set(nodes))
 
     def test_no_such_node(self):
-        fake_inst = self.mock_etcd.createInstance('fake-inst', 'fakeuuid')
+        fake_inst = self.mock_etcd.create_instance('fake-inst', 'fakeuuid')
         self.assertRaises(
             exceptions.CandidateNodeNotFoundException,
             scheduler.Scheduler().place_instance,
@@ -202,7 +202,7 @@ class MetricsRefreshTestCase(SchedulerTestCase):
             'cpu_available': 12
         })
 
-        fake_inst = self.mock_etcd.createInstance('fake-inst', 'fakeuuid')
+        fake_inst = self.mock_etcd.create_instance('fake-inst', 'fakeuuid')
 
         s = scheduler.Scheduler()
         s.place_instance(fake_inst, None)
@@ -230,82 +230,82 @@ class CPUloadAffinityTestCase(SchedulerTestCase):
         self.mock_etcd.set_node_metrics_same()
 
     def test_affinity_to_same_node(self):
-        self.mock_etcd.createInstance('instance-1', 'uuid-inst-1',
-                                      place_on_node='node3',
-                                      metadata={'tags': ['socialite']})
+        self.mock_etcd.create_instance('instance-1', 'uuid-inst-1',
+                                       place_on_node='node3',
+                                       metadata={'tags': ['socialite']})
 
         # Start test
-        inst = self.mock_etcd.createInstance('instance-3', 'uuid-inst-3',
-                                             metadata={
-                                                "affinity": {
-                                                    "cpu": {
-                                                        "socialite": 2,
-                                                        "nerd": -100,
-                                                    }
-                                                },
-                                             })
+        inst = self.mock_etcd.create_instance('instance-3', 'uuid-inst-3',
+                                              metadata={
+                                                 "affinity": {
+                                                     "cpu": {
+                                                         "socialite": 2,
+                                                         "nerd": -100,
+                                                     }
+                                                 },
+                                              })
 
         nodes = scheduler.Scheduler().place_instance(inst, [])
         self.assertSetEqual({'node3'}, set(nodes))
 
     def test_anti_affinity_single_inst(self):
-        self.mock_etcd.createInstance('instance-1', 'uuid-inst-1',
-                                      place_on_node='node3',
-                                      metadata={'tags': ['nerd']})
+        self.mock_etcd.create_instance('instance-1', 'uuid-inst-1',
+                                       place_on_node='node3',
+                                       metadata={'tags': ['nerd']})
 
         # Start test
-        inst = self.mock_etcd.createInstance('instance-3', 'uuid-inst-3',
-                                             metadata={
-                                                "affinity": {
-                                                    "cpu": {
-                                                        "socialite": 2,
-                                                        "nerd": -100,
-                                                    }
-                                                },
-                                             })
+        inst = self.mock_etcd.create_instance('instance-3', 'uuid-inst-3',
+                                              metadata={
+                                                 "affinity": {
+                                                     "cpu": {
+                                                         "socialite": 2,
+                                                         "nerd": -100,
+                                                     }
+                                                 },
+                                              })
         nodes = scheduler.Scheduler().place_instance(inst, [])
         self.assertSetEqual({'node2', 'node4'}, set(nodes))
 
     def test_anti_affinity_multiple_inst(self):
-        self.mock_etcd.createInstance('instance-1', 'uuid-inst-1',
-                                      place_on_node='node3',
-                                      metadata={'tags': ['nerd']})
+        self.mock_etcd.create_instance('instance-1', 'uuid-inst-1',
+                                       place_on_node='node3',
+                                       metadata={'tags': ['nerd']})
 
-        self.mock_etcd.createInstance('instance-2', 'uuid-inst-2',
-                                      place_on_node='node4',
-                                      metadata={'tags': ['nerd']})
+        self.mock_etcd.create_instance('instance-2', 'uuid-inst-2',
+                                       place_on_node='node4',
+                                       metadata={'tags': ['nerd']})
 
         # Start test
-        inst = self.mock_etcd.createInstance('instance-3', 'uuid-inst-3',
-                                             metadata={
-                                                "affinity": {
-                                                    "cpu": {
-                                                        "socialite": 2,
-                                                        "nerd": -100,
-                                                    }
-                                                },
-                                             })
+        inst = self.mock_etcd.create_instance('instance-3', 'uuid-inst-3',
+                                              metadata={
+                                                 "affinity": {
+                                                     "cpu": {
+                                                         "socialite": 2,
+                                                         "nerd": -100,
+                                                     }
+                                                 },
+                                              })
         nodes = scheduler.Scheduler().place_instance(inst, [])
         self.assertSetEqual({'node2'}, set(nodes))
 
     def test_anti_affinity_multiple_inst_different_tags(self):
-        self.mock_etcd.createInstance('instance-1', 'uuid-inst-1',
-                                      place_on_node='node3',
-                                      metadata={'tags': ['socialite']})
+        self.mock_etcd.create_instance('instance-1', 'uuid-inst-1',
+                                       place_on_node='node3',
+                                       metadata={'tags': ['socialite']})
 
-        self.mock_etcd.createInstance('instance-2', 'uuid-inst-2',
-                                      place_on_node='node4',
-                                      metadata={'tags': ['nerd']})
+        self.mock_etcd.create_instance('instance-2', 'uuid-inst-2',
+                                       place_on_node='node4',
+                                       metadata={'tags': ['nerd']})
 
         # Start test
-        inst = self.mock_etcd.createInstance('instance-3', 'uuid-inst-3',
-                                             metadata={
-                                                "affinity": {
-                                                    "cpu": {
-                                                        "socialite": 2,
-                                                        "nerd": -100,
-                                                    }
-                                                },
-                                             })
+        inst = self.mock_etcd.create_instance('instance-3', 'uuid-inst-3',
+                                              metadata={
+                                                 "affinity": {
+                                                     "cpu": {
+                                                         "socialite": 2,
+                                                         "nerd": -100,
+                                                     }
+                                                 },
+                                              })
         nodes = scheduler.Scheduler().place_instance(inst, [])
         self.assertSetEqual({'node3'}, set(nodes))

--- a/shakenfist/upload.py
+++ b/shakenfist/upload.py
@@ -38,17 +38,6 @@ class Upload(dbo):
         u.state = Upload.STATE_CREATED
         return u
 
-    @staticmethod
-    def from_db(upload_uuid):
-        if not upload_uuid:
-            return None
-
-        static_values = Upload._db_get(upload_uuid)
-        if not static_values:
-            return None
-
-        return Upload(static_values)
-
     # Static values
     @property
     def node(self):

--- a/shakenfist/util/general.py
+++ b/shakenfist/util/general.py
@@ -9,6 +9,8 @@ import string
 import sys
 import time
 import traceback
+import uuid
+
 
 # To avoid circular imports, util modules should only import a limited
 # set of shakenfist modules, mainly exceptions, logutils, and specific
@@ -144,3 +146,11 @@ def link(source, destination):
         os.symlink(source, destination)
 
     pathlib.Path(destination).touch(exist_ok=True)
+
+
+def valid_uuid4(uuid_string):
+    try:
+        uuid.UUID(uuid_string, version=4)
+    except ValueError:
+        return False
+    return True


### PR DESCRIPTION
Specify instance or network by name in API calls
Test instance and netowrk API using names
Add Network object to MockEtcd

Note that the tests are not wholly moved to the new etcd mock (too worn out)
Upside is that the testing is more complete.