### PR TITLE
Don't forward debug syslog messages to the primary.

### DIFF
--- a/deploy/ansible/files/rsyslog-client-01-sf.conf
+++ b/deploy/ansible/files/rsyslog-client-01-sf.conf
@@ -1,4 +1,6 @@
-*.* @{{syslog}}:514
+*.*;*.!=debug action(type="omfwd" target="{{syslog}}" port="514" protocol="tcp"
+                     action.resumeRetryCount="100"
+                     queue.type="linkedList" queue.size="10000")
 
 # Don't mangle multi-line log messages
 $EscapeControlCharactersOnReceive off


### PR DESCRIPTION
This implies that if you want to read debug messages, you would need to go to the node which logged them. That said, it should keep the noise down on the primary node.