### PR TITLE
Clean up interface events.

### DIFF
--- a/shakenfist/baseobject.py
+++ b/shakenfist/baseobject.py
@@ -60,9 +60,16 @@ class DatabaseBackedObject(object):
         return (self.object_type, self.__uuid)
 
     def add_event(self, operation, phase, duration=None, msg=None):
-        if not self.__in_memory_only:
-            eventlog.add_event(
-                self.object_type, self.__uuid, operation, phase, duration, msg)
+        if self.__in_memory_only:
+            return
+
+        # We do not record events for network interfaces, as they are not an
+        # independent element like a blob or an instance.
+        if self.object_type == 'networkinterface':
+            return
+
+        eventlog.add_event(
+            self.object_type, self.__uuid, operation, phase, duration, msg)
 
     # Shim to track what hasn't been converted to the new style yet
     def add_event2(self, message, duration=None):

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -272,8 +272,6 @@ class Monitor(daemon.WorkerPoolDaemon):
         if isinstance(workitem, DefloatNetworkInterfaceTask):
             n.remove_floating_ip(ni.floating.get('floating_address'), ni.ipv4)
 
-            eventlog.add_event('interface', ni.uuid, 'api',
-                               'defloat', None, None)
             with db.get_lock('ipmanager', None, 'floating', ttl=120, op='Instance defloat'):
                 ipm = IPManager.from_db('floating')
                 ipm.release(ni.floating.get('floating_address'))

--- a/shakenfist/external_api/util.py
+++ b/shakenfist/external_api/util.py
@@ -3,7 +3,6 @@ from flask_jwt_extended import get_jwt_identity
 from shakenfist.daemons import daemon
 from shakenfist.external_api import base as api_base
 from shakenfist import db
-from shakenfist import eventlog
 from shakenfist.instance import Instance
 from shakenfist.ipmanager import IPManager
 from shakenfist import logutil
@@ -38,7 +37,6 @@ def assign_floating_ip(ni):
         return api_base.error(404, 'floating network not found')
 
     # Address is allocated and added to the record here, so the job has it later.
-    eventlog.add_event('interface', ni.uuid, 'api', 'float', None, None)
     with db.get_lock('ipmanager', None, 'floating', ttl=120, op='Interface float'):
         ipm = IPManager.from_db('floating')
         addr = ipm.get_random_free_address(ni.unique_label())


### PR DESCRIPTION
Interface events were a mess. Remove them all, we'll do something more coherent when we audit instance events.