### PR TITLE
Update Click package to use a modern version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pycdlib                     # lgpl
 oslo.concurrency            # apache2
 jinja2<3.0,>=2.10.1         # bsd
 setproctitle                # bsd
-click<8.0,>=7.1.1           # bsd
+click>=8.0.0                # bsd
 prettytable                 # bsd
 tox                         # mit
 flake8                      # mit


### PR DESCRIPTION
The client requires >=8.0.0. The reason for requiring
an old version of Click for the server has been lost
in the mists of time.

Noting that was June 2021 #799 