### PR TITLE
Fix Grafana display for multi-disk systems

### DIFF
--- a/deploy/ansible/files/grafana/provisioning/dashboards/shakenfist.json
+++ b/deploy/ansible/files/grafana/provisioning/dashboards/shakenfist.json
@@ -1564,7 +1564,7 @@
           },
           {
             "exemplar": true,
-            "expr": "disk_free / disk_total",
+            "expr": "node_filesystem_free_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"}",
             "hide": true,
             "interval": "",
             "legendFormat": "{{instance}}",


### PR DESCRIPTION
On multi-disk systems (eg. md RAID arrays), the total physical disk is reported by disk_total. To report usable disk space, a different metric is required.