### PR TITLE
Cleanup stray libvirt apparmor profile files.

### DIFF
--- a/shakenfist/tests/test_daemon_cleaner.py
+++ b/shakenfist/tests/test_daemon_cleaner.py
@@ -39,6 +39,9 @@ class FakeLibvirtConnection(object):
 
         return FakeLibvirtDomain(*args.get(id))
 
+    def lookupByName(self, name):
+        return FakeLibvirtDomain(name, FakeLibvirt.VIR_DOMAIN_RUNNING)
+
 
 class FakeLibvirtDomain(object):
     def __init__(self, name, state):
@@ -50,6 +53,9 @@ class FakeLibvirtDomain(object):
 
     def state(self):
         return [self._state, 1]
+
+    def UUIDString(self):
+        return 'fake_uuid'
 
 
 def fake_exists(path):
@@ -129,8 +135,9 @@ class CleanerTestCase(base.ShakenFistTestCase):
     @mock.patch('shakenfist.etcd.put', side_effect=fake_put)
     @mock.patch('os.path.exists', side_effect=fake_exists)
     @mock.patch('time.time', return_value=7)
-    def test_update_power_states(self, mock_time, mock_exists, mock_put,
-                                 mock_get_instance, mock_see,
+    @mock.patch('os.listdir', return_value=[])
+    def test_update_power_states(self, mock_listdir, mock_time, mock_exists,
+                                 mock_put, mock_get_instance, mock_see,
                                  mock_lock, mock_etcd_get, mock_error,
                                  mock_state_value, mock_state):
         mock_state_value.return_value = 'created'


### PR DESCRIPTION
Debian 11 is failing to cleanup apparmor profiles for terminated
VMs, I have about 10,000 stray files on my CI cluster. We should
clean them up if they exist.

Fixes #1346.