### PR TITLE
Don't create artifacts for missing labels and uploads.

### DIFF
--- a/deploy/shakenfist_ci/base.py
+++ b/deploy/shakenfist_ci/base.py
@@ -395,7 +395,7 @@ class BaseNamespacedTestCase(BaseTestCase):
             for net in non_blocking_client.get_networks():
                 try:
                     non_blocking_client.delete_network(net['uuid'])
-                except apiclient.ResourceCannotBeDeletedException:
+                except apiclient.ResourceStateConflictException:
                     pass
 
             time.sleep(5)

--- a/deploy/shakenfist_ci/tests/test_artifacts.py
+++ b/deploy/shakenfist_ci/tests/test_artifacts.py
@@ -240,3 +240,22 @@ class TestSharedImages(base.BaseNamespacedTestCase):
         self.assertRaises(
             apiclient.UnauthorizedException,
             self.test_client.cache_artifact, url, shared=True)
+
+
+class TestTypoedLabel(base.BaseNamespacedTestCase):
+    def __init__(self, *args, **kwargs):
+        kwargs['namespace_prefix'] = 'sharedimages'
+        super(TestTypoedLabel, self).__init__(*args, **kwargs)
+
+    def test_typo_is_error(self):
+        self.assertRaises(apiclient.ResourceNotFoundException,
+                          self.test_client.create_instance,
+                          'typoedlabel', 1, 1024, None,
+                          [
+                                {
+                                    'size': 20,
+                                    'base': 'label:doesnotexist',
+                                    'type': 'disk'
+                                }
+                          ],
+                          None, None, side_channels=['sf-agent'])

--- a/shakenfist/artifact.py
+++ b/shakenfist/artifact.py
@@ -117,15 +117,17 @@ class Artifact(dbo):
         return a
 
     @staticmethod
-    def from_url(artifact_type, url, max_versions=0, namespace=None):
+    def from_url(artifact_type, url, max_versions=0, namespace=None, create_if_new=False):
         with etcd.get_lock('artifact_from_url', None, url):
             artifacts = list(Artifacts([partial(url_filter, url),
                                         partial(type_filter, artifact_type),
                                         not_dead_states_filter,
                                         partial(namespace_filter, namespace)]))
             if len(artifacts) == 0:
-                return Artifact.new(artifact_type, url, max_versions=max_versions,
-                                    namespace=namespace)
+                if create_if_new:
+                    return Artifact.new(artifact_type, url, max_versions=max_versions,
+                                        namespace=namespace)
+                return None
             if len(artifacts) == 1:
                 return artifacts[0]
             raise exceptions.TooManyMatches()

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -213,7 +213,8 @@ def handle(jobname, workitem):
 
 
 def image_fetch(url, namespace, inst):
-    a = Artifact.from_url(Artifact.TYPE_IMAGE, url, namespace=namespace)
+    a = Artifact.from_url(Artifact.TYPE_IMAGE, url, namespace=namespace,
+                          create_if_new=True)
     try:
         # TODO(andy): Wait up to 15 mins for another queue process to download
         # the required image. This will be changed to queue on a

--- a/shakenfist/external_api/artifact.py
+++ b/shakenfist/external_api/artifact.py
@@ -132,7 +132,8 @@ class ArtifactsEndpoint(api_base.Resource):
                 return api_base.error(
                     403, 'only the system namespace can create shared artifacts')
             namespace = 'sharedwithall'
-        a = Artifact.from_url(Artifact.TYPE_IMAGE, url, namespace=namespace)
+        a = Artifact.from_url(Artifact.TYPE_IMAGE, url, namespace=namespace,
+                              create_if_new=True)
 
         etcd.enqueue(config.NODE_NAME, {
             'tasks': [FetchImageTask(url, namespace=namespace)],
@@ -187,7 +188,7 @@ class ArtifactUploadEndpoint(api_base.Resource):
             namespace = 'sharedwithall'
 
         a = Artifact.from_url(Artifact.TYPE_IMAGE, source_url,
-                              namespace=namespace)
+                              namespace=namespace, create_if_new=True)
 
         with a.get_lock(ttl=(12 * constants.LOCK_REFRESH_SECONDS),
                         timeout=config.MAX_IMAGE_TRANSFER_SECONDS):

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -222,7 +222,7 @@ class InstancesEndpoint(api_base.Resource):
                 # here so that it will show up in image list requests. The image is
                 # fetched by the queued job later.
                 Artifact.from_url(Artifact.TYPE_IMAGE, disk_base,
-                                  namespace=namespace)
+                                  namespace=namespace, create_if_new=True)
 
             transformed_disk.append(d)
 

--- a/shakenfist/external_api/label.py
+++ b/shakenfist/external_api/label.py
@@ -30,7 +30,8 @@ class LabelEndpoint(api_base.Resource):
             return api_base.error(400, 'blob has been deleted')
 
         a = Artifact.from_url(Artifact.TYPE_LABEL, _label_url(label_name),
-                              max_versions, namespace=get_jwt_identity()[0])
+                              max_versions, namespace=get_jwt_identity()[0],
+                              create_if_new=True)
         a.add_index(blob_uuid)
         a.state = dbo.STATE_CREATED
         return a.external_view()

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -759,7 +759,7 @@ class Instance(dbo):
                     elif disk.get('base') and not util_general.noneish(disk.get('base')):
                         a = artifact.Artifact.from_url(
                             artifact.Artifact.TYPE_IMAGE, disk['base'],
-                            namespace=self.namespace)
+                            namespace=self.namespace, create_if_new=True)
                         mri = a.most_recent_index
 
                         if 'blob_uuid' not in mri:
@@ -1287,7 +1287,7 @@ class Instance(dbo):
             a = artifact.Artifact.from_url(
                 artifact.Artifact.TYPE_SNAPSHOT,
                 '%s%s/%s' % (artifact.INSTANCE_URL, self.uuid, disk['device']),
-                max_versions, namespace=self.namespace)
+                max_versions, namespace=self.namespace, create_if_new=True)
 
             blob_uuid = str(uuid4())
             entry = a.add_index(blob_uuid)


### PR DESCRIPTION
Previously we'd create an artifact in the initial state and it would
be confusing. Fixes #1310.