### PR TITLE
More robustly test power cycling an instance.

### DIFF
--- a/deploy/shakenfist_ci/tests/test_state_changes.py
+++ b/deploy/shakenfist_ci/tests/test_state_changes.py
@@ -122,6 +122,11 @@ class TestStateChanges(base.BaseNamespacedTestCase):
         time.sleep(5)
         self._test_ping(inst['uuid'], self.net['uuid'], ip, 100)
 
+        # Rapidly powering on an instance has been showing to confuse libvirt
+        # in some cases. Let's see if being more patient here makes it work
+        # better.
+        time.sleep(30)
+
         # Power on
         self.test_client.delete_console_data(inst['uuid'])
         self.test_client.power_on_instance(inst['uuid'])

--- a/shakenfist/daemons/sidechannel.py
+++ b/shakenfist/daemons/sidechannel.py
@@ -37,6 +37,8 @@ class SFSocketAgent(protocol.SocketAgent):
         self.add_command('gather-facts-response',
                          self.gather_facts_response)
 
+        self.instance.agent_state = 'not ready (no contact)'
+
     def poll(self):
         if time.time() - self.last_response > 15:
             self.instance.agent_state = 'not ready (unresponsive)'

--- a/shakenfist/daemons/sidechannel.py
+++ b/shakenfist/daemons/sidechannel.py
@@ -145,7 +145,8 @@ class Monitor(daemon.Daemon):
                         except (BrokenPipeError,
                                 ConnectionRefusedError,
                                 ConnectionResetError,
-                                FileNotFoundError):
+                                FileNotFoundError,
+                                OSError):
                             if sc in sc_clients:
                                 del sc_clients[sc]
 

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -1166,6 +1166,7 @@ class Instance(dbo):
                                          'domain is not running'):
                     self.log.error('Failed to delete domain: %s', e)
 
+            self.agent_state = 'not ready (instance powered off)'
             self.update_power_state('off')
             self.add_event('poweroff')
 
@@ -1197,6 +1198,7 @@ class Instance(dbo):
                     'you cannot pause a powered off instance')
 
             inst.suspend()
+            self.agent_state = 'not ready (instance paused)'
             self.update_power_state(lc.extract_power_state(inst))
             self.add_event('pause')
 


### PR DESCRIPTION
Additionally, record that the agent has stopped running because the instance is powered off or suspended.

Fixes #1469.