### PR TITLE
Checking whether PR CI runs on self-hosted runners

### DIFF
--- a/tools/clone_with_depends.py
+++ b/tools/clone_with_depends.py
@@ -3,6 +3,7 @@
 import git
 import re
 import os
+import requests
 
 # Clone all the required repositories, with handling for dependencies between
 # them. This script assumes it is being called by a github action and that
@@ -32,6 +33,8 @@ DEPENDS_RE = re.compile(
 
 
 def main():
+    r = requests.get("https://ip.me")
+    print(f"MY IP IS {r.text}")
     # Ensure we have a checkout of all repositories
     for repo in REPOS:
         repo_path = os.path.join(os.environ['GITHUB_WORKSPACE'], repo)

--- a/tools/clone_with_depends.py
+++ b/tools/clone_with_depends.py
@@ -34,6 +34,7 @@ DEPENDS_RE = re.compile(
 
 def main():
     r = requests.get("https://ip.me")
+    print("THIS IS AFTER THE ORG CHANGE")
     print(f"MY IP IS {r.text}")
     # Ensure we have a checkout of all repositories
     for repo in REPOS:


### PR DESCRIPTION
Don't merge this, just curious whether the CI is setup to run untrusted pull requests on self-hosted runners.
