### PR TITLE
Document checksums, and don't add a duplicate artifact index.

### DIFF
--- a/docs/operator_guide/artifact_checksums.md
+++ b/docs/operator_guide/artifact_checksums.md
@@ -3,13 +3,18 @@
 As of Shaken Fist v0.7, blobs are regularly checksumed to verify that data loss
 has not occurred. The following events imply a checksum operation:
 
-* download of a new blob from an external source (artifact fetch for example).
-* snapshotting a disk or NVRAM template.
+* snapshotting an NVRAM template.
 * transfer of a blob from another machine in the cluster (the destination is
   checksumed to verify the transfer).
 * transcode of a blob into a new format (the new format is stored as a
   separate blob).
 * conversion of an upload to an artifact.
+
+The following events _should_ imply an artifact checksum, but we found that
+performance suffered too much:
+
+* download of a new blob from an external source (artifact fetch for example).
+* snapshotting a disk.
 
 Additionally, all blob copies are regularly checksumed and compared with what
 the record in etcd believes the correct value should be. These comparisons are

--- a/docs/operator_guide/artifact_checksums.md
+++ b/docs/operator_guide/artifact_checksums.md
@@ -1,0 +1,26 @@
+# Artifact checksums
+
+As of Shaken Fist v0.7, blobs are regularly checksumed to verify that data loss
+has not occurred. The following events imply a checksum operation:
+
+* download of a new blob from an external source (artifact fetch for example).
+* snapshotting a disk or NVRAM template.
+* transfer of a blob from another machine in the cluster (the destination is
+  checksumed to verify the transfer).
+* transcode of a blob into a new format (the new format is stored as a
+  separate blob).
+* conversion of an upload to an artifact.
+
+Additionally, all blob copies are regularly checksumed and compared with what
+the record in etcd believes the correct value should be. These comparisons are
+rate limited, but should happen with a maximum frequency of
+CHECKSUM_VERIFICATION_FREQUENCY seconds, which defaults to every 24 hours.
+
+If a copy of a blob fails the checksum verification _and is not in use on that node_,
+the copy is deleted and the cluster will re-replicate the blob as required. If
+the blob is in use, there isn't much Shaken Fist can do without disturbing
+running instances, so the error is ignored for now.
+
+Checksums are also used when a new version of an artifact is created. If the
+checksum of the previous version is the same as the checksum for the proposed
+new version, the proposed new version is skipped.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,33 +3,34 @@ site_url: https://shakenfist.com
 repo_url: https://github.com/shakenfist/shakenfist
 site_description: A minimal cloud aimed at small and edge deployments
 theme:
-        name: material
+    name: material
 markdown_extensions:
-        - admonition
-        - pymdownx.magiclink:
-                  repo_url_shorthand: true
-                  user: shakenfist
+    - admonition
+    - pymdownx.magiclink:
+        repo_url_shorthand: true
+        user: shakenfist
 nav:
-        - Introduction: index.md
-        - Manifesto: manifesto.md
-        - Features: features.md
-        - Community: community.md
-        - User Guide:
-                  - "Installation": user_guide/installation.md
-                  - "Usage": user_guide/usage.md
-                  - "Artifacts": user_guide/artifacts.md
-                  - "Events": user_guide/events.md
-        - Developer Guide:
-                  - "Authentication": developer_guide/authentication.md
-                  - "Artifact uploads and downloads": developer_guide/artifact_uploads_downloads.md
-                  - "CI API coverage": developer_guide/ci_api_coverage.md
-                  - "Release process": developer_guide/release_process.md
-                  - "Standards": developer_guide/standards.md
-                  - "State machine": developer_guide/state_machine.md
-                  - "Updating docs": developer_guide/updating_docs.md
-                  - "Workflow": developer_guide/workflow.md
-        - Operator Guide:
-                  - "Networking":
-                            - "Overview": "operator_guide/networking/overview.md"
-                            - "Single Instance": "operator_guide/networking/single_instance.md"
-                  - "Power States": "operator_guide/power_states.md"
+    - Introduction: index.md
+    - Manifesto: manifesto.md
+    - Features: features.md
+    - Community: community.md
+    - User Guide:
+        - "Installation": user_guide/installation.md
+        - "Usage": user_guide/usage.md
+        - "Artifacts": user_guide/artifacts.md
+        - "Events": user_guide/events.md
+    - Developer Guide:
+        - "Authentication": developer_guide/authentication.md
+        - "Artifact uploads and downloads": developer_guide/artifact_uploads_downloads.md
+        - "CI API coverage": developer_guide/ci_api_coverage.md
+        - "Release process": developer_guide/release_process.md
+        - "Standards": developer_guide/standards.md
+        - "State machine": developer_guide/state_machine.md
+        - "Updating docs": developer_guide/updating_docs.md
+        - "Workflow": developer_guide/workflow.md
+    - Operator Guide:
+       - "Artifact checksums": operator_guide/artifact_checksums.md
+       - "Networking":
+           - "Overview": "operator_guide/networking/overview.md"
+           - "Single Instance": "operator_guide/networking/single_instance.md"
+       - "Power States": "operator_guide/power_states.md"

--- a/shakenfist/artifact.py
+++ b/shakenfist/artifact.py
@@ -257,8 +257,14 @@ class Artifact(dbo):
                 if not old_blob:
                     raise exceptions.BlobMissing()
                 old_checksums = old_blob.checksums
+                old_blob_uuid = old_blob.uuid
             else:
                 old_checksums = {}
+                old_blob_uuid = None
+
+            if old_blob_uuid and old_blob_uuid == blob_uuid:
+                # Skip using the same blob UUID as two consecutive indexes
+                return mri
 
             new_blob = blob.Blob.from_db(blob_uuid)
             if not new_blob:

--- a/shakenfist/artifact.py
+++ b/shakenfist/artifact.py
@@ -251,9 +251,24 @@ class Artifact(dbo):
 
     def add_index(self, blob_uuid):
         with self.get_lock_attr('index', 'Artifact index creation'):
-            b = blob.Blob.from_db(blob_uuid)
-            if not b:
+            mri = self.most_recent_index
+            if 'blob_uuid' in mri:
+                old_blob = blob.Blob.from_db(mri['blob_uuid'])
+                if not old_blob:
+                    raise exceptions.BlobMissing()
+                old_checksums = old_blob.checksums
+            else:
+                old_checksums = {}
+
+            new_blob = blob.Blob.from_db(blob_uuid)
+            if not new_blob:
                 raise exceptions.BlobMissing()
+            new_checksums = new_blob.checksums
+
+            if old_checksums.get('sha512') and new_checksums.get('sha512'):
+                if old_checksums.get('sha512') == new_checksums.get('sha512'):
+                    # Skipping the update, the blobs have the same content...
+                    return mri
 
             highest_index = self._db_get_attribute(
                 'highest_index', {'index': 0})
@@ -266,7 +281,7 @@ class Artifact(dbo):
             }
             self._db_set_attribute('index_%012d' % index, entry)
             self.add_event('Added index %d to artifact' % index)
-            b.ref_count_inc()
+            new_blob.ref_count_inc()
             self.delete_old_versions()
             return entry
 

--- a/shakenfist/blob.py
+++ b/shakenfist/blob.py
@@ -139,7 +139,8 @@ class Blob(dbo):
             'depends_on': self.depends_on,
             'transcodes': self.transcoded,
             'locations': self.locations,
-            'reference_count': self.ref_count
+            'reference_count': self.ref_count,
+            'sha512': self.checksums.get('sha512')
         })
 
         # The order of these two calls matters, as instances updates last_used

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -128,6 +128,8 @@ api.add_resource(api_auth.AuthNamespaceTrustEndpoint,
 api.add_resource(api_blob.BlobsEndpoint, '/blobs')
 api.add_resource(api_blob.BlobEndpoint, '/blobs/<blob_uuid>')
 api.add_resource(api_blob.BlobDataEndpoint, '/blobs/<blob_uuid>/data')
+api.add_resource(api_blob.BlobChecksumsEndpoint,
+                 '/blob_checksum/sha512/<hash>')
 
 api.add_resource(api_instance.InstancesEndpoint, '/instances')
 api.add_resource(api_instance.InstanceEndpoint, '/instances/<instance_ref>')

--- a/shakenfist/external_api/artifact.py
+++ b/shakenfist/external_api/artifact.py
@@ -404,6 +404,7 @@ class ArtifactUploadEndpoint(sf_api.Resource):
                 time.time())
             b.state = Blob.STATE_CREATED
             b.observe()
+            b.verify_checksum()
             b.request_replication()
 
             a.add_event('upload complete')

--- a/shakenfist/external_api/blob.py
+++ b/shakenfist/external_api/blob.py
@@ -101,3 +101,18 @@ class BlobsEndpoint(sf_api.Resource):
                     retval.append(b.external_view())
 
         return retval
+
+
+class BlobChecksumsEndpoint(sf_api.Resource):
+    @api_base.verify_token
+    @api_base.log_token_use
+    def get(self, hash=None):
+        if not hash:
+            return sf_api.error(400, 'you must specify a hash')
+
+        with etcd.ThreadLocalReadOnlyCache():
+            for b in Blobs(filters=[baseobject.active_states_filter]):
+                if b.checksums.get('sha512') == hash:
+                    return b.external_view()
+
+        return None

--- a/shakenfist/images.py
+++ b/shakenfist/images.py
@@ -284,6 +284,7 @@ class ImageFetchHelper(object):
                 transcode_blob_uuid, st.st_size, time.time(), time.time())
             transcode_blob.state = Blob.STATE_CREATED
             transcode_blob.observe()
+            transcode_blob.verify_checksum()
             transcode_blob.request_replication()
             self.log.with_fields({
                 'blob': b,

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -1318,6 +1318,7 @@ class Instance(dbo):
                 b = blob.Blob.new(blob_uuid, st.st_size,
                                   time.time(), time.time())
                 b.observe()
+                b.verify_checksum()
                 a.state = artifact.Artifact.STATE_CREATED
 
             else:

--- a/shakenfist/util/access_tokens.py
+++ b/shakenfist/util/access_tokens.py
@@ -1,0 +1,26 @@
+import datetime
+from flask_jwt_extended import create_access_token
+
+from shakenfist.config import config
+
+
+def create_token(ns, keyname, nonce, duration=config.API_TOKEN_DURATION):
+    token = create_access_token(
+        identity=[ns.uuid, keyname],
+        additional_claims={
+            'iss': config.ZONE,
+            'nonce': nonce
+        },
+        expires_delta=datetime.timedelta(minutes=duration))
+    ns.add_event(
+        'Token created from key',
+        extra={
+            'keyname': keyname,
+            'nonce': nonce,
+            'token': token
+        })
+    return {
+        'access_token': token,
+        'token_type': 'Bearer',
+        'expires_in': duration * 60
+    }


### PR DESCRIPTION
Use checksums to ensure artifacts don't have updates when nothing has changed.