### PR TITLE
Start exposing simple API capability information for backwards compatability.

### DIFF
--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -95,8 +95,13 @@ def log_response_info(response):
 class Root(sf_api.Resource):
     def get(self):
         resp = flask.Response(
-            'Shaken Fist REST API service',
-            mimetype='text/plain')
+            ('<html><head><title>Shaken Fist REST API service</title></head>'
+             '<body><h1>Shaken Fist REST API service</h1>'
+             '<p>You might be interested in the <a href="/apidocs">apidocs</a>.</p>'
+             '<p>Machine searchable API capabilities:</p><ul>'
+             '<li>blob-search-by-hash</li>'
+             '</ul></p></body></html>'),
+            mimetype='text/html')
         resp.status_code = 200
         return resp
 

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -203,10 +203,10 @@ class ExternalApiGeneralTestCase(ExternalApiTestCase):
 
     def test_get_root(self):
         resp = self.client.get('/')
-        self.assertEqual('Shaken Fist REST API service',
-                         resp.get_data().decode('utf-8'))
+        self.assertTrue('Shaken Fist REST API service' in
+                        resp.get_data().decode('utf-8'))
         self.assertEqual(200, resp.status_code)
-        self.assertEqual('text/plain; charset=utf-8', resp.content_type)
+        self.assertEqual('text/html; charset=utf-8', resp.content_type)
 
     def test_get_instance(self):
         self.mock_etcd.create_instance('barry')


### PR DESCRIPTION
Fixes #1668.