### PR TITLE
Don't include tracebacks for expected errors.

### DIFF
--- a/shakenfist/external_api/artifact.py
+++ b/shakenfist/external_api/artifact.py
@@ -45,7 +45,7 @@ def arg_is_artifact_ref(func):
                     kwargs['artifact_from_db'] = Artifact.from_db_by_ref(
                         kwargs.get('artifact_ref'), get_jwt_identity()[0])
                 except exceptions.MultipleObjects as e:
-                    return sf_api.error(400, str(e))
+                    return sf_api.error(400, str(e), suppress_traceback=True)
 
         if not kwargs.get('artifact_from_db'):
             return sf_api.error(404, 'artifact not found')

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -170,7 +170,7 @@ def arg_is_instance_ref(func):
                 inst = Instance.from_db_by_ref(kwargs.get('instance_ref'),
                                                get_jwt_identity()[0])
             except exceptions.MultipleObjects as e:
-                return sf_api.error(400, str(e))
+                return sf_api.error(400, str(e), suppress_traceback=True)
 
             if not inst:
                 LOG.with_fields({'instance': kwargs.get('instance_ref')}).info(
@@ -263,7 +263,7 @@ def arg_is_network_ref(func):
                 n = network.Network.from_db_by_ref(kwargs.get('network_ref'),
                                                    get_jwt_identity()[0])
             except exceptions.MultipleObjects as e:
-                return sf_api.error(400, str(e))
+                return sf_api.error(400, str(e), suppress_traceback=True)
 
             if not n:
                 LOG.with_fields({'network': kwargs.get('network_ref')}).info(

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -300,9 +300,10 @@ class InstancesEndpoint(sf_api.Resource):
                 # Allow network to be specified by name or UUID (and error early
                 # if not found)
                 try:
-                    n = sfnet.Network.from_db_by_ref(netdesc['network_uuid'])
+                    n = sfnet.Network.from_db_by_ref(netdesc['network_uuid'],
+                                                     get_jwt_identity()[0])
                 except exceptions.MultipleObjects as e:
-                    return sf_api.error(400, str(e))
+                    return sf_api.error(400, str(e), suppress_traceback=True)
 
                 if not n:
                     return sf_api.error(
@@ -402,7 +403,7 @@ class InstancesEndpoint(sf_api.Resource):
                 except exceptions.CongestedNetwork as e:
                     inst.enqueue_delete_due_error(
                         'cannot allocate address: %s' % e)
-                    return sf_api.error(507, str(e))
+                    return sf_api.error(507, str(e), suppress_traceback=True)
 
                 if 'model' not in netdesc or not netdesc['model']:
                     netdesc['model'] = 'virtio'
@@ -430,7 +431,7 @@ class InstancesEndpoint(sf_api.Resource):
                 except exceptions.CongestedNetwork as e:
                     inst.enqueue_delete_due_error(
                         'cannot allocate address: %s' % e)
-                    return sf_api.error(507, str(e))
+                    return sf_api.error(507, str(e), suppress_traceback=True)
 
                 # Include the interface uuid in the network description we
                 # pass through to the instance start task.

--- a/shakenfist/external_api/interface.py
+++ b/shakenfist/external_api/interface.py
@@ -38,7 +38,7 @@ class InterfaceFloatEndpoint(sf_api.Resource):
         try:
             api_util.assign_floating_ip(ni)
         except exceptions.CongestedNetwork as e:
-            return sf_api.error(507, str(e))
+            return sf_api.error(507, str(e), suppress_traceback=True)
 
         etcd.enqueue('networknode',
                      FloatNetworkInterfaceTask(n.uuid, interface_uuid))

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -656,5 +656,5 @@ class ExternalApiInstanceTestCase(ExternalApiTestCase):
             }))
         self.assertEqual(400, resp.status_code)
         self.assertEqual(
-            'multiple networks have the name "betsy" in namespace "None"',
+            'multiple networks have the name "betsy" in namespace "two"',
             resp.get_json().get('error'))


### PR DESCRIPTION
Additionally, include the namespace if specified for network lookups by reference. Fixes #1684.