### PR TITLE
Require a new pycdlib.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
+# Dependancies where we require something modern because of a bug upstream.
+pycdlib>=1.14.0             # lgpl
+                            # Version 1.13.0 has a bug where timezone offsets are
+                            # incorrectly calculated for some timezones at the very
+                            # start of a year. See https://github.com/clalancette/pycdlib/issues/107
+                            # for details.
+
 # Pinned dependancies of our requirements, locked because of compatability issues
 protobuf<4.0.0              # google license: https://github.com/protocolbuffers/protobuf/blob/main/LICENSE
                             # Version 4.21 and greater requires that a different version of protoc be used
@@ -13,7 +20,6 @@ importlib-metadata<5;python_version<"3.8"
 
 # Our requirements.
 pyyaml>=5.1                 # mit
-pycdlib                     # lgpl
 oslo.concurrency            # apache2
 jinja2>=3.1.2               # bsd
 setproctitle                # bsd


### PR DESCRIPTION
Fixes #1682 after an upstream bug was fixed for us. See https://github.com/clalancette/pycdlib/issues/107 for details.