### PR TITLE
Rearrange the API to select VDI console type.

### DIFF
--- a/deploy/ansible/deploy.yml
+++ b/deploy/ansible/deploy.yml
@@ -281,7 +281,7 @@
 
     - name: Check if the CA is already setup
       stat:
-        path: /etc/pki/CA/ca-cert.pem
+        path: /etc/pki/libvirt-spice/ca-cert.pem
       register: ca_cert
 
     - name: Copy CA certificate to host
@@ -293,6 +293,11 @@
         mode: '0444'
       when: not ca_cert.stat.exists
 
+    - name: Check if the host certificate is already setup
+      stat:
+        path: /etc/pki/libvirt-spice/server-cert.pem
+      register: host_cert
+
     - name: Copy host key to host
       copy:
         src: /etc/pki/CA/{{inventory_hostname}}_server_key.pem
@@ -300,7 +305,7 @@
         owner: root
         group: root
         mode: '0444'
-      when: not ca_cert.stat.exists
+      when: not host_cert.stat.exists
 
     - name: Copy host certificate to host
       copy:
@@ -309,7 +314,7 @@
         owner: root
         group: root
         mode: '0444'
-      when: not ca_cert.stat.exists
+      when: not host_cert.stat.exists
 
 - hosts: hypervisors, network_node, eventlog_node
   any_errors_fatal: true

--- a/docs/user_guide/consoles.md
+++ b/docs/user_guide/consoles.md
@@ -59,12 +59,17 @@ telnet sf-2 30049
 
 There is also a graphical console. Similarly to the telnet console, it requires
 direct network access to the hypervisor node, and is accessed at the "vdi port"
-TCP port. By default this console is VNC, although SPICE was added as an
-option in v0.7.
+TCP port. By default this console is SPICE since v0.7, although VNC is also
+available.
 
-You can select from 'vnc' or 'spice' by passing the `--vdi-type` argument on the
-command line when creating an instance, or using the equivalent API argument.
-Additionally, if you add `--spice-concurrent` to your command line, then
+You can select from 'vnc' or 'spice' by setting the `vdi` argument in your video
+specification for the instance. If you set `vdi=spice-concurrent`, then
 experimental support for multiple users accessing the same SPICE console at the
 same time is enabled. For more details about the experimental nature of concurrent
 SPICE consoles, see https://www.spice-space.org/multiple-clients.html.
+
+And example video specification would be:
+
+```
+--video model=qxl,memory=65536,vdi=spiceconcurrent
+```

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -335,12 +335,14 @@ class InstancesEndpoint(sf_api.Resource):
                     return sf_api.error(404, 'network %s does not exist' % n.uuid)
 
         if not video:
-            video = {'model': 'cirrus', 'memory': 16384}
+            video = {'model': 'cirrus', 'memory': 16384, 'vdi': 'spice'}
         else:
             if 'model' not in video:
                 return sf_api.error(400, 'video specification requires "model"')
             if 'memory' not in video:
                 return sf_api.error(400, 'video specification requires "memory"')
+            if 'vdi' not in video:
+                video['vdi'] = 'spice'
 
         # Validate metadata before instance creation
         if metadata:
@@ -368,9 +370,7 @@ class InstancesEndpoint(sf_api.Resource):
             nvram_template=nvram_template,
             secure_boot=secure_boot,
             machine_type=machine_type,
-            side_channels=side_channels,
-            vdi_type=vdi_type,
-            spice_concurrent=spice_concurrent
+            side_channels=side_channels
         )
 
         # Initialise metadata

--- a/shakenfist/tests/test_instance.py
+++ b/shakenfist/tests/test_instance.py
@@ -77,7 +77,7 @@ class VirtMetaTestCase(base.ShakenFistTestCase):
                     'ssh_key': 'thisisasshkey',
                     'user_data': str(base64.b64encode(
                         'thisisuserdata'.encode('utf-8')), 'utf-8'),
-                    'video': {'model': 'cirrus', 'memory': 16384},
+                    'video': {'model': 'cirrus', 'memory': 16384, 'vdi': 'spice'},
                     'uefi': False,
                     'configdrive': 'openstack-disk',
                     'version': 6,
@@ -92,10 +92,10 @@ class VirtMetaTestCase(base.ShakenFistTestCase):
     @mock.patch('time.time', return_value=1234)
     def test_instance_new(self, mock_time, mock_get_lock, mock_get_attribute,
                           mock_create, mock_put, mock_get):
-        instance.Instance.new('barry', 1, 2048, 'namespace', 'sshkey',
-                              [{}], 'userdata', {
-                                  'memory': 16384, 'model': 'cirrus'},
-                              instance_uuid='uuid42',)
+        instance.Instance.new(
+            'barry', 1, 2048, 'namespace', 'sshkey',
+            [{}], 'userdata', {'memory': 16384, 'model': 'cirrus', 'vdi': 'spice'},
+            instance_uuid='uuid42',)
 
         self.assertEqual(
             ('attribute/instance', 'uuid42', 'state',
@@ -120,14 +120,12 @@ class VirtMetaTestCase(base.ShakenFistTestCase):
                  'user_data': 'userdata',
                  'uuid': 'uuid42',
                  'version': 10,
-                 'video': {'memory': 16384, 'model': 'cirrus'},
+                 'video': {'memory': 16384, 'model': 'cirrus', 'vdi': 'spice'},
                  'uefi': False,
                  'configdrive': 'openstack-disk',
                  'nvram_template': None,
                  'secure_boot': False,
-                 'side_channels': None,
-                 'vdi_type': 'vnc',
-                 'spice_concurrent': False
+                 'side_channels': None
              }),
             mock_create.mock_calls[0][1])
 
@@ -176,7 +174,7 @@ class InstanceTestCase(base.ShakenFistTestCase):
                     'ssh_key': 'thisisasshkey',
                     'user_data': str(base64.b64encode(
                         'thisisuserdata'.encode('utf-8')), 'utf-8'),
-                    'video': {'model': 'cirrus', 'memory': 16384},
+                    'video': {'model': 'cirrus', 'memory': 16384, 'vdi': 'spice'},
                     'uefi': False,
                     'configdrive': 'openstack-disk',
                     'version': 6,
@@ -524,7 +522,7 @@ GET_ALL_INSTANCES = [
         'requested_placement': None,
         'ssh_key': 'thisisasshkey',
         'user_data': None,
-        'video': {'model': 'cirrus', 'memory': 16384},
+        'video': {'model': 'cirrus', 'memory': 16384, 'vdi': 'spice'},
         'uefi': False,
         'configdrive': 'openstack-disk',
         'version': 6,
@@ -545,7 +543,7 @@ GET_ALL_INSTANCES = [
         'requested_placement': None,
         'ssh_key': 'thisisasshkey',
         'user_data': None,
-        'video': {'model': 'cirrus', 'memory': 16384},
+        'video': {'model': 'cirrus', 'memory': 16384, 'vdi': 'spice'},
         'uefi': False,
         'configdrive': 'openstack-disk',
         'version': 6,
@@ -565,7 +563,7 @@ GET_ALL_INSTANCES = [
         'requested_placement': None,
         'ssh_key': 'thisisasshkey',
         'user_data': None,
-        'video': {'model': 'cirrus', 'memory': 16384},
+        'video': {'model': 'cirrus', 'memory': 16384, 'vdi': 'spice'},
         'uefi': False,
         'configdrive': 'openstack-disk',
         'version': 6,


### PR DESCRIPTION
I regret it being extra arguments, it should just have been in the video spec all along. Thankfully we didn't release this.