### PR TITLE
Remove local event fast path.

### DIFF
--- a/shakenfist/eventlog.py
+++ b/shakenfist/eventlog.py
@@ -56,23 +56,18 @@ def add_event(object_type, object_uuid, message, duration=None,
                 'message': message
             }).info('Added event')
 
-    if config.NODE_MESH_IP == config.EVENTLOG_NODE_IP:
-        with EventLog(object_type, object_uuid) as eventdb:
-            eventdb.write_event(timestamp, config.NODE_NAME,
-                                duration, message, extra=extra)
-    else:
-        # We use the old eventlog mechanism as a queueing system to get the logs
-        # to the eventlog node.
-        etcd.put('event/%s' % object_type, object_uuid, timestamp,
-                 {
-                     'timestamp': timestamp,
-                     'object_type': object_type,
-                     'object_uuid': object_uuid,
-                     'fqdn': config.NODE_NAME,
-                     'duration': duration,
-                     'message': message,
-                     'extra': extra
-                 })
+    # We use the old eventlog mechanism as a queueing system to get the logs
+    # to the eventlog node.
+    etcd.put('event/%s' % object_type, object_uuid, timestamp,
+             {
+                 'timestamp': timestamp,
+                 'object_type': object_type,
+                 'object_uuid': object_uuid,
+                 'fqdn': config.NODE_NAME,
+                 'duration': duration,
+                 'message': message,
+                 'extra': extra
+             })
 
 
 class EventLog(object):
@@ -175,7 +170,7 @@ class EventLog(object):
                             'VALUES (%f, "Compacted database")'
                             % time.time())
                     self.log.info('Database upgrade took %.02f seconds'
-                                % (time.time() - start_upgrade))
+                                  % (time.time() - start_upgrade))
 
     def write_event(self, timestamp, fqdn, duration, message, extra=None):
         if not self.con:
@@ -241,5 +236,3 @@ class EventLog(object):
         if changes == limit:
             self.log.info('Vacuuming event database')
             cur.execute('VACUUM')
-
-


### PR DESCRIPTION
This seemed like a good idea at the time, but it makes some odd assumptions in hindsight -- like the API process being allowed to write to the eventlog directory. Instead, let's just proxy everything consistently.