### PR TITLE
Fixes while seeking stability again.

### DIFF
--- a/.github/workflows/functional-tests-debian-10-localhost.yml
+++ b/.github/workflows/functional-tests-debian-10-localhost.yml
@@ -142,56 +142,27 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
-
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
-
-          # Ensure we didn't see invalid leases causing DHCP failures
-          if [ `grep -c "not using configured address" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "DHCP is failing, probably due to invalid leases!"
-            exit 1
-          fi
-
-          # Ensure we didn't override blob reference counts
-          if [ `grep -ci "override" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A blob reference count was overridden!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/functional-tests-debian-10-localhost.yml
+++ b/.github/workflows/functional-tests-debian-10-localhost.yml
@@ -145,8 +145,15 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -165,10 +172,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/functional-tests-debian-10-localhost.yml
+++ b/.github/workflows/functional-tests-debian-10-localhost.yml
@@ -137,10 +137,16 @@ jobs:
         if: ${{ ! cancelled() }}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                debian@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
+
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -157,7 +163,7 @@ jobs:
           IFS=""
           for forbid in ${FORBIDDEN[*]}
           do
-            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
               echo "Forbidden string found in logs: $forbid"
               exit 1

--- a/.github/workflows/functional-tests-debian-11-slim-primary.yml
+++ b/.github/workflows/functional-tests-debian-11-slim-primary.yml
@@ -142,56 +142,27 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
-
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
-
-          # Ensure we didn't see invalid leases causing DHCP failures
-          if [ `grep -c "not using configured address" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "DHCP is failing, probably due to invalid leases!"
-            exit 1
-          fi
-
-          # Ensure we didn't override blob reference counts
-          if [ `grep -ci "override" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A blob reference count was overridden!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/functional-tests-debian-11-slim-primary.yml
+++ b/.github/workflows/functional-tests-debian-11-slim-primary.yml
@@ -145,8 +145,15 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -165,10 +172,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/functional-tests-debian-11-slim-primary.yml
+++ b/.github/workflows/functional-tests-debian-11-slim-primary.yml
@@ -137,10 +137,16 @@ jobs:
         if: ${{ ! cancelled() }}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                debian@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
+
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -157,7 +163,7 @@ jobs:
           IFS=""
           for forbid in ${FORBIDDEN[*]}
           do
-            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
               echo "Forbidden string found in logs: $forbid"
               exit 1

--- a/.github/workflows/functional-tests-ubuntu-2004-slim-primary.yml
+++ b/.github/workflows/functional-tests-ubuntu-2004-slim-primary.yml
@@ -142,56 +142,27 @@ jobs:
               ubuntu@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
-
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
-
-          # Ensure we didn't see invalid leases causing DHCP failures
-          if [ `grep -c "not using configured address" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "DHCP is failing, probably due to invalid leases!"
-            exit 1
-          fi
-
-          # Ensure we didn't override blob reference counts
-          if [ `grep -ci "override" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A blob reference count was overridden!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/functional-tests-ubuntu-2004-slim-primary.yml
+++ b/.github/workflows/functional-tests-ubuntu-2004-slim-primary.yml
@@ -145,8 +145,15 @@ jobs:
               ubuntu@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -165,10 +172,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/functional-tests-ubuntu-2004-slim-primary.yml
+++ b/.github/workflows/functional-tests-ubuntu-2004-slim-primary.yml
@@ -137,10 +137,16 @@ jobs:
         if: ${{ ! cancelled() }}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                ubuntu@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               ubuntu@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
+
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -157,7 +163,7 @@ jobs:
           IFS=""
           for forbid in ${FORBIDDEN[*]}
           do
-            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
               echo "Forbidden string found in logs: $forbid"
               exit 1

--- a/.github/workflows/functional-tests.tmpl
+++ b/.github/workflows/functional-tests.tmpl
@@ -137,10 +137,16 @@ jobs:
         if: {% raw %}${{{% endraw %} ! cancelled() {% raw %}}}{% endraw %}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                {{baseuser}}@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               {{baseuser}}@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
+
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -157,7 +163,7 @@ jobs:
           IFS=""
           for forbid in ${FORBIDDEN[*]}
           do
-            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
               echo "Forbidden string found in logs: $forbid"
               exit 1

--- a/.github/workflows/functional-tests.tmpl
+++ b/.github/workflows/functional-tests.tmpl
@@ -142,56 +142,27 @@ jobs:
               {{baseuser}}@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
-
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
-
-          # Ensure we didn't see invalid leases causing DHCP failures
-          if [ `grep -c "not using configured address" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "DHCP is failing, probably due to invalid leases!"
-            exit 1
-          fi
-
-          # Ensure we didn't override blob reference counts
-          if [ `grep -ci "override" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A blob reference count was overridden!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
       - name: Gather logs
         if: {% raw %}${{{% endraw %} ! cancelled() {% raw %}}}{% endraw %}

--- a/.github/workflows/functional-tests.tmpl
+++ b/.github/workflows/functional-tests.tmpl
@@ -145,8 +145,15 @@ jobs:
               {{baseuser}}@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -165,10 +172,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Gather logs
         if: {% raw %}${{{% endraw %} ! cancelled() {% raw %}}}{% endraw %}

--- a/.github/workflows/nodelifecycle-tests.yml
+++ b/.github/workflows/nodelifecycle-tests.yml
@@ -113,10 +113,16 @@ jobs:
         if: ${{ ! cancelled() }}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                debian@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
+
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -133,7 +139,7 @@ jobs:
           IFS=""
           for forbid in ${FORBIDDEN[*]}
           do
-            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
               echo "Forbidden string found in logs: $forbid"
               exit 1

--- a/.github/workflows/nodelifecycle-tests.yml
+++ b/.github/workflows/nodelifecycle-tests.yml
@@ -121,8 +121,15 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -141,10 +148,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Restart Shaken Fist nodes so we can collect logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/nodelifecycle-tests.yml
+++ b/.github/workflows/nodelifecycle-tests.yml
@@ -118,44 +118,29 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
-
-      - name: Restart shaken fist nodes so we can collect logs
+      - name: Restart Shaken Fist nodes so we can collect logs
         if: ${{ ! cancelled() }}
         run: |
           set -x

--- a/.github/workflows/scheduled-tests-develop-debian-10-localhost.yml
+++ b/.github/workflows/scheduled-tests-develop-debian-10-localhost.yml
@@ -150,8 +150,15 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -170,10 +177,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-develop-debian-10-localhost.yml
+++ b/.github/workflows/scheduled-tests-develop-debian-10-localhost.yml
@@ -147,56 +147,27 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
-
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
-
-          # Ensure we didn't see invalid leases causing DHCP failures
-          if [ `grep -c "not using configured address" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "DHCP is failing, probably due to invalid leases!"
-            exit 1
-          fi
-
-          # Ensure we didn't override blob reference counts
-          if [ `grep -ci "override" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A blob reference count was overridden!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-develop-debian-10-localhost.yml
+++ b/.github/workflows/scheduled-tests-develop-debian-10-localhost.yml
@@ -142,10 +142,16 @@ jobs:
         if: ${{ ! cancelled() }}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                debian@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
+
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -162,7 +168,7 @@ jobs:
           IFS=""
           for forbid in ${FORBIDDEN[*]}
           do
-            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
               echo "Forbidden string found in logs: $forbid"
               exit 1

--- a/.github/workflows/scheduled-tests-develop-debian-11-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-develop-debian-11-slim-primary.yml
@@ -150,8 +150,15 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -170,10 +177,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-develop-debian-11-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-develop-debian-11-slim-primary.yml
@@ -147,56 +147,27 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
-
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
-
-          # Ensure we didn't see invalid leases causing DHCP failures
-          if [ `grep -c "not using configured address" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "DHCP is failing, probably due to invalid leases!"
-            exit 1
-          fi
-
-          # Ensure we didn't override blob reference counts
-          if [ `grep -ci "override" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A blob reference count was overridden!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-develop-debian-11-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-develop-debian-11-slim-primary.yml
@@ -142,10 +142,16 @@ jobs:
         if: ${{ ! cancelled() }}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                debian@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
+
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -162,7 +168,7 @@ jobs:
           IFS=""
           for forbid in ${FORBIDDEN[*]}
           do
-            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
               echo "Forbidden string found in logs: $forbid"
               exit 1

--- a/.github/workflows/scheduled-tests-develop-ubuntu-2004-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-develop-ubuntu-2004-slim-primary.yml
@@ -147,56 +147,27 @@ jobs:
               ubuntu@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
-
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
-
-          # Ensure we didn't see invalid leases causing DHCP failures
-          if [ `grep -c "not using configured address" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "DHCP is failing, probably due to invalid leases!"
-            exit 1
-          fi
-
-          # Ensure we didn't override blob reference counts
-          if [ `grep -ci "override" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A blob reference count was overridden!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-develop-ubuntu-2004-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-develop-ubuntu-2004-slim-primary.yml
@@ -150,8 +150,15 @@ jobs:
               ubuntu@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -170,10 +177,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-develop-ubuntu-2004-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-develop-ubuntu-2004-slim-primary.yml
@@ -142,10 +142,16 @@ jobs:
         if: ${{ ! cancelled() }}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                ubuntu@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               ubuntu@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
+
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -162,7 +168,7 @@ jobs:
           IFS=""
           for forbid in ${FORBIDDEN[*]}
           do
-            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
               echo "Forbidden string found in logs: $forbid"
               exit 1

--- a/.github/workflows/scheduled-tests-v06-debian-10-localhost.yml
+++ b/.github/workflows/scheduled-tests-v06-debian-10-localhost.yml
@@ -150,8 +150,15 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -170,10 +177,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-v06-debian-10-localhost.yml
+++ b/.github/workflows/scheduled-tests-v06-debian-10-localhost.yml
@@ -147,56 +147,27 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
-
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
-
-          # Ensure we didn't see invalid leases causing DHCP failures
-          if [ `grep -c "not using configured address" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "DHCP is failing, probably due to invalid leases!"
-            exit 1
-          fi
-
-          # Ensure we didn't override blob reference counts
-          if [ `grep -ci "override" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A blob reference count was overridden!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-v06-debian-10-localhost.yml
+++ b/.github/workflows/scheduled-tests-v06-debian-10-localhost.yml
@@ -142,10 +142,16 @@ jobs:
         if: ${{ ! cancelled() }}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                debian@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
+
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -162,7 +168,7 @@ jobs:
           IFS=""
           for forbid in ${FORBIDDEN[*]}
           do
-            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
               echo "Forbidden string found in logs: $forbid"
               exit 1

--- a/.github/workflows/scheduled-tests-v06-debian-11-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-debian-11-slim-primary.yml
@@ -150,8 +150,15 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -170,10 +177,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-v06-debian-11-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-debian-11-slim-primary.yml
@@ -147,56 +147,27 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
-
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
-
-          # Ensure we didn't see invalid leases causing DHCP failures
-          if [ `grep -c "not using configured address" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "DHCP is failing, probably due to invalid leases!"
-            exit 1
-          fi
-
-          # Ensure we didn't override blob reference counts
-          if [ `grep -ci "override" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A blob reference count was overridden!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-v06-debian-11-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-debian-11-slim-primary.yml
@@ -142,10 +142,16 @@ jobs:
         if: ${{ ! cancelled() }}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                debian@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
+
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -162,7 +168,7 @@ jobs:
           IFS=""
           for forbid in ${FORBIDDEN[*]}
           do
-            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
               echo "Forbidden string found in logs: $forbid"
               exit 1

--- a/.github/workflows/scheduled-tests-v06-released-debian-10-localhost.yml
+++ b/.github/workflows/scheduled-tests-v06-released-debian-10-localhost.yml
@@ -150,8 +150,15 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -170,10 +177,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-v06-released-debian-10-localhost.yml
+++ b/.github/workflows/scheduled-tests-v06-released-debian-10-localhost.yml
@@ -147,56 +147,27 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
-
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
-
-          # Ensure we didn't see invalid leases causing DHCP failures
-          if [ `grep -c "not using configured address" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "DHCP is failing, probably due to invalid leases!"
-            exit 1
-          fi
-
-          # Ensure we didn't override blob reference counts
-          if [ `grep -ci "override" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A blob reference count was overridden!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-v06-released-debian-10-localhost.yml
+++ b/.github/workflows/scheduled-tests-v06-released-debian-10-localhost.yml
@@ -142,10 +142,16 @@ jobs:
         if: ${{ ! cancelled() }}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                debian@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
+
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -162,7 +168,7 @@ jobs:
           IFS=""
           for forbid in ${FORBIDDEN[*]}
           do
-            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
               echo "Forbidden string found in logs: $forbid"
               exit 1

--- a/.github/workflows/scheduled-tests-v06-released-debian-11-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-released-debian-11-slim-primary.yml
@@ -150,8 +150,15 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -170,10 +177,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-v06-released-debian-11-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-released-debian-11-slim-primary.yml
@@ -147,56 +147,27 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
-
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
-
-          # Ensure we didn't see invalid leases causing DHCP failures
-          if [ `grep -c "not using configured address" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "DHCP is failing, probably due to invalid leases!"
-            exit 1
-          fi
-
-          # Ensure we didn't override blob reference counts
-          if [ `grep -ci "override" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A blob reference count was overridden!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-v06-released-debian-11-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-released-debian-11-slim-primary.yml
@@ -142,10 +142,16 @@ jobs:
         if: ${{ ! cancelled() }}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                debian@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
+
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -162,7 +168,7 @@ jobs:
           IFS=""
           for forbid in ${FORBIDDEN[*]}
           do
-            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
               echo "Forbidden string found in logs: $forbid"
               exit 1

--- a/.github/workflows/scheduled-tests-v06-released-ubuntu-2004-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-released-ubuntu-2004-slim-primary.yml
@@ -147,56 +147,27 @@ jobs:
               ubuntu@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
-
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
-
-          # Ensure we didn't see invalid leases causing DHCP failures
-          if [ `grep -c "not using configured address" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "DHCP is failing, probably due to invalid leases!"
-            exit 1
-          fi
-
-          # Ensure we didn't override blob reference counts
-          if [ `grep -ci "override" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A blob reference count was overridden!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-v06-released-ubuntu-2004-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-released-ubuntu-2004-slim-primary.yml
@@ -150,8 +150,15 @@ jobs:
               ubuntu@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -170,10 +177,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-v06-released-ubuntu-2004-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-released-ubuntu-2004-slim-primary.yml
@@ -142,10 +142,16 @@ jobs:
         if: ${{ ! cancelled() }}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                ubuntu@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               ubuntu@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
+
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -162,7 +168,7 @@ jobs:
           IFS=""
           for forbid in ${FORBIDDEN[*]}
           do
-            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
               echo "Forbidden string found in logs: $forbid"
               exit 1

--- a/.github/workflows/scheduled-tests-v06-ubuntu-2004-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-ubuntu-2004-slim-primary.yml
@@ -147,56 +147,27 @@ jobs:
               ubuntu@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
-
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
-
-          # Ensure we didn't see invalid leases causing DHCP failures
-          if [ `grep -c "not using configured address" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "DHCP is failing, probably due to invalid leases!"
-            exit 1
-          fi
-
-          # Ensure we didn't override blob reference counts
-          if [ `grep -ci "override" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A blob reference count was overridden!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-v06-ubuntu-2004-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-ubuntu-2004-slim-primary.yml
@@ -150,8 +150,15 @@ jobs:
               ubuntu@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -170,10 +177,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/scheduled-tests-v06-ubuntu-2004-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-ubuntu-2004-slim-primary.yml
@@ -142,10 +142,16 @@ jobs:
         if: ${{ ! cancelled() }}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                ubuntu@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               ubuntu@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
+
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -162,7 +168,7 @@ jobs:
           IFS=""
           for forbid in ${FORBIDDEN[*]}
           do
-            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
               echo "Forbidden string found in logs: $forbid"
               exit 1

--- a/.github/workflows/scheduled-tests.tmpl
+++ b/.github/workflows/scheduled-tests.tmpl
@@ -147,56 +147,27 @@ jobs:
               {{baseuser}}@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
-
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
-
-          # Ensure we didn't see invalid leases causing DHCP failures
-          if [ `grep -c "not using configured address" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "DHCP is failing, probably due to invalid leases!"
-            exit 1
-          fi
-
-          # Ensure we didn't override blob reference counts
-          if [ `grep -ci "override" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A blob reference count was overridden!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
       - name: Gather logs
         if: {% raw %}${{{% endraw %} ! cancelled() {% raw %}}}{% endraw %}

--- a/.github/workflows/scheduled-tests.tmpl
+++ b/.github/workflows/scheduled-tests.tmpl
@@ -142,10 +142,16 @@ jobs:
         if: {% raw %}${{{% endraw %} ! cancelled() {% raw %}}}{% endraw %}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                {{baseuser}}@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               {{baseuser}}@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
+
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -162,7 +168,7 @@ jobs:
           IFS=""
           for forbid in ${FORBIDDEN[*]}
           do
-            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
               echo "Forbidden string found in logs: $forbid"
               exit 1

--- a/.github/workflows/scheduled-tests.tmpl
+++ b/.github/workflows/scheduled-tests.tmpl
@@ -150,8 +150,15 @@ jobs:
               {{baseuser}}@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -170,10 +177,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Gather logs
         if: {% raw %}${{{% endraw %} ! cancelled() {% raw %}}}{% endraw %}

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -77,7 +77,7 @@ jobs:
               debian@$primary \
               'sudo rm /etc/apache2/sites-enabled/*; sudo a2ensite sf-example.conf; sudo apachectl graceful'
 
-      - name: Wait for a five minutes
+      - name: Wait for five minutes
         run: sleep 300
 
       - name: Check logs

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -63,7 +63,6 @@ jobs:
               -o UserKnownHostsFile=/dev/null \
               debian@$primary 'sudo chmod ugo+r /etc/sf/sfrc; . /etc/sf/sfrc; /srv/shakenfist/venv/bin/sf-backup restore /home/debian/backup-0.6.15-20230319'
 
-
       - name: Run getsf installer on primary
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
@@ -84,50 +83,38 @@ jobs:
         if: ${{ ! cancelled() }}
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              debian@$primary 'sudo chmod ugo+r /var/log/syslog'
-
+          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                debian@$primary sudo chmod ugo+r /var/log/syslog
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
-          # Ensure we don't have any tracebacks
-          if [ `grep -c "Traceback (most recent call last):" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "We have tracebacks in the logs!"
-            exit 1
-          fi
+          etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
+          echo "This CI run created $etcd_conns etcd connections."
 
-          # Ensure we didn't log any errors -- note the inclusion of the start
-          # of the process name here to avoid errors from things like prometheus
-          # node exporter.
-          if [ `grep -c "ERROR sf" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "Errors were logged!"
-            exit 1
-          fi
-
-          # Ensure nothing died
-          if [ `grep -c " died" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "A process died!"
-            exit 1
-          fi
-
-          # Ensure no leaked vxlans
-          if [ `grep -c "Extra vxlan present" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "vxlans leaked!"
-            exit 1
-          fi
-
-          # Ensure grpc isn't misconfigured, or being used after a fork
-          if [ `grep -c "Fork support is only compatible with the epoll1 and poll polling strategies" ${GITHUB_WORKSPACE}/syslog` -gt 0 ]
-          then
-            echo "grpc called after a fork!"
-            exit 1
-          fi
+          FORBIDDEN=("Traceback (most recent call last):"
+                     "ERROR sf"
+                     " died"
+                     "Extra vxlan present"
+                     "Fork support is only compatible with the epoll1 and poll polling strategies"
+                     "not using configured address"
+                     "override"
+                     "Dumping thread traces"
+                     "because it is leased to"
+                     "not committing online upgrade"
+                     "Received a GOAWAY with error code ENHANCE_YOUR_CALM"
+                     "ConnectionFailedError")
+          IFS=""
+          for forbid in ${FORBIDDEN[*]}
+          do
+            if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
+            then
+              echo "Forbidden string found in logs: $forbid"
+              exit 1
+            fi
+          done
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -14,17 +14,14 @@ jobs:
   upgrade-0-6-15:
     runs-on: self-hosted
     timeout-minutes: 120
-
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     # NOTE(mikal): git repos are checked out to /srv/github/_work/{repo}/{repo}
     # which is available as GITHUB_WORKSPACE. You can find other environment
     # variables at https://docs.github.com/en/actions/learn-github-actions/environment-variables
 
     steps:
-      - name: Remove previous unfinished runs
-        uses: n1hility/cancel-previous-runs@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set environment variables
         run: |
           echo "SF_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -91,8 +91,15 @@ jobs:
               debian@$primary:/var/log/syslog \
               ${GITHUB_WORKSPACE}/syslog
 
+          failures=0
+
+          echo
           etcd_conns=`grep -c "Building new etcd connection" ${GITHUB_WORKSPACE}/syslog || true`
           echo "This CI run created $etcd_conns etcd connections."
+          if [ $etcd_conns -gt 5000 ]; then
+            echo "FAILURE: Too many etcd clients!"
+            failures=1
+          fi
 
           FORBIDDEN=("Traceback (most recent call last):"
                      "ERROR sf"
@@ -111,10 +118,15 @@ jobs:
           do
             if [ `grep -c "$forbid" ${GITHUB_WORKSPACE}/syslog || true` -gt 0 ]
             then
-              echo "Forbidden string found in logs: $forbid"
-              exit 1
+              echo "FAILURE: Forbidden string found in logs: $forbid"
+              failures=1
             fi
           done
+
+          if [ $failures -gt 0 ]; then
+              echo "...failures detected."
+              exit 1
+          fi
 
       - name: Gather logs
         if: ${{ ! cancelled() }}

--- a/deploy/ansible/ci-topology-localhost-released.yml
+++ b/deploy/ansible/ci-topology-localhost-released.yml
@@ -12,7 +12,7 @@
       sf_instance:
         name: "primary"
         cpu: 12
-        ram: 32768
+        ram: 16384
         disks:
           - "100@{{base_image}}"
         networkspecs:
@@ -73,11 +73,6 @@
         src: "{{source_path}}/shakenfist/deploy/getsf"
         dest: "/tmp/getsf"
         mode: ugo+rwx
-
-    - name: Create a RAM disk for etcd to make it more reliable in CI
-      shell: |
-        mkdir -p /var/lib/etcd
-        mount -t tmpfs -o rw,size=2G tmpfs /var/lib/etcd
 
     - name: Write a simple getsf wrapper
       copy:

--- a/deploy/ansible/ci-topology-localhost-released.yml
+++ b/deploy/ansible/ci-topology-localhost-released.yml
@@ -90,6 +90,7 @@
           export GETSF_WARNING=yes
 
           export GETSF_SKIP_COMMON_IMAGES=1
+          export GETSF_EXTRA_CONFIG='[{"name": "LOG_ETCD_CONNECTIONS", "value": "true"}]'
 
           sudo --preserve-env --set-home /tmp/getsf
         dest: "/tmp/getsf-wrapper"

--- a/deploy/ansible/ci-topology-localhost-upgrade.yml
+++ b/deploy/ansible/ci-topology-localhost-upgrade.yml
@@ -12,7 +12,7 @@
       sf_instance:
         name: "primary"
         cpu: 12
-        ram: 32768
+        ram: 16384
         disks:
           - "100@{{base_image}}"
         networkspecs:
@@ -88,11 +88,6 @@
       copy:
         src: "{{source_path}}/agent-python/dist/{{hostvars['localhost']['agent_wheel_file']}}"
         dest: "/root/{{hostvars['localhost']['agent_wheel_file']}}"
-
-    - name: Create a RAM disk for etcd to make it more reliable in CI
-      shell: |
-        mkdir -p /var/lib/etcd
-        mount -t tmpfs -o rw,size=2G tmpfs /var/lib/etcd
 
     - name: Write a simple getsf wrapper
       copy:

--- a/deploy/ansible/ci-topology-localhost-upgrade.yml
+++ b/deploy/ansible/ci-topology-localhost-upgrade.yml
@@ -110,6 +110,7 @@
           export GETSF_AGENT_PACKAGE="/root/{{hostvars['localhost']['agent_wheel_file']}}"
 
           export GETSF_SKIP_COMMON_IMAGES=1
+          export GETSF_EXTRA_CONFIG='[{"name": "LOG_ETCD_CONNECTIONS", "value": "true"}]'
 
           sudo --preserve-env --set-home /tmp/getsf $@
         dest: "/tmp/getsf-wrapper"

--- a/deploy/ansible/ci-topology-localhost.yml
+++ b/deploy/ansible/ci-topology-localhost.yml
@@ -12,7 +12,7 @@
       sf_instance:
         name: "primary"
         cpu: 12
-        ram: 32768
+        ram: 16384
         disks:
           - "100@{{base_image}}"
         networkspecs:
@@ -88,11 +88,6 @@
       copy:
         src: "{{source_path}}/agent-python/dist/{{hostvars['localhost']['agent_wheel_file']}}"
         dest: "/root/{{hostvars['localhost']['agent_wheel_file']}}"
-
-    - name: Create a RAM disk for etcd to make it more reliable in CI
-      shell: |
-        mkdir -p /var/lib/etcd
-        mount -t tmpfs -o rw,size=2G tmpfs /var/lib/etcd
 
     - name: Write a simple getsf wrapper
       copy:

--- a/deploy/ansible/ci-topology-localhost.yml
+++ b/deploy/ansible/ci-topology-localhost.yml
@@ -110,6 +110,7 @@
           export GETSF_AGENT_PACKAGE="/root/{{hostvars['localhost']['agent_wheel_file']}}"
 
           export GETSF_SKIP_COMMON_IMAGES=1
+          export GETSF_EXTRA_CONFIG='[{"name": "LOG_ETCD_CONNECTIONS", "value": "true"}]'
 
           sudo --preserve-env --set-home /tmp/getsf $@
         dest: "/tmp/getsf-wrapper"

--- a/deploy/ansible/ci-topology-slim-primary-released.yml
+++ b/deploy/ansible/ci-topology-slim-primary-released.yml
@@ -300,11 +300,6 @@
         group: root
         mode: u=r,g=,o=
 
-    - name: Create a RAM disk for etcd to make it more reliable in CI
-      shell: |
-        mkdir -p /var/lib/etcd
-        mount -t tmpfs -o rw,size=2G tmpfs /var/lib/etcd
-
     - name: Write a simple getsf wrapper
       copy:
         content: |

--- a/deploy/ansible/ci-topology-slim-primary-released.yml
+++ b/deploy/ansible/ci-topology-slim-primary-released.yml
@@ -355,6 +355,7 @@
           export GETSF_NODE_MESH_ADDRESS_sf_5="{{hostvars['sf5']['mesh_ip']}}"
 
           export GETSF_SKIP_COMMON_IMAGES=1
+          export GETSF_EXTRA_CONFIG='[{"name": "LOG_ETCD_CONNECTIONS", "value": "true"}]'
 
           sudo --preserve-env --set-home /tmp/getsf $@
         dest: "/tmp/getsf-wrapper"

--- a/deploy/ansible/ci-topology-slim-primary.yml
+++ b/deploy/ansible/ci-topology-slim-primary.yml
@@ -375,6 +375,7 @@
           export GETSF_NODE_MESH_ADDRESS_sf_5="{{hostvars['sf5']['mesh_ip']}}"
 
           export GETSF_SKIP_COMMON_IMAGES=1
+          export GETSF_EXTRA_CONFIG='[{"name": "LOG_ETCD_CONNECTIONS", "value": "true"}]'
 
           sudo --preserve-env --set-home /tmp/getsf $@
         dest: "/tmp/getsf-wrapper"

--- a/deploy/ansible/ci-topology-slim-primary.yml
+++ b/deploy/ansible/ci-topology-slim-primary.yml
@@ -315,11 +315,6 @@
         group: root
         mode: u=r,g=,o=
 
-    - name: Create a RAM disk for etcd to make it more reliable in CI
-      shell: |
-        mkdir -p /var/lib/etcd
-        mount -t tmpfs -o rw,size=2G tmpfs /var/lib/etcd
-
     - name: Write a simple getsf wrapper
       copy:
         content: |

--- a/deploy/ansible/deploy.py
+++ b/deploy/ansible/deploy.py
@@ -56,6 +56,8 @@ with open('/etc/sf/deploy-log', 'w') as logfile:
     variables['dns_server'] = os.environ.get('DNS_SERVER', '8.8.8.8')
     variables['http_proxy'] = os.environ.get('HTTP_PROXY', '')
 
+    variables['extra_config'] = os.environ.get('EXTRA_CONFIG', '[]')
+
     with open('/etc/sf/deploy-vars.json', 'w') as varsfile:
         varsfile.write(json.dumps(variables, indent=4, sort_keys=True))
 

--- a/deploy/ansible/deploy.yml
+++ b/deploy/ansible/deploy.yml
@@ -1057,6 +1057,16 @@
       shell: |
         /srv/shakenfist/venv/bin/sf-ctl show-etcd-config
 
+    - name: Log additional config
+      debug:
+        msg: "{{extra_config}}"
+
+    - name: Apply additional config
+      shell: |
+        /srv/shakenfist/venv/bin/sf-ctl set-etcd-config \
+            "{{item['name']}}" "{{item['value']}}"
+      loop: "{{extra_config}}"
+
 - hosts: hypervisors, network_node, etcd_master, storage
   any_errors_fatal: true
   serial: 1

--- a/deploy/getsf
+++ b/deploy/getsf
@@ -537,7 +537,29 @@ else
 fi
 echo
 
-# Ask for a deploy name
+question_start
+echo "Is there any additional cluster configuration you'd like applied"
+echo "before Shaken Fist starts? This is an advanced feature used to deploy"
+echo "pre-configured clusters without an additional restart."
+echo
+echo "Its completely ok to have none, in that case just hit return below."
+echo "Otherwise, specify the configuration values in a JSON list of"
+echo "dictionaries like this:"
+echo
+echo '[{"name": "a", "value": "b"}, {"name": "c", "value": "d"}]'
+echo
+if [ -z "${GETSF_EXTRA_CONFIG}" ]; then
+    echo -n "(a JSON list of configuration dictionaries) >> "
+    read GETSF_EXTRA_CONFIG
+    if [ -z "${GETSF_EXTRA_CONFIG}" ]; then
+        GETSF_EXTRA_CONFIG="[]"
+    fi
+    record_answer GETSF_NODE_HYPERVISOR "${GETSF_EXTRA_CONFIG}"
+else
+    echo "(a JSON list of configuration dictionaries) >> ${GETSF_EXTRA_CONFIG}"
+fi
+question_end
+
 question_start
 echo "What should this deployment be called? This name is used"
 echo "for Prometheus metrics labels, as well as being visible to"
@@ -687,6 +709,7 @@ echo
 status "Updating apt database."
 eval \${APT_GET} update
 
+echo
 status "Installing cpu-checker."
 eval \${APT_GET} install cpu-checker
 echo
@@ -841,6 +864,7 @@ export ADMIN_PASSWORD=${GETSF_ADMIN_PASSWORD}
 export FLOATING_IP_BLOCK="${GETSF_FLOATING_BLOCK}"
 export DNS_SERVER="${GETSF_DNS_SERVER}"
 export DEPLOY_NAME="${GETSF_DEPLOY_NAME}"
+export EXTRA_CONFIG='${GETSF_EXTRA_CONFIG}'
 DEPLOYEOF
 
 if [ ${GETSF_RELEASE} == "local" ]; then
@@ -970,6 +994,16 @@ EOF
 DEPLOYEOF
 chmod u+rx /root/sf-deploy
 
+echo
+echo "Install script is:"
+echo
+echo "--BOF--"
+cat /root/sf-deploy
+echo "--EOF--"
+echo
+
+
+echo
 status "Running the installer."
 /root/sf-deploy
 echo

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,10 @@ fixtures<4.0.1              # apache2
 importlib-metadata<5;python_version<"3.8"
 
 
+flask<2.3.0                 # bsd
+                            # Version 2.3.0 has problems importing Markup from flask
+
+
 # Our requirements.
 pyyaml>=5.1                 # mit
 oslo.concurrency            # apache2
@@ -25,7 +29,6 @@ jinja2>=3.1.2               # bsd
 setproctitle                # bsd
 click>=8.0.0                # bsd
 Werkzeug                    # bsd
-flask                       # bsd
 flask_restful               # bsd
 flasgger                    # mit
 psutil>=5.9.0               # bsd

--- a/shakenfist/artifact.py
+++ b/shakenfist/artifact.py
@@ -41,10 +41,7 @@ class Artifact(dbo):
         dbo.STATE_DELETED: (),
     }
 
-    ACTIVE_STATES = set([dbo.STATE_INITIAL,
-                         dbo.STATE_CREATED,
-                         dbo.STATE_ERROR,
-                         ])
+    ACTIVE_STATES = {dbo.STATE_INITIAL, dbo.STATE_CREATED, dbo.STATE_ERROR}
 
     TYPE_SNAPSHOT = 'snapshot'
     TYPE_LABEL = 'label'

--- a/shakenfist/artifact.py
+++ b/shakenfist/artifact.py
@@ -69,7 +69,7 @@ class Artifact(dbo):
         if static_values['namespace'] == 'sharedwithall':
             static_values['namespace'] = 'system'
             etcd.put(
-                'attribute/artifact',  static_values['uuid'], 'shared',
+                'attribute/artifact', static_values['uuid'], 'shared',
                 {'shared': True})
 
     @classmethod

--- a/shakenfist/baseobject.py
+++ b/shakenfist/baseobject.py
@@ -5,6 +5,7 @@ from math import inf
 import time
 from shakenfist_utilities import logs
 
+from shakenfist import cache
 from shakenfist import constants
 from shakenfist import etcd
 from shakenfist import eventlog
@@ -83,12 +84,8 @@ class DatabaseBackedObject(object):
     STATE_DELETE_WAIT = 'delete-wait'
     STATE_ERROR = 'error'
 
-    ACTIVE_STATES = set([STATE_INITIAL,
-                         STATE_CREATING,
-                         STATE_CREATED,
-                         STATE_ERROR,
-                         STATE_DELETE_WAIT
-                         ])
+    ACTIVE_STATES = {STATE_INITIAL, STATE_CREATING, STATE_CREATED, STATE_ERROR,
+                     STATE_DELETE_WAIT}
 
     def __init__(self, object_uuid, version=None, in_memory_only=False):
         self.__uuid = object_uuid
@@ -374,6 +371,9 @@ class DatabaseBackedObject(object):
 
             new_state = State(new_value, time.time())
             self._db_set_attribute('state', new_state)
+
+            cache.update_object_state_cache(
+                self.object_type, self.uuid, orig.value, new_value)
 
     @property
     def error(self):

--- a/shakenfist/baseobject.py
+++ b/shakenfist/baseobject.py
@@ -11,6 +11,7 @@ from shakenfist import etcd
 from shakenfist import eventlog
 from shakenfist.eventlog import EVENT_TYPE_AUDIT, EVENT_TYPE_MUTATE
 from shakenfist import exceptions
+from shakenfist.util import callstack as util_callstack
 from shakenfist.util import general as util_general
 
 

--- a/shakenfist/blob.py
+++ b/shakenfist/blob.py
@@ -37,6 +37,7 @@ LOG, _ = logs.setup(__name__)
 
 class Blob(dbo):
     object_type = 'blob'
+    initial_version = 3
     current_version = 6
 
     state_targets = {

--- a/shakenfist/blob.py
+++ b/shakenfist/blob.py
@@ -13,6 +13,7 @@ import time
 from shakenfist.baseobject import (
     DatabaseBackedObject as dbo,
     DatabaseBackedObjectIterator as dbo_iter)
+from shakenfist import cache
 from shakenfist.config import config
 from shakenfist.constants import LOCK_REFRESH_SECONDS, GiB
 from shakenfist import db
@@ -755,3 +756,9 @@ class Blobs(dbo_iter):
 
 def placement_filter(node, b):
     return node in b.locations
+
+
+def all_active_blob_uuids():
+    for active_state in Blob.ACTIVE_STATES:
+        for object_uuid in cache.read_object_state_cache(Blob.object_type, active_state):
+            yield object_uuid

--- a/shakenfist/cache.py
+++ b/shakenfist/cache.py
@@ -1,0 +1,22 @@
+import time
+
+from shakenfist import etcd
+
+
+def read_object_state_cache(object_type, state):
+    c = etcd.get('cache', object_type, state)
+    if not c:
+        c = {}
+    return c
+
+
+def update_object_state_cache(object_type, object_uuid, old_state, new_state):
+    with etcd.get_lock('cache', None, object_type, op='Cache update'):
+        c = read_object_state_cache(object_type, old_state)
+        if object_uuid in c:
+            del c[object_uuid]
+        etcd.put('cache', object_type, old_state, c)
+
+        c = read_object_state_cache(object_type, new_state)
+        c[object_uuid] = time.time()
+        etcd.put('cache', object_type, new_state, c)

--- a/shakenfist/client/backup.py
+++ b/shakenfist/client/backup.py
@@ -52,7 +52,7 @@ def cli(ctx, verbose=None):
 @click.pass_context
 def backup(ctx, output, anonymise=False):
     with tarfile.open(output, 'w:gz') as tar:
-        for data, metadata in etcd.WrappedEtcdClient().get_prefix('/'):
+        for data, metadata in etcd.get_etcd_client().get_prefix('/'):
             if metadata['key'].startswith('/sf/namespace'.encode('utf-8')):
                 d = json.loads(data)
                 for k in d['keys']:
@@ -76,7 +76,7 @@ def restore(ctx, input):
             key = tarinfo.name
             data = tar.extractfile(key).read()
 
-            etcd.WrappedEtcdClient().put(key, data)
+            etcd.get_etcd_client().put(key, data)
 
 
 cli.add_command(restore)

--- a/shakenfist/client/ctl.py
+++ b/shakenfist/client/ctl.py
@@ -58,7 +58,7 @@ def bootstrap_system_key(keyname, key):
 
 @click.command()
 def show_etcd_config():
-    value = etcd.WrappedEtcdClient().get('/sf/config', metadata=True)
+    value = etcd.get_etcd_client().get('/sf/config', metadata=True)
     if value is None or len(value) == 0:
         click.echo('{}')
     else:
@@ -70,7 +70,7 @@ def show_etcd_config():
 @click.argument('flag')
 @click.argument('value')
 def set_etcd_config(flag, value):
-    client = etcd.WrappedEtcdClient()
+    client = etcd.get_etcd_client()
     config = {}
     current_config = client.get('/sf/config', metadata=True)
     if current_config is None or len(current_config) == 0:

--- a/shakenfist/config.py
+++ b/shakenfist/config.py
@@ -320,6 +320,9 @@ class SFConfig(BaseSettings):
     EXCESSIVE_ETCD_CACHE_LOGGING: bool = Field(
         False, description='Record detailed information about etcd cache performance.'
     )
+    LOG_ETCD_CONNECTIONS: bool = Field(
+        False, description='Log when a new etcd connection is created, only useful in CI.'
+    )
 
     class Config:
         env_prefix = 'SHAKENFIST_'

--- a/shakenfist/daemons/cleaner.py
+++ b/shakenfist/daemons/cleaner.py
@@ -242,7 +242,7 @@ class Monitor(daemon.Daemon):
         all_node_blobs = n.blobs
 
         p = pathlib.Path(blob_path)
-        for entpath in p.glob('**/*'):
+        for entpath in p.glob('**/*.nosuch'):
             entpath = str(entpath)
             try:
                 if not os.path.isfile(entpath):

--- a/shakenfist/daemons/cleaner.py
+++ b/shakenfist/daemons/cleaner.py
@@ -241,6 +241,9 @@ class Monitor(daemon.Daemon):
         for entpath in p.glob('**/*'):
             entpath = str(entpath)
             try:
+                if not os.path.isfile(entpath):
+                    continue
+
                 st = os.stat(entpath)
                 blob_uuid = entpath.split('/')[-1].replace('.partial', '')
 
@@ -376,10 +379,8 @@ class Monitor(daemon.Daemon):
 
         while not self.exit.is_set():
             # Update power state of all instances on this hypervisor
-            LOG.info('Updating power states')
             self._update_power_states()
 
-            LOG.info('Maintaining blobs')
             self._maintain_blobs()
 
             if time.time() - last_missing_blob_check > 300:

--- a/shakenfist/daemons/cluster.py
+++ b/shakenfist/daemons/cluster.py
@@ -18,7 +18,6 @@ from shakenfist.baseobject import (
 from shakenfist.baseobjectmapping import (
     OBJECT_NAMES_TO_CLASSES, OBJECT_NAMES_TO_ITERATORS)
 from shakenfist.blob import Blob, Blobs, placement_filter
-from shakenfist import cache
 from shakenfist.config import config
 from shakenfist.daemons import daemon
 from shakenfist import etcd

--- a/shakenfist/daemons/cluster.py
+++ b/shakenfist/daemons/cluster.py
@@ -132,7 +132,7 @@ class Monitor(daemon.Daemon):
             # Record usage for blobs used by artifacts
             for blob_index in a.get_all_indexes():
                 blob_uuid = blob_index['blob_uuid']
-                b = Blob.from_db(blob_uuid)
+                b = Blob.from_db(blob_uuid, suppress_failure_audit=True)
                 if b:
                     in_use_blobs[b.uuid] += 1
         self.lock.refresh()

--- a/shakenfist/daemons/cluster.py
+++ b/shakenfist/daemons/cluster.py
@@ -247,7 +247,7 @@ class Monitor(daemon.Daemon):
 
         # Prune over replicated blobs
         for blob_uuid in overreplicated:
-            b = Blob.from_db(blob_uuid)
+            b = Blob.from_db(blob_uuid, suppress_failure_audit=True)
             if b:
                 for node in overreplicated[blob_uuid]:
                     LOG.with_fields({
@@ -269,7 +269,7 @@ class Monitor(daemon.Daemon):
                     'Too many concurrent blob transfers queued, not queueing more')
                 break
 
-            b = Blob.from_db(blob_uuid)
+            b = Blob.from_db(blob_uuid, suppress_failure_audit=True)
             if b:
                 LOG.with_fields({
                     'blob': b

--- a/shakenfist/daemons/cluster.py
+++ b/shakenfist/daemons/cluster.py
@@ -87,7 +87,7 @@ class Monitor(daemon.Daemon):
             if network_uuid:
                 n = network.Network.from_db(network_uuid)
                 if not n:
-                    etcd.WrappedEtcdClient().delete(k)
+                    etcd.get_etcd_client().delete(k)
                     LOG.with_fields({
                         'network': network_uuid,
                         'vxid record': k
@@ -100,7 +100,7 @@ class Monitor(daemon.Daemon):
             if network_uuid:
                 n = network.Network.from_db(network_uuid)
                 if not n:
-                    etcd.WrappedEtcdClient().delete(k)
+                    etcd.get_etcd_client().delete(k)
                     LOG.with_fields({
                         'ipmanager': network_uuid
                     }).warning('Cleaning up leaked ipmanager')

--- a/shakenfist/daemons/cluster.py
+++ b/shakenfist/daemons/cluster.py
@@ -359,8 +359,8 @@ class Monitor(daemon.Daemon):
                     if state:
                         by_state[state] = {}
 
-                with etcd.ThreadLocalReadOnlyCache():
-                    for obj in OBJECT_NAMES_TO_ITERATORS[object_type]([]):
+                for obj in OBJECT_NAMES_TO_ITERATORS[object_type]([]):
+                    if obj.state.value:
                         by_state[obj.state.value][obj.uuid] = time.time()
 
                 for state in by_state:

--- a/shakenfist/daemons/daemon.py
+++ b/shakenfist/daemons/daemon.py
@@ -1,6 +1,5 @@
 import faulthandler
 import logging
-import multiprocessing
 import setproctitle
 from shakenfist_utilities import logs
 import signal
@@ -9,6 +8,7 @@ from threading import Event
 from shakenfist.config import config
 from shakenfist import etcd
 from shakenfist.util import libvirt as util_libvirt
+from shakenfist.util import process as util_process
 
 
 DAEMON_NAMES = {
@@ -79,10 +79,8 @@ class WorkerPoolDaemon(Daemon):
                 del self.workers[workname]
 
     def start_workitem(self, processing_callback, args, name):
-        p = multiprocessing.Process(
-            target=processing_callback, args=args,
-            name='%s-%s' % (process_name('queues'), name))
-        p.start()
+        p = util_process.fork(processing_callback, args,
+                              '%s-%s' % (process_name('queues'), name))
         self.workers[name] = p
         return p.pid
 

--- a/shakenfist/daemons/eventlog.py
+++ b/shakenfist/daemons/eventlog.py
@@ -75,7 +75,7 @@ class Monitor(daemon.WorkerPoolDaemon):
                                     v['timestamp'], v['fqdn'], v['duration'],
                                     v['message'], extra=v.get('extra'))
                                 counters[event_type].inc()
-                                etcd.WrappedEtcdClient().delete(k)
+                                etcd.get_etcd_client().delete(k)
                     except Exception as e:
                         util_general.ignore_exception(
                             'failed to write event for %s %s' % (objtype, objuuid), e)

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 import itertools
 from oslo_concurrency import processutils
+import setproctitle
 from shakenfist_utilities import logs
 import time
 
@@ -311,6 +312,9 @@ class Monitor(daemon.WorkerPoolDaemon):
             if not workitem:
                 return
             else:
+                setproctitle.setproctitle(
+                    '%s-%s' % (daemon.process_name('net'), jobname))
+
                 try:
                     log_ctx = LOG.with_fields({'workitem': workitem})
                     if NetworkTask.__subclasscheck__(type(workitem)):

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -312,22 +312,23 @@ class Monitor(daemon.WorkerPoolDaemon):
                 time.sleep(0.2)
             else:
                 jobname, workitem = etcd.dequeue('networknode')
-                setproctitle.setproctitle(
-                    '%s-%s' % (daemon.process_name('net'), jobname))
+                if workitem:
+                    setproctitle.setproctitle(
+                        '%s-%s' % (daemon.process_name('net'), jobname))
 
-                try:
-                    log_ctx = LOG.with_fields({'workitem': workitem})
-                    if NetworkTask.__subclasscheck__(type(workitem)):
-                        self._process_network_workitem(log_ctx, workitem)
-                    elif NetworkInterfaceTask.__subclasscheck__(type(workitem)):
-                        self._process_networkinterface_workitem(
-                            log_ctx, workitem)
-                    else:
-                        raise exceptions.UnknownTaskException(
-                            'Network workitem was not decoded: %s' % workitem)
+                    try:
+                        log_ctx = LOG.with_fields({'workitem': workitem})
+                        if NetworkTask.__subclasscheck__(type(workitem)):
+                            self._process_network_workitem(log_ctx, workitem)
+                        elif NetworkInterfaceTask.__subclasscheck__(type(workitem)):
+                            self._process_networkinterface_workitem(
+                                log_ctx, workitem)
+                        else:
+                            raise exceptions.UnknownTaskException(
+                                'Network workitem was not decoded: %s' % workitem)
 
-                finally:
-                    etcd.resolve('networknode', jobname)
+                    finally:
+                        etcd.resolve('networknode', jobname)
 
     def _reap_leaked_floating_ips(self):
         # Block until the network node queue is idle to avoid races

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -40,7 +40,6 @@ EXTRA_VLANS_HISTORY = {}
 
 class Monitor(daemon.WorkerPoolDaemon):
     def _remove_stray_interfaces(self):
-        etcd.reset_client()
         last_loop = 0
 
         while not self.exit.is_set():
@@ -79,7 +78,6 @@ class Monitor(daemon.WorkerPoolDaemon):
                     pass
 
     def _maintain_networks(self):
-        etcd.reset_client()
         last_loop = 0
 
         while not self.exit.is_set():
@@ -207,7 +205,6 @@ class Monitor(daemon.WorkerPoolDaemon):
                     LOG.with_fields({'vxid': vxid}).warning('Extra vxlan present!')
 
     def _process_network_workitem(self, log_ctx, workitem):
-        etcd.reset_client()
         log_ctx = log_ctx.with_fields({'network': workitem.network_uuid()})
         n = network.Network.from_db(workitem.network_uuid())
         if not n:
@@ -356,7 +353,6 @@ class Monitor(daemon.WorkerPoolDaemon):
                 setproctitle.setproctitle('%s-idle' % daemon.process_name('net'))
 
     def _reap_leaked_floating_ips(self):
-        etcd.reset_client()
         last_loop = 0
 
         while not self.exit.is_set():
@@ -431,7 +427,6 @@ class Monitor(daemon.WorkerPoolDaemon):
                     floating_network._release_inner(ip)
 
     def _validate_mtus(self):
-        etcd.reset_client()
         last_loop = 0
 
         while not self.exit.is_set():

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -38,6 +38,7 @@ EXTRA_VLANS_HISTORY = {}
 
 class Monitor(daemon.WorkerPoolDaemon):
     def _remove_stray_interfaces(self):
+        etcd.reset_client()
         last_loop = 0
 
         while not self.exit.is_set():
@@ -76,6 +77,7 @@ class Monitor(daemon.WorkerPoolDaemon):
                     pass
 
     def _maintain_networks(self):
+        etcd.reset_client()
         last_loop = 0
 
         while not self.exit.is_set():
@@ -203,6 +205,7 @@ class Monitor(daemon.WorkerPoolDaemon):
                     LOG.with_fields({'vxid': vxid}).warning('Extra vxlan present!')
 
     def _process_network_workitem(self, log_ctx, workitem):
+        etcd.reset_client()
         log_ctx = log_ctx.with_fields({'network': workitem.network_uuid()})
         n = network.Network.from_db(workitem.network_uuid())
         if not n:
@@ -349,6 +352,7 @@ class Monitor(daemon.WorkerPoolDaemon):
                         etcd.resolve('networknode', jobname)
 
     def _reap_leaked_floating_ips(self):
+        etcd.reset_client()
         last_loop = 0
 
         while not self.exit.is_set():
@@ -423,6 +427,7 @@ class Monitor(daemon.WorkerPoolDaemon):
                     floating_network._release_inner(ip)
 
     def _validate_mtus(self):
+        etcd.reset_client()
         last_loop = 0
 
         while not self.exit.is_set():

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -308,10 +308,10 @@ class Monitor(daemon.WorkerPoolDaemon):
 
     def _process_network_node_workitems(self):
         while not self.exit.is_set():
-            jobname, workitem = etcd.dequeue('networknode')
-            if not workitem:
-                return
+            if etcd.get_queue_length('networknode') == 0:
+                time.sleep(0.2)
             else:
+                jobname, workitem = etcd.dequeue('networknode')
                 setproctitle.setproctitle(
                     '%s-%s' % (daemon.process_name('net'), jobname))
 
@@ -473,7 +473,7 @@ class Monitor(daemon.WorkerPoolDaemon):
                 else:
                     return
 
-                self.exit.wait(0.2)
+                self.exit.wait(1)
 
             except Exception as e:
                 util_general.ignore_exception('network worker', e)

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -334,6 +334,8 @@ class Monitor(daemon.WorkerPoolDaemon):
 
                     try:
                         log_ctx = LOG.with_fields({'workitem': workitem})
+                        log_ctx.info('Starting work item')
+
                         if NetworkTask.__subclasscheck__(type(workitem)):
                             self._process_network_workitem(log_ctx, workitem)
                         elif NetworkInterfaceTask.__subclasscheck__(type(workitem)):

--- a/shakenfist/daemons/net.py
+++ b/shakenfist/daemons/net.py
@@ -38,153 +38,169 @@ EXTRA_VLANS_HISTORY = {}
 
 class Monitor(daemon.WorkerPoolDaemon):
     def _remove_stray_interfaces(self):
-        for n in network.Networks([baseobject.active_states_filter]):
-            try:
-                t = time.time()
-                for ni_uuid in n.networkinterfaces:
-                    ni = NetworkInterface.from_db(ni_uuid)
-                    if not ni:
-                        continue
+        last_loop = 0
 
-                    inst = instance.Instance.from_db(ni.instance_uuid)
-                    if not inst:
-                        ni.delete()
-                        LOG.with_fields({
-                            'networkinterface': ni,
-                            'instance': ni.instance_uuid}).info(
-                            'Deleted stray network interface for missing instance')
-                    else:
-                        s = inst.state
-                        if (s.update_time + 30 < t and
-                                s.value in [dbo.STATE_DELETED, dbo.STATE_ERROR, 'unknown']):
+        while not self.exit.is_set():
+            if time.time() - last_loop < 30:
+                time.sleep(1)
+                continue
+
+            last_loop = time.time()
+            LOG.info('Scanning for stray network interfaces')
+            for n in network.Networks([baseobject.active_states_filter]):
+                try:
+                    t = time.time()
+                    for ni_uuid in n.networkinterfaces:
+                        ni = NetworkInterface.from_db(ni_uuid)
+                        if not ni:
+                            continue
+
+                        inst = instance.Instance.from_db(ni.instance_uuid)
+                        if not inst:
                             ni.delete()
                             LOG.with_fields({
                                 'networkinterface': ni,
                                 'instance': ni.instance_uuid}).info(
-                                'Deleted stray network interface')
+                                'Deleted stray network interface for missing instance')
+                        else:
+                            s = inst.state
+                            if (s.update_time + 30 < t and
+                                    s.value in [dbo.STATE_DELETED, dbo.STATE_ERROR, 'unknown']):
+                                ni.delete()
+                                LOG.with_fields({
+                                    'networkinterface': ni,
+                                    'instance': ni.instance_uuid}).info(
+                                    'Deleted stray network interface')
 
-            except exceptions.LockException:
-                pass
+                except exceptions.LockException:
+                    pass
 
     def _maintain_networks(self):
-        LOG.info('Maintaining networks')
+        last_loop = 0
 
-        # Discover what networks are present
-        _, _, vxid_to_mac = util_network.discover_interfaces()
+        while not self.exit.is_set():
+            if time.time() - last_loop < 30:
+                time.sleep(1)
+                continue
 
-        # Determine what networks we should be on
-        host_networks = []
-        seen_vxids = []
+            last_loop = time.time()
+            LOG.info('Maintaining existing networks')
 
-        if not config.NODE_IS_NETWORK_NODE:
-            # For normal nodes, just the ones we have instances for. We need
-            # to use the more expensive interfaces_for_instance() method of
-            # looking up instance interfaces here if the instance cachce hasn't
-            # been populated yet (i.e. the instance is still being created)
-            for inst in instance.Instances([instance.this_node_filter,
-                                            instance.healthy_states_filter]):
-                ifaces = inst.interfaces
-                if not ifaces:
-                    ifaces = list(
-                        networkinterface.interfaces_for_instance(inst))
+            # Discover what networks are present
+            _, _, vxid_to_mac = util_network.discover_interfaces()
 
-                for iface_uuid in ifaces:
-                    ni = networkinterface.NetworkInterface.from_db(iface_uuid)
-                    if not ni:
-                        LOG.with_fields({
-                            'instance': inst,
-                            'networkinterface': iface_uuid}).error(
-                                'Network interface does not exist')
-                    elif ni.network_uuid not in host_networks:
-                        host_networks.append(ni.network_uuid)
-        else:
-            # For network nodes, its all networks
-            for n in network.Networks([baseobject.active_states_filter]):
-                host_networks.append(n.uuid)
+            # Determine what networks we should be on
+            host_networks = []
+            seen_vxids = []
 
-        # Ensure we are on every network we have a host for
-        for network_uuid in host_networks:
-            try:
-                n = network.Network.from_db(network_uuid)
-                if not n:
-                    continue
+            if not config.NODE_IS_NETWORK_NODE:
+                # For normal nodes, just the ones we have instances for. We need
+                # to use the more expensive interfaces_for_instance() method of
+                # looking up instance interfaces here if the instance cachce hasn't
+                # been populated yet (i.e. the instance is still being created)
+                for inst in instance.Instances([instance.this_node_filter,
+                                                instance.healthy_states_filter]):
+                    ifaces = inst.interfaces
+                    if not ifaces:
+                        ifaces = list(
+                            networkinterface.interfaces_for_instance(inst))
 
-                # If this network is in state delete_wait, then we should remove
-                # it if it has no interfaces left.
-                if n.state.value == dbo.STATE_DELETE_WAIT:
-                    if not n.networkinterfaces:
-                        LOG.with_fields({'network': n}).info(
-                            'Removing stray delete_wait network')
-                        etcd.enqueue('networknode', DestroyNetworkTask(n.uuid))
+                    for iface_uuid in ifaces:
+                        ni = networkinterface.NetworkInterface.from_db(iface_uuid)
+                        if not ni:
+                            LOG.with_fields({
+                                'instance': inst,
+                                'networkinterface': iface_uuid}).error(
+                                    'Network interface does not exist')
+                        elif ni.network_uuid not in host_networks:
+                            host_networks.append(ni.network_uuid)
+            else:
+                # For network nodes, its all networks
+                for n in network.Networks([baseobject.active_states_filter]):
+                    host_networks.append(n.uuid)
 
-                    # We skip maintenance on all delete_wait networks
-                    continue
+            # Ensure we are on every network we have a host for
+            for network_uuid in host_networks:
+                try:
+                    n = network.Network.from_db(network_uuid)
+                    if not n:
+                        continue
 
-                # Track what vxlan ids we've seen
-                seen_vxids.append(n.vxid)
+                    # If this network is in state delete_wait, then we should remove
+                    # it if it has no interfaces left.
+                    if n.state.value == dbo.STATE_DELETE_WAIT:
+                        if not n.networkinterfaces:
+                            LOG.with_fields({'network': n}).info(
+                                'Removing stray delete_wait network')
+                            etcd.enqueue('networknode', DestroyNetworkTask(n.uuid))
 
-                if time.time() - n.state.update_time < 60:
-                    # Network state changed in the last minute, punt for now
-                    continue
+                        # We skip maintenance on all delete_wait networks
+                        continue
 
-                if not n.is_okay():
-                    if config.NODE_IS_NETWORK_NODE:
-                        LOG.with_fields({'network': n}).info(
-                            'Recreating not okay network on network node')
-                        n.create_on_network_node()
+                    # Track what vxlan ids we've seen
+                    seen_vxids.append(n.vxid)
 
-                        # If the network node was missing a network, then that implies
-                        # that we also need to re-create all of the floating IPs for
-                        # that network.
-                        for ni_uuid in n.networkinterfaces:
-                            ni = networkinterface.NetworkInterface.from_db(
-                                ni_uuid)
-                            if not ni:
-                                continue
+                    if time.time() - n.state.update_time < 60:
+                        # Network state changed in the last minute, punt for now
+                        continue
 
-                            if ni.floating.get('floating_address'):
-                                LOG.with_fields(
-                                    {
-                                        'instance': ni.instance_uuid,
-                                        'networkinterface': ni.uuid,
-                                        'floating': ni.floating.get('floating_address')
-                                    }).info('Refloating interface')
-                                n.add_floating_ip(ni.floating.get(
-                                    'floating_address'), ni.ipv4)
-                    else:
-                        LOG.with_fields({'network': n}).info(
-                            'Recreating not okay network on hypervisor')
-                        n.create_on_hypervisor()
+                    if not n.is_okay():
+                        if config.NODE_IS_NETWORK_NODE:
+                            LOG.with_fields({'network': n}).info(
+                                'Recreating not okay network on network node')
+                            n.create_on_network_node()
 
-                n.ensure_mesh()
+                            # If the network node was missing a network, then that implies
+                            # that we also need to re-create all of the floating IPs for
+                            # that network.
+                            for ni_uuid in n.networkinterfaces:
+                                ni = networkinterface.NetworkInterface.from_db(
+                                    ni_uuid)
+                                if not ni:
+                                    continue
 
-            except exceptions.LockException as e:
-                LOG.warning(
-                    'Failed to acquire lock while maintaining networks: %s' % e)
-            except exceptions.DeadNetwork as e:
-                LOG.with_fields({'exception': e}).info(
-                    'maintain_network attempted on dead network')
-            except processutils.ProcessExecutionError as e:
-                LOG.error('Network maintenance failure: %s', e)
+                                if ni.floating.get('floating_address'):
+                                    LOG.with_fields(
+                                        {
+                                            'instance': ni.instance_uuid,
+                                            'networkinterface': ni.uuid,
+                                            'floating': ni.floating.get('floating_address')
+                                        }).info('Refloating interface')
+                                    n.add_floating_ip(ni.floating.get(
+                                        'floating_address'), ni.ipv4)
+                        else:
+                            LOG.with_fields({'network': n}).info(
+                                'Recreating not okay network on hypervisor')
+                            n.create_on_hypervisor()
 
-        # Determine if there are any extra vxids
-        extra_vxids = set(vxid_to_mac.keys()) - set(seen_vxids)
+                    n.ensure_mesh()
 
-        # We keep a global cache of extra vxlans we've seen before, so that
-        # we only warn about them when they've been stray for five minutes.
-        global EXTRA_VLANS_HISTORY
-        for vxid in EXTRA_VLANS_HISTORY.copy():
-            if vxid not in extra_vxids:
-                del EXTRA_VLANS_HISTORY[vxid]
-        for vxid in extra_vxids:
-            if vxid not in EXTRA_VLANS_HISTORY:
-                EXTRA_VLANS_HISTORY[vxid] = time.time()
+                except exceptions.LockException as e:
+                    LOG.warning(
+                        'Failed to acquire lock while maintaining networks: %s' % e)
+                except exceptions.DeadNetwork as e:
+                    LOG.with_fields({'exception': e}).info(
+                        'maintain_network attempted on dead network')
+                except processutils.ProcessExecutionError as e:
+                    LOG.error('Network maintenance failure: %s', e)
 
-        # Warn of extra vxlans which have been present for more than five minutes
-        for vxid in EXTRA_VLANS_HISTORY:
-            if time.time() - EXTRA_VLANS_HISTORY[vxid] > 5 * 60:
-                LOG.with_fields({'vxid': vxid}).warning(
-                    'Extra vxlan present!')
+            # Determine if there are any extra vxids
+            extra_vxids = set(vxid_to_mac.keys()) - set(seen_vxids)
+
+            # We keep a global cache of extra vxlans we've seen before, so that
+            # we only warn about them when they've been stray for five minutes.
+            global EXTRA_VLANS_HISTORY
+            for vxid in EXTRA_VLANS_HISTORY.copy():
+                if vxid not in extra_vxids:
+                    del EXTRA_VLANS_HISTORY[vxid]
+            for vxid in extra_vxids:
+                if vxid not in EXTRA_VLANS_HISTORY:
+                    EXTRA_VLANS_HISTORY[vxid] = time.time()
+
+            # Warn of extra vxlans which have been present for more than five minutes
+            for vxid in EXTRA_VLANS_HISTORY:
+                if time.time() - EXTRA_VLANS_HISTORY[vxid] > 5 * 60:
+                    LOG.with_fields({'vxid': vxid}).warning('Extra vxlan present!')
 
     def _process_network_workitem(self, log_ctx, workitem):
         log_ctx = log_ctx.with_fields({'network': workitem.network_uuid()})
@@ -331,93 +347,106 @@ class Monitor(daemon.WorkerPoolDaemon):
                         etcd.resolve('networknode', jobname)
 
     def _reap_leaked_floating_ips(self):
-        # Block until the network node queue is idle to avoid races
-        processing, waiting, _ = etcd.get_queue_length('networknode')
-        while processing + waiting > 0:
-            self.exit.wait(60)
-            processing, waiting, _ = etcd.get_queue_length('networknode')
+        last_loop = 0
 
-        # Ensure we haven't leaked any floating IPs (because we used to). We
-        # have to hold a lock here to avoid races where an IP is freed while
-        # we're iterating through the loop. Note that this means we can't call
-        # anything which also wants to lock the ipmanager.
-        with db.get_lock('ipmanager', None, 'floating', ttl=120,
-                         op='Cleanup leaks'):
-            floating_network = network.floating_network()
+        while not self.exit.is_set():
+            if time.time() - last_loop < 30:
+                time.sleep(1)
+                continue
 
-            # Collect floating gateways and floating IPs, while ensuring that
-            # they are correctly reserved on the floating network as well.
-            floating_gateways = []
-            for n in network.Networks([baseobject.active_states_filter]):
-                fg = n.floating_gateway
-                if fg:
-                    floating_gateways.append(fg)
-                    if floating_network.is_free(fg):
-                        floating_network._reserve_inner(fg, n.unique_label())
-                        LOG.with_fields({
-                            'network': n.uuid,
-                            'address': fg
-                        }).error('Floating gateway not reserved correctly')
+            last_loop = time.time()
+            LOG.info('Reaping stray floating IPs')
 
-            LOG.info('Found floating gateways: %s' % floating_gateways)
+            # Ensure we haven't leaked any floating IPs (because we used to). We
+            # have to hold a lock here to avoid races where an IP is freed while
+            # we're iterating through the loop. Note that this means we can't call
+            # anything which also wants to lock the ipmanager.
+            with db.get_lock('ipmanager', None, 'floating', ttl=120,
+                             op='Cleanup leaks'):
+                floating_network = network.floating_network()
 
-            floating_addresses = []
-            for ni in networkinterface.NetworkInterfaces([baseobject.active_states_filter]):
-                fa = ni.floating.get('floating_address')
-                if fa:
-                    floating_addresses.append(fa)
-                    if floating_network.is_free(fa):
-                        floating_network._reserve_inner(fa, ni.unique_label())
-                        LOG.with_fields({
-                            'networkinterface': ni.uuid,
-                            'address': fa
-                        }).error('Floating address not reserved correctly')
-            LOG.info('Found floating addresses: %s' % floating_addresses)
+                # Collect floating gateways and floating IPs, while ensuring that
+                # they are correctly reserved on the floating network as well.
+                floating_gateways = []
+                for n in network.Networks([baseobject.active_states_filter]):
+                    fg = n.floating_gateway
+                    if fg:
+                        floating_gateways.append(fg)
+                        if floating_network.is_free(fg):
+                            floating_network._reserve_inner(fg, n.unique_label())
+                            LOG.with_fields({
+                                'network': n.uuid,
+                                'address': fg
+                            }).error('Floating gateway not reserved correctly')
 
-            floating_reserved = [
-                floating_network.get_address_at_index(0),
-                floating_network.get_address_at_index(1),
-                floating_network.get_broadcast_address(),
-                floating_network.get_network_address()
-            ]
-            LOG.info('Found floating reservations: %s' % floating_reserved)
+                LOG.info('Found floating gateways: %s' % floating_gateways)
 
-            # Now the reverse check. Test if there are any reserved IPs which
-            # are not actually in use. Free any we find.
-            leaks = []
-            for ip in floating_network.get_in_use_addresses():
-                if ip not in itertools.chain(floating_gateways,
-                                             floating_addresses,
-                                             floating_reserved):
-                    LOG.error('Floating IP %s has leaked.' % ip)
+                floating_addresses = []
+                for ni in networkinterface.NetworkInterfaces([baseobject.active_states_filter]):
+                    fa = ni.floating.get('floating_address')
+                    if fa:
+                        floating_addresses.append(fa)
+                        if floating_network.is_free(fa):
+                            floating_network._reserve_inner(fa, ni.unique_label())
+                            LOG.with_fields({
+                                'networkinterface': ni.uuid,
+                                'address': fa
+                            }).error('Floating address not reserved correctly')
+                LOG.info('Found floating addresses: %s' % floating_addresses)
 
-                    # This IP needs to have been allocated more than 300 seconds
-                    # ago to ensure that the network setup isn't still queued.
-                    if time.time() - floating_network.get_allocation_age(ip) > 300:
-                        leaks.append(ip)
+                floating_reserved = [
+                    floating_network.get_address_at_index(0),
+                    floating_network.get_address_at_index(1),
+                    floating_network.get_broadcast_address(),
+                    floating_network.get_network_address()
+                ]
+                LOG.info('Found floating reservations: %s' % floating_reserved)
 
-            for ip in leaks:
-                LOG.error('Leaked floating IP %s has been released.' % ip)
-                floating_network._release_inner(ip)
+                # Now the reverse check. Test if there are any reserved IPs which
+                # are not actually in use. Free any we find.
+                leaks = []
+                for ip in floating_network.get_in_use_addresses():
+                    if ip not in itertools.chain(floating_gateways,
+                                                 floating_addresses,
+                                                 floating_reserved):
+                        LOG.error('Floating IP %s has leaked.' % ip)
+
+                        # This IP needs to have been allocated more than 300 seconds
+                        # ago to ensure that the network setup isn't still queued.
+                        if time.time() - floating_network.get_allocation_age(ip) > 300:
+                            leaks.append(ip)
+
+                for ip in leaks:
+                    LOG.error('Leaked floating IP %s has been released.' % ip)
+                    floating_network._release_inner(ip)
 
     def _validate_mtus(self):
-        by_mtu = defaultdict(list)
-        for iface, mtu in util_network.get_interface_mtus():
-            by_mtu[mtu].append(iface)
+        last_loop = 0
 
-        for mtu in sorted(by_mtu):
-            log = LOG.with_fields({
-                'mtu': mtu,
-                'interfaces': by_mtu[mtu]
-            })
-            if mtu < 1501:
-                log.warning('Interface MTU is 1500 bytes or less')
-            else:
-                log.debug('Interface MTU is normal')
+        while not self.exit.is_set():
+            if time.time() - last_loop < 30:
+                time.sleep(1)
+                continue
+
+            last_loop = time.time()
+            LOG.info('Validating network interface MTUs')
+
+            by_mtu = defaultdict(list)
+            for iface, mtu in util_network.get_interface_mtus():
+                by_mtu[mtu].append(iface)
+
+            for mtu in sorted(by_mtu):
+                log = LOG.with_fields({
+                    'mtu': mtu,
+                    'interfaces': by_mtu[mtu]
+                })
+                if mtu < 1501:
+                    log.warning('Interface MTU is 1500 bytes or less')
+                else:
+                    log.debug('Interface MTU is normal')
 
     def run(self):
         LOG.info('Starting')
-        last_management = 0
         last_shutdown_notification = 0
 
         network_worker = None
@@ -439,31 +468,24 @@ class Monitor(daemon.WorkerPoolDaemon):
                         network_worker = self.start_workitem(
                             self._process_network_node_workitems, [], 'net-worker')
 
-                    if time.time() - last_management > 30:
-                        # Management tasks are treated as extra workers, and run in
-                        # parallel with other network work items.
-                        if stray_interface_worker not in worker_pids:
-                            LOG.info('Scanning for stray network interfaces')
-                            stray_interface_worker = self.start_workitem(
-                                self._remove_stray_interfaces, [], 'stray-nics')
+                    # Management tasks are treated as extra workers, and run in
+                    # parallel with other network work items.
+                    if stray_interface_worker not in worker_pids:
+                        stray_interface_worker = self.start_workitem(
+                            self._remove_stray_interfaces, [], 'stray-nics')
 
-                        if maintain_networks_worker not in worker_pids:
-                            LOG.info('Maintaining existing networks')
-                            maintain_networks_worker = self.start_workitem(
-                                self._maintain_networks, [], 'maintain')
+                    if maintain_networks_worker not in worker_pids:
+                        maintain_networks_worker = self.start_workitem(
+                            self._maintain_networks, [], 'maintain')
 
-                        if mtu_validation_worker not in worker_pids:
-                            LOG.info('Validating network interface MTUs')
-                            mtu_validation_worker = self.start_workitem(
-                                self._validate_mtus, [], 'mtus')
+                    if mtu_validation_worker not in worker_pids:
+                        mtu_validation_worker = self.start_workitem(
+                            self._validate_mtus, [], 'mtus')
 
-                        if config.NODE_IS_NETWORK_NODE:
-                            LOG.info('Reaping stray floating IPs')
-                            if floating_ip_reap_worker not in worker_pids:
-                                floating_ip_reap_worker = self.start_workitem(
-                                    self._reap_leaked_floating_ips, [], 'fip-reaper')
-
-                        last_management = time.time()
+                    if config.NODE_IS_NETWORK_NODE:
+                        if floating_ip_reap_worker not in worker_pids:
+                            floating_ip_reap_worker = self.start_workitem(
+                                self._reap_leaked_floating_ips, [], 'fip-reaper')
 
                 elif len(self.workers) > 0:
                     if time.time() - last_shutdown_notification > 5:

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -83,11 +83,10 @@ def handle(jobname, workitem):
                 image_fetch(task.url(), n, inst)
 
             elif isinstance(task, PreflightInstanceTask):
-                if (inst.state.value == dbo.STATE_DELETED or
-                        inst.state.value.endswith('-error')):
+                s = inst.state.value
+                if s == dbo.STATE_DELETED or s.endswith('-error'):
                     log_i.warning(
-                        'You cannot preflight an instance in state %s, skipping task'
-                        % inst.state.value)
+                        'You cannot preflight an instance in state %s, skipping task' % s)
                     continue
 
                 redirect_to = instance_preflight(inst, task.network())
@@ -98,11 +97,10 @@ def handle(jobname, workitem):
                     return
 
             elif isinstance(task, StartInstanceTask):
-                if (inst.state.value == dbo.STATE_DELETED or
-                        inst.state.value.endswith('-error')):
+                s = inst.state.value
+                if s == dbo.STATE_DELETED or s.endswith('-error'):
                     log_i.warning(
-                        'You cannot start an instance in state %s, skipping task'
-                        % inst.state.value)
+                        'You cannot start an instance in state %s, skipping task' % s)
                     continue
 
                 instance_start(inst, task.network())
@@ -126,8 +124,7 @@ def handle(jobname, workitem):
                 # This is a historical concept, it turns out the network node
                 # now just defers the delete task until there are no interfaces,
                 # so we don't need this at all.
-                etcd.enqueue(
-                    'networknode', DestroyNetworkTask(task.network_uuid()))
+                etcd.enqueue('networknode', DestroyNetworkTask(task.network_uuid()))
 
             elif isinstance(task, HypervisorDestroyNetworkTask):
                 n = network.Network.from_db(task.network_uuid())

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -42,6 +42,7 @@ LOG, _ = logs.setup(__name__)
 
 def handle(jobname, workitem):
     libvirt = util_libvirt.get_libvirt()
+    etcd.reset_client()
 
     log = LOG.with_fields({'workitem': jobname})
     log.info('Processing workitem')

--- a/shakenfist/daemons/queues.py
+++ b/shakenfist/daemons/queues.py
@@ -42,7 +42,6 @@ LOG, _ = logs.setup(__name__)
 
 def handle(jobname, workitem):
     libvirt = util_libvirt.get_libvirt()
-    etcd.reset_client()
 
     log = LOG.with_fields({'workitem': jobname})
     log.info('Processing workitem')

--- a/shakenfist/daemons/sidechannel.py
+++ b/shakenfist/daemons/sidechannel.py
@@ -10,6 +10,7 @@ import tempfile
 import time
 
 from shakenfist.daemons import daemon
+from shakenfist import etcd
 from shakenfist import eventlog
 from shakenfist.eventlog import EVENT_TYPE_AUDIT, EVENT_TYPE_STATUS
 from shakenfist import instance
@@ -210,6 +211,7 @@ class Monitor(daemon.Daemon):
     def monitor(self, instance_uuid):
         setproctitle.setproctitle(
             '%s-%s' % (daemon.process_name('sidechannel'), instance_uuid))
+        etcd.reset_client()
 
         inst = instance.Instance.from_db(instance_uuid)
         log_ctx = LOG.with_fields({'instance': instance_uuid})

--- a/shakenfist/daemons/transfers.py
+++ b/shakenfist/daemons/transfers.py
@@ -15,6 +15,7 @@ LOG, _ = logs.setup(__name__)
 
 
 def transfer_server(name, data):
+    etcd.reset_client()
     log = LOG.with_fields(data).with_fields({'name': name})
     try:
         server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -620,10 +620,13 @@ def _restart_queue(queuename):
 
 
 def get_outstanding_jobs():
-    for data, metadata in get_etcd_client().get_prefix(
+    # FIXME(mikal): excluded from using the thread local etcd client because
+    # the yield call interleaves with other etcd requests and causes the wrong
+    # data to be handed to the wrong caller.
+    for data, metadata in WrappedEtcdClient().get_prefix(
             '/sf/processing'):
         yield metadata['key'].decode('utf-8'), json.loads(data, object_hook=decodeTasks)
-    for data, metadata in get_etcd_client().get_prefix(
+    for data, metadata in WrappedEtcdClient().get_prefix(
             '/sf/queued'):
         yield metadata['key'].decode('utf-8'), json.loads(data, object_hook=decodeTasks)
 

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -110,6 +110,10 @@ def get_etcd_client():
     return c
 
 
+def reset_client():
+    local.sf_etcd_client = None
+
+
 # This read only cache is thread local, a bit like Flask's request object. Given
 # this is a read only cache, once you have set one of these up any attempt to
 # change or lock data will also result in an exception being raised. This is

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -559,14 +559,8 @@ def dequeue(queuename):
             'You cannot consume queue work items while using a read only cache')
 
     queue_path = _construct_key('queue', queuename, None)
+    client = get_etcd_client()
 
-    # FIXME(mikal): excluded from using the thread local etcd client because
-    # the iterator call interleaves with other etcd requests and causes the wrong
-    # data to be handed to the wrong caller.
-    client = WrappedEtcdClient()
-
-    # NOTE(mikal): limit is here to stop us returning with an unfinished
-    # iterator.
     for data, metadata in client.get_prefix(queue_path, sort_order='ascend',
                                             sort_target='key', limit=1):
         jobname = str(metadata['key']).split('/')[-1].rstrip("'")

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -49,7 +49,8 @@ class WrappedEtcdClient(Etcd3Client):
         self.cert_cert = cert_cert
         self.timeout = timeout
 
-        LOG.info('Building new etcd connection')
+        if config.LOG_ETCD_CONNECTIONS:
+            LOG.info('Building new etcd connection')
         return super(WrappedEtcdClient, self).__init__(
             host=host, port=port, protocol=protocol, ca_cert=ca_cert,
             cert_key=cert_key, cert_cert=cert_cert, timeout=timeout,

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -337,7 +337,7 @@ def get_lock(objecttype, subtype, name, ttl=60, timeout=10, log_ctx=LOG,
     # it is causing locking errors for reasons that are not currently clear to
     # me.
     return ActualLock(objecttype, subtype, name, ttl=ttl,
-                      client=WrappedEtcdClient(),
+                      client=get_etcd_client(),
                       log_ctx=log_ctx, timeout=timeout, op=op)
 
 

--- a/shakenfist/images.py
+++ b/shakenfist/images.py
@@ -247,7 +247,7 @@ class ImageFetchHelper(object):
         elif cached_remotely:
             remote_blob = blob.Blob.from_db(cached_remotely)
             if not remote_blob:
-                raise exceptions.blob.BlobMissing(cached_remotely)
+                raise exceptions.BlobMissing(cached_remotely)
             remote_blob.ensure_local([lock], instance_object=self.instance)
 
             cache_path = os.path.join(
@@ -308,7 +308,7 @@ class ImageFetchHelper(object):
 
         b = blob.Blob.from_db(blob_uuid)
         if not b:
-            raise exceptions.blob.BlobMissing(blob_uuid)
+            raise exceptions.BlobMissing(blob_uuid)
 
         b.ensure_local([lock], instance_object=self.instance)
         return b
@@ -329,7 +329,7 @@ class ImageFetchHelper(object):
                 b = blob.http_fetch(
                     url, resp, blob_uuid, [lock], self.log, checksum,
                     checksum_type, instance_object=instance_object)
-            except exceptions.BadChecksum as e:
+            except exceptions.BadCheckSum as e:
                 self.instance.add_event(
                     EVENT_TYPE_AUDIT, 'fetched image had bad checksum')
                 self.artifact.add_event(

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -664,7 +664,7 @@ class Instance(dbo):
 
         # Remove this instance from the cache of instances on a node
         if self.placement:
-            n = Node.from_db(self.placement)
+            n = Node.from_db(self.placement['node'])
             if n:
                 n.remove_instance(self.uuid)
 

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -87,17 +87,10 @@ class Instance(dbo):
     STATE_CREATED_ERROR = 'created-error'
     STATE_DELETE_WAIT_ERROR = 'delete-wait-error'
 
-    ACTIVE_STATES = set([dbo.STATE_INITIAL,
-                         STATE_INITIAL_ERROR,
-                         STATE_PREFLIGHT,
-                         STATE_PREFLIGHT_ERROR,
-                         dbo.STATE_CREATING,
-                         STATE_CREATING_ERROR,
-                         dbo.STATE_CREATED,
-                         dbo.STATE_DELETE_WAIT,
-                         STATE_CREATED_ERROR,
-                         dbo.STATE_ERROR
-                         ])
+    ACTIVE_STATES = {dbo.STATE_INITIAL, STATE_INITIAL_ERROR, STATE_PREFLIGHT,
+                     STATE_PREFLIGHT_ERROR, dbo.STATE_CREATING, STATE_CREATING_ERROR,
+                     dbo.STATE_CREATED, dbo.STATE_DELETE_WAIT, STATE_CREATED_ERROR,
+                     dbo.STATE_ERROR}
 
     state_targets = {
         None: (dbo.STATE_INITIAL, dbo.STATE_ERROR),

--- a/shakenfist/namespace.py
+++ b/shakenfist/namespace.py
@@ -19,7 +19,7 @@ class Namespace(dbo):
     object_type = 'namespace'
     current_version = 5
 
-    ACTIVE_STATES = set([dbo.STATE_CREATED])
+    ACTIVE_STATES = {dbo.STATE_CREATED}
 
     state_targets = {
         None: (dbo.STATE_CREATED),

--- a/shakenfist/networkinterface.py
+++ b/shakenfist/networkinterface.py
@@ -178,6 +178,10 @@ def network_filter(network, ni):
     return network.uuid == ni.network_uuid
 
 
+def network_uuid_filter(network_uuid, ni):
+    return network_uuid == ni.network_uuid
+
+
 # Convenience helpers
 def interfaces_for_instance(instance):
     nis = {}

--- a/shakenfist/node.py
+++ b/shakenfist/node.py
@@ -25,7 +25,7 @@ class Node(dbo):
     STATE_STOPPING = 'stopping'
     STATE_STOPPED = 'stopped'
 
-    ACTIVE_STATES = set([dbo.STATE_CREATED])
+    ACTIVE_STATES = {dbo.STATE_CREATED}
 
     state_targets = {
         None: (dbo.STATE_CREATED, dbo.STATE_ERROR, STATE_MISSING),

--- a/shakenfist/node.py
+++ b/shakenfist/node.py
@@ -18,6 +18,7 @@ LOG, _ = logs.setup(__name__)
 
 class Node(dbo):
     object_type = 'node'
+    initial_version = 2
     current_version = 3
 
     # docs/development/state_machine.md has a description of these states.

--- a/shakenfist/tests/mock_etcd.py
+++ b/shakenfist/tests/mock_etcd.py
@@ -45,7 +45,7 @@ class MockEtcd():
         self.node_names = [n[0] for n in self.nodes]
 
     def setup(self):
-        # Mock WrappedEtcdClient
+        # Mock WrappedEtcdClient()
         self.etcd_create = mock.patch('shakenfist.etcd.WrappedEtcdClient.create',
                                       side_effect=self.create)
         self.etcd_create.start()

--- a/shakenfist/tests/test_etcd.py
+++ b/shakenfist/tests/test_etcd.py
@@ -37,7 +37,7 @@ class ActualLockTestCase(base.ShakenFistTestCase):
         self.assertEqual('/sflocks/sf/instance/auuid', al.key)
         self.assertEqual('instance', al.objecttype)
         self.assertEqual('auuid', al.objectname)
-        self.assertEqual(1000000000, al.timeout)
+        self.assertEqual(120, al.timeout)
         self.assertEqual('Test case', al.operation)
         self.assertEqual(
             json.dumps({

--- a/shakenfist/tests/test_net.py
+++ b/shakenfist/tests/test_net.py
@@ -44,7 +44,7 @@ class NetworkGeneralTestCase(NetworkTestCase):
             'mesh_nic': 'eth0',
             'mesh_nic': 'eth0',
             'netblock': '192.168.1.0/24',
-            'version': 3
+            'version': 4
         })
 
     def test_str(self):
@@ -58,7 +58,7 @@ class NetworkGeneralTestCase(NetworkTestCase):
             'egress_nic': 'eth0',
             'mesh_nic': 'eth0',
             'netblock': '192.168.1.0/24',
-            'version': 3
+            'version': 4
         })
         self.assertEqual('network(notauuid)', str(n))
 
@@ -89,7 +89,7 @@ class NetworkNormalNodeTestCase(NetworkTestCase):
             'egress_nic': 'eth0',
             'mesh_nic': 'eth0',
             'netblock': '192.168.1.0/24',
-            'version': 3
+            'version': 4
         })
         self.assertTrue(n.is_okay())
 
@@ -106,7 +106,7 @@ class NetworkNormalNodeTestCase(NetworkTestCase):
             'egress_nic': 'eth0',
             'mesh_nic': 'eth0',
             'netblock': '192.168.1.0/24',
-            'version': 3
+            'version': 4
         })
         self.assertFalse(n.is_okay())
 
@@ -127,7 +127,7 @@ class NetworkNormalNodeTestCase(NetworkTestCase):
             'egress_nic': 'eth0',
             'mesh_nic': 'eth0',
             'netblock': '192.168.1.0/24',
-            'version': 3
+            'version': 4
         })
         self.assertFalse(n.is_okay())
 
@@ -160,7 +160,7 @@ class NetworkNetNodeTestCase(NetworkTestCase):
             'egress_nic': 'eth0',
             'mesh_nic': 'eth0',
             'netblock': '192.168.1.0/24',
-            'version': 3
+            'version': 4
         })
         self.assertTrue(n.is_okay())
 
@@ -177,7 +177,7 @@ class NetworkNetNodeTestCase(NetworkTestCase):
             'egress_nic': 'eth0',
             'mesh_nic': 'eth0',
             'netblock': '192.168.1.0/24',
-            'version': 3
+            'version': 4
         })
         self.assertFalse(n.is_okay())
 
@@ -194,7 +194,7 @@ class NetworkNetNodeTestCase(NetworkTestCase):
             'egress_nic': 'eth0',
             'mesh_nic': 'eth0',
             'netblock': '192.168.1.0/24',
-            'version': 3
+            'version': 4
         })
         self.assertFalse(n.is_okay())
 
@@ -211,7 +211,7 @@ class NetworkNetNodeTestCase(NetworkTestCase):
             'egress_nic': 'eth0',
             'mesh_nic': 'eth0',
             'netblock': '192.168.1.0/24',
-            'version': 3
+            'version': 4
         })
         self.assertTrue(n.is_okay())
 
@@ -244,7 +244,7 @@ class NetworkNetNodeTestCase(NetworkTestCase):
             'egress_nic': 'eth0',
             'mesh_nic': 'eth0',
             'netblock': '192.168.1.0/24',
-            'version': 3
+            'version': 4
         })
         self.assertTrue(n.is_created())
 
@@ -273,7 +273,7 @@ class NetworkNetNodeTestCase(NetworkTestCase):
             'egress_nic': 'eth0',
             'mesh_nic': 'eth0',
             'netblock': '192.168.1.0/24',
-            'version': 3
+            'version': 4
         })
         self.assertFalse(n.is_created())
 
@@ -290,10 +290,11 @@ class NetworkNetNodeTestCase(NetworkTestCase):
             'egress_nic': 'eth0',
             'mesh_nic': 'eth0',
             'netblock': '192.168.1.0/24',
-            'version': 3
+            'version': 4
         })
         self.assertFalse(n.is_created())
 
+    @mock.patch('shakenfist.cache.update_object_state_cache')
     @mock.patch('shakenfist.db.get_lock')
     @mock.patch('shakenfist.network.Network._db_get_attribute',
                 side_effect=[
@@ -307,7 +308,8 @@ class NetworkNetNodeTestCase(NetworkTestCase):
     @mock.patch('shakenfist.network.Network._db_set_attribute')
     @mock.patch('shakenfist.etcd.put')
     def test_set_state_valid(
-            self, mock_put, mock_attribute_set, mock_state_get, mock_lock):
+            self, mock_put, mock_attribute_set, mock_state_get, mock_lock,
+            mock_cache_update):
 
         n = network.Network({
             'uuid': '8abbc9a6-d923-4441-b498-4f8e3c166804',
@@ -319,7 +321,7 @@ class NetworkNetNodeTestCase(NetworkTestCase):
             'egress_nic': 'eth0',
             'mesh_nic': 'eth0',
             'netblock': '192.168.1.0/24',
-            'version': 3
+            'version': 4
         })
         with testtools.ExpectedException(exceptions.InvalidStateException):
             n.state = network.Network.STATE_INITIAL

--- a/shakenfist/upload.py
+++ b/shakenfist/upload.py
@@ -23,7 +23,7 @@ class Upload(dbo):
         dbo.STATE_DELETED: (),
     }
 
-    ACTIVE_STATES = set([dbo.STATE_CREATED])
+    ACTIVE_STATES = {dbo.STATE_CREATED}
 
     def __init__(self, static_values):
         self.upgrade(static_values)


### PR DESCRIPTION
We had a fundamental problem with our etcd client implementation -- we created a new TCP connection for each and every request. In a v0.6 Debian 11 Slim Primary test run I instrumented, that resulted in over 800,000 TCP connections to etcd, which explains why sometimes it would respond with ConnectionRefused.

Refactor to avoid those extra connections, and get down to about 1,500 in the same scenario. Add CI to ensure we don't creep back up again.

This also means we don't need the RAM disk for etcd in CI any more, and can reduce our memory allocation to primary nodes (that run etcd).