### PR TITLE
v0.6 CI no longer files issues for failures.

### DIFF
--- a/.github/workflows/configure-tests.py
+++ b/.github/workflows/configure-tests.py
@@ -3,26 +3,6 @@
 import jinja2
 
 JOBS = {
-    'ci-images': [
-        {
-            'name': 'debian-10',
-            'baseimage': 'debian:10',
-            'baseuser': 'debian',
-            'outputlabel': 'ci-images/debian-10'
-        },
-        {
-            'name': 'debian-11',
-            'baseimage': 'debian:11',
-            'baseuser': 'debian',
-            'outputlabel': 'ci-images/debian-11'
-        },
-        {
-            'name': 'ubuntu-2004',
-            'baseimage': 'ubuntu:20.04',
-            'baseuser': 'ubuntu',
-            'outputlabel': 'ci-images/ubuntu-2004'
-        },
-    ],
     'functional-tests': [
         {
             'name': 'debian-10-localhost',

--- a/.github/workflows/scheduled-tests-develop-debian-10-localhost.yml
+++ b/.github/workflows/scheduled-tests-develop-debian-10-localhost.yml
@@ -223,19 +223,3 @@ jobs:
           name: bundle.zip
           retention-days: 14
           path: ${{ github.workspace }}/artifacts/bundle.zip
-
-      - uses: JasonEtco/create-an-issue@v2
-        if: failure()
-        id: create-issue
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SF_CI_NAME: develop-debian-10-localhost
-          SF_BRANCH: develop
-          SF_ACTION_RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          filename: shakenfist/.github/workflows/scheduled-tests-failure.md
-          update_existing: true
-          search_existing: open
-
-      - if: failure()
-        run: 'echo Created ${{ steps.create-issue.outputs.url }}'

--- a/.github/workflows/scheduled-tests-develop-debian-11-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-develop-debian-11-slim-primary.yml
@@ -223,19 +223,3 @@ jobs:
           name: bundle.zip
           retention-days: 14
           path: ${{ github.workspace }}/artifacts/bundle.zip
-
-      - uses: JasonEtco/create-an-issue@v2
-        if: failure()
-        id: create-issue
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SF_CI_NAME: develop-debian-11-slim-primary
-          SF_BRANCH: develop
-          SF_ACTION_RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          filename: shakenfist/.github/workflows/scheduled-tests-failure.md
-          update_existing: true
-          search_existing: open
-
-      - if: failure()
-        run: 'echo Created ${{ steps.create-issue.outputs.url }}'

--- a/.github/workflows/scheduled-tests-develop-ubuntu-2004-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-develop-ubuntu-2004-slim-primary.yml
@@ -223,19 +223,3 @@ jobs:
           name: bundle.zip
           retention-days: 14
           path: ${{ github.workspace }}/artifacts/bundle.zip
-
-      - uses: JasonEtco/create-an-issue@v2
-        if: failure()
-        id: create-issue
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SF_CI_NAME: develop-ubuntu-2004-slim-primary
-          SF_BRANCH: develop
-          SF_ACTION_RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          filename: shakenfist/.github/workflows/scheduled-tests-failure.md
-          update_existing: true
-          search_existing: open
-
-      - if: failure()
-        run: 'echo Created ${{ steps.create-issue.outputs.url }}'

--- a/.github/workflows/scheduled-tests-v06-debian-10-localhost.yml
+++ b/.github/workflows/scheduled-tests-v06-debian-10-localhost.yml
@@ -223,19 +223,3 @@ jobs:
           name: bundle.zip
           retention-days: 14
           path: ${{ github.workspace }}/artifacts/bundle.zip
-
-      - uses: JasonEtco/create-an-issue@v2
-        if: failure()
-        id: create-issue
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SF_CI_NAME: v06-debian-10-localhost
-          SF_BRANCH: v0.6-releases
-          SF_ACTION_RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          filename: shakenfist/.github/workflows/scheduled-tests-failure.md
-          update_existing: true
-          search_existing: open
-
-      - if: failure()
-        run: 'echo Created ${{ steps.create-issue.outputs.url }}'

--- a/.github/workflows/scheduled-tests-v06-debian-11-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-debian-11-slim-primary.yml
@@ -223,19 +223,3 @@ jobs:
           name: bundle.zip
           retention-days: 14
           path: ${{ github.workspace }}/artifacts/bundle.zip
-
-      - uses: JasonEtco/create-an-issue@v2
-        if: failure()
-        id: create-issue
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SF_CI_NAME: v06-debian-11-slim-primary
-          SF_BRANCH: v0.6-releases
-          SF_ACTION_RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          filename: shakenfist/.github/workflows/scheduled-tests-failure.md
-          update_existing: true
-          search_existing: open
-
-      - if: failure()
-        run: 'echo Created ${{ steps.create-issue.outputs.url }}'

--- a/.github/workflows/scheduled-tests-v06-released-debian-10-localhost.yml
+++ b/.github/workflows/scheduled-tests-v06-released-debian-10-localhost.yml
@@ -223,19 +223,3 @@ jobs:
           name: bundle.zip
           retention-days: 14
           path: ${{ github.workspace }}/artifacts/bundle.zip
-
-      - uses: JasonEtco/create-an-issue@v2
-        if: failure()
-        id: create-issue
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SF_CI_NAME: v06-released-debian-10-localhost
-          SF_BRANCH: v0.6-releases
-          SF_ACTION_RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          filename: shakenfist/.github/workflows/scheduled-tests-failure.md
-          update_existing: true
-          search_existing: open
-
-      - if: failure()
-        run: 'echo Created ${{ steps.create-issue.outputs.url }}'

--- a/.github/workflows/scheduled-tests-v06-released-debian-11-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-released-debian-11-slim-primary.yml
@@ -223,19 +223,3 @@ jobs:
           name: bundle.zip
           retention-days: 14
           path: ${{ github.workspace }}/artifacts/bundle.zip
-
-      - uses: JasonEtco/create-an-issue@v2
-        if: failure()
-        id: create-issue
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SF_CI_NAME: v06-released-debian-11-slim-primary
-          SF_BRANCH: v0.6-releases
-          SF_ACTION_RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          filename: shakenfist/.github/workflows/scheduled-tests-failure.md
-          update_existing: true
-          search_existing: open
-
-      - if: failure()
-        run: 'echo Created ${{ steps.create-issue.outputs.url }}'

--- a/.github/workflows/scheduled-tests-v06-released-ubuntu-2004-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-released-ubuntu-2004-slim-primary.yml
@@ -223,19 +223,3 @@ jobs:
           name: bundle.zip
           retention-days: 14
           path: ${{ github.workspace }}/artifacts/bundle.zip
-
-      - uses: JasonEtco/create-an-issue@v2
-        if: failure()
-        id: create-issue
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SF_CI_NAME: v06-released-ubuntu-2004-slim-primary
-          SF_BRANCH: v0.6-releases
-          SF_ACTION_RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          filename: shakenfist/.github/workflows/scheduled-tests-failure.md
-          update_existing: true
-          search_existing: open
-
-      - if: failure()
-        run: 'echo Created ${{ steps.create-issue.outputs.url }}'

--- a/.github/workflows/scheduled-tests-v06-ubuntu-2004-slim-primary.yml
+++ b/.github/workflows/scheduled-tests-v06-ubuntu-2004-slim-primary.yml
@@ -223,19 +223,3 @@ jobs:
           name: bundle.zip
           retention-days: 14
           path: ${{ github.workspace }}/artifacts/bundle.zip
-
-      - uses: JasonEtco/create-an-issue@v2
-        if: failure()
-        id: create-issue
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SF_CI_NAME: v06-ubuntu-2004-slim-primary
-          SF_BRANCH: v0.6-releases
-          SF_ACTION_RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          filename: shakenfist/.github/workflows/scheduled-tests-failure.md
-          update_existing: true
-          search_existing: open
-
-      - if: failure()
-        run: 'echo Created ${{ steps.create-issue.outputs.url }}'

--- a/.github/workflows/scheduled-tests.tmpl
+++ b/.github/workflows/scheduled-tests.tmpl
@@ -223,19 +223,3 @@ jobs:
           name: bundle.zip
           retention-days: 14
           path: {% raw %}${{{% endraw %} github.workspace {% raw %}}}{% endraw %}/artifacts/bundle.zip
-
-      - uses: JasonEtco/create-an-issue@v2
-        if: failure()
-        id: create-issue
-        env:
-          GITHUB_TOKEN: {% raw %}${{{% endraw %} secrets.GITHUB_TOKEN {% raw %}}}{% endraw %}
-          SF_CI_NAME: {{name}}
-          SF_BRANCH: {{branch}}
-          SF_ACTION_RUN: {% raw %}${{{% endraw %} github.server_url {% raw %}}}{% endraw %}/{% raw %}${{{% endraw %} github.repository {% raw %}}}{% endraw %}/actions/runs/{% raw %}${{{% endraw %} github.run_id {% raw %}}}{% endraw %}
-        with:
-          filename: shakenfist/.github/workflows/scheduled-tests-failure.md
-          update_existing: true
-          search_existing: open
-
-      - if: failure()
-        run: 'echo Created {% raw %}${{{% endraw %} steps.create-issue.outputs.url {% raw %}}}{% endraw %}'


### PR DESCRIPTION
As I get closer to releasing v0.7, and the code bases diverge more and more, CI failures from v0.6 are no longer particularly helpful.