### PR TITLE
Disallow etcd locking while producing an artifact external view.

### DIFF
--- a/shakenfist/artifact.py
+++ b/shakenfist/artifact.py
@@ -199,6 +199,7 @@ class Artifact(dbo):
         })
         return out
 
+    @etcd.disallow_locking
     def external_view(self):
         # If this is an external view, then mix back in attributes that users
         # expect

--- a/shakenfist/exceptions.py
+++ b/shakenfist/exceptions.py
@@ -15,7 +15,7 @@ class NoEtcd(Exception):
     ...
 
 
-# Objects
+# Code quality
 class ObjectException(Exception):
     ...
 
@@ -33,6 +33,10 @@ class MultipleObjects(ObjectException):
 
 
 class UpgradeException(ObjectException):
+    ...
+
+
+class LocksDisallowedException(ObjectException):
     ...
 
 


### PR DESCRIPTION
This is part of chasing why listing relatively small numbers of artifacts is slow slow it causes API timeouts. It turns out getting the artifact objects from etcd isn't the slow bit, its producing the external views for the artifacts. Are we holding lots of locks or something?

Hopefully progresses #1974.