### PR TITLE
Pin requests to a newer version to avoid appengine errors.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,11 @@ symbolicmode>=1.0           # CC0 1.0 Universal (CC0 1.0) Public Domain Dedicati
 pydantic                    # mit
 pydantic-settings           # mit
 
+requests>=2.31.0            # apache2
+requests_toolbelt>=1.0.0    # apache2
+chardet>=5.1.0              # lgpl -- required by requests with this version pin
+urllib3>=1.26.14            # mit -- required by requests with this version pin
+
 # Is difficult to get install working, use system packages instead. On Ubuntu
 # those are: libvirt-daemon-system libvirt-dev python3-libvirt
 #libvirt-python      # lgpl


### PR DESCRIPTION
Specifically, I was seeing:

Traceback (most recent call last):
File "/usr/bin/twine", line 33, in
sys.exit(load_entry_point('twine==3.3.0', 'console_scripts', 'twine')()) File "/usr/bin/twine", line 25, in importlib_load_entry_point return next(matches).load()
File "/usr/lib/python3.9/importlib/metadata.py", line 77, in load module = import_module(match.group('module'))
File "/usr/lib/python3.9/importlib/init.py", line 127, in import_module return _bootstrap._gcd_import(name[level:], package, level) File "", line 1030, in _gcd_import
File "", line 1007, in _find_and_load
File "", line 986, in _find_and_load_unlocked
File "", line 680, in _load_unlocked
File "", line 790, in exec_module
File "", line 228, in _call_with_frames_removed
File "/usr/lib/python3/dist-packages/twine/main.py", line 22, in from twine import cli
File "/usr/lib/python3/dist-packages/twine/cli.py", line 20, in import requests_toolbelt
File "/usr/lib/python3/dist-packages/requests_toolbelt/init.py", line 12, in from .adapters import SSLAdapter, SourceAddressAdapter File "/usr/lib/python3/dist-packages/requests_toolbelt/adapters/init.py", line 12, in from .ssl import SSLAdapter
File "/usr/lib/python3/dist-packages/requests_toolbelt/adapters/ssl.py", line 16, in from .._compat import poolmanager
File "/usr/lib/python3/dist-packages/requests_toolbelt/_compat.py", line 50, in from urllib3.contrib import appengine as gaecontrib ImportError: cannot import name 'appengine' from 'urllib3.contrib' (/usr/local/lib/python3.9/dist-packages/urllib3/contrib/init.py)