### PR TITLE
Refresh the block_devices lock as well.

### DIFF
--- a/deploy/ansible/deploy.yml
+++ b/deploy/ansible/deploy.yml
@@ -997,7 +997,7 @@
         group: root
         mode: "0644"
 
-- hosts: hypervisors, network_node, etcd_master, storage
+- hosts: hypervisors, network_node, etcd_master, storage, primary_node
   any_errors_fatal: true
   become: yes
   become_method: sudo

--- a/deploy/shakenfist_ci/tests/test_state_changes.py
+++ b/deploy/shakenfist_ci/tests/test_state_changes.py
@@ -151,8 +151,7 @@ class TestStateChanges(base.BaseNamespacedTestCase):
 
         # Unpause
         self.test_client.unpause_instance(inst['uuid'])
-        # No new login prompt after unpause, so just forgive a few fails while
-        # the instance is un-paused.
+        self._await_instance_ready(inst['uuid'])
         self._test_ping(inst['uuid'], self.net['uuid'], ip, 0, 10)
 
 

--- a/shakenfist/baseobject.py
+++ b/shakenfist/baseobject.py
@@ -334,13 +334,14 @@ class DatabaseBackedObject(object):
         return etcd.get_lock(self.object_type, subtype, self.uuid, ttl=ttl,
                              log_ctx=self.log, op=op, timeout=timeout)
 
-    def get_lock_attr(self, name, op):
+    def get_lock_attr(self, name, op, ttl=60, timeout=10):
         # There is no point locking in-memory objects
         if self.in_memory_only:
             return NoopLock()
 
         return etcd.get_lock('attribute/%s' % self.object_type,
-                             self.__uuid, name, op=op, log_ctx=self.log)
+                             self.__uuid, name, op=op, ttl=ttl, timeout=timeout,
+                             log_ctx=self.log)
 
     # Properties common to all objects which are routed to attributes
     @property

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -788,7 +788,8 @@ class Instance(dbo):
         self._db_delete_attribute('ports')
 
     def _configure_block_devices(self, lock):
-        with self.get_lock_attr('block_devices', 'Initialize block devices') as bd_lock:
+        with self.get_lock_attr(
+                'block_devices', 'Initialize block devices', ttl=300) as bd_lock:
             # Locks to refresh
             locks = [bd_lock]
             if lock:


### PR DESCRIPTION
Fixes #2186, where we refreshed the callers locks but not our own, which meant sometimes our lock expired.