### PR TITLE
Drop the old etcd3 client.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ flask==3.0.1                       # bsd
 flask-restful==0.3.10              # bsd
 flasgger==0.9.7.1                  # mit
 prometheus-client==0.19.0          # apache2
-etcd3==0.12.0                      # apache2
 etcd3gw==2.3.0                     # apache2
 flask-jwt-extended==4.6.0          # mit
 bcrypt==4.1.2                      # apache2

--- a/shakenfist/etcd.py
+++ b/shakenfist/etcd.py
@@ -164,14 +164,14 @@ class ActualLock(Lock):
 
     @retry_etcd_forever
     def get_holder(self, key_prefix=''):
-        value = get_etcd_client().get(self.key, metadata=True)
+        value = get_etcd_client().get(self.key)
         if value is None or len(value) == 0:
             return {'holder': None}
 
         if not value[0][0]:
             return {'holder': None}
 
-        holder = json.loads(value[0][0])
+        holder = json.loads(value[0])
         if key_prefix:
             new_holder = {}
             for key in holder:
@@ -341,19 +341,19 @@ def create(objecttype, subtype, name, data, ttl=None):
 
 @retry_etcd_forever
 def get_raw(path):
-    value = get_etcd_client().get(path, metadata=True)
+    value = get_etcd_client().get(path)
     if value is None or len(value) == 0:
         return None
-    return json.loads(value[0][0])
+    return json.loads(value[0])
 
 
 @retry_etcd_forever
 def get(objecttype, subtype, name):
     path = _construct_key(objecttype, subtype, name)
-    value = get_etcd_client().get(path, metadata=True)
+    value = get_etcd_client().get(path)
     if value is None or len(value) == 0:
         return None
-    return json.loads(value[0][0])
+    return json.loads(value[0])
 
 
 @retry_etcd_forever

--- a/shakenfist/tests/mock_etcd.py
+++ b/shakenfist/tests/mock_etcd.py
@@ -116,7 +116,11 @@ class MockEtcd():
         self._trace('MockEtcd.get() retrieving data for key %s: %s' % (path, d))
         if not d:
             return None
-        return [[d]]
+
+        if metadata:
+            return [[d]]
+        else:
+            return [d]
 
     def get_prefix(self, path, sort_order=None, sort_target=None, limit=0):
         ret = []

--- a/shakenfist/tests/test_instance.py
+++ b/shakenfist/tests/test_instance.py
@@ -116,8 +116,7 @@ class InstanceTestCase(base.ShakenFistTestCase):
             ETCD_HOST='127.0.0.1'
         )
 
-        self.config = mock.patch('shakenfist.instance.config',
-                                 fake_config)
+        self.config = mock.patch('shakenfist.instance.config', fake_config)
         self.mock_config = self.config.start()
         self.addCleanup(self.config.stop)
 

--- a/shakenfist/tests/test_net.py
+++ b/shakenfist/tests/test_net.py
@@ -24,10 +24,6 @@ class NetworkTestCase(base.ShakenFistTestCase):
         self.mock_ipmanager_persist = self.ipmanager_persist.start()
         self.addCleanup(self.ipmanager_persist.stop)
 
-        self.etcd_client = mock.patch('etcd3.client')
-        self.mock_etcd_client = self.etcd_client.start()
-        self.addCleanup(self.etcd_client.stop)
-
         self.etcd_lock = mock.patch('shakenfist.etcd.ActualLock')
         self.mock_etcd_lock = self.etcd_lock.start()
         self.addCleanup(self.etcd_lock.stop)


### PR DESCRIPTION
This means we wont be pinned to such an old grpc implementation. It does imply that we do compactions a little bit differently, but its not too bad.

At the same time, stop fetching metadata we're not using from etcd.

All of this is because it looks like #2242 might be related to etcd load...