### PR TITLE
Handle UUIDs from the blob hash cache correctly.

### DIFF
--- a/shakenfist/external_api/blob.py
+++ b/shakenfist/external_api/blob.py
@@ -249,7 +249,10 @@ class BlobChecksumsEndpoint(sf_api.Resource):
             return sf_api.error(400, 'you must specify a hash')
 
         blobs = cache.search_blob_hash_cache('sha512', hash)
-        for b in blobs:
+        for blob_uuid in blobs:
+            b = Blob.from_db(blob_uuid)
+            if not b:
+                continue
             if not b.state.value == dbo.STATE_CREATED:
                 continue
 

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -626,7 +626,7 @@ class Instance(dbo):
         block_devices['finalized'] = False
 
         # Increment blob references
-        self.blob_references = blob_refs
+        self.blob_references = dict(blob_refs)
         for blob_uuid in blob_refs:
             b = blob.Blob.from_db(blob_uuid)
             b.ref_count_inc(self, blob_refs[blob_uuid])
@@ -924,6 +924,9 @@ class Instance(dbo):
                             backing_chain = []
                             backing_uuid = disk['blob_uuid']
                             while backing_uuid:
+                                self.log.with_fields(disk).with_fields({
+                                    'backing_uuid': backing_uuid
+                                }).info('traversing backing blob')
                                 backing_path = os.path.join(
                                     config.STORAGE_PATH, 'image_cache', backing_uuid + '.qcow2')
                                 backing_chain.append(backing_path)


### PR DESCRIPTION
Specifically, this is sad:

```
sf-1 ERROR gunicorn: worker [sf-api][3532632] Server error Traceback (most recent call last):
sf-1   File ".../shakenfist_utilities/api.py", line 124, in wrapper
sf-1     return func(*args, **kwargs)
sf-1   File ".../flasgger/utils.py", line 305, in wrapper
sf-1     return function(*args, **kwargs)
sf-1   File ".../shakenfist/external_api/base.py", line 165, in wrapper
sf-1     return func(*args, **kwargs)
sf-1   File ".../shakenfist/external_api/base.py", line 188, in wrapper
sf-1     return func(*args, **kwargs)
sf-1   File ".../shakenfist/external_api/blob.py", line 253, in get
sf-1     if not b.state.value == dbo.STATE_CREATED:
sf-1 AttributeError: 'str' object has no attribute 'state'
```