### PR TITLE
Add exception tracking to record unhandled exceptions.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -537,7 +537,7 @@ jobs:
     name: "Automated exception fixer"
     runs-on: [self-hosted, claude-code]
     needs: functional_matrix_pr
-    if: ${{ always() && contains(needs.functional_matrix_pr.outputs.check_logs_failed, 'true') }}
+    if: ${{ !cancelled() && contains(needs.functional_matrix_pr.outputs.check_logs_failed, 'true') }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-exception-fixer
       cancel-in-progress: true

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -18,6 +18,7 @@ jobs:
   # These sanity checks used to be three separate jobs, but are now combined
   # to save a little time and reduce CI runner churn.
   sanity_checks:
+    name: "Sanity checks"
     runs-on: [self-hosted, vm, debian-12]
     needs: enqueue_pr_comment
     outputs:
@@ -155,9 +156,9 @@ jobs:
   # Uses always() so it runs even when sanity_checks fails.
   # Skip if the last commit was from the bot to prevent infinite loops.
   automated_delinter:
+    name: "Automated delinter"
     runs-on: [self-hosted, claude-code]
     needs: sanity_checks
-    name: "Automated delinter"
     if: ${{ always() && needs.sanity_checks.outputs.flake8_failed == 'true' }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-delinter
@@ -198,10 +199,10 @@ jobs:
           tools/fix-lint-with-claude.sh --ci
 
   functional_matrix_pr:
+    name: "${{ matrix.pr.name }}"
     if: always() && github.event_name != 'merge_group'
     runs-on: [self-hosted, vm, debian-12]
     needs: enqueue_pr_comment
-    name: "${{ matrix.os.description }}"
     outputs:
       # For matrix jobs, we use a JSON object keyed by job_name. Each matrix run
       # sets its own key, and the outputs get merged. The consuming job can then
@@ -210,9 +211,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [
+        pr: [
           {
-            description: 'smoke',
+            name: 'smoke',
             job_name: 'smoke',
             base_image: 'sf://label/ci-images/debian-12',
             base_image_user: 'debian',
@@ -222,17 +223,17 @@ jobs:
           },
         ]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os.job_name }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.pr.job_name }}
       cancel-in-progress: true
 
     steps:
       - name: Log matrix details
         run: |
-          echo "job_name: ${{ matrix.os.job_name }}"
-          echo "base_image: ${{ matrix.os.base_image }}"
-          echo "base_image_user: ${{ matrix.os.base_image_user }}"
-          echo "topology: ${{ matrix.os.topology }}"
-          echo "concurrency: ${{ matrix.os.concurrency }}"
+          echo "job_name: ${{ matrix.pr.job_name }}"
+          echo "base_image: ${{ matrix.pr.base_image }}"
+          echo "base_image_user: ${{ matrix.pr.base_image_user }}"
+          echo "topology: ${{ matrix.pr.topology }}"
+          echo "concurrency: ${{ matrix.pr.concurrency }}"
 
       - name: Setup test environment
         uses: shakenfist/actions/setup-test-environment@main
@@ -242,10 +243,10 @@ jobs:
           cd ${GITHUB_WORKSPACE}/actions
           ansible-playbook -i /home/debian/ansible-hosts \
               --extra-vars "identifier=${SHAKENFIST_NAMESPACE} \
-              base_image=${{ matrix.os.base_image }} base_image_user=${{ matrix.os.base_image_user }}" \
-              ansible/ci-topology-${{ matrix.os.topology }}.yml
+              base_image=${{ matrix.pr.base_image }} base_image_user=${{ matrix.pr.base_image_user }}" \
+              ansible/ci-topology-${{ matrix.pr.topology }}.yml
 
-          if [ "${{ matrix.os.topology }}" == "localhost" ]; then
+          if [ "${{ matrix.pr.topology }}" == "localhost" ]; then
             echo "UPLOAD_TARGET=10.0.0.10" >> $GITHUB_ENV
           else
             nodes=(10.0.0.20 10.0.0.21 10.0.0.22 10.0.0.23 10.0.0.24)
@@ -269,13 +270,13 @@ jobs:
           cd ${GITHUB_WORKSPACE}/actions
           scp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null -rp tools \
-              ${{ matrix.os.base_image_user }}@${primary}:.
+              ${{ matrix.pr.base_image_user }}@${primary}:.
 
           echo ""
           echo "Copied tools:"
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} "ls tools"
+              ${{ matrix.pr.base_image_user }}@${primary} "ls tools"
 
       - name: Log github actions buffering status
         run: |
@@ -290,7 +291,7 @@ jobs:
           . ${GITHUB_WORKSPACE}/ci-environment.sh
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} /tmp/getsf-wrapper
+              ${{ matrix.pr.base_image_user }}@${primary} /tmp/getsf-wrapper
 
       - name: Wait for API to start answering
         run: |
@@ -298,13 +299,13 @@ jobs:
 
           . ${GITHUB_WORKSPACE}/ci-environment.sh
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} 'sudo chmod ugo+r /etc/sf/* /var/log/syslog'
+              ${{ matrix.pr.base_image_user }}@${primary} 'sudo chmod ugo+r /etc/sf/* /var/log/syslog'
 
           count=0
           while [ $count -lt 60 ]
           do
             ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} \
+              ${{ matrix.pr.base_image_user }}@${primary} \
               '. /etc/sf/sfrc; /srv/shakenfist/venv/bin/sf-client instance list'
             if [ $? == 0 ]; then
               exit 0
@@ -326,14 +327,14 @@ jobs:
           setup="${setup} export SHAKENFIST_API_URL=http://localhost:13000;"
           setup="${setup} /srv/shakenfist/venv/bin/sf-client artifact upload"
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${UPLOAD_TARGET} \
+              ${{ matrix.pr.base_image_user }}@${UPLOAD_TARGET} \
               "${setup} debian-11 /srv/ci/debian:11 --shared --no-checksum"
 
       - name: Make the traces directory
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} "sudo mkdir -p /srv/ci/traces; sudo chown -R ${{ matrix.os.base_image_user }}:${{ matrix.os.base_image_user }} /srv/ci/traces"
+              ${{ matrix.pr.base_image_user }}@${primary} "sudo mkdir -p /srv/ci/traces; sudo chown -R ${{ matrix.pr.base_image_user }}:${{ matrix.pr.base_image_user }} /srv/ci/traces"
 
       - name: Run functional tests
         timeout-minutes: 45
@@ -343,11 +344,11 @@ jobs:
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               ${GITHUB_WORKSPACE}/shakenfist \
-              ${{ matrix.os.base_image_user }}@${primary}:shakenfist
+              ${{ matrix.pr.base_image_user }}@${primary}:shakenfist
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               ${GITHUB_WORKSPACE}/client-python \
-              ${{ matrix.os.base_image_user }}@${primary}:client-python
+              ${{ matrix.pr.base_image_user }}@${primary}:client-python
 
           script="cd shakenfist/;"
           script="${script} . /etc/sf/sfrc;"
@@ -367,17 +368,17 @@ jobs:
 
           script="${script} cd ~/shakenfist/shakenfist/deploy/;"
           script="${script} set -e;"
-          script="${script} stestr run --config ${{ matrix.os.stestr_config }} --concurrency=${{ matrix.os.concurrency}};"
+          script="${script} stestr run --config ${{ matrix.pr.stestr_config }} --concurrency=${{ matrix.pr.concurrency}};"
 
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} "${script}"
+              ${{ matrix.pr.base_image_user }}@${primary} "${script}"
 
       - name: List slowest tests
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
 
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} \
+              ${{ matrix.pr.base_image_user }}@${primary} \
               "cd shakenfist/shakenfist/deploy; stestr slowest || true"
 
       - name: List failing tests
@@ -389,7 +390,7 @@ jobs:
           echo "Gathering list of failed tests..."
           touch /srv/ci/failed
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} \
+              ${{ matrix.pr.base_image_user }}@${primary} \
               "cd shakenfist/shakenfist/deploy; stestr failing || true" > /srv/ci/failed
           echo
 
@@ -412,13 +413,13 @@ jobs:
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
           cd ${GITHUB_WORKSPACE}/actions
-          tools/run_remote ${primary} "sudo bash tools/ci_log_checks.sh develop ${{ matrix.os.job_name }}"
+          tools/run_remote ${primary} "sudo bash tools/ci_log_checks.sh develop ${{ matrix.pr.job_name }}"
 
       - name: Set check_logs output for matrix aggregation
         id: set_output
         if: always()
         run: |
-          echo "${{ matrix.os.job_name }}=${{ steps.check_logs.outcome == 'failure' }}" >> $GITHUB_OUTPUT
+          echo "${{ matrix.pr.job_name }}=${{ steps.check_logs.outcome == 'failure' }}" >> $GITHUB_OUTPUT
 
       # On Ubuntu 22.04 the cleaner is rated a CPU hog because of etcd cleanup
       # cost. That's not really something we can control, so just ignore the CPU
@@ -428,7 +429,7 @@ jobs:
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} '. /etc/sf/sfrc; /srv/shakenfist/venv/bin/sf-client node cpuhogs -t 1.75 --ignore sf_cleaner'
+              ${{ matrix.pr.base_image_user }}@${primary} '. /etc/sf/sfrc; /srv/shakenfist/venv/bin/sf-client node cpuhogs -t 1.75 --ignore sf_cleaner'
 
       - name: Check for reasonable data rates
         timeout-minutes: 5
@@ -443,7 +444,7 @@ jobs:
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
           scp -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary}:/etc/sf/inventory.yaml /srv/github/
+              ${{ matrix.pr.base_image_user }}@${primary}:/etc/sf/inventory.yaml /srv/github/
           sed -i 's|/root/.ssh|/home/debian/.ssh|g' /srv/github/inventory.yaml
           sed -i 's|localhost|primary|g' /srv/github/inventory.yaml
 
@@ -463,7 +464,7 @@ jobs:
           # super early in the CI job.
           scp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null -rp \
-              ${{ matrix.os.base_image_user }}@${primary}:/srv/ci/traces \
+              ${{ matrix.pr.base_image_user }}@${primary}:/srv/ci/traces \
               /srv/github/bundle/ || true
 
           # We need the ssh key in the place ansible expects it to be, which isn't
@@ -472,7 +473,7 @@ jobs:
           cp /srv/github/id_ci.pub /home/debian/.ssh/id_rsa.pub
 
           ansible-playbook -i /srv/github/inventory.yaml \
-              --extra-vars "base_image_user=${{ matrix.os.base_image_user }} \
+              --extra-vars "base_image_user=${{ matrix.pr.base_image_user }} \
               ansible_ssh_common_args='-o StrictHostKeyChecking=no'" \
               ${GITHUB_WORKSPACE}/actions/ansible/ci-gather-logs.yml
 
@@ -487,7 +488,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: bundle-functional-cluster-${{ matrix.os.job_name }}
+          name: bundle-functional-cluster-${{ matrix.pr.job_name }}
           retention-days: 90
           if-no-files-found: error
           path: /srv/github/artifacts/bundle.zip
@@ -533,9 +534,9 @@ jobs:
   # values. We check if any value contains 'true' to trigger this job.
   # Skip if the last commit was from the bot to prevent infinite loops.
   automated_exception_fixer:
+    name: "Automated exception fixer"
     runs-on: [self-hosted, claude-code]
     needs: functional_matrix_pr
-    name: "Automated exception fixer"
     if: ${{ always() && contains(needs.functional_matrix_pr.outputs.check_logs_failed, 'true') }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-exception-fixer
@@ -605,9 +606,9 @@ jobs:
           tools/fix-exceptions-with-claude.sh --ci
 
   automated_reviewer:
+    name: "Automated reviewer"
     runs-on: [self-hosted, claude-code]
     needs: [sanity_checks, functional_matrix_pr]
-    name: "Automated reviewer"
     if: github.event_name == 'pull_request'
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-reviewer
@@ -626,15 +627,15 @@ jobs:
           tools/review-pr-with-claude.sh --ci --pr ${{ github.event.pull_request.number }}
 
   functional_matrix_merge:
+    name: "${{ matrix.merge.name }}"
     if: github.event_name == 'merge_group'
-    name: "${{ matrix.os.description }}"
     needs: merge_pr_comment
     strategy:
       fail-fast: false
       matrix:
-        os: [
+        merge: [
           {
-            description: 'debian 12 cluster',
+            name: 'Debian 12 cluster',
             job_name: 'debian-12-slim-primary',
             base_image: 'sf://label/ci-images/debian-12',
             base_image_user: 'debian',
@@ -643,7 +644,7 @@ jobs:
             stestr_config: 'cluster-ci.conf'
           },
           {
-            description: 'ubuntu 24.04 cluster',
+            name: 'Ubuntu 24.04 cluster',
             job_name: 'ubuntu-2404-slim-primary',
             base_image: 'sf://label/ci-images/ubuntu-2404',
             base_image_user: 'ubuntu',
@@ -652,7 +653,7 @@ jobs:
             stestr_config: 'cluster-ci.conf'
           },
           {
-            description: 'guests',
+            name: 'Guests',
             job_name: 'guests',
             base_image: 'sf://label/ci-images/debian-12',
             base_image_user: 'debian',
@@ -663,17 +664,17 @@ jobs:
         ]
     runs-on: [self-hosted, vm, debian-12]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os.job_name }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.merge.job_name }}
       cancel-in-progress: true
 
     steps:
       - name: Log matrix details
         run: |
-          echo "job_name: ${{ matrix.os.job_name }}"
-          echo "base_image: ${{ matrix.os.base_image }}"
-          echo "base_image_user: ${{ matrix.os.base_image_user }}"
-          echo "topology: ${{ matrix.os.topology }}"
-          echo "concurrency: ${{ matrix.os.concurrency }}"
+          echo "job_name: ${{ matrix.merge.job_name }}"
+          echo "base_image: ${{ matrix.merge.base_image }}"
+          echo "base_image_user: ${{ matrix.merge.base_image_user }}"
+          echo "topology: ${{ matrix.merge.topology }}"
+          echo "concurrency: ${{ matrix.merge.concurrency }}"
 
       - name: Setup test environment
         uses: shakenfist/actions/setup-test-environment@main
@@ -683,10 +684,10 @@ jobs:
           cd ${GITHUB_WORKSPACE}/actions
           ansible-playbook -i /home/debian/ansible-hosts \
               --extra-vars "identifier=${SHAKENFIST_NAMESPACE} \
-              base_image=${{ matrix.os.base_image }} base_image_user=${{ matrix.os.base_image_user }}" \
-              ansible/ci-topology-${{ matrix.os.topology }}.yml
+              base_image=${{ matrix.merge.base_image }} base_image_user=${{ matrix.merge.base_image_user }}" \
+              ansible/ci-topology-${{ matrix.merge.topology }}.yml
 
-          if [ "${{ matrix.os.topology }}" == "localhost" ]; then
+          if [ "${{ matrix.merge.topology }}" == "localhost" ]; then
             echo "UPLOAD_TARGET=10.0.0.10" >> $GITHUB_ENV
           else
             nodes=(10.0.0.20 10.0.0.21 10.0.0.22 10.0.0.23 10.0.0.24)
@@ -710,13 +711,13 @@ jobs:
           cd ${GITHUB_WORKSPACE}/actions
           scp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null -rp tools \
-              ${{ matrix.os.base_image_user }}@${primary}:.
+              ${{ matrix.merge.base_image_user }}@${primary}:.
 
           echo ""
           echo "Copied tools:"
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} "ls tools"
+              ${{ matrix.merge.base_image_user }}@${primary} "ls tools"
 
       - name: Log github actions buffering status
         run: |
@@ -731,7 +732,7 @@ jobs:
           . ${GITHUB_WORKSPACE}/ci-environment.sh
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} /tmp/getsf-wrapper
+              ${{ matrix.merge.base_image_user }}@${primary} /tmp/getsf-wrapper
 
       - name: Wait for API to start answering
         run: |
@@ -739,13 +740,13 @@ jobs:
 
           . ${GITHUB_WORKSPACE}/ci-environment.sh
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} 'sudo chmod ugo+r /etc/sf/* /var/log/syslog'
+              ${{ matrix.merge.base_image_user }}@${primary} 'sudo chmod ugo+r /etc/sf/* /var/log/syslog'
 
           count=0
           while [ $count -lt 60 ]
           do
             ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} '. /etc/sf/sfrc; /srv/shakenfist/venv/bin/sf-client instance list'
+              ${{ matrix.merge.base_image_user }}@${primary} '. /etc/sf/sfrc; /srv/shakenfist/venv/bin/sf-client instance list'
             if [ $? == 0 ]; then
               exit 0
             fi
@@ -768,22 +769,22 @@ jobs:
 
           # The cluster CI image, used by all CI types
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-                ${{ matrix.os.base_image_user }}@${UPLOAD_TARGET} \
+                ${{ matrix.merge.base_image_user }}@${UPLOAD_TARGET} \
                 "${setup} debian-11 /srv/ci/debian:11 --shared --no-checksum"
 
           # Additional images used only by guest CI
-          if [ "${{ matrix.os.stestr_config }}" == "guest-ci.conf" ]; then
+          if [ "${{ matrix.merge.stestr_config }}" == "guest-ci.conf" ]; then
               ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
                   -o UserKnownHostsFile=/dev/null \
-                  ${{ matrix.os.base_image_user }}@${UPLOAD_TARGET} \
+                  ${{ matrix.merge.base_image_user }}@${UPLOAD_TARGET} \
                   "${setup} ubuntu-2004 /srv/ci/ubuntu:20.04 --shared --no-checksum"
               ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
                   -o UserKnownHostsFile=/dev/null \
-                  ${{ matrix.os.base_image_user }}@${UPLOAD_TARGET} \
+                  ${{ matrix.merge.base_image_user }}@${UPLOAD_TARGET} \
                   "${setup} debian-12 /srv/ci/debian:12 --shared --no-checksum"
               ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
                   -o UserKnownHostsFile=/dev/null \
-                  ${{ matrix.os.base_image_user }}@${UPLOAD_TARGET} \
+                  ${{ matrix.merge.base_image_user }}@${UPLOAD_TARGET} \
                   "${setup} cirros /srv/ci/cirros --shared"
           fi
 
@@ -791,12 +792,12 @@ jobs:
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} \
+              ${{ matrix.merge.base_image_user }}@${primary} \
               'echo "==== sfrc ===="; cat /etc/sf/sfrc; echo "==== end sfrc ===="'
           echo ""
           echo ""
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} \
+              ${{ matrix.merge.base_image_user }}@${primary} \
               '. /etc/sf/sfrc; for i in `seq 100`; do /srv/shakenfist/venv/bin/sf-client --async=continue network create background-$i 10.$i.0.0/24 > /dev/null; echo -n "."; done'
           echo ""
 
@@ -804,7 +805,7 @@ jobs:
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} "sudo mkdir -p /srv/ci/traces; sudo chown -R ${{ matrix.os.base_image_user }}:${{ matrix.os.base_image_user }} /srv/ci/traces"
+              ${{ matrix.merge.base_image_user }}@${primary} "sudo mkdir -p /srv/ci/traces; sudo chown -R ${{ matrix.merge.base_image_user }}:${{ matrix.merge.base_image_user }} /srv/ci/traces"
 
       - name: Run functional tests
         timeout-minutes: 120
@@ -814,11 +815,11 @@ jobs:
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               ${GITHUB_WORKSPACE}/shakenfist \
-              ${{ matrix.os.base_image_user }}@${primary}:shakenfist
+              ${{ matrix.merge.base_image_user }}@${primary}:shakenfist
           scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null \
               ${GITHUB_WORKSPACE}/client-python \
-              ${{ matrix.os.base_image_user }}@${primary}:client-python
+              ${{ matrix.merge.base_image_user }}@${primary}:client-python
 
           script="cd shakenfist/;"
           script="${script} . /etc/sf/sfrc;"
@@ -838,17 +839,17 @@ jobs:
 
           script="${script} cd ~/shakenfist/shakenfist/deploy/;"
           script="${script} set -e;"
-          script="${script} stestr run --config ${{ matrix.os.stestr_config }} --concurrency=${{ matrix.os.concurrency}};"
+          script="${script} stestr run --config ${{ matrix.merge.stestr_config }} --concurrency=${{ matrix.merge.concurrency}};"
 
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} "${script}"
+              ${{ matrix.merge.base_image_user }}@${primary} "${script}"
 
       - name: List slowest tests
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
 
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} \
+              ${{ matrix.merge.base_image_user }}@${primary} \
               "cd shakenfist/shakenfist/deploy; stestr slowest || true"
 
       - name: List failing tests
@@ -860,7 +861,7 @@ jobs:
           echo "Gathering list of failed tests..."
           touch /srv/ci/failed
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} \
+              ${{ matrix.merge.base_image_user }}@${primary} \
               "cd shakenfist/shakenfist/deploy; stestr failing || true" > /srv/ci/failed
           echo
 
@@ -882,14 +883,14 @@ jobs:
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
           cd ${GITHUB_WORKSPACE}/actions
-          tools/run_remote ${primary} "sudo bash tools/ci_log_checks.sh develop ${{ matrix.os.job_name }}"
+          tools/run_remote ${primary} "sudo bash tools/ci_log_checks.sh develop ${{ matrix.merge.job_name }}"
 
       - name: Check SF process CPU usage
         if: always()
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} '. /etc/sf/sfrc; /srv/shakenfist/venv/bin/sf-client node cpuhogs -t 1.75'
+              ${{ matrix.merge.base_image_user }}@${primary} '. /etc/sf/sfrc; /srv/shakenfist/venv/bin/sf-client node cpuhogs -t 1.75'
 
       - name: Check for reasonable data rates
         timeout-minutes: 5
@@ -904,7 +905,7 @@ jobs:
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
           scp -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary}:/etc/sf/inventory.yaml /srv/github/
+              ${{ matrix.merge.base_image_user }}@${primary}:/etc/sf/inventory.yaml /srv/github/
           sed -i 's|/root/.ssh|/home/debian/.ssh|g' /srv/github/inventory.yaml
 
           echo "====="
@@ -919,7 +920,7 @@ jobs:
           mkdir -p /srv/github/bundle/
           scp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
               -o UserKnownHostsFile=/dev/null -rp \
-              ${{ matrix.os.base_image_user }}@${primary}:/srv/ci/traces \
+              ${{ matrix.merge.base_image_user }}@${primary}:/srv/ci/traces \
               /srv/github/bundle/ || true
 
           # We need the ssh key in the place ansible expects it to be, which isn't
@@ -928,7 +929,7 @@ jobs:
           cp /srv/github/id_ci.pub /home/debian/.ssh/id_rsa.pub
 
           ansible-playbook -i /srv/github/inventory.yaml \
-              --extra-vars "base_image_user=${{ matrix.os.base_image_user }} \
+              --extra-vars "base_image_user=${{ matrix.merge.base_image_user }} \
               ansible_ssh_common_args='-o StrictHostKeyChecking=no'" \
               ${GITHUB_WORKSPACE}/actions/ansible/ci-gather-logs.yml
 
@@ -943,7 +944,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: bundle-functional-cluster-${{ matrix.os.job_name }}
+          name: bundle-functional-cluster-${{ matrix.merge.job_name }}
           retention-days: 90
           if-no-files-found: error
           path: /srv/github/artifacts/bundle.zip
@@ -990,6 +991,7 @@ jobs:
       #   name: Cancel entire workflow on failure
 
   ansible_modules:
+    name: "Ansible modules"
     if: github.event_name == 'merge_group'
     runs-on: [self-hosted, vm, debian-12]
     needs: merge_pr_comment
@@ -1180,6 +1182,7 @@ jobs:
       #   name: Cancel entire workflow on failure
 
   node_lifecycle:
+    name: "Node lifecycle"
     if: github.event_name == 'merge_group'
     needs: merge_pr_comment
     runs-on: [self-hosted, vm, debian-12]
@@ -1372,6 +1375,7 @@ jobs:
       #   name: Cancel entire workflow on failure
 
   upgrade_0_6_15:
+    name: "Upgrade from 0.6.15"
     if: github.event_name == 'merge_group'
     needs: merge_pr_comment
     runs-on: [self-hosted, vm, debian-12]
@@ -1546,6 +1550,7 @@ jobs:
       #   name: Cancel entire workflow on failure
 
   enqueue_pr_comment:
+    name: "Enqueue PR slack comment"
     if: always() && github.event_name == 'pull_request'
     runs-on: [self-hosted, static]
     permissions:
@@ -1582,6 +1587,7 @@ jobs:
                     value: "In Progress"
 
   merge_pr_comment:
+    name: "Merge attempt slack comment"
     if: always() && github.event_name == 'merge_group'
     runs-on: [self-hosted, static]
     permissions:
@@ -1637,12 +1643,14 @@ jobs:
                     value: "In Progress"
 
   can_see_status:
+    name: "Can see status"
     runs-on: [self-hosted, static]
     steps:
       - name: "Immediate success"
         run: true
 
   can_enqueue:
+    name: "Can enqueue"
     needs:
       - functional_matrix_pr
       - enqueue_pr_comment
@@ -1681,6 +1689,7 @@ jobs:
                     value: "Success"
 
   can_merge:
+    name: "Can merge"
     needs:
       - functional_matrix_merge
       - ansible_modules

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -197,33 +197,16 @@ jobs:
         run: |
           tools/fix-lint-with-claude.sh --ci
 
-  # Reviews PRs using Claude Code. Runs on all PRs after sanity_checks completes.
-  automated_reviewer:
-    runs-on: [self-hosted, claude-code]
-    needs: sanity_checks
-    name: "Automated reviewer"
-    if: github.event_name == 'pull_request'
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-reviewer
-      cancel-in-progress: true
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run automated reviewer
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          tools/review-pr-with-claude.sh --ci --pr ${{ github.event.pull_request.number }}
-
   functional_matrix_pr:
     if: always() && github.event_name != 'merge_group'
     runs-on: [self-hosted, vm, debian-12]
     needs: enqueue_pr_comment
     name: "${{ matrix.os.description }}"
+    outputs:
+      # For matrix jobs, we use a JSON object keyed by job_name. Each matrix run
+      # sets its own key, and the outputs get merged. The consuming job can then
+      # check if any value in the object is 'true'.
+      check_logs_failed: ${{ toJSON(steps.set_output.outputs) }}
     strategy:
       fail-fast: false
       matrix:
@@ -424,11 +407,18 @@ jobs:
           cat ${GITHUB_OUTPUT}
 
       - name: Check logs
+        id: check_logs
         if: always()
         run: |
           . ${GITHUB_WORKSPACE}/ci-environment.sh
           cd ${GITHUB_WORKSPACE}/actions
           tools/run_remote ${primary} "sudo bash tools/ci_log_checks.sh develop ${{ matrix.os.job_name }}"
+
+      - name: Set check_logs output for matrix aggregation
+        id: set_output
+        if: always()
+        run: |
+          echo "${{ matrix.os.job_name }}=${{ steps.check_logs.outcome == 'failure' }}" >> $GITHUB_OUTPUT
 
       # On Ubuntu 22.04 the cleaner is rated a CPU hog because of etcd cleanup
       # cost. That's not really something we can control, so just ignore the CPU
@@ -536,6 +526,104 @@ jobs:
               Failures are:
 
               ${{ steps.failures.outputs.failures }}
+
+  # Runs if the "Check logs" step in any functional_matrix_pr matrix job fails.
+  # Uses always() so it runs even when functional_matrix_pr fails.
+  # The check_logs_failed output is a JSON object with job_name keys and boolean
+  # values. We check if any value contains 'true' to trigger this job.
+  # Skip if the last commit was from the bot to prevent infinite loops.
+  automated_exception_fixer:
+    runs-on: [self-hosted, claude-code]
+    needs: functional_matrix_pr
+    name: "Automated exception fixer"
+    if: ${{ always() && contains(needs.functional_matrix_pr.outputs.check_logs_failed, 'true') }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-exception-fixer
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Use DEPENDENCIES_TOKEN (a PAT) instead of GITHUB_TOKEN so that
+          # commits pushed by this workflow will trigger other workflows.
+          # The default GITHUB_TOKEN deliberately doesn't trigger workflows
+          # to prevent infinite loops.
+          token: ${{ secrets.DEPENDENCIES_TOKEN }}
+
+      - name: Check if last commit was from bot and list failed jobs
+        id: check_bot
+        run: |
+          LAST_AUTHOR_EMAIL=$(git log -1 --format='%ae')
+          echo "Last commit author: $LAST_AUTHOR_EMAIL"
+          if [ "$LAST_AUTHOR_EMAIL" = "bot@shakenfist.com" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Skipping exception fixer - last commit was from bot"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Parse the JSON output to find which matrix jobs had log check failures
+          # The output is like: {"smoke": "true", "other": "false"}
+          CHECK_LOGS_OUTPUT='${{ needs.functional_matrix_pr.outputs.check_logs_failed }}'
+          echo "Raw check_logs_failed output: $CHECK_LOGS_OUTPUT"
+
+          FAILED_JOBS=$(echo "$CHECK_LOGS_OUTPUT" | jq -r 'to_entries | .[] | select(.value == "true") | .key' | tr '\n' ' ')
+          echo "Matrix jobs with log check failures: $FAILED_JOBS"
+          echo "failed_jobs=$FAILED_JOBS" >> $GITHUB_OUTPUT
+
+      - name: Download bundles for failed jobs
+        if: steps.check_bot.outputs.skip != 'true'
+        env:
+          FAILED_JOBS: ${{ steps.check_bot.outputs.failed_jobs }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /srv/github/bundles
+          for job in ${FAILED_JOBS}; do
+            echo "Downloading bundle for failed job: ${job}"
+            gh run download ${{ github.run_id }} \
+              --name "bundle-functional-cluster-${job}" \
+              --dir "/srv/github/bundles/${job}"
+          done
+
+          echo
+          echo "Downloaded bundles:"
+          ls -lh /srv/github/bundles/
+
+      - name: Configure git
+        if: steps.check_bot.outputs.skip != 'true'
+        run: |
+          git config user.name "Claude Code run by Shakenfist Bot"
+          git config user.email "bot@shakenfist.com"
+
+      - name: Run automated exception fixer
+        if: steps.check_bot.outputs.skip != 'true'
+        env:
+          BUNDLES_DIR: /srv/github/bundles
+        run: |
+          tools/fix-exceptions-with-claude.sh --ci
+
+  automated_reviewer:
+    runs-on: [self-hosted, claude-code]
+    needs: [sanity_checks, functional_matrix_pr]
+    name: "Automated reviewer"
+    if: github.event_name == 'pull_request'
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-reviewer
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run automated reviewer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tools/review-pr-with-claude.sh --ci --pr ${{ github.event.pull_request.number }}
 
   functional_matrix_merge:
     if: github.event_name == 'merge_group'

--- a/docs/operator_guide/exception_tracking.md
+++ b/docs/operator_guide/exception_tracking.md
@@ -1,0 +1,71 @@
+# Exception Tracking
+
+Shaken Fist includes an exception tracking system that records unhandled
+exceptions to disk for later analysis. This helps operators identify and
+debug recurring issues in production clusters.
+
+## How It Works
+
+When an exception occurs, it is recorded to `/srv/shakenfist/exceptions/` as
+a JSON file. Each unique exception traceback is hashed (using SHA-256) and
+stored in a file named after the last 8 characters of that hash. This means
+identical exceptions are deduplicated automatically.
+
+Each JSON file contains:
+
+* `traceback`: The full exception traceback
+* `count`: The number of times this exception has occurred
+* `events`: A list of Unix timestamps for each occurrence
+
+For example:
+
+```json
+{
+    "traceback": "\nTraceback (most recent call last):\n  File ...",
+    "count": 3,
+    "events": [1703692800.123, 1703693100.456, 1703693400.789]
+}
+```
+
+## What Gets Tracked
+
+The exception tracking system captures:
+
+* Unhandled exceptions in the main thread via `sys.excepthook`
+* Unhandled exceptions in worker threads via `threading.excepthook`
+* Exceptions passed to `ignore_exception()`, which are caught but logged
+
+## Viewing Exceptions
+
+To list all recorded exceptions:
+
+```bash
+ls -la /srv/shakenfist/exceptions/
+```
+
+To view the details of a specific exception:
+
+```bash
+cat /srv/shakenfist/exceptions/<hash>.json | jq .
+```
+
+To find the most frequently occurring exceptions:
+
+```bash
+for f in /srv/shakenfist/exceptions/*.json; do
+    echo "$(jq -r .count $f) $f"
+done | sort -rn | head -10
+```
+
+## Cleanup
+
+Exception files accumulate over time. You may wish to periodically clean up
+old exception files, particularly after addressing the underlying issues:
+
+```bash
+# Remove all exception files
+rm /srv/shakenfist/exceptions/*.json
+
+# Or remove files older than 7 days
+find /srv/shakenfist/exceptions/ -name "*.json" -mtime +7 -delete
+```

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -137,6 +137,9 @@
 
 ## Minor changes
 
+* Unhandled exceptions are now recorded to `/srv/shakenfist/exceptions/` for
+  later analysis. See [the operator guide](/operator_guide/exception_tracking/)
+  for details.
 * CI has been moved from relatively unreliable scraping of the instance serial
   console over telnet to using the Shaken Fist in-guest agent to inspect the
   state of instances for correctness.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
        - "Artifacts": operator_guide/artifacts.md
        - "Authentication": operator_guide/authentication.md
        - "Database": operator_guide/database.md
+       - "Exception Tracking": operator_guide/exception_tracking.md
        - "Locks": operator_guide/locks.md
        - "Networking": operator_guide/networking/overview.md
        - "Power States": operator_guide/power_states.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,6 @@ dependencies = [
 sf-ctl = "shakenfist.client.ctl:cli"
 sf-backup = "shakenfist.client.backup:cli"
 
-sf-api = "shakenfist.daemons.external_api.main:main"
 sf-cleaner = "shakenfist.daemons.cleaner.main:main"
 sf-cluster = "shakenfist.daemons.cluster.main:main"
 sf-database = "shakenfist.daemons.database.main:main"

--- a/shakenfist/daemons/cleaner/main.py
+++ b/shakenfist/daemons/cleaner/main.py
@@ -17,6 +17,7 @@ from shakenfist.config import config
 from shakenfist.constants import EVENT_TYPE_STATUS
 from shakenfist.daemons.cleaner import scheduled_tasks
 from shakenfist.daemons import daemon
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -181,7 +182,7 @@ class Monitor(daemon.Daemon):
                         extra={'mod_revision': int(kv['mod_revision'])})
 
         except Exception as e:
-            util_general.ignore_exception('etcd compaction', e)
+            util_exceptions.ignore_exception('etcd compaction', e)
 
     def _run_inner(self):
         last_defer_message = 0
@@ -247,6 +248,7 @@ class Monitor(daemon.Daemon):
 
 
 def main():
+    util_exceptions.install_exception_tracking()
     daemon.write_pid_file('cleaner')
     m = Monitor('cleaner')
 

--- a/shakenfist/daemons/cluster/main.py
+++ b/shakenfist/daemons/cluster/main.py
@@ -35,6 +35,7 @@ from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import get_all_node_queues
 from shakenfist.upload import Uploads
 from shakenfist.util import concurrency as util_concurrency
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 from shakenfist.util import json as util_json
 
@@ -452,14 +453,14 @@ class Monitor(daemon.Daemon):
                             'scheduled cluster operations', None, threshold=10):
                         schedule.run_pending()
                 except Exception as e:
-                    util_general.ignore_exception('cluster', e)
+                    util_exceptions.ignore_exception('cluster', e)
 
                 try:
                     with util_general.RecordedOperation(
                             'cluster wide cleanup', None, threshold=10):
                         self._cluster_wide_cleanup(last_loop_run)
                 except Exception as e:
-                    util_general.ignore_exception('cluster', e)
+                    util_exceptions.ignore_exception('cluster', e)
 
                 last_loop_run = time.time()
 
@@ -471,6 +472,7 @@ class Monitor(daemon.Daemon):
 
 
 def main():
+    util_exceptions.install_exception_tracking()
     daemon.write_pid_file('cluster')
     m = Monitor('cluster')
     m.run()

--- a/shakenfist/daemons/database/main.py
+++ b/shakenfist/daemons/database/main.py
@@ -30,7 +30,6 @@ from shakenfist.node import Node
 from shakenfist.protos import database_pb2
 from shakenfist.protos import database_pb2_grpc
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 from shakenfist.util import json as util_json
 
 

--- a/shakenfist/daemons/database/main.py
+++ b/shakenfist/daemons/database/main.py
@@ -29,6 +29,7 @@ from shakenfist.exceptions import InvalidStateException
 from shakenfist.node import Node
 from shakenfist.protos import database_pb2
 from shakenfist.protos import database_pb2_grpc
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 from shakenfist.util import json as util_json
 
@@ -57,7 +58,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
                 value=util_json.json_dump(value)
             )
         except Exception as e:
-            util_general.ignore_exception('database Get failed', e)
+            util_exceptions.ignore_exception('database Get failed', e)
             context.set_code(grpc.StatusCode.INTERNAL)
             context.set_details(str(e))
             return database_pb2.GetReply(found=False, value='')
@@ -77,7 +78,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
                 ))
             return database_pb2.GetPrefixReply(results=results)
         except Exception as e:
-            util_general.ignore_exception('database GetPrefix failed', e)
+            util_exceptions.ignore_exception('database GetPrefix failed', e)
             context.set_code(grpc.StatusCode.INTERNAL)
             context.set_details(str(e))
             return database_pb2.GetPrefixReply(results=[])
@@ -90,7 +91,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
             etcd.put(request.object_type, request.subtype, request.name, data)
             return database_pb2.StatusReply(success=True, error='')
         except Exception as e:
-            util_general.ignore_exception('database Put failed', e)
+            util_exceptions.ignore_exception('database Put failed', e)
             return database_pb2.StatusReply(success=False, error=str(e))
 
     def Create(self, request, context):
@@ -102,7 +103,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
                 request.object_type, request.subtype, request.name, data)
             return database_pb2.StatusReply(success=success, error='')
         except Exception as e:
-            util_general.ignore_exception('database Create failed', e)
+            util_exceptions.ignore_exception('database Create failed', e)
             return database_pb2.StatusReply(success=False, error=str(e))
 
     def Delete(self, request, context):
@@ -112,7 +113,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
             etcd.delete(request.object_type, request.subtype, request.name)
             return database_pb2.StatusReply(success=True, error='')
         except Exception as e:
-            util_general.ignore_exception('database Delete failed', e)
+            util_exceptions.ignore_exception('database Delete failed', e)
             return database_pb2.StatusReply(success=False, error=str(e))
 
     def DeletePrefix(self, request, context):
@@ -122,7 +123,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
             etcd.delete_prefix(request.path)
             return database_pb2.StatusReply(success=True, error='')
         except Exception as e:
-            util_general.ignore_exception('database DeletePrefix failed', e)
+            util_exceptions.ignore_exception('database DeletePrefix failed', e)
             return database_pb2.StatusReply(success=False, error=str(e))
 
     def ReplaceMany(self, request, context):
@@ -166,7 +167,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
                 failures=failure_msgs
             )
         except Exception as e:
-            util_general.ignore_exception('database ReplaceMany failed', e)
+            util_exceptions.ignore_exception('database ReplaceMany failed', e)
             return database_pb2.ReplaceManyReply(
                 success=False,
                 failures=[database_pb2.MutationFailure(
@@ -184,7 +185,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
             etcd.enqueue(request.queue_name, workitem, delay=request.delay)
             return database_pb2.StatusReply(success=True, error='')
         except Exception as e:
-            util_general.ignore_exception('database Enqueue failed', e)
+            util_exceptions.ignore_exception('database Enqueue failed', e)
             return database_pb2.StatusReply(success=False, error=str(e))
 
     def Dequeue(self, request, context):
@@ -202,7 +203,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
                 work_item=util_json.json_dump(workitem)
             )
         except Exception as e:
-            util_general.ignore_exception('database Dequeue failed', e)
+            util_exceptions.ignore_exception('database Dequeue failed', e)
             return database_pb2.DequeueReply(
                 found=False, job_name='', work_item='')
 
@@ -213,7 +214,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
             etcd.resolve(request.queue_name, request.job_name)
             return database_pb2.StatusReply(success=True, error='')
         except Exception as e:
-            util_general.ignore_exception('database Resolve failed', e)
+            util_exceptions.ignore_exception('database Resolve failed', e)
             return database_pb2.StatusReply(success=False, error=str(e))
 
     def GetQueueLength(self, request, context):
@@ -228,7 +229,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
                 deferred=deferred
             )
         except Exception as e:
-            util_general.ignore_exception('database GetQueueLength failed', e)
+            util_exceptions.ignore_exception('database GetQueueLength failed', e)
             return database_pb2.QueueLengthReply(
                 processing=0, queued=0, deferred=0)
 
@@ -239,7 +240,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
             etcd.restart_queue(request.queue_name)
             return database_pb2.StatusReply(success=True, error='')
         except Exception as e:
-            util_general.ignore_exception('database RestartQueue failed', e)
+            util_exceptions.ignore_exception('database RestartQueue failed', e)
             return database_pb2.StatusReply(success=False, error=str(e))
 
     # Lock Operations
@@ -256,7 +257,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
             acquired = etcd.create_raw(path, lock_data)
             return database_pb2.ClusterLockReply(acquired=acquired)
         except Exception as e:
-            util_general.ignore_exception('database AcquireLock failed', e)
+            util_exceptions.ignore_exception('database AcquireLock failed', e)
             return database_pb2.ClusterLockReply(acquired=False)
 
     def ReleaseLock(self, request, context):
@@ -271,7 +272,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
             released = etcd.transactional_delete_raw(path, lock_data)
             return database_pb2.StatusReply(success=released, error='')
         except Exception as e:
-            util_general.ignore_exception('database ReleaseLock failed', e)
+            util_exceptions.ignore_exception('database ReleaseLock failed', e)
             return database_pb2.StatusReply(success=False, error=str(e))
 
     def GetLockHolder(self, request, context):
@@ -290,7 +291,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
                 holder=util_json.json_dump(holder)
             )
         except Exception as e:
-            util_general.ignore_exception('database GetLockHolder failed', e)
+            util_exceptions.ignore_exception('database GetLockHolder failed', e)
             return database_pb2.ClusterLockHolderReply(held=False, holder='')
 
     def ClearStaleLocks(self, request, context):
@@ -300,7 +301,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
             etcd.clear_stale_locks()
             return database_pb2.StatusReply(success=True, error='')
         except Exception as e:
-            util_general.ignore_exception(
+            util_exceptions.ignore_exception(
                 'database ClearStaleLocks failed', e)
             return database_pb2.StatusReply(success=False, error=str(e))
 
@@ -317,7 +318,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
                 ))
             return database_pb2.ClusterGetExistingLocksReply(locks=lock_entries)
         except Exception as e:
-            util_general.ignore_exception(
+            util_exceptions.ignore_exception(
                 'database GetExistingLocks failed', e)
             return database_pb2.ClusterGetExistingLocksReply(locks=[])
 
@@ -330,7 +331,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
             etcd.compact(request.revision)
             return database_pb2.StatusReply(success=True, error='')
         except Exception as e:
-            util_general.ignore_exception('database Compact failed', e)
+            util_exceptions.ignore_exception('database Compact failed', e)
             return database_pb2.StatusReply(success=False, error=str(e))
 
     # Object State Operations (MariaDB)
@@ -352,7 +353,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
                 message=state.message or ''
             )
         except Exception as e:
-            util_general.ignore_exception('database GetObjectState failed', e)
+            util_exceptions.ignore_exception('database GetObjectState failed', e)
             context.set_code(grpc.StatusCode.INTERNAL)
             context.set_details(str(e))
             return database_pb2.GetObjectStateReply(found=False)
@@ -371,7 +372,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
                 request.object_type, request.object_uuid, state)
             return database_pb2.StatusReply(success=success, error='')
         except Exception as e:
-            util_general.ignore_exception('database SetObjectState failed', e)
+            util_exceptions.ignore_exception('database SetObjectState failed', e)
             return database_pb2.StatusReply(success=False, error=str(e))
 
     def DeleteObjectState(self, request, context):
@@ -382,7 +383,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
                 request.object_type, request.object_uuid)
             return database_pb2.StatusReply(success=success, error='')
         except Exception as e:
-            util_general.ignore_exception(
+            util_exceptions.ignore_exception(
                 'database DeleteObjectState failed', e)
             return database_pb2.StatusReply(success=False, error=str(e))
 
@@ -394,7 +395,7 @@ class DatabaseService(database_pb2_grpc.DatabaseServiceServicer):
                 request.object_type, list(request.state_values))
             return database_pb2.GetObjectsByStateReply(object_uuids=uuids)
         except Exception as e:
-            util_general.ignore_exception(
+            util_exceptions.ignore_exception(
                 'database GetObjectsByState failed', e)
             return database_pb2.GetObjectsByStateReply(object_uuids=[])
 
@@ -472,12 +473,13 @@ class Monitor(daemon.WorkerPoolDaemon):
                 # it just serves gRPC requests. We check health periodically.
                 self.idle(10)
             except Exception as e:
-                util_general.ignore_exception('database daemon', e)
+                util_exceptions.ignore_exception('database daemon', e)
 
             self.check_daemon_state()
 
 
 def main():
+    util_exceptions.install_exception_tracking()
     daemon.write_pid_file('database')
 
     # MariaDB is required for the database service. Abort early with a clear

--- a/shakenfist/daemons/eventlog/main.py
+++ b/shakenfist/daemons/eventlog/main.py
@@ -30,7 +30,6 @@ from shakenfist.node import Node
 from shakenfist.protos import event_pb2
 from shakenfist.protos import event_pb2_grpc
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 
 
 LOG, _ = logs.setup(__name__)

--- a/shakenfist/daemons/eventlog/main.py
+++ b/shakenfist/daemons/eventlog/main.py
@@ -29,6 +29,7 @@ from shakenfist.exceptions import InvalidStateException
 from shakenfist.node import Node
 from shakenfist.protos import event_pb2
 from shakenfist.protos import event_pb2_grpc
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -120,7 +121,7 @@ class EventService(event_pb2_grpc.EventServiceServicer):
                     extra, timestamp, request.fqdn, correlation_id=correlation_id)
 
         except Exception as e:
-            util_general.ignore_exception(
+            util_exceptions.ignore_exception(
                 'failed to write event for %s %s'
                 % (request.object_type, request.object_uuid), e)
             return event_pb2.EventReply(ack=False)
@@ -161,7 +162,7 @@ class EventService(event_pb2_grpc.EventServiceServicer):
                     correlation_id=correlation_id)
 
         except Exception as e:
-            util_general.ignore_exception(
+            util_exceptions.ignore_exception(
                 'failed to write event for %s' % request.objects, e)
             return event_pb2.EventReply(ack=False)
 
@@ -260,7 +261,7 @@ class Monitor(daemon.WorkerPoolDaemon):
                     try:
                         _, _, _, objtype, objuuid, _ = k.split('/')
                     except ValueError as e:
-                        util_general.ignore_exception(
+                        util_exceptions.ignore_exception(
                             'failed to parse event key "%s"' % k, e)
                         continue
 
@@ -282,7 +283,7 @@ class Monitor(daemon.WorkerPoolDaemon):
                                 self.counters[event_type].inc()
                                 etcd.get_etcd_client().delete(k)
                     except Exception as e:
-                        util_general.ignore_exception(
+                        util_exceptions.ignore_exception(
                             f'Failed to write event for {objtype} {objuuid}, will retry', e)
 
                 if results:
@@ -337,12 +338,13 @@ class Monitor(daemon.WorkerPoolDaemon):
                     self.idle(10)
 
             except Exception as e:
-                util_general.ignore_exception('eventlog daemon', e)
+                util_exceptions.ignore_exception('eventlog daemon', e)
 
             self.check_daemon_state()
 
 
 def main():
+    util_exceptions.install_exception_tracking()
     daemon.write_pid_file('eventlog')
     m = Monitor('eventlog')
 

--- a/shakenfist/daemons/network/main.py
+++ b/shakenfist/daemons/network/main.py
@@ -13,9 +13,10 @@ from shakenfist.config import config
 from shakenfist.daemons import daemon
 from shakenfist import etcd
 from shakenfist.node import Node
+from shakenfist.util import concurrency as util_concurrency
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 from shakenfist.util import network as util_network
-from shakenfist.util import concurrency as util_concurrency
 
 
 LOG, _ = logs.setup(__name__)
@@ -77,12 +78,13 @@ class Monitor(daemon.WorkerPoolDaemon):
                             job_classes[job_name], [job_name], job_name)
 
             except Exception as e:
-                util_general.ignore_exception('network worker', e)
+                util_exceptions.ignore_exception('network worker', e)
 
             self.idle(5)
 
 
 def main():
+    util_exceptions.install_exception_tracking()
     daemon.write_pid_file('net')
     procname = daemon.process_name('net')
     setproctitle.setproctitle(procname)

--- a/shakenfist/daemons/network/main.py
+++ b/shakenfist/daemons/network/main.py
@@ -15,7 +15,6 @@ from shakenfist import etcd
 from shakenfist.node import Node
 from shakenfist.util import concurrency as util_concurrency
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 from shakenfist.util import network as util_network
 
 

--- a/shakenfist/daemons/nodelock/main.py
+++ b/shakenfist/daemons/nodelock/main.py
@@ -16,6 +16,7 @@ from shakenfist_utilities import logs
 
 from shakenfist.daemons.daemon import send_systemd_ready
 from shakenfist.protos import nodelock_pb2
+from shakenfist.util import exceptions as util_exceptions
 
 
 LOG, _ = logs.setup(__name__)
@@ -38,6 +39,7 @@ def write_pid_file():
 
 
 def main():
+    util_exceptions.install_exception_tracking()
     write_pid_file()
     setproctitle.setproctitle('sf-nodelock')
 

--- a/shakenfist/daemons/privexec/main.py
+++ b/shakenfist/daemons/privexec/main.py
@@ -23,6 +23,7 @@ from shakenfist.daemons.daemon import send_systemd_stopping
 from shakenfist.daemons.privexec import util as privexec_util
 from shakenfist.protos import common_pb2
 from shakenfist.protos import privexec_pb2
+from shakenfist.util import exceptions as util_exceptions
 
 
 LOG, _ = logs.setup(__name__)
@@ -520,6 +521,7 @@ def write_pid_file():
 
 
 def main():
+    util_exceptions.install_exception_tracking()
     write_pid_file()
     setproctitle.setproctitle('sf-privexec')
 

--- a/shakenfist/daemons/queues/main.py
+++ b/shakenfist/daemons/queues/main.py
@@ -12,6 +12,7 @@ from shakenfist.daemons.queues import startup_tasks
 from shakenfist.daemons.queues import workitem
 from shakenfist.node import Node
 from shakenfist.util import concurrency as util_concurrency
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -128,12 +129,13 @@ class Monitor(daemon.WorkerPoolDaemon):
                     self.idle(0.2)
 
             except Exception as e:
-                util_general.ignore_exception('queue worker', e)
+                util_exceptions.ignore_exception('queue worker', e)
 
             self.check_daemon_state()
 
 
 def main():
+    util_exceptions.install_exception_tracking()
     daemon.write_pid_file('queues')
 
     # Because we do work before starting the queue thread, we need to name

--- a/shakenfist/daemons/queues/main.py
+++ b/shakenfist/daemons/queues/main.py
@@ -13,7 +13,6 @@ from shakenfist.daemons.queues import workitem
 from shakenfist.node import Node
 from shakenfist.util import concurrency as util_concurrency
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 
 
 LOG, _ = logs.setup(__name__)

--- a/shakenfist/daemons/queues/startup_tasks.py
+++ b/shakenfist/daemons/queues/startup_tasks.py
@@ -21,6 +21,7 @@ from shakenfist.network.interface import interfaces_for_instance
 from shakenfist.node import Node
 from shakenfist.operations.baseoperation import get_all_node_queues
 from shakenfist.util import concurrency as util_concurrency
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 from shakenfist.util import json as util_json
 
@@ -141,7 +142,7 @@ def restore_instances():
                 n.create_on_hypervisor()
                 n.ensure_mesh()
         except Exception as e:
-            util_general.ignore_exception(
+            util_exceptions.ignore_exception(
                 'restore network %s' % network_uuid, e)
 
     for inst in instances:
@@ -156,7 +157,7 @@ def restore_instances():
                 LOG.with_fields({'instance': inst}).info('Restoring instance')
                 inst.create_on_hypervisor()
         except Exception as e:
-            util_general.ignore_exception(
+            util_exceptions.ignore_exception(
                 'restore instance %s' % inst, e)
             inst.etcd.enqueue_delete_due_error(
                 'exception while restoring instance on daemon restart')

--- a/shakenfist/daemons/resources/main.py
+++ b/shakenfist/daemons/resources/main.py
@@ -27,7 +27,6 @@ from shakenfist.operations.baseoperation import get_all_network_queues
 from shakenfist.operations.baseoperation import get_node_user_facing_node_queues
 from shakenfist.util import concurrency as util_concurrency
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 from shakenfist.util import libvirt as util_libvirt
 from shakenfist.util import network as util_network
 

--- a/shakenfist/daemons/resources/main.py
+++ b/shakenfist/daemons/resources/main.py
@@ -25,10 +25,11 @@ from shakenfist.node import Node
 from shakenfist.operations.baseoperation import get_all_background_node_queues
 from shakenfist.operations.baseoperation import get_all_network_queues
 from shakenfist.operations.baseoperation import get_node_user_facing_node_queues
+from shakenfist.util import concurrency as util_concurrency
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 from shakenfist.util import libvirt as util_libvirt
 from shakenfist.util import network as util_network
-from shakenfist.util import concurrency as util_concurrency
 
 
 LOG, _ = logs.setup(__name__)
@@ -83,7 +84,7 @@ class Monitor(daemon.Daemon):
                     'cpu_load_15': load_15,
                 })
             except Exception as e:
-                util_general.ignore_exception('load average', e)
+                util_exceptions.ignore_exception('load average', e)
 
             # System memory info, converting bytes to mb
             stats = psutil.virtual_memory()
@@ -493,12 +494,13 @@ class Monitor(daemon.Daemon):
                     last_billing = time.time()
 
             except Exception as e:
-                util_general.ignore_exception('resource statistics', e)
+                util_exceptions.ignore_exception('resource statistics', e)
 
             self.idle(1)
 
 
 def main():
+    util_exceptions.install_exception_tracking()
     daemon.write_pid_file('resources')
     m = Monitor('resources')
 

--- a/shakenfist/daemons/sentinel_first/main.py
+++ b/shakenfist/daemons/sentinel_first/main.py
@@ -14,6 +14,7 @@ from shakenfist.daemons import daemon
 from shakenfist.daemons.daemon import send_systemd_ready
 from shakenfist.daemons.daemon import send_systemd_stopping
 from shakenfist.node import Node
+from shakenfist.util import exceptions as util_exceptions
 
 
 LOG, _ = logs.setup(__name__)
@@ -31,6 +32,7 @@ signal.signal(signal.SIGTERM, exit_gracefully)
 
 
 def main():
+    util_exceptions.install_exception_tracking()
     daemon.clear_abort_path(ABORT_PATH)
     setproctitle.setproctitle('sf-sentinel-first')
     LOG.info('Started')

--- a/shakenfist/daemons/sentinel_last/main.py
+++ b/shakenfist/daemons/sentinel_last/main.py
@@ -12,6 +12,7 @@ from shakenfist.daemons import daemon
 from shakenfist.daemons.daemon import send_systemd_ready
 from shakenfist.daemons.daemon import send_systemd_stopping
 from shakenfist.node import Node
+from shakenfist.util import exceptions as util_exceptions
 
 
 LOG, _ = logs.setup(__name__)
@@ -28,6 +29,7 @@ signal.signal(signal.SIGTERM, exit_gracefully)
 
 
 def main():
+    util_exceptions.install_exception_tracking()
     daemon.clear_abort_path(ABORT_PATH)
     setproctitle.setproctitle('sf-sentinel-last')
     LOG.info('Started')

--- a/shakenfist/daemons/sidechannel/main.py
+++ b/shakenfist/daemons/sidechannel/main.py
@@ -28,9 +28,10 @@ from shakenfist import instance
 from shakenfist.operations.agentoperation import AgentOperation
 from shakenfist.protos import agent_pb2
 from shakenfist.protos import common_pb2
+from shakenfist.util import concurrency as util_concurrency
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 from shakenfist.util import libvirt as util_libvirt
-from shakenfist.util import concurrency as util_concurrency
 
 
 LOG, _ = logs.setup(__name__)
@@ -995,7 +996,7 @@ class Monitor(daemon.Daemon):
                     self.idle(1)
 
             except Exception as e:
-                util_general.ignore_exception('side channel monitor', e)
+                util_exceptions.ignore_exception('side channel monitor', e)
 
         LOG.info('Stopping')
         send_systemd_stopping()
@@ -1011,6 +1012,7 @@ class Monitor(daemon.Daemon):
 
 
 def main():
+    util_exceptions.install_exception_tracking()
     daemon.write_pid_file('sidechannel')
     m = Monitor('sidechannel')
 

--- a/shakenfist/daemons/transfers/main.py
+++ b/shakenfist/daemons/transfers/main.py
@@ -12,7 +12,6 @@ from shakenfist.config import config
 from shakenfist.daemons import daemon
 from shakenfist.util import concurrency as util_concurrency
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 
 
 LOG, _ = logs.setup(__name__)

--- a/shakenfist/daemons/transfers/main.py
+++ b/shakenfist/daemons/transfers/main.py
@@ -10,8 +10,9 @@ from shakenfist import etcd
 from shakenfist.baseobject import DatabaseBackedObject as dbo
 from shakenfist.config import config
 from shakenfist.daemons import daemon
-from shakenfist.util import general as util_general
 from shakenfist.util import concurrency as util_concurrency
+from shakenfist.util import exceptions as util_exceptions
+from shakenfist.util import general as util_general
 
 
 LOG, _ = logs.setup(__name__)
@@ -112,12 +113,13 @@ class Monitor(daemon.WorkerPoolDaemon):
                         }
 
             except Exception as e:
-                util_general.ignore_exception('transfer worker', e)
+                util_exceptions.ignore_exception('transfer worker', e)
 
             self.idle(0.2)
 
 
 def main():
+    util_exceptions.install_exception_tracking()
     daemon.write_pid_file('transfers')
     m = Monitor('transfers')
 

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -40,11 +40,13 @@ from shakenfist.external_api import network as api_network
 from shakenfist.external_api import node as api_node
 from shakenfist.external_api import snapshot as api_snapshot
 from shakenfist.external_api import upload as api_upload
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
 LOG, HANDLER = logs.setup(__name__)
 daemon.set_log_level(LOG, 'api')
+util_exceptions.install_exception_tracking()
 
 
 app = flask.Flask(__name__)

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -54,6 +54,7 @@ from shakenfist.constants import EVENT_TYPE_STATUS
 from shakenfist.node import Node
 from shakenfist.schema.object_types import ObjectType
 from shakenfist.operations.baseoperation import BaseClusterOperation as bco
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 from shakenfist.util import image as util_image
 from shakenfist.util import libvirt as util_libvirt
@@ -852,7 +853,7 @@ class Instance(dbowo):
                 if inst:
                     inst.undefine()
         except Exception as e:
-            util_general.ignore_exception(
+            util_exceptions.ignore_exception(
                 'instance delete domain %s' % self, e)
 
         with util_general.RecordedOperation('delete disks', self):
@@ -860,7 +861,7 @@ class Instance(dbowo):
                 if os.path.exists(self.instance_path):
                     shutil.rmtree(self.instance_path)
             except Exception as e:
-                util_general.ignore_exception(
+                util_exceptions.ignore_exception(
                     'instance delete disks %s' % self, e)
 
     def _delete_globally(self):

--- a/shakenfist/operations/artifact_fetch_op.py
+++ b/shakenfist/operations/artifact_fetch_op.py
@@ -12,6 +12,7 @@ from shakenfist import images
 from shakenfist.instance import Instance
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -91,7 +92,7 @@ class ArtifactFetchOp(BaseClusterOperation):
         try:
             self.__getattribute__(f'_{task.name}')(inst)
         except Exception as e:
-            util_general.ignore_exception('artifact_fetch_op', e)
+            util_exceptions.ignore_exception('artifact_fetch_op', e)
             self.state = ArtifactFetchOp.STATE_ERROR
 
     def _image_fetch(self, inst):

--- a/shakenfist/operations/artifact_fetch_op.py
+++ b/shakenfist/operations/artifact_fetch_op.py
@@ -13,7 +13,6 @@ from shakenfist.instance import Instance
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 
 
 LOG, HANDLER = logs.setup(__name__)

--- a/shakenfist/operations/imgcache_op.py
+++ b/shakenfist/operations/imgcache_op.py
@@ -12,6 +12,7 @@ from shakenfist.eventlog import add_event_multi
 from shakenfist.exceptions import BlobDeleted
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -107,7 +108,7 @@ class ImageCacheOp(BaseClusterOperation):
         try:
             self.__getattribute__(f'_{task.name}')(b)
         except Exception as e:
-            util_general.ignore_exception('imgcache_op', e)
+            util_exceptions.ignore_exception('imgcache_op', e)
             self.state = ImageCacheOp.STATE_ERROR
 
     def _archive_transcode(self, b):

--- a/shakenfist/operations/net_iface_ip_op.py
+++ b/shakenfist/operations/net_iface_ip_op.py
@@ -6,7 +6,6 @@ from shakenfist.network.interface import NetworkInterface
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 
 
 LOG, HANDLER = logs.setup(__name__)

--- a/shakenfist/operations/net_iface_ip_op.py
+++ b/shakenfist/operations/net_iface_ip_op.py
@@ -5,6 +5,7 @@ from shakenfist.network.network import Network
 from shakenfist.network.interface import NetworkInterface
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -105,7 +106,7 @@ class NetIfaceIPOp(BaseClusterOperation):
         try:
             self.__getattribute__(f'_{task.name}')(n, ni)
         except Exception as e:
-            util_general.ignore_exception('net_iface_ip_op', e)
+            util_exceptions.ignore_exception('net_iface_ip_op', e)
             self.state = NetIfaceIPOp.STATE_ERROR
 
     def _interface_defloat(self, n, ni):

--- a/shakenfist/operations/net_iface_op.py
+++ b/shakenfist/operations/net_iface_op.py
@@ -6,7 +6,6 @@ from shakenfist.network.interface import NetworkInterface
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 
 
 LOG, HANDLER = logs.setup(__name__)

--- a/shakenfist/operations/net_iface_op.py
+++ b/shakenfist/operations/net_iface_op.py
@@ -5,6 +5,7 @@ from shakenfist.network.network import Network
 from shakenfist.network.interface import NetworkInterface
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -103,7 +104,7 @@ class NetIfaceOp(BaseClusterOperation):
         try:
             self.__getattribute__(f'_{task.name}')(n, ni)
         except Exception as e:
-            util_general.ignore_exception('net_iface_op', e)
+            util_exceptions.ignore_exception('net_iface_op', e)
             self.state = NetIfaceOp.STATE_ERROR
 
     def _interface_float(self, n, ni):

--- a/shakenfist/operations/net_ip_op.py
+++ b/shakenfist/operations/net_ip_op.py
@@ -5,7 +5,6 @@ from shakenfist.network.network import Network
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 
 
 LOG, HANDLER = logs.setup(__name__)

--- a/shakenfist/operations/net_ip_op.py
+++ b/shakenfist/operations/net_ip_op.py
@@ -4,6 +4,7 @@ from shakenfist.schema.operations import net_ip_op as schema
 from shakenfist.network.network import Network
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -86,7 +87,7 @@ class NetIPOp(BaseClusterOperation):
         try:
             self.__getattribute__(f'_{task.name}')(n)
         except Exception as e:
-            util_general.ignore_exception('net_ip_op', e)
+            util_exceptions.ignore_exception('net_ip_op', e)
             self.state = NetIPOp.STATE_ERROR
 
     def _route_address(self, n):

--- a/shakenfist/operations/net_macaddr_ip_op.py
+++ b/shakenfist/operations/net_macaddr_ip_op.py
@@ -5,7 +5,6 @@ from shakenfist.network.network import Network
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 
 
 LOG, HANDLER = logs.setup(__name__)

--- a/shakenfist/operations/net_macaddr_ip_op.py
+++ b/shakenfist/operations/net_macaddr_ip_op.py
@@ -4,6 +4,7 @@ from shakenfist.schema.operations import net_macaddr_ip_op as schema
 from shakenfist.network.network import Network
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -94,7 +95,7 @@ class NetMacaddrIPOp(BaseClusterOperation):
         try:
             self.__getattribute__(f'_{task.name}')(n)
         except Exception as e:
-            util_general.ignore_exception('net_macaddr_ip_op', e)
+            util_exceptions.ignore_exception('net_macaddr_ip_op', e)
             self.state = NetMacaddrIPOp.STATE_ERROR
 
     def _remove_dhcp_lease(self, n):

--- a/shakenfist/operations/net_op.py
+++ b/shakenfist/operations/net_op.py
@@ -8,7 +8,6 @@ from shakenfist.network.interface import NetworkInterface
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 
 
 LOG, HANDLER = logs.setup(__name__)

--- a/shakenfist/operations/net_op.py
+++ b/shakenfist/operations/net_op.py
@@ -7,6 +7,7 @@ from shakenfist.network.network import Network
 from shakenfist.network.interface import NetworkInterface
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -84,12 +85,12 @@ class NetOp(BaseClusterOperation):
         except EnsureMeshFailed as e:
             if n.state.value in n.ACTIVE_STATES:
                 # This should not happen with an active network
-                util_general.ignore_exception('net_op', e)
+                util_exceptions.ignore_exception('net_op', e)
 
             self.state = NetOp.STATE_ERROR
 
         except Exception as e:
-            util_general.ignore_exception('net_op', e)
+            util_exceptions.ignore_exception('net_op', e)
             self.state = NetOp.STATE_ERROR
 
     def _network_deploy(self, n):

--- a/shakenfist/operations/node_aop_op.py
+++ b/shakenfist/operations/node_aop_op.py
@@ -6,6 +6,7 @@ from shakenfist.instance import Instance
 from shakenfist.operations.agentoperation import AgentOperation
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -84,7 +85,7 @@ class NodeAgentopOp(BaseClusterOperation):
         try:
             self.__getattribute__(f'_{task.name}')(aop)
         except Exception as e:
-            util_general.ignore_exception('node_aop_op', e)
+            util_exceptions.ignore_exception('node_aop_op', e)
             self.state = NodeAgentopOp.STATE_ERROR
             aop.state = Instance.STATE_ERROR
 

--- a/shakenfist/operations/node_aop_op.py
+++ b/shakenfist/operations/node_aop_op.py
@@ -7,7 +7,6 @@ from shakenfist.operations.agentoperation import AgentOperation
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 
 
 LOG, HANDLER = logs.setup(__name__)

--- a/shakenfist/operations/node_blob_op.py
+++ b/shakenfist/operations/node_blob_op.py
@@ -11,7 +11,6 @@ from shakenfist.exceptions import BlobAlreadyBeingTransferred
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 
 
 LOG, HANDLER = logs.setup(__name__)

--- a/shakenfist/operations/node_blob_op.py
+++ b/shakenfist/operations/node_blob_op.py
@@ -10,6 +10,7 @@ from shakenfist.schema.operations import node_blob_op as schema
 from shakenfist.exceptions import BlobAlreadyBeingTransferred
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -95,7 +96,7 @@ class NodeBlobOp(BaseClusterOperation):
         try:
             self.__getattribute__(f'_{task.name}')(b)
         except Exception as e:
-            util_general.ignore_exception('node_blob_op', e)
+            util_exceptions.ignore_exception('node_blob_op', e)
             self.state = NodeBlobOp.STATE_ERROR
 
     def _verify_size_and_checksum(self, b):

--- a/shakenfist/operations/node_inst_net_iface_op.py
+++ b/shakenfist/operations/node_inst_net_iface_op.py
@@ -10,6 +10,7 @@ from shakenfist.network.network import Network
 from shakenfist.network.interface import NetworkInterface
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -124,7 +125,7 @@ class NodeInstNetIfaceOp(BaseClusterOperation):
         try:
             self.__getattribute__(f'_{task.name}')(inst, n, ni)
         except Exception as e:
-            util_general.ignore_exception('node_inst_net_iface_op', e)
+            util_exceptions.ignore_exception('node_inst_net_iface_op', e)
             self.state = NodeInstNetIfaceOp.STATE_ERROR
             inst.state = Instance.STATE_ERROR
             ni.state = NetworkInterface.STATE_ERROR

--- a/shakenfist/operations/node_inst_net_iface_op.py
+++ b/shakenfist/operations/node_inst_net_iface_op.py
@@ -11,7 +11,6 @@ from shakenfist.network.interface import NetworkInterface
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 
 
 LOG, HANDLER = logs.setup(__name__)

--- a/shakenfist/operations/node_inst_netdesc_op.py
+++ b/shakenfist/operations/node_inst_netdesc_op.py
@@ -18,6 +18,7 @@ from shakenfist.schema.operations.net_iface_op \
 from shakenfist.schema.operations.net_iface_op \
     import model_tasks as ni_tasks
 from shakenfist import scheduler
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -124,7 +125,7 @@ class NodeInstNetdescOp(BaseClusterOperation):
             except InvalidStateException:
                 self.add_event(EVENT_TYPE_AUDIT, 'failed to abort operation')
         except Exception as e:
-            util_general.ignore_exception('node_inst_netdesc_op', e)
+            util_exceptions.ignore_exception('node_inst_netdesc_op', e)
             inst.enqueue_delete_due_error(f'Unhandled error: {e}')
             self.state = NodeInstNetdescOp.STATE_ERROR
 

--- a/shakenfist/operations/node_inst_op.py
+++ b/shakenfist/operations/node_inst_op.py
@@ -14,6 +14,7 @@ from shakenfist.network.interface import interfaces_for_instance
 from shakenfist.network.interface import NetworkInterface
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 from shakenfist.util import libvirt as util_libvirt
 
@@ -92,7 +93,7 @@ class NodeInstOp(BaseClusterOperation):
         try:
             self.__getattribute__(f'_{task.name}')(inst)
         except Exception as e:
-            util_general.ignore_exception('node_inst_op', e)
+            util_exceptions.ignore_exception('node_inst_op', e)
             self.state = NodeInstOp.STATE_ERROR
             if inst:
                 inst.state = Instance.STATE_ERROR

--- a/shakenfist/operations/node_inst_op.py
+++ b/shakenfist/operations/node_inst_op.py
@@ -15,7 +15,6 @@ from shakenfist.network.interface import NetworkInterface
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 from shakenfist.util import libvirt as util_libvirt
 
 

--- a/shakenfist/operations/node_inst_snap_op.py
+++ b/shakenfist/operations/node_inst_snap_op.py
@@ -11,6 +11,7 @@ from shakenfist.exceptions import InvalidStateException
 from shakenfist.instance import Instance
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -133,7 +134,7 @@ class NodeInstSnapOp(BaseClusterOperation):
                 self.add_event(EVENT_TYPE_AUDIT, 'failed to abort operation')
 
         except Exception as e:
-            util_general.ignore_exception('node_inst_snap_op', e)
+            util_exceptions.ignore_exception('node_inst_snap_op', e)
             self.state = NodeInstSnapOp.STATE_ERROR
             inst.state = Instance.STATE_ERROR
             for a in self.accumulated_artifacts:

--- a/shakenfist/operations/node_inst_snap_op.py
+++ b/shakenfist/operations/node_inst_snap_op.py
@@ -12,7 +12,6 @@ from shakenfist.instance import Instance
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 
 
 LOG, HANDLER = logs.setup(__name__)

--- a/shakenfist/operations/node_net_op.py
+++ b/shakenfist/operations/node_net_op.py
@@ -5,7 +5,6 @@ from shakenfist.network.network import Network
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
 from shakenfist.util import exceptions as util_exceptions
-from shakenfist.util import general as util_general
 
 
 LOG, HANDLER = logs.setup(__name__)

--- a/shakenfist/operations/node_net_op.py
+++ b/shakenfist/operations/node_net_op.py
@@ -4,6 +4,7 @@ from shakenfist.schema.operations import node_net_op as schema
 from shakenfist.network.network import Network
 from shakenfist.operations.baseoperation import BaseClusterOperation
 from shakenfist.operations.baseoperation import BaseOperationException
+from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
 
@@ -81,7 +82,7 @@ class NodeNetOp(BaseClusterOperation):
         try:
             self.__getattribute__(f'_{task.name}')(n)
         except Exception as e:
-            util_general.ignore_exception('node_net_op', e)
+            util_exceptions.ignore_exception('node_net_op', e)
             self.state = NodeNetOp.STATE_ERROR
 
     def _network_destroy(self, n):

--- a/shakenfist/tests/test_util_exceptions.py
+++ b/shakenfist/tests/test_util_exceptions.py
@@ -1,0 +1,324 @@
+import json
+import os
+import sys
+import tempfile
+import threading
+from unittest import mock
+
+from shakenfist.tests import base
+from shakenfist.util import exceptions as util_exceptions
+
+
+class RecordExceptionTestCase(base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+        # Create a temporary directory for exception files
+        self.temp_dir = tempfile.mkdtemp()
+        self.exceptions_path = os.path.join(self.temp_dir, 'exceptions')
+        os.makedirs(self.exceptions_path, exist_ok=True)
+
+    def tearDown(self):
+        super().tearDown()
+        # Clean up temp directory
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _get_exception_info(self):
+        """Helper to generate exception info for testing."""
+        try:
+            raise ValueError('test error')
+        except ValueError:
+            return sys.exc_info()
+
+    @mock.patch('shakenfist.util.exceptions.os.makedirs')
+    @mock.patch('shakenfist.util.exceptions.os.open')
+    @mock.patch('shakenfist.util.exceptions.fcntl.flock')
+    @mock.patch('shakenfist.util.exceptions.os.fstat')
+    @mock.patch('shakenfist.util.exceptions.os.write')
+    @mock.patch('shakenfist.util.exceptions.os.close')
+    def test_record_exception_new_file(self, mock_close, mock_write,
+                                       mock_fstat, mock_flock, mock_open,
+                                       mock_makedirs):
+        """Test recording an exception to a new file."""
+        mock_open.return_value = 42  # fake file descriptor
+        mock_fstat.return_value = mock.Mock(st_size=0)
+
+        exc_type, exc_value, exc_tb = self._get_exception_info()
+        util_exceptions.record_exception(exc_type, exc_value, exc_tb)
+
+        mock_makedirs.assert_called_once()
+        mock_open.assert_called_once()
+        mock_flock.assert_called_once()
+        mock_write.assert_called_once()
+        mock_close.assert_called_once_with(42)
+
+        # Check the written data
+        written_data = mock_write.call_args[0][1]
+        data = json.loads(written_data.decode())
+        self.assertEqual(1, data['count'])
+        self.assertIn('ValueError', data['traceback'])
+        self.assertIn('test error', data['traceback'])
+        self.assertEqual(1, len(data['events']))
+
+    @mock.patch('shakenfist.util.exceptions.os.makedirs')
+    @mock.patch('shakenfist.util.exceptions.os.open')
+    @mock.patch('shakenfist.util.exceptions.fcntl.flock')
+    @mock.patch('shakenfist.util.exceptions.os.fstat')
+    @mock.patch('shakenfist.util.exceptions.os.read')
+    @mock.patch('shakenfist.util.exceptions.os.lseek')
+    @mock.patch('shakenfist.util.exceptions.os.write')
+    @mock.patch('shakenfist.util.exceptions.os.close')
+    def test_record_exception_existing_file(self, mock_close, mock_write,
+                                            mock_lseek, mock_read, mock_fstat,
+                                            mock_flock, mock_open,
+                                            mock_makedirs):
+        """Test recording an exception to an existing file with previous data."""
+        mock_open.return_value = 42
+        existing_data = {
+            'traceback': 'old traceback',
+            'count': 5,
+            'events': [1000.0, 2000.0]
+        }
+        existing_json = json.dumps(existing_data).encode()
+        mock_fstat.return_value = mock.Mock(st_size=len(existing_json))
+        mock_read.return_value = existing_json
+
+        exc_type, exc_value, exc_tb = self._get_exception_info()
+        util_exceptions.record_exception(exc_type, exc_value, exc_tb)
+
+        # Check the written data has incremented count
+        written_data = mock_write.call_args[0][1]
+        data = json.loads(written_data.decode())
+        self.assertEqual(6, data['count'])
+        self.assertEqual(3, len(data['events']))
+        # Traceback should be updated to new one
+        self.assertIn('ValueError', data['traceback'])
+
+    @mock.patch('shakenfist.util.exceptions.os.makedirs')
+    @mock.patch('shakenfist.util.exceptions.os.open')
+    @mock.patch('shakenfist.util.exceptions.fcntl.flock')
+    @mock.patch('shakenfist.util.exceptions.os.close')
+    def test_record_exception_handles_errors_gracefully(self, mock_close,
+                                                        mock_flock, mock_open,
+                                                        mock_makedirs):
+        """Test that errors in record_exception don't propagate."""
+        mock_open.return_value = 42
+        mock_flock.side_effect = OSError('lock failed')
+
+        exc_type, exc_value, exc_tb = self._get_exception_info()
+        # Should not raise
+        util_exceptions.record_exception(exc_type, exc_value, exc_tb)
+        mock_close.assert_called_once_with(42)
+
+    def test_hash_is_deterministic(self):
+        """Test that the same traceback produces the same hash."""
+        # We can't easily test this without running the full function,
+        # but we can verify the hashing approach is consistent
+        import hashlib
+        traceback_str = 'test traceback line 1\ntest traceback line 2'
+        h1 = hashlib.sha256(traceback_str.encode()).hexdigest()[-8:]
+        h2 = hashlib.sha256(traceback_str.encode()).hexdigest()[-8:]
+        self.assertEqual(h1, h2)
+
+
+class IgnoreExceptionTestCase(base.ShakenFistTestCase):
+    @mock.patch('shakenfist.util.exceptions.record_exception')
+    @mock.patch('shakenfist.util.exceptions.LOG')
+    def test_ignore_exception_with_traceback(self, mock_log, mock_record):
+        """Test ignore_exception logs and records when called in except block."""
+        try:
+            raise RuntimeError('something went wrong')
+        except RuntimeError as e:
+            util_exceptions.ignore_exception('test_process', e)
+
+        mock_log.error.assert_called_once()
+        log_msg = mock_log.error.call_args[0][0]
+        self.assertIn('[Exception]', log_msg)
+        self.assertIn('test_process', log_msg)
+        self.assertIn('something went wrong', log_msg)
+        self.assertIn('RuntimeError', log_msg)
+
+        mock_record.assert_called_once()
+
+    @mock.patch('shakenfist.util.exceptions.record_exception')
+    @mock.patch('shakenfist.util.exceptions.LOG')
+    def test_ignore_exception_without_traceback(self, mock_log, mock_record):
+        """Test ignore_exception when called outside an except block."""
+        e = ValueError('no traceback available')
+        util_exceptions.ignore_exception('test_process', e)
+
+        mock_log.error.assert_called_once()
+        log_msg = mock_log.error.call_args[0][0]
+        self.assertIn('[Exception]', log_msg)
+        self.assertIn('test_process', log_msg)
+        self.assertIn('no traceback available', log_msg)
+
+        # Should not call record_exception when there's no traceback
+        mock_record.assert_not_called()
+
+
+class ExceptHookTestCase(base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+        # Save original hooks
+        self._orig_sys_excepthook = sys.excepthook
+        self._orig_threading_excepthook = threading.excepthook
+
+    def tearDown(self):
+        # Restore original hooks
+        sys.excepthook = self._orig_sys_excepthook
+        threading.excepthook = self._orig_threading_excepthook
+        super().tearDown()
+
+    @mock.patch('shakenfist.util.exceptions.record_exception')
+    def test_install_exception_tracking(self, mock_record):
+        """Test that install_exception_tracking sets up the correct hooks."""
+        # Reset to Python's default hooks before testing
+        sys.excepthook = sys.__excepthook__
+        threading.excepthook = threading.__excepthook__
+
+        util_exceptions.install_exception_tracking()
+
+        # After installation, hooks should be our custom ones
+        self.assertEqual(sys.excepthook, util_exceptions._tracking_excepthook)
+        self.assertEqual(threading.excepthook, util_exceptions._thread_excepthook)
+
+    @mock.patch('shakenfist.util.exceptions.record_exception')
+    @mock.patch('shakenfist.util.exceptions._original_excepthook')
+    def test_tracking_excepthook_calls_record_and_original(self, mock_orig,
+                                                           mock_record):
+        """Test that _tracking_excepthook records and calls original hook."""
+        exc_type = ValueError
+        exc_value = ValueError('test')
+        exc_tb = None
+
+        util_exceptions._tracking_excepthook(exc_type, exc_value, exc_tb)
+
+        mock_record.assert_called_once_with(exc_type, exc_value, exc_tb)
+        mock_orig.assert_called_once_with(exc_type, exc_value, exc_tb)
+
+    @mock.patch('shakenfist.util.exceptions.record_exception')
+    def test_thread_excepthook(self, mock_record):
+        """Test that _thread_excepthook extracts args correctly."""
+        # Create a mock args object like threading passes
+        args = mock.Mock()
+        args.exc_type = RuntimeError
+        args.exc_value = RuntimeError('thread error')
+        args.exc_traceback = None
+
+        util_exceptions._thread_excepthook(args)
+
+        mock_record.assert_called_once_with(
+            args.exc_type, args.exc_value, args.exc_traceback)
+
+
+class IntegrationTestCase(base.ShakenFistTestCase):
+    """Integration tests that verify the full flow with real files."""
+
+    def setUp(self):
+        super().setUp()
+        self.temp_dir = tempfile.mkdtemp()
+        self.exceptions_path = os.path.join(self.temp_dir, 'exceptions')
+        os.makedirs(self.exceptions_path, exist_ok=True)
+
+    def tearDown(self):
+        super().tearDown()
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_record_exception_full_flow(self):
+        """Test recording an exception with a real temp file."""
+        # Store reference to real os.open before any patching
+        real_os_open = os.open
+        exceptions_path = self.exceptions_path
+
+        def redirect_open(path, flags, mode):
+            new_path = path.replace('/srv/shakenfist/exceptions',
+                                    exceptions_path)
+            return real_os_open(new_path, flags, mode)
+
+        with mock.patch('shakenfist.util.exceptions.os.makedirs'):
+            with mock.patch('shakenfist.util.exceptions.os.open',
+                            side_effect=redirect_open):
+                try:
+                    raise KeyError('missing key')
+                except KeyError:
+                    exc_type, exc_value, exc_tb = sys.exc_info()
+                    util_exceptions.record_exception(exc_type, exc_value,
+                                                     exc_tb)
+
+        # Find the created file
+        files = os.listdir(self.exceptions_path)
+        self.assertEqual(1, len(files))
+
+        with open(os.path.join(self.exceptions_path, files[0])) as f:
+            data = json.load(f)
+
+        self.assertEqual(1, data['count'])
+        self.assertIn('KeyError', data['traceback'])
+        self.assertIn('missing key', data['traceback'])
+        self.assertEqual(1, len(data['events']))
+
+    def test_record_exception_increments_count(self):
+        """Test that recording the same exception twice increments count."""
+        real_os_open = os.open
+        exceptions_path = self.exceptions_path
+
+        def redirect_open(path, flags, mode):
+            new_path = path.replace('/srv/shakenfist/exceptions',
+                                    exceptions_path)
+            return real_os_open(new_path, flags, mode)
+
+        def raise_and_record():
+            try:
+                raise TypeError('type mismatch')
+            except TypeError:
+                exc_type, exc_value, exc_tb = sys.exc_info()
+                util_exceptions.record_exception(exc_type, exc_value, exc_tb)
+
+        with mock.patch('shakenfist.util.exceptions.os.makedirs'):
+            with mock.patch('shakenfist.util.exceptions.os.open',
+                            side_effect=redirect_open):
+                # Record the same exception twice
+                raise_and_record()
+                raise_and_record()
+
+        files = os.listdir(self.exceptions_path)
+        self.assertEqual(1, len(files))
+
+        with open(os.path.join(self.exceptions_path, files[0])) as f:
+            data = json.load(f)
+
+        self.assertEqual(2, data['count'])
+        self.assertEqual(2, len(data['events']))
+
+    def test_different_exceptions_create_different_files(self):
+        """Test that different exception types create separate files."""
+        real_os_open = os.open
+        exceptions_path = self.exceptions_path
+
+        def redirect_open(path, flags, mode):
+            new_path = path.replace('/srv/shakenfist/exceptions',
+                                    exceptions_path)
+            return real_os_open(new_path, flags, mode)
+
+        with mock.patch('shakenfist.util.exceptions.os.makedirs'):
+            with mock.patch('shakenfist.util.exceptions.os.open',
+                            side_effect=redirect_open):
+                try:
+                    raise ValueError('value error')
+                except ValueError:
+                    exc_type, exc_value, exc_tb = sys.exc_info()
+                    util_exceptions.record_exception(exc_type, exc_value,
+                                                     exc_tb)
+
+                try:
+                    raise KeyError('key error')
+                except KeyError:
+                    exc_type, exc_value, exc_tb = sys.exc_info()
+                    util_exceptions.record_exception(exc_type, exc_value,
+                                                     exc_tb)
+
+        files = os.listdir(self.exceptions_path)
+        # Different tracebacks should create different files
+        self.assertEqual(2, len(files))

--- a/shakenfist/util/exceptions.py
+++ b/shakenfist/util/exceptions.py
@@ -18,15 +18,16 @@ def ignore_exception(processname, e):
     msg = f'[Exception] Ignored error in {processname}: {e}'
     exc_type, exc_value, exc_tb = sys.exc_info()
     if exc_tb:
-        msg += '\n%s' % traceback.format_exc(exc_type, exc_value, exc_tb)
+        msg += '\n'
+        msg += '\n'.join(traceback.format_exception(exc_type, exc_value, exc_tb))
         record_exception(exc_type, exc_value, exc_tb)
     LOG.error(msg)
 
 
 def record_exception(exc_type, exc_value, exc_tb):
-    traceback_str = '\n%s' % traceback.format_exc(exc_type, exc_value, exc_tb)
+    traceback_str = '\n'.join(traceback.format_exception(exc_type, exc_value, exc_tb))
 
-    h = hashlib.sha256(traceback_str).hexdigest()[-8:]
+    h = hashlib.sha256(traceback_str.encode()).hexdigest()[-8:]
     os.makedirs(os.path.join('/srv/shakenfist/exceptions'), exist_ok=True)
     
     flags = os.O_RDWR | os.O_CREAT
@@ -40,7 +41,7 @@ def record_exception(exc_type, exc_value, exc_tb):
         if size > 0:
             d = os.read(fd, size)
             if d:
-                data = json.loads(d)
+                data = json.loads(d.decode())
             os.lseek(fd, 0, os.SEEK_SET)
 
         data['traceback'] = traceback_str
@@ -50,10 +51,12 @@ def record_exception(exc_type, exc_value, exc_tb):
             data['events'] = []
         data['events'].append(time.time())
 
-        os.write(fd, json.dumps(data, indent=4, sort_keys=True))
+        os.write(fd, json.dumps(data, indent=4, sort_keys=True).encode())
 
-    except:
+    except Exception:
         # Ignore the exception here because we're already on the error path
+        pass
+    finally:
         os.close(fd)
 
 

--- a/shakenfist/util/exceptions.py
+++ b/shakenfist/util/exceptions.py
@@ -28,10 +28,10 @@ def record_exception(exc_type, exc_value, exc_tb):
 
     h = hashlib.sha256(traceback_str).hexdigest()[-8:]
     os.makedirs(os.path.join('/srv/shakenfist/exceptions'), exist_ok=True)
-    
+
     flags = os.O_RDWR | os.O_CREAT
     fd = os.open(f'/srv/shakenfist/exceptions/{h}.json', flags, 0o644)
-    
+
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)
         data = {}
@@ -52,7 +52,7 @@ def record_exception(exc_type, exc_value, exc_tb):
 
         os.write(fd, json.dumps(data, indent=4, sort_keys=True))
 
-    except:
+    except Exception:
         # Ignore the exception here because we're already on the error path
         os.close(fd)
 

--- a/shakenfist/util/exceptions.py
+++ b/shakenfist/util/exceptions.py
@@ -1,0 +1,74 @@
+
+import fcntl
+import hashlib
+import json
+import os
+import sys
+import threading
+import time
+import traceback
+
+from shakenfist_utilities import logs  # noreorder
+
+
+LOG, _ = logs.setup(__name__)
+
+
+def ignore_exception(processname, e):
+    msg = f'[Exception] Ignored error in {processname}: {e}'
+    exc_type, exc_value, exc_tb = sys.exc_info()
+    if exc_tb:
+        msg += '\n%s' % traceback.format_exc(exc_type, exc_value, exc_tb)
+        record_exception(exc_type, exc_value, exc_tb)
+    LOG.error(msg)
+
+
+def record_exception(exc_type, exc_value, exc_tb):
+    traceback_str = '\n%s' % traceback.format_exc(exc_type, exc_value, exc_tb)
+
+    h = hashlib.sha256(traceback_str).hexdigest()[-8:]
+    os.makedirs(os.path.join('/srv/shakenfist/exceptions'), exist_ok=True)
+    
+    flags = os.O_RDWR | os.O_CREAT
+    fd = os.open(f'/srv/shakenfist/exceptions/{h}.json', flags, 0o644)
+    
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        data = {}
+
+        size = os.fstat(fd).st_size
+        if size > 0:
+            d = os.read(fd, size)
+            if d:
+                data = json.loads(d)
+            os.lseek(fd, 0, os.SEEK_SET)
+
+        data['traceback'] = traceback_str
+        data['count'] = data.get('count', 0) + 1
+
+        if 'events' not in data:
+            data['events'] = []
+        data['events'].append(time.time())
+
+        os.write(fd, json.dumps(data, indent=4, sort_keys=True))
+
+    except:
+        # Ignore the exception here because we're already on the error path
+        os.close(fd)
+
+
+_original_excepthook = sys.excepthook
+
+
+def _tracking_excepthook(exc_type, exc_value, exc_tb):
+    record_exception(exc_type, exc_value, exc_tb)
+    _original_excepthook(exc_type, exc_value, exc_tb)
+
+
+def _thread_excepthook(args):
+    record_exception(args.exc_type, args.exc_value, args.exc_traceback)
+
+
+def install_exception_tracking():
+    sys.excepthook = _tracking_excepthook
+    threading.excepthook = _thread_excepthook

--- a/shakenfist/util/general.py
+++ b/shakenfist/util/general.py
@@ -1,9 +1,7 @@
 import os
 import pathlib
 import stat
-import sys
 import time
-import traceback
 import uuid
 
 import cpuinfo
@@ -87,15 +85,6 @@ def get_user_agent():
                 'vendor': architecture['vendor_id_raw'],
                 'version': get_version()
             })
-
-
-def ignore_exception(processname, e):
-    msg = f'[Exception] Ignored error in {processname}: {e}'
-    _, _, tb = sys.exc_info()
-    if tb:
-        msg += '\n%s' % traceback.format_exc()
-
-    LOG.error(msg)
 
 
 def noneish(value):

--- a/tools/fix-exceptions-with-claude.sh
+++ b/tools/fix-exceptions-with-claude.sh
@@ -1,0 +1,456 @@
+#!/bin/bash
+
+# Auto-fix exceptions using Claude Code.
+#
+# This script analyzes exception JSON files from CI bundles, finds the most
+# frequent exception (by traceback), and uses Claude Code to fix it in the
+# codebase. If fixes are successful, it commits the changes and pushes to
+# the PR branch.
+#
+# Exception files are named by a hash of the traceback and contain:
+#   - traceback: the full Python traceback string
+#   - count: number of times this exact traceback occurred
+#   - events: list of unix timestamps when it occurred
+#
+# Usage:
+#   tools/fix-exceptions-with-claude.sh [options] [job_names...]
+#
+# Options:
+#   --no-push           Fix and commit but don't push
+#   --no-commit         Fix but don't commit or push
+#   --max-turns N       Maximum Claude turns (default: 100)
+#   --interactive       Run Claude in interactive mode (default: headless)
+#   --ci                CI mode: output machine-readable status, no colors
+#   --bundles-dir DIR   Directory containing downloaded bundles
+#   --help              Show this help message
+#
+# Arguments:
+#   job_names           Space-separated list of failed job names (optional)
+#
+# Environment Variables:
+#   BUNDLES_DIR         Directory containing downloaded bundles (alternative to
+#                       --bundles-dir)
+#   FAILED_JOBS         Space-separated list of failed job names (alternative
+#                       to positional arguments)
+#
+# Exit codes:
+#   0 - No exceptions found or fixes were committed and pushed
+#   1 - Exceptions found but could not be fixed
+#   2 - Exceptions fixed but push failed
+#   3 - No bundles or exception files found
+#
+# Examples:
+#   # Run in CI with bundles already downloaded
+#   BUNDLES_DIR=/srv/github/bundles tools/fix-exceptions-with-claude.sh --ci
+#
+#   # Interactive mode for debugging
+#   tools/fix-exceptions-with-claude.sh --interactive --bundles-dir ./bundles
+#
+#   # Just analyze, don't fix anything
+#   tools/fix-exceptions-with-claude.sh --no-commit --bundles-dir ./bundles
+
+set -e
+
+topdir=$(cd "$(dirname "$0")/.." && pwd)
+cd "${topdir}"
+
+# Default options
+do_push=true
+do_commit=true
+max_turns=100
+interactive=false
+ci_mode=false
+bundles_dir="${BUNDLES_DIR:-}"
+failed_jobs="${FAILED_JOBS:-}"
+
+# Colors for output (disabled in CI mode)
+setup_colors() {
+    if [ "${ci_mode}" = true ]; then
+        RED=''
+        GREEN=''
+        YELLOW=''
+        BLUE=''
+        NC=''
+    else
+        RED='\033[0;31m'
+        GREEN='\033[0;32m'
+        YELLOW='\033[1;33m'
+        BLUE='\033[0;34m'
+        NC='\033[0m'
+    fi
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --no-push)
+            do_push=false
+            shift
+            ;;
+        --no-commit)
+            do_commit=false
+            do_push=false
+            shift
+            ;;
+        --max-turns)
+            max_turns="$2"
+            shift 2
+            ;;
+        --interactive)
+            interactive=true
+            shift
+            ;;
+        --ci)
+            ci_mode=true
+            shift
+            ;;
+        --bundles-dir)
+            bundles_dir="$2"
+            shift 2
+            ;;
+        --help|-h)
+            head -50 "$0" | tail -47
+            exit 0
+            ;;
+        -*)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+        *)
+            # Positional arguments are job names
+            if [ -z "${failed_jobs}" ]; then
+                failed_jobs="$1"
+            else
+                failed_jobs="${failed_jobs} $1"
+            fi
+            shift
+            ;;
+    esac
+done
+
+setup_colors
+
+# Validate bundles directory
+if [ -z "${bundles_dir}" ]; then
+    echo -e "${RED}Error: No bundles directory specified${NC}"
+    echo "Use --bundles-dir or set BUNDLES_DIR environment variable"
+    exit 3
+fi
+
+if [ ! -d "${bundles_dir}" ]; then
+    echo -e "${RED}Error: Bundles directory does not exist: ${bundles_dir}${NC}"
+    exit 3
+fi
+
+# Create working directory
+work_dir=$(mktemp -d)
+cleanup() {
+    rm -rf "${work_dir}"
+}
+trap cleanup EXIT
+
+# CI mode output helper
+ci_output() {
+    local key="$1"
+    local value="$2"
+    if [ "${ci_mode}" = true ]; then
+        echo "${key}=${value}"
+    fi
+}
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Shaken Fist Exception Fixer${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo
+
+# Step 1: Extract bundles and collect exception files
+echo -e "${YELLOW}Step 1: Extracting bundles and collecting exception files...${NC}"
+echo
+
+exceptions_dir="${work_dir}/exceptions"
+mkdir -p "${exceptions_dir}"
+
+for job_dir in "${bundles_dir}"/*/; do
+    job_name=$(basename "$job_dir")
+    echo "Processing bundle for job: $job_name"
+
+    if [ -f "${job_dir}/bundle.zip" ]; then
+        unzip -q "${job_dir}/bundle.zip" -d "${job_dir}"
+
+        # Copy exception files from srv/shakenfist/exceptions if they exist
+        # The bundle structure is: bundle/<node_name>/srv/shakenfist/exceptions/
+        for node_dir in "${job_dir}"/bundle/*/; do
+            exc_dir="${node_dir}srv/shakenfist/exceptions"
+            if [ -d "$exc_dir" ]; then
+                node_name=$(basename "$node_dir")
+                echo "  Found exceptions in node: $node_name"
+                # Copy files - same traceback hash from different nodes will
+                # have same filename, we'll aggregate counts later
+                for f in "$exc_dir"/*.json; do
+                    if [ -f "$f" ]; then
+                        base=$(basename "$f")
+                        # If file already exists, we need to merge counts
+                        if [ -f "${exceptions_dir}/${base}" ]; then
+                            # Add counts together
+                            existing_count=$(jq -r '.count' "${exceptions_dir}/${base}")
+                            new_count=$(jq -r '.count' "$f")
+                            total_count=$((existing_count + new_count))
+                            # Merge events arrays and update count
+                            jq -s '.[0] * {count: (.[0].count + .[1].count), events: (.[0].events + .[1].events)}' \
+                                "${exceptions_dir}/${base}" "$f" > "${exceptions_dir}/${base}.tmp"
+                            mv "${exceptions_dir}/${base}.tmp" "${exceptions_dir}/${base}"
+                        else
+                            cp "$f" "${exceptions_dir}/${base}"
+                        fi
+                    fi
+                done
+            fi
+        done
+    else
+        echo "  Warning: No bundle.zip found in ${job_dir}"
+    fi
+done
+
+echo
+echo "Collected exception files:"
+exception_count=$(find "${exceptions_dir}" -name "*.json" 2>/dev/null | wc -l)
+echo "  Unique tracebacks: ${exception_count}"
+
+if [ "${exception_count}" -eq 0 ]; then
+    echo -e "${GREEN}✓ No exception files found in bundles${NC}"
+    ci_output "exceptions_found" "false"
+    exit 0
+fi
+
+ci_output "exceptions_found" "true"
+ci_output "unique_tracebacks" "${exception_count}"
+
+# Step 2: Find the most frequent exception (highest count)
+echo
+echo -e "${YELLOW}Step 2: Finding the most frequent exception...${NC}"
+echo
+
+# List all exceptions with their counts
+echo "Exception frequency (by traceback hash):"
+for f in "${exceptions_dir}"/*.json; do
+    if [ -f "$f" ]; then
+        hash=$(basename "$f" .json)
+        count=$(jq -r '.count' "$f")
+        echo "  ${hash}: ${count} occurrences"
+    fi
+done | sort -t: -k2 -rn | head -10
+
+echo
+
+# Find the file with the highest count
+most_frequent_file=""
+highest_count=0
+
+for f in "${exceptions_dir}"/*.json; do
+    if [ -f "$f" ]; then
+        count=$(jq -r '.count' "$f")
+        if [ "${count}" -gt "${highest_count}" ]; then
+            highest_count="${count}"
+            most_frequent_file="$f"
+        fi
+    fi
+done
+
+if [ -z "${most_frequent_file}" ]; then
+    echo -e "${RED}Error: Could not determine most frequent exception${NC}"
+    exit 1
+fi
+
+traceback_hash=$(basename "${most_frequent_file}" .json)
+echo -e "${BLUE}Most frequent exception: ${traceback_hash} (${highest_count} occurrences)${NC}"
+
+ci_output "target_traceback_hash" "${traceback_hash}"
+ci_output "target_exception_count" "${highest_count}"
+
+echo
+echo "Traceback:"
+jq -r '.traceback' "${most_frequent_file}"
+
+# Step 3: Check Claude availability
+echo
+echo -e "${YELLOW}Step 3: Checking Claude Code availability...${NC}"
+
+if ! command -v claude &> /dev/null; then
+    echo -e "${RED}Error: Claude Code CLI not found${NC}"
+    echo "Install with: npm install -g @anthropic-ai/claude-code"
+    ci_output "claude_available" "false"
+    ci_output "fix_succeeded" "false"
+    exit 1
+fi
+
+ci_output "claude_available" "true"
+echo -e "${GREEN}✓ Claude Code is available${NC}"
+echo
+
+# Step 4: Build prompt and run Claude
+echo -e "${YELLOW}Step 4: Running Claude Code to fix the exception...${NC}"
+echo
+
+# Extract the traceback
+exc_traceback=$(jq -r '.traceback' "${most_frequent_file}")
+
+# Build the prompt
+cat > "${work_dir}/claude-prompt.txt" << PROMPT_EOF
+During CI testing, an unhandled exception was detected ${highest_count} times.
+This is the most frequent exception found in the test run. Please analyze
+and fix the root cause in the codebase.
+
+## Traceback
+
+\`\`\`
+${exc_traceback}
+\`\`\`
+
+## Your Task
+
+1. Analyze the traceback to understand what caused this exception
+2. Find the relevant source file(s) in the codebase
+3. Implement a fix that prevents this exception from occurring
+4. The fix should handle the error condition gracefully, not just suppress it
+5. Consider edge cases and ensure the fix is robust
+
+## Guidelines
+
+- Focus on fixing the ROOT CAUSE, not just adding try/except to hide the error
+- If the exception indicates a logic error, fix the logic
+- If it's a missing null check, add appropriate validation
+- If it's a race condition, add proper synchronization
+- Add appropriate logging if the fix involves handling an error condition
+- Follow existing code style (single quotes, 80 char lines, etc.)
+
+## After Making Fixes
+
+1. Review your changes to ensure they're correct
+2. Only stage your changes with 'git add' - do NOT commit
+3. Briefly explain what you fixed and why
+
+## Important Notes
+
+- This exception occurred ${highest_count} times during testing
+- Fix only this specific exception, not other issues you might notice
+- Be careful not to introduce new bugs while fixing this one
+- If you're unsure about the fix, explain your reasoning
+PROMPT_EOF
+
+echo "Prompt prepared. Starting Claude Code..."
+echo
+
+# Run Claude Code
+if [ "${interactive}" = true ]; then
+    # Interactive mode
+    echo "Prompt file: ${work_dir}/claude-prompt.txt"
+    echo
+    cat "${work_dir}/claude-prompt.txt"
+    echo
+    echo "Run 'claude' and paste the prompt above to fix the exception."
+    exit 1
+else
+    # Headless mode
+    claude -p "$(cat "${work_dir}/claude-prompt.txt")" \
+        --dangerously-skip-permissions \
+        --max-turns "${max_turns}" \
+        --output-format text || true
+fi
+
+echo
+echo -e "${YELLOW}Step 5: Checking for changes...${NC}"
+
+# Check if Claude made any changes
+if git diff --quiet && git diff --staged --quiet; then
+    echo -e "${YELLOW}No changes were made by Claude${NC}"
+    echo "This could mean:"
+    echo "  - Claude couldn't find a fix"
+    echo "  - The fix requires more context"
+    echo "  - The issue is in external code"
+    ci_output "fix_succeeded" "false"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Changes detected${NC}"
+echo
+echo "Changed files:"
+git status --short
+
+ci_output "fix_succeeded" "true"
+echo
+
+# Step 6: Commit and push if requested
+if [ "${do_commit}" = false ]; then
+    echo -e "${YELLOW}Skipping commit (--no-commit specified)${NC}"
+    echo "Changes made but not committed:"
+    git diff
+    exit 0
+fi
+
+echo -e "${YELLOW}Step 6: Committing fixes...${NC}"
+
+# Stage all Python file changes
+git add -A shakenfist/
+
+# Check if there are changes to commit
+if git diff --staged --quiet; then
+    echo "No changes to commit (fixes may have been staged already)"
+else
+    # Extract a short description from the traceback (first line of actual error)
+    short_desc=$(echo "${exc_traceback}" | grep -E "^[A-Za-z]+Error:|^[A-Za-z]+Exception:" | head -1 | cut -c1-60)
+    if [ -z "${short_desc}" ]; then
+        short_desc="unhandled exception"
+    fi
+
+    # Commit the fixes
+    git commit -m "$(cat <<EOF
+Fix ${short_desc}.
+
+This exception occurred ${highest_count} times during CI testing.
+The fix addresses the root cause identified in the traceback.
+
+Traceback hash: ${traceback_hash}
+
+Assisted-By: Claude Code
+
+Signed-off-by: Claude Code run by Shakenfist Bot <bot@shakenfist.com>
+EOF
+)"
+    echo -e "${GREEN}✓ Changes committed${NC}"
+fi
+
+if [ "${do_push}" = false ]; then
+    echo -e "${YELLOW}Skipping push (--no-push specified)${NC}"
+    exit 0
+fi
+
+echo -e "${YELLOW}Step 7: Pushing to remote...${NC}"
+
+# Get current branch - in GitHub Actions PR context, use GITHUB_HEAD_REF
+# as the checkout is in detached HEAD state
+if [ -n "${GITHUB_HEAD_REF}" ]; then
+    current_branch="${GITHUB_HEAD_REF}"
+else
+    current_branch=$(git rev-parse --abbrev-ref HEAD)
+fi
+
+echo "Pushing to branch: ${current_branch}"
+
+# Push to origin
+set +e
+git push origin "HEAD:${current_branch}"
+push_exit_code=$?
+set -e
+
+if [ ${push_exit_code} -ne 0 ]; then
+    echo -e "${RED}✗ Push failed${NC}"
+    ci_output "push_succeeded" "false"
+    exit 2
+fi
+
+echo -e "${GREEN}✓ Pushed to origin/${current_branch}${NC}"
+ci_output "push_succeeded" "true"
+echo
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}Exception fix committed and pushed!${NC}"
+echo -e "${GREEN}========================================${NC}"

--- a/tools/fix-exceptions-with-claude.sh
+++ b/tools/fix-exceptions-with-claude.sh
@@ -350,11 +350,31 @@ if [ "${interactive}" = true ]; then
     echo "Run 'claude' and paste the prompt above to fix the exception."
     exit 1
 else
-    # Headless mode
+    # Headless mode - use JSON output to capture turn count and other metadata
     claude -p "$(cat "${work_dir}/claude-prompt.txt")" \
         --dangerously-skip-permissions \
         --max-turns "${max_turns}" \
-        --output-format text || true
+        --output-format json > "${work_dir}/claude-output.json" || true
+
+    # Extract and display the result text
+    if [ -f "${work_dir}/claude-output.json" ]; then
+        jq -r '.result // empty' "${work_dir}/claude-output.json"
+
+        # Extract metadata for CI output
+        num_turns=$(jq -r '.num_turns // "unknown"' "${work_dir}/claude-output.json")
+        duration_ms=$(jq -r '.duration_ms // "unknown"' "${work_dir}/claude-output.json")
+        cost_usd=$(jq -r '.total_cost_usd // "unknown"' "${work_dir}/claude-output.json")
+
+        echo
+        echo -e "${BLUE}Claude execution stats:${NC}"
+        echo "  Turns: ${num_turns} / ${max_turns}"
+        echo "  Duration: ${duration_ms}ms"
+        echo "  Cost: \$${cost_usd}"
+
+        ci_output "claude_turns" "${num_turns}"
+        ci_output "claude_duration_ms" "${duration_ms}"
+        ci_output "claude_cost_usd" "${cost_usd}"
+    fi
 fi
 
 echo

--- a/tools/fix-lint-with-claude.sh
+++ b/tools/fix-lint-with-claude.sh
@@ -11,7 +11,7 @@
 # Options:
 #   --no-push           Fix and commit but don't push
 #   --no-commit         Fix but don't commit or push
-#   --max-turns N       Maximum Claude turns (default: 30)
+#   --max-turns N       Maximum Claude turns (default: 100)
 #   --interactive       Run Claude in interactive mode (default: headless)
 #   --ci                CI mode: output machine-readable status, no colors
 #   --output-dir DIR    Directory for output files (default: temp dir)
@@ -40,7 +40,7 @@ cd "${topdir}"
 # Default options
 do_push=true
 do_commit=true
-max_turns=30
+max_turns=100
 interactive=false
 ci_mode=false
 output_dir=""

--- a/tools/fix-lint-with-claude.sh
+++ b/tools/fix-lint-with-claude.sh
@@ -251,11 +251,31 @@ if [ "${interactive}" = true ]; then
     echo "Run 'claude' and paste the prompt above to fix lint errors interactively."
     exit 1
 else
-    # Headless mode
+    # Headless mode - use JSON output to capture turn count and other metadata
     claude -p "$(cat "${output_dir}/claude-prompt.txt")" \
         --dangerously-skip-permissions \
         --max-turns "${max_turns}" \
-        --output-format text || true
+        --output-format json > "${output_dir}/claude-output.json" || true
+
+    # Extract and display the result text
+    if [ -f "${output_dir}/claude-output.json" ]; then
+        jq -r '.result // empty' "${output_dir}/claude-output.json"
+
+        # Extract metadata for CI output
+        num_turns=$(jq -r '.num_turns // "unknown"' "${output_dir}/claude-output.json")
+        duration_ms=$(jq -r '.duration_ms // "unknown"' "${output_dir}/claude-output.json")
+        cost_usd=$(jq -r '.total_cost_usd // "unknown"' "${output_dir}/claude-output.json")
+
+        echo
+        echo -e "${BLUE}Claude execution stats:${NC}"
+        echo "  Turns: ${num_turns} / ${max_turns}"
+        echo "  Duration: ${duration_ms}ms"
+        echo "  Cost: \$${cost_usd}"
+
+        ci_output "claude_turns" "${num_turns}"
+        ci_output "claude_duration_ms" "${duration_ms}"
+        ci_output "claude_cost_usd" "${cost_usd}"
+    fi
 fi
 
 echo

--- a/tools/review-pr-with-claude.sh
+++ b/tools/review-pr-with-claude.sh
@@ -10,7 +10,7 @@
 #
 # Options:
 #   --pr NUMBER         PR number to review (required in CI, auto-detected locally)
-#   --max-turns N       Maximum Claude turns (default: 20)
+#   --max-turns N       Maximum Claude turns (default: 50)
 #   --interactive       Run Claude in interactive mode (default: headless)
 #   --ci                CI mode: output machine-readable status, no colors
 #   --dry-run           Don't post the review, just print it
@@ -43,7 +43,7 @@ cd "${topdir}"
 
 # Default options
 pr_number=""
-max_turns=20
+max_turns=50
 interactive=false
 ci_mode=false
 dry_run=false

--- a/tools/review-pr-with-claude.sh
+++ b/tools/review-pr-with-claude.sh
@@ -304,11 +304,31 @@ if [ "${dry_run}" = true ]; then
     exit 0
 fi
 
-# Run Claude Code
+# Run Claude Code - use JSON output to capture turn count and other metadata
 cat "${output_dir}/claude-prompt.txt" | claude -p - \
     --dangerously-skip-permissions \
     --max-turns "${max_turns}" \
-    --output-format text || true
+    --output-format json > "${output_dir}/claude-output.json" || true
+
+# Extract and display the result text
+if [ -f "${output_dir}/claude-output.json" ]; then
+    jq -r '.result // empty' "${output_dir}/claude-output.json"
+
+    # Extract metadata for CI output
+    num_turns=$(jq -r '.num_turns // "unknown"' "${output_dir}/claude-output.json")
+    duration_ms=$(jq -r '.duration_ms // "unknown"' "${output_dir}/claude-output.json")
+    cost_usd=$(jq -r '.total_cost_usd // "unknown"' "${output_dir}/claude-output.json")
+
+    echo
+    echo -e "${BLUE}Claude execution stats:${NC}"
+    echo "  Turns: ${num_turns} / ${max_turns}"
+    echo "  Duration: ${duration_ms}ms"
+    echo "  Cost: \$${cost_usd}"
+
+    ci_output "claude_turns" "${num_turns}"
+    ci_output "claude_duration_ms" "${duration_ms}"
+    ci_output "claude_cost_usd" "${cost_usd}"
+fi
 
 echo
 echo -e "${GREEN}========================================${NC}"


### PR DESCRIPTION
Add a new util/exceptions module that records unhandled exceptions to /srv/shakenfist/exceptions/ as JSON files. Each unique traceback is hashed and stored separately with occurrence counts and timestamps.

The module provides:
- install_exception_tracking(): installs hooks for sys.excepthook and threading.excepthook to capture unhandled exceptions
- record_exception(): records an exception to disk
- ignore_exception(): moved from util/general, now also records to disk

All daemon entrypoints now call install_exception_tracking() at startup. The sf-api Flask app also installs tracking at module load time.

Prompt: Add exception tracking to record unhandled exceptions, update all callers of ignore_exception to use the new location, and install exception tracking in all daemon entrypoints.


Assisted-By: Claude Code