### PR TITLE
Remove node.blobs etcd cache in favor of MariaDB query.

### DIFF
--- a/shakenfist/blob.py
+++ b/shakenfist/blob.py
@@ -464,15 +464,8 @@ class Blob(dbo):
     def add_node_location(self) -> None:
         self.add_location(config.NODE_NAME)
 
-        n = Node.from_db(config.NODE_NAME)
-        n.add_blob(self.uuid)
-
     def drop_node_location(self, node: str = config.NODE_NAME) -> None:
         self.remove_location(node)
-
-        # Remove from cached node blob list
-        n = Node.from_db(node)
-        n.remove_blob(self.uuid)
 
     def observe(self) -> None:
         self.add_node_location()
@@ -1086,9 +1079,8 @@ def observe_local_blobs() -> int:
     """Observe all blob files on this node to update BLOB_LOCATION references.
 
     This function scans the local blob storage directory and calls observe()
-    on each valid blob. This updates:
-    1. The BLOB_LOCATION reference in MariaDB (with last_active timestamp)
-    2. The node.blobs cache in etcd
+    on each valid blob. This updates the BLOB_LOCATION reference in MariaDB
+    (with last_active timestamp).
 
     This replaces the cluster daemon's periodic cache rebuild, making each
     node authoritative for its own blob locations.
@@ -1118,7 +1110,7 @@ def observe_local_blobs() -> int:
             b = Blob.from_db(blob_uuid, suppress_failure_audit=True)
             if b and b.state.value == Blob.STATE_CREATED:
                 # Calling observe() updates the BLOB_LOCATION reference
-                # (with last_active timestamp) and the node.blobs cache
+                # in MariaDB (with last_active timestamp)
                 b.observe()
                 observed_count += 1
 

--- a/shakenfist/node.py
+++ b/shakenfist/node.py
@@ -15,6 +15,7 @@ from shakenfist.exceptions import NoSuchDaemon
 from shakenfist.exceptions import NoSuchDaemonState
 from shakenfist.schema.object_reference import references_to_grouped_dict
 from shakenfist.schema.object_types import ObjectType
+from shakenfist.schema.relationship_types import RelationshipType
 from shakenfist.util import general as util_general
 
 
@@ -24,7 +25,7 @@ LOG, _ = logs.setup(__name__)
 class Node(dbo):
     object_type = ObjectType.NODE
     initial_version = 2
-    current_version = 9
+    current_version = 10
 
     # docs/developer_guide/state_machine.md has a description of these states.
     STATE_MISSING = 'missing'
@@ -128,6 +129,12 @@ class Node(dbo):
     def _upgrade_step_8_to_9(cls, static_values):
         # State migration to MariaDB is now handled by sf-ctl migrate-state-to-mariadb
         ...
+
+    @classmethod
+    def _upgrade_step_9_to_10(cls, static_values):
+        # The node.blobs cache has been removed. Blob locations are now queried
+        # directly from MariaDB's object_references table (BLOB_LOCATION).
+        etcd.delete('attribute/node', static_values['fqdn'], 'blobs')
 
     @classmethod
     def new(cls, name, ip):
@@ -273,17 +280,14 @@ class Node(dbo):
 
     @property
     def blobs(self):
-        return self._db_get_attribute('blobs').get('blobs', [])
+        """Return list of blob UUIDs present on this node.
 
-    @blobs.setter
-    def blobs(self, value):
-        self._db_set_attribute('blobs', {'blobs': value})
-
-    def add_blob(self, blob):
-        self._add_item_in_attribute_list('blobs', blob)
-
-    def remove_blob(self, blob):
-        self._remove_item_in_attribute_list('blobs', blob)
+        This queries the object_references table for BLOB_LOCATION relationships
+        where this node is the source (meaning the node has the blob).
+        """
+        refs = mariadb.get_references_from(
+            ObjectType.NODE, self.uuid, RelationshipType.BLOB_LOCATION)
+        return [str(ref.target_uuid) for ref in refs]
 
     @property
     def instances(self):

--- a/shakenfist/tests/test_node.py
+++ b/shakenfist/tests/test_node.py
@@ -1,0 +1,65 @@
+from unittest import mock
+
+from shakenfist.node import Node
+from shakenfist.schema.object_reference import ObjectReference
+from shakenfist.schema.object_types import ObjectType
+from shakenfist.schema.relationship_types import RelationshipType
+from shakenfist.tests import base
+
+
+class NodeBlobsTestCase(base.ShakenFistTestCase):
+    """Tests for the Node.blobs property."""
+
+    @mock.patch('shakenfist.node.mariadb.get_references_from')
+    @mock.patch.object(Node, '__init__', lambda self, static_values: None)
+    def test_blobs_returns_blob_uuids(self, mock_get_refs):
+        """Test that Node.blobs returns a list of blob UUIDs."""
+        blob_uuid1 = '11111111-1111-1111-1111-111111111111'
+        blob_uuid2 = '22222222-2222-2222-2222-222222222222'
+
+        mock_get_refs.return_value = [
+            ObjectReference(
+                source_object_type=ObjectType.NODE,
+                source_uuid='node1.example.com',
+                relationship=RelationshipType.BLOB_LOCATION,
+                relationship_value=None,
+                target_object_type=ObjectType.BLOB,
+                target_uuid=blob_uuid1,
+                created=1234567890.0,
+                last_active=1234567890.0
+            ),
+            ObjectReference(
+                source_object_type=ObjectType.NODE,
+                source_uuid='node1.example.com',
+                relationship=RelationshipType.BLOB_LOCATION,
+                relationship_value=None,
+                target_object_type=ObjectType.BLOB,
+                target_uuid=blob_uuid2,
+                created=1234567890.0,
+                last_active=1234567890.0
+            ),
+        ]
+
+        node = Node.__new__(Node)
+        node._Node__node_fqdn = 'node1.example.com'
+
+        blobs = node.blobs
+
+        self.assertEqual(blobs, [blob_uuid1, blob_uuid2])
+        mock_get_refs.assert_called_once_with(
+            ObjectType.NODE, 'node1.example.com', RelationshipType.BLOB_LOCATION)
+
+    @mock.patch('shakenfist.node.mariadb.get_references_from')
+    @mock.patch.object(Node, '__init__', lambda self, static_values: None)
+    def test_blobs_returns_empty_list_when_no_blobs(self, mock_get_refs):
+        """Test that Node.blobs returns empty list when node has no blobs."""
+        mock_get_refs.return_value = []
+
+        node = Node.__new__(Node)
+        node._Node__node_fqdn = 'node1.example.com'
+
+        blobs = node.blobs
+
+        self.assertEqual(blobs, [])
+        mock_get_refs.assert_called_once_with(
+            ObjectType.NODE, 'node1.example.com', RelationshipType.BLOB_LOCATION)


### PR DESCRIPTION
The node.blobs property now queries MariaDB's object_references table for BLOB_LOCATION relationships instead of maintaining a separate cache in etcd. This simplifies the codebase by removing redundant state and ensures blob location data is always consistent with the authoritative source in MariaDB.

Changes:
- Node.blobs property now calls mariadb.get_references_from()
- Removed blobs.setter, add_blob(), and remove_blob() methods from Node
- Removed n.add_blob/n.remove_blob calls from Blob.add_node_location() and drop_node_location()
- Added schema upgrade step 9->10 to clean up old etcd blobs attribute
- Added unit tests for Node.blobs property

Prompt: Let's remove the node blob cache. That should be a cheap query to mariadb now right?


Assisted-By: Claude Code