### PR TITLE
Scope PLAN-*.md gitignore to repo root.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,5 +145,5 @@ deploy/gitrepos/
 # Generated version file
 shakenfist/_version.py
 
-# Claude planning files
-PLAN-*.md
+# Claude planning files (root only, not synced docs)
+/PLAN-*.md


### PR DESCRIPTION
The unscoped PLAN-*.md pattern was preventing the docs sync workflow from committing plan files synced from component repos (e.g. occystrap's PLAN-info-check.md). Prefix with / so it only ignores planning files at the repo root, not under docs/components/.

Prompt: Why did the docs-sync CI job not copy
PLAN-info-check.md into the shakenfist repo?