### PR TITLE
Ensure dependencies label exists before creating PR.

### DIFF
--- a/.github/workflows/pin-indirect-dependencies.yml
+++ b/.github/workflows/pin-indirect-dependencies.yml
@@ -89,6 +89,11 @@ jobs:
             git commit -a -m "Update pinned dependencies."
             git push -f origin pin-dependencies-${datestamp}
             echo
+            # Ensure the label exists before creating the PR
+            gh label create dependencies --color 0075ca \
+                --description "Pull requests that update a dependency file" \
+                2>/dev/null || true
+
             gh pr create \
                 --assignee mikalstill \
                 --reviewer mikalstill \


### PR DESCRIPTION
The pin-indirect-dependencies workflow uses --label dependencies when creating PRs, but this label may not exist in all repos. Create the label if it doesn't already exist before attempting to use it.

Prompt: The export-config CI job is failing because its trying to use the non-existant "dependencies" label for the PR it creates. We need to fix occystrap, but also correct the shakenfist/development template and shakenfist/actions if needed so that other repos don't have this problem as well.