### PR TITLE
Fix docs sync workflow push permission.

### DIFF
--- a/.github/workflows/sync-external-docs.yml
+++ b/.github/workflows/sync-external-docs.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           path: shakenfist
           fetch-depth: 0
+          token: ${{ secrets.DEPENDENCIES_TOKEN }}
 
       - name: Checkout the actions repository
         uses: actions/checkout@v6


### PR DESCRIPTION
The recent addition of top-level permissions blocks (3af85388) restricted the default GITHUB_TOKEN to
read-only for this workflow. However, actions/checkout configures git credentials with that read-only token, causing the subsequent git push to fail with a 403.

Pass DEPENDENCIES_TOKEN to the checkout step so git is configured with a write-capable token for pushing the sync-docs branch.

Prompt: The automated docs syncer github actions workflow is failing, probably because of a permissions issue?