### PR TITLE
Remove pre-MariaDB upgrade steps from Blob.

### DIFF
--- a/.github/workflows/ci-dependencies.yml
+++ b/.github/workflows/ci-dependencies.yml
@@ -66,7 +66,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/actions
           ansible-playbook -i /home/debian/ansible-hosts \
             --extra-vars "identifier=${SHAKENFIST_NAMESPACE} \
-              base_image=sf://label/ci-images/debian-11 base_image_user=debian \
+              base_image=sf://label/ci-images/debian-12 base_image_user=debian \
               label=ci-images/dependencies actions_url=$GITHUB_ACTIONS_URL" \
             ansible/ci-dependencies.yml
 

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -371,7 +371,7 @@ jobs:
           setup="${setup} /srv/shakenfist/venv/bin/sf-client artifact upload"
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               ${{ matrix.pr.base_image_user }}@${UPLOAD_TARGET} \
-              "${setup} debian-12 /srv/ci/debian:11 --shared --no-checksum"
+              "${setup} debian-12 /srv/ci/debian:12 --shared --no-checksum"
 
       - name: Make the traces directory
         run: |
@@ -848,7 +848,7 @@ jobs:
           # The cluster CI image, used by all CI types
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
                 ${{ matrix.merge.base_image_user }}@${UPLOAD_TARGET} \
-                "${setup} debian-12 /srv/ci/debian:11 --shared --no-checksum"
+                "${setup} debian-12 /srv/ci/debian:12 --shared --no-checksum"
 
           # Additional images used only by guest CI
           if [ "${{ matrix.merge.stestr_config }}" == "guest-ci.conf" ]; then
@@ -1338,7 +1338,7 @@ jobs:
           # The cluster CI image, used by all CI types
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
                 debian@${UPLOAD_TARGET} \
-                "${setup} debian-12 /srv/ci/debian:11 --shared --no-checksum"
+                "${setup} debian-12 /srv/ci/debian:12 --shared --no-checksum"
 
       - name: Run ansible module tests
         timeout-minutes: 60
@@ -1528,7 +1528,7 @@ jobs:
 
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               debian@${UPLOAD_TARGET} \
-              "${setup} debian-12 /srv/ci/debian:11 --shared --no-checksum"
+              "${setup} debian-12 /srv/ci/debian:12 --shared --no-checksum"
 
       - name: Run node lifecycle tests
         timeout-minutes: 60

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -371,7 +371,7 @@ jobs:
           setup="${setup} /srv/shakenfist/venv/bin/sf-client artifact upload"
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               ${{ matrix.pr.base_image_user }}@${UPLOAD_TARGET} \
-              "${setup} debian-11 /srv/ci/debian:11 --shared --no-checksum"
+              "${setup} debian-12 /srv/ci/debian:11 --shared --no-checksum"
 
       - name: Make the traces directory
         run: |
@@ -848,7 +848,7 @@ jobs:
           # The cluster CI image, used by all CI types
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
                 ${{ matrix.merge.base_image_user }}@${UPLOAD_TARGET} \
-                "${setup} debian-11 /srv/ci/debian:11 --shared --no-checksum"
+                "${setup} debian-12 /srv/ci/debian:11 --shared --no-checksum"
 
           # Additional images used only by guest CI
           if [ "${{ matrix.merge.stestr_config }}" == "guest-ci.conf" ]; then
@@ -1338,7 +1338,7 @@ jobs:
           # The cluster CI image, used by all CI types
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
                 debian@${UPLOAD_TARGET} \
-                "${setup} debian-11 /srv/ci/debian:11 --shared --no-checksum"
+                "${setup} debian-12 /srv/ci/debian:11 --shared --no-checksum"
 
       - name: Run ansible module tests
         timeout-minutes: 60
@@ -1528,7 +1528,7 @@ jobs:
 
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               debian@${UPLOAD_TARGET} \
-              "${setup} debian-11 /srv/ci/debian:11 --shared --no-checksum"
+              "${setup} debian-12 /srv/ci/debian:11 --shared --no-checksum"
 
       - name: Run node lifecycle tests
         timeout-minutes: 60

--- a/.github/workflows/pin-indirect-dependencies.yml
+++ b/.github/workflows/pin-indirect-dependencies.yml
@@ -83,7 +83,7 @@ jobs:
             dep=$(echo ${depver} | sed 's/==.*//')
 
             if [ $(egrep -ic "${dep}==" pyproject.toml) -lt 1 ]; then
-              sed -i pyproject.toml "s/    # END_OF_INDIRECT_DEPS/    \"${depver}\",\n    # END_OF_INDIRECT_DEPS/"
+              sed -i "s/    # END_OF_INDIRECT_DEPS/    \"${depver}\",\n    # END_OF_INDIRECT_DEPS/" pyproject.toml
             fi
           done
 

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -184,7 +184,7 @@ jobs:
               "${setup} ubuntu-2004 /srv/ci/ubuntu:20.04 --shared --no-checksum"
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               ${{ matrix.os.base_image_user }}@${UPLOAD_TARGET} \
-              "${setup} debian-12 /srv/ci/debian:11 --shared --no-checksum"
+              "${setup} debian-12 /srv/ci/debian:12 --shared --no-checksum"
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               ${{ matrix.os.base_image_user }}@${UPLOAD_TARGET} \
               "${setup} debian-12 /srv/ci/debian:12 --shared --no-checksum"

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -187,9 +187,6 @@ jobs:
               "${setup} debian-12 /srv/ci/debian:12 --shared --no-checksum"
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               ${{ matrix.os.base_image_user }}@${UPLOAD_TARGET} \
-              "${setup} debian-12 /srv/ci/debian:12 --shared --no-checksum"
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${UPLOAD_TARGET} \
               "${setup} cirros /srv/ci/cirros --shared"
 
       - name: Create a base level of activity in the cluster

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -32,8 +32,8 @@ jobs:
         os: [
           {
             description: 'develop branch on debian 11 single machine',
-            job_name: 'develop-debian-11-localhost',
-            base_image: 'sf://label/ci-images/debian-11',
+            job_name: 'develop-debian-12-localhost',
+            base_image: 'sf://label/ci-images/debian-12',
             base_image_user: 'debian',
             topology: 'localhost',
             concurrency: 3,
@@ -184,7 +184,7 @@ jobs:
               "${setup} ubuntu-2004 /srv/ci/ubuntu:20.04 --shared --no-checksum"
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               ${{ matrix.os.base_image_user }}@${UPLOAD_TARGET} \
-              "${setup} debian-11 /srv/ci/debian:11 --shared --no-checksum"
+              "${setup} debian-12 /srv/ci/debian:11 --shared --no-checksum"
           ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               ${{ matrix.os.base_image_user }}@${UPLOAD_TARGET} \
               "${setup} debian-12 /srv/ci/debian:12 --shared --no-checksum"

--- a/shakenfist/blob.py
+++ b/shakenfist/blob.py
@@ -19,7 +19,6 @@ import magic
 from shakenfist_utilities import logs  # noreorder
 from shakenfist_utilities import random as sf_random  # noreorder
 
-from shakenfist import etcd
 from shakenfist import mariadb
 from shakenfist.schema.blob_attributes import BlobAttributesData
 from shakenfist.schema.blob_data import BlobData
@@ -69,7 +68,7 @@ LOG, _ = logs.setup(__name__)
 # creation.
 class Blob(dbo):
     object_type = ObjectType.BLOB
-    initial_version = 2
+    initial_version = 8
     current_version = 11
 
     # docs/developer_guide/state_machine.md has a description of these states.
@@ -109,52 +108,6 @@ class Blob(dbo):
             mariadb.create_blob_attributes(attrs)
             self.__attributes = attrs
         return attrs
-
-    @classmethod
-    def _upgrade_step_2_to_3(cls, static_values: dict[str, Any]) -> None:
-        static_values['depends_on'] = None
-
-    @classmethod
-    def _upgrade_step_3_to_4(cls, static_values: dict[str, Any]) -> None:
-        static_values['modified'] = cls.normalize_timestamp(
-                static_values.get('modified'))
-
-    @classmethod
-    def _upgrade_step_4_to_5(cls, static_values: dict[str, Any]) -> None:
-        try:
-            cls._upgrade_metadata_to_attribute(static_values['uuid'])
-        except KeyError as e:
-            # I am currently unsure why you'd end up here, but am seeing it in
-            # CI. Let's gather some more information so we can chase it down.
-            LOG.with_fields(static_values).error(
-                'KeyError while upgrading metadata (v4 to v5): %s' % e)
-
-    @classmethod
-    def _upgrade_step_5_to_6(cls, static_values: dict[str, Any]) -> None:
-        try:
-            etcd.put('attribute/blob', static_values['uuid'], 'retention',
-                     {'expires_at': 0})
-        except KeyError as e:
-            # I am currently unsure why you'd end up here, but am seeing it in
-            # CI. Let's gather some more information so we can chase it down.
-            LOG.with_fields(static_values).error(
-                'KeyError while upgrading retention (v5 to v6): %s' % e)
-
-    @classmethod
-    def _upgrade_step_6_to_7(cls, static_values: dict[str, Any]) -> None:
-        try:
-            etcd.put('attribute/blob', static_values['uuid'], 'size',
-                     {'size': static_values['size']})
-        except KeyError as e:
-            # I am currently unsure why you'd end up here, but am seeing it in
-            # CI. Let's gather some more information so we can chase it down.
-            LOG.with_fields(static_values).error(
-                'KeyError while upgrading retention (v6 to v7): %s' % e)
-
-    @classmethod
-    def _upgrade_step_7_to_8(cls, static_values: dict[str, Any]) -> None:
-        # We added the concept of "incomplete locations".
-        ...
 
     @classmethod
     def _upgrade_step_8_to_9(cls, static_values: dict[str, Any]) -> None:

--- a/shakenfist/deploy/shakenfist_ci/base.py
+++ b/shakenfist/deploy/shakenfist_ci/base.py
@@ -21,7 +21,7 @@ LOG = logging.getLogger()
 TRACE_PATH = '/srv/ci/traces'
 
 
-CLUSTER_CI_IMAGE = 'sf://upload/system/debian-11'
+CLUSTER_CI_IMAGE = 'sf://upload/system/debian-12'
 
 
 class TimeoutException(Exception):

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_imagefetch.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_imagefetch.py
@@ -21,14 +21,14 @@ class TestHTTPFetch(base.BaseNamespacedTestCase):
     def test_disappearing_source_cache(self):
         p = subprocess.run(
             ['sudo /srv/shakenfist/venv/bin/sf-client '
-             'artifact download debian-11 '
-             '/var/www/html/debian-11-disappearing-cache'],
+             'artifact download debian-12 '
+             '/var/www/html/debian-12-disappearing-cache'],
             shell=True, capture_output=True, timeout=300)
         self.assertEqual(
             0, p.returncode,
             f'Command failed:\n\tstdout = {p.stdout}\n\tstderr = {p.stderr}\n')
 
-        url = 'http://10.0.0.10/debian-11-disappearing-cache'
+        url = 'http://10.0.0.10/debian-12-disappearing-cache'
         img = self.system_client.cache_artifact(url)
 
         # Get all artifacts once to make sure we get added to the list
@@ -53,7 +53,7 @@ class TestHTTPFetch(base.BaseNamespacedTestCase):
 
         # Remove the source image
         p = subprocess.run(
-            ['sudo rm /var/www/html/debian-11-disappearing-cache'],
+            ['sudo rm /var/www/html/debian-12-disappearing-cache'],
             shell=True, capture_output=True, timeout=300)
         self.assertEqual(
             0, p.returncode,
@@ -78,14 +78,14 @@ class TestHTTPFetch(base.BaseNamespacedTestCase):
 
         p = subprocess.run(
             ['sudo /srv/shakenfist/venv/bin/sf-client '
-             'artifact download debian-11 '
-             '/var/www/html/debian-11-disappearing-instance'],
+             'artifact download debian-12 '
+             '/var/www/html/debian-12-disappearing-instance'],
             shell=True, capture_output=True, timeout=300)
         self.assertEqual(
             0, p.returncode,
             f'Command failed:\n\tstdout = {p.stdout}\n\tstderr = {p.stderr}\n')
 
-        url = 'http://10.0.0.10/debian-11-disappearing-instance'
+        url = 'http://10.0.0.10/debian-12-disappearing-instance'
         inst = self.test_client.create_instance(
             'inst1', 1, 1024, None,
             [
@@ -101,7 +101,7 @@ class TestHTTPFetch(base.BaseNamespacedTestCase):
 
         # Remove the source image
         p = subprocess.run(
-            ['sudo rm /var/www/html/debian-11-disappearing-instance'],
+            ['sudo rm /var/www/html/debian-12-disappearing-instance'],
             shell=True, capture_output=True, timeout=300)
         self.assertEqual(
             0, p.returncode,

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_agentops.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_agentops.py
@@ -119,7 +119,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -285,7 +285,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -305,7 +305,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -329,7 +329,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -393,7 +393,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_boot.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_boot.py
@@ -12,9 +12,9 @@ class TestBoot(testscenarios.WithScenarios, base.BaseNamespacedTestCase):
 
     scenarios = [
         (
-            'debian-11',
+            'debian-12',
             {
-                'base': 'debian-11'
+                'base': 'debian-12'
             }
         ),
         (

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_cloudinit.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_cloudinit.py
@@ -46,7 +46,7 @@ sudo echo 'banana' >  /tmp/output"""
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ],

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_multiple_nics.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_multiple_nics.py
@@ -52,7 +52,7 @@ sudo /etc/init.d/S40network restart"""
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, str(base64.b64encode(ud.encode('utf-8')), 'utf-8'))

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_networking.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_networking.py
@@ -275,17 +275,26 @@ class TestNetworking(base.BaseNamespacedTestCase):
                         f'cloud-init.log contained warnings:\n\n{data}\n\n'
                         f'"cloud-init schema --system" says:\n\n{schema_warnings}')
 
-        # Ensure the gateway is set as the DNS server in /etc/resolv.conf
+        # Ensure the gateway is set as the DNS server. Debian 12 uses
+        # systemd-resolved, so /etc/resolv.conf may point to the local
+        # stub resolver (127.0.0.53). In that case, check the real
+        # upstream config at /run/systemd/resolve/resolv.conf.
         data = self.test_client.await_agent_fetch(
             inst1['uuid'], '/etc/resolv.conf')
         if data.find('192.168.242.1') == -1:
-            self.fail(
-                '/etc/resolv.conf did not have the gateway set as the '
-                f'DNS address:\n\n{data}')
+            if data.find('127.0.0.53') != -1:
+                data = self.test_client.await_agent_fetch(
+                    inst1['uuid'],
+                    '/run/systemd/resolve/resolv.conf')
+            if data.find('192.168.242.1') == -1:
+                self.fail(
+                    '/etc/resolv.conf (or systemd-resolved '
+                    'upstream) did not have the gateway set '
+                    f'as the DNS address:\n\n{data}')
         if data.find(f'{self.namespace}.bonkerslab') == -1:
             self.fail(
-                '/etc/resolv.conf did not have the namespace set as the '
-                f'DNS search domain:\n\n{data}')
+                'resolv.conf did not have the namespace set '
+                f'as the DNS search domain:\n\n{data}')
 
         # Lookup our addresses
         nics = self.test_client.get_instance_interfaces(inst1['uuid'])

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_networking.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_networking.py
@@ -55,7 +55,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -88,7 +88,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -105,7 +105,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None, side_channels=['sf-agent2'])
@@ -128,7 +128,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -172,7 +172,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
                 [
                     {
                         'size': 8,
-                        'base': 'sf://upload/system/debian-11',
+                        'base': 'sf://upload/system/debian-12',
                         'type': 'disk'
                     }
                 ], None, None, force_placement='sf-2')
@@ -236,7 +236,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -250,7 +250,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -353,7 +353,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -591,7 +591,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_state_changes.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_state_changes.py
@@ -37,7 +37,7 @@ class TestStateChanges(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -63,7 +63,7 @@ class TestStateChanges(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None,
@@ -209,7 +209,7 @@ class TestDetectReboot(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
@@ -122,7 +122,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -274,7 +274,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -294,7 +294,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -318,7 +318,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -382,7 +382,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
@@ -438,6 +438,22 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             -1, data.find('02:00:00:ea:3a:28'),
             'Interface not found in `ip -json link` output:\n%s' % data)
 
+        # Determine which interface the new one is post reboot
+        d = json.loads(data)
+        new_interface_after_reboot = None
+        for i in d:
+            if i['address'] == '02:00:00:ea:3a:28':
+                new_interface_after_reboot = i['ifname']
+        self.assertNotEqual(None, new_interface_after_reboot)
+        self.assertEqual(
+            new_interface,
+            new_interface_after_reboot,
+            (
+                f'The interface name changed from {new_interface} to '
+                f'{new_interface_after_reboot} across the reboot!'
+            )
+        )
+
         # Collect the config drive network configuration to ensure that the new
         # device is listed
         self.test_client.await_agent_command(

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
@@ -403,11 +403,13 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             inst['uuid'],
             'ls -la /etc/udev/rules.d/'
             '80-net-setup-link.rules',
+            exit_codes=[0, 2],
             ignore_stderr=True)
         _, systemd_link = self.test_client.await_agent_command(
             inst['uuid'],
             'ls -la /etc/systemd/network/'
             '99-default.link',
+            exit_codes=[0, 2],
             ignore_stderr=True)
         _, ifaces = self.test_client.await_agent_command(
             inst['uuid'], 'ip -json link')

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
@@ -390,6 +390,44 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
         # Wait for the instance agent to report in
         self._await_instance_ready(inst['uuid'])
 
+        # Debug: check that predictable interface naming is
+        # disabled inside the instance
+        _, cmdline = self.test_client.await_agent_command(
+            inst['uuid'], 'cat /proc/cmdline')
+        self.assertIn(
+            'net.ifnames=0', cmdline,
+            'net.ifnames=0 not in kernel cmdline: '
+            '%s' % cmdline)
+
+        _, udev_rule = self.test_client.await_agent_command(
+            inst['uuid'],
+            'ls -la /etc/udev/rules.d/'
+            '80-net-setup-link.rules',
+            ignore_stderr=True)
+        _, systemd_link = self.test_client.await_agent_command(
+            inst['uuid'],
+            'ls -la /etc/systemd/network/'
+            '99-default.link',
+            ignore_stderr=True)
+        _, ifaces = self.test_client.await_agent_command(
+            inst['uuid'], 'ip -json link')
+        iface_names = [
+            i['ifname'] for i in json.loads(ifaces)
+            if i['ifname'] != 'lo'
+        ]
+        for name in iface_names:
+            self.assertTrue(
+                name.startswith('eth'),
+                'Interface %s does not use eth naming. '
+                'All interfaces: %s. '
+                'Kernel cmdline: %s. '
+                'udev rule: %s. '
+                'systemd link: %s.'
+                % (name, iface_names,
+                   cmdline.strip(),
+                   udev_rule.strip(),
+                   systemd_link.strip()))
+
         # Hot plug an interface in
         netdesc = {
             'network_uuid': hotnet['uuid'],

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_networking.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_networking.py
@@ -281,17 +281,26 @@ class TestNetworking(base.BaseNamespacedTestCase):
                         f'cloud-init.log contained warnings:\n\n{data}\n\n'
                         f'"cloud-init schema --system" says:\n\n{schema_warnings}')
 
-        # Ensure the gateway is set as the DNS server in /etc/resolv.conf
+        # Ensure the gateway is set as the DNS server. Debian 12 uses
+        # systemd-resolved, so /etc/resolv.conf may point to the local
+        # stub resolver (127.0.0.53). In that case, check the real
+        # upstream config at /run/systemd/resolve/resolv.conf.
         data = self.test_client.await_agent_fetch(
             inst1['uuid'], '/etc/resolv.conf')
         if data.find('192.168.242.1') == -1:
-            self.fail(
-                '/etc/resolv.conf did not have the gateway set as the '
-                f'DNS address:\n\n{data}')
+            if data.find('127.0.0.53') != -1:
+                data = self.test_client.await_agent_fetch(
+                    inst1['uuid'],
+                    '/run/systemd/resolve/resolv.conf')
+            if data.find('192.168.242.1') == -1:
+                self.fail(
+                    '/etc/resolv.conf (or systemd-resolved '
+                    'upstream) did not have the gateway set '
+                    f'as the DNS address:\n\n{data}')
         if data.find(f'{self.namespace}.bonkerslab') == -1:
             self.fail(
-                '/etc/resolv.conf did not have the namespace set as the '
-                f'DNS search domain:\n\n{data}')
+                'resolv.conf did not have the namespace set '
+                f'as the DNS search domain:\n\n{data}')
 
         # Lookup our addresses
         nics = self.test_client.get_instance_interfaces(inst1['uuid'])

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_networking.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_networking.py
@@ -55,7 +55,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -94,7 +94,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -111,7 +111,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None, side_channels=['sf-agent2'])
@@ -134,7 +134,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -178,7 +178,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
                 [
                     {
                         'size': 8,
-                        'base': 'sf://upload/system/debian-11',
+                        'base': 'sf://upload/system/debian-12',
                         'type': 'disk'
                     }
                 ], None, None, force_placement='sf-2')
@@ -242,7 +242,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -256,7 +256,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -359,7 +359,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)
@@ -418,7 +418,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             [
                 {
                     'size': 8,
-                    'base': 'sf://upload/system/debian-11',
+                    'base': 'sf://upload/system/debian-12',
                     'type': 'disk'
                 }
             ], None, None)


### PR DESCRIPTION
Bump initial_version from 2 to 8 and delete the six upgrade steps (2→3 through 7→8) that predate the MariaDB migration. These steps wrote to etcd, which is no longer read for blob data. This eliminates the last etcd
dependency from blob.py.

Prompt: I see two remaining users of etcd in shakenfist/blob.py. Let's come up with a plan to eliminate them.