### PR TITLE
Fix pin-indirect-dependencies CI path.

### DIFF
--- a/.github/workflows/pin-indirect-dependencies.yml
+++ b/.github/workflows/pin-indirect-dependencies.yml
@@ -61,7 +61,7 @@ jobs:
           python3 -m venv  --system-site-packages /srv/ci/venv
           . /srv/ci/venv/bin/activate
 
-          cd ${GITHUB_WORKSPACE}/shakenfist
+          cd ${GITHUB_WORKSPACE}
 
           pip3 install uv
           uv pip install -r pyproject.toml
@@ -74,7 +74,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.DEPENDENCIES_TOKEN }}
         run: |
-          cd ${GITHUB_WORKSPACE}/shakenfist
+          cd ${GITHUB_WORKSPACE}
 
           datestamp=$(date "+%Y%m%d")
           git checkout -b pin-dependencies-${datestamp}


### PR DESCRIPTION
The workflow was cd-ing into ${GITHUB_WORKSPACE}/shakenfist (the Python package subdirectory) instead of
${GITHUB_WORKSPACE} (the repo root) where pyproject.toml lives, causing `uv pip install -r pyproject.toml` to fail with "File not found".

Prompt: The pin indirect dependencies CI job is failing.