### PR TITLE
Fix permissions for pin indirect deps workflow.

### DIFF
--- a/.github/workflows/pin-indirect-dependencies.yml
+++ b/.github/workflows/pin-indirect-dependencies.yml
@@ -6,7 +6,8 @@
 name: Pin indirect dependencies
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 on:
   workflow_dispatch:
@@ -40,6 +41,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.DEPENDENCIES_TOKEN }}
 
       - name: Install the github command line
         run: |


### PR DESCRIPTION
The workflow was using contents: read which prevented git push from working. Changed to contents: write and added pull-requests: write. Also pass DEPENDENCIES_TOKEN to the checkout action so git push uses the PAT instead of the default read-only GITHUB_TOKEN.

Prompt: The pin indirect dependencies workflow now has a permissions problem.