### PR TITLE
Add desktop image to CI image build matrix.

### DIFF
--- a/.github/workflows/ci-images.yml
+++ b/.github/workflows/ci-images.yml
@@ -86,6 +86,15 @@ jobs:
                 'scheduled': True,
                 'runs_on': 'debian-12'
             },
+            {
+                'name': 'debian-gnome-12',
+                'baseimage': 'debian-gnome:12',
+                'baseuser': 'debian',
+                'outputlabel': 'ci-images/debian-gnome-12',
+                'scheduled': True,
+                'runs_on': 'debian-12',
+                'playbook': 'ansible/ci-image-desktop.yml'
+            },
         ]
     runs-on: [self-hosted, vm, '${{ matrix.os.runs_on }}']
     concurrency:
@@ -117,7 +126,7 @@ jobs:
             ansible-playbook -i /home/debian/ansible-hosts \
               --extra-vars "identifier=${SHAKENFIST_NAMESPACE} \
                 base_image=${{ matrix.os.baseimage }} base_image_user=${{ matrix.os.baseuser }} label=${{ matrix.os.outputlabel }}" \
-              ansible/ci-image.yml
+              ${{ matrix.os.playbook || 'ansible/ci-image.yml' }}
 
         - uses: JasonEtco/create-an-issue@v2
           if: failure()


### PR DESCRIPTION
Add debian-gnome-12 entry using a separate playbook that installs qemu-guest-agent and spice-vdagent on the desktop base image. Use per-matrix playbook selection with fallback to the default ci-image.yml.

Prompt: Add a build to ci-dependencies.yml that starts a debian-gnome:12 instance and installs qemu guest agent before snapshotting it.