### PR TITLE
Add diagnostic output to ci-dependencies.

### DIFF
--- a/.github/workflows/ci-dependencies.yml
+++ b/.github/workflows/ci-dependencies.yml
@@ -71,9 +71,11 @@ jobs:
       - name: Build dependencies image
         env:
           GITLAB_TESTDATA_TOKEN: ${{ secrets.GITLAB_TESTDATA_TOKEN }}
+          PYTHONUNBUFFERED: "1"
         run: |
+          df -h && free -m
           cd ${GITHUB_WORKSPACE}/actions
-          ansible-playbook -i /home/debian/ansible-hosts \
+          ansible-playbook -v -i /home/debian/ansible-hosts \
             --extra-vars "identifier=${SHAKENFIST_NAMESPACE} \
               base_image=sf://label/ci-images/debian-12 base_image_user=debian \
               label=ci-images/dependencies actions_url=$GITHUB_ACTIONS_URL \


### PR DESCRIPTION
Add PYTHONUNBUFFERED=1 so ansible output is flushed line-by-line and survives runner crashes. Add df/free baseline before ansible starts, and -v flag for task-level detail.

Prompt: Add more progress output to the ansible steps to diagnose zero-output runner failures.

Assisted-By: Claude Code