### PR TITLE
Remove etcd fallbacks for tier 1 attributes.

### DIFF
--- a/docs/operator_guide/database.md
+++ b/docs/operator_guide/database.md
@@ -761,3 +761,7 @@ states, IPAM reservations, uploads, blobs, nodes, and other object types.
 No manual `sf-ctl` commands are needed for data migration -- simply
 upgrading and restarting the database daemon is sufficient. Migrations are
 idempotent and safe to re-run if the daemon restarts during migration.
+
+If any objects fail to migrate, the table version is not bumped and the
+migration will retry on the next daemon restart. This ensures all objects
+are successfully migrated before the version advances.

--- a/shakenfist/mariadb.py
+++ b/shakenfist/mariadb.py
@@ -1332,6 +1332,23 @@ def ensure_data_migrations() -> list[dict[str, Any]]:
             try:
                 from_ver = current_ver
                 stats = migrate_func(engine)
+
+                error_count = stats.get('error_count', 0)
+                if error_count > 0:
+                    LOG.error(
+                        f'Data migration for {table_name} had '
+                        f'{error_count} errors, not bumping version '
+                        f'(will retry on next restart)')
+                    results.append({
+                        'table': table_name,
+                        'from_version': from_ver,
+                        'to_version': target_ver,
+                        'migrated': False,
+                        'stats': stats,
+                        'error': f'{error_count} objects failed'
+                    })
+                    break
+
                 _set_table_version(engine, table_name, target_ver)
                 current_ver = target_ver
 
@@ -1345,8 +1362,7 @@ def ensure_data_migrations() -> list[dict[str, Any]]:
 
                 LOG.info(
                     f'Data migration complete for {table_name}: '
-                    f'migrated {stats.get("migrated_count", "?")} items, '
-                    f'{stats.get("error_count", 0)} errors'
+                    f'migrated {stats.get("migrated_count", "?")} items'
                 )
 
             except Exception as e:

--- a/shakenfist/network/interface.py
+++ b/shakenfist/network/interface.py
@@ -10,6 +10,7 @@ from shakenfist_utilities import logs  # noreorder
 from shakenfist import etcd
 from shakenfist import exceptions
 from shakenfist import mariadb
+from shakenfist.constants import EVENT_TYPE_MUTATE
 from shakenfist.network import network
 from shakenfist.baseobject import DatabaseBackedObject as dbo
 from shakenfist.baseobject import DatabaseBackedObjectIterator as dbo_iter
@@ -30,7 +31,7 @@ LOG, _ = logs.setup(__name__)
 
 class NetworkInterface(dbo):
     object_type = ObjectType.INTERFACE
-    initial_version = 2
+    initial_version = 4
     current_version = 5
 
     # docs/developer_guide/state_machine.md has a description of these states.
@@ -53,15 +54,6 @@ class NetworkInterface(dbo):
         self.__ipv4 = static_values['ipv4']
         self.__order = static_values['order']
         self.__model = static_values['model']
-
-    @classmethod
-    def _upgrade_step_2_to_3(cls, static_values):
-        cls._upgrade_metadata_to_attribute(static_values['uuid'])
-
-    @classmethod
-    def _upgrade_step_3_to_4(cls, static_values):
-        # State migration to MariaDB is now handled by sf-ctl migrate-state-to-mariadb
-        ...
 
     @classmethod
     def _upgrade_step_4_to_5(cls, static_values):
@@ -154,9 +146,8 @@ class NetworkInterface(dbo):
         )
 
         ni = NetworkInterface.from_db(interface_uuid)
-        ni._db_set_attribute('floating', {'floating_address': None})
 
-        # Also create initial attributes record in MariaDB
+        # Create initial attributes record in MariaDB
         attrs = NetworkInterfaceAttributesData(
             uuid=UUID(interface_uuid),
             floating_address=None
@@ -217,27 +208,37 @@ class NetworkInterface(dbo):
     # Values routed to attributes, writes are via helper methods.
     @property
     def floating(self):
-        # Try MariaDB first
         attrs = mariadb.get_network_interface_attributes(self.uuid)
-        if attrs:
-            return {'floating_address': attrs.floating_address}
-        # Fall back to etcd for unmigrated objects
-        return self._db_get_attribute('floating')
+        if not attrs:
+            _uuid = self.uuid if isinstance(self.uuid, UUID) else UUID(str(self.uuid))
+            attrs = NetworkInterfaceAttributesData(uuid=_uuid, floating_address=None)
+            if not mariadb.create_network_interface_attributes(attrs):
+                # Another thread created the record; re-read it
+                attrs = mariadb.get_network_interface_attributes(self.uuid)
+        return {'floating_address': attrs.floating_address}
 
     @floating.setter
     def floating(self, address):
         if address and self.floating.get('floating_address') is not None:
             raise exceptions.NetworkInterfaceAlreadyFloating()
-        self._db_set_attribute('floating', {'floating_address': address})
 
-        # Also update MariaDB
+        _uuid = self.uuid if isinstance(self.uuid, UUID) else UUID(str(self.uuid))
         attrs = mariadb.get_network_interface_attributes(self.uuid)
-        if attrs:
+        if not attrs:
+            attrs = NetworkInterfaceAttributesData(uuid=_uuid, floating_address=address)
+            if not mariadb.create_network_interface_attributes(attrs):
+                # Another thread created the record; update instead
+                updated = NetworkInterfaceAttributesData(
+                    uuid=_uuid, floating_address=address)
+                mariadb.update_network_interface_attributes(updated)
+        else:
             updated = NetworkInterfaceAttributesData(
-                uuid=attrs.uuid,
-                floating_address=address
-            )
+                uuid=attrs.uuid, floating_address=address)
             mariadb.update_network_interface_attributes(updated)
+
+        self.add_event(EVENT_TYPE_MUTATE, 'set attribute',
+                       extra={'attribute': 'floating',
+                              'floating_address': address})
 
     def delete(self):
         floating_address = self.floating['floating_address']

--- a/shakenfist/network/network.py
+++ b/shakenfist/network/network.py
@@ -1,5 +1,4 @@
 # Copyright 2020 Michael Still
-import copy
 import os
 import random
 import time
@@ -275,15 +274,6 @@ class Network(dbowo):
             'last_cluster_operation': self.last_cluster_operation
         })
 
-        for attrname in ['routing']:
-            d = self._db_get_attribute(attrname)
-            for key in d:
-                # We skip keys with no value
-                if d[key] is None:
-                    continue
-
-                n[key] = d[key]
-
         return n
 
     # Static values
@@ -293,21 +283,8 @@ class Network(dbowo):
 
     @property
     def floating_gateway(self):
-        # Try MariaDB first
-        attrs = self._load_attributes()
-        if attrs:
-            return attrs.floating_gateway
-        # Fall back to etcd for unmigrated objects
-        fg = self._db_get_attribute('routing', {'floating_gateway': None})
-        return fg['floating_gateway']
-
-    @property
-    def routing(self):
-        # Try MariaDB first — reconstruct dict for backward compat
-        attrs = self._load_attributes()
-        if attrs:
-            return {'floating_gateway': attrs.floating_gateway}
-        return self._db_get_attribute('routing')
+        attrs = self._ensure_attributes()
+        return attrs.floating_gateway
 
     @property
     def name(self):
@@ -364,70 +341,41 @@ class Network(dbowo):
 
     @property
     def networkinterfaces(self):
-        # Try MariaDB first
-        attrs = self._load_attributes()
-        if attrs:
-            return attrs.networkinterfaces
-        # Fall back to etcd for unmigrated objects
-        nis = self._db_get_attribute('networkinterfaces', {})
-        return nis.get('networkinterfaces', [])
+        attrs = self._ensure_attributes()
+        return attrs.networkinterfaces
 
     def add_networkinterface(self, ni):
-        attrs = self._load_attributes()
-        if attrs:
-            ni_uuid = str(ni.uuid)
-            if ni_uuid not in attrs.networkinterfaces:
-                attrs.networkinterfaces.append(ni_uuid)
-                attrs.networkinterfaces_initialized = True
-                self._save_attributes()
-        else:
-            self._add_item_in_attribute_list(
-                'networkinterfaces', str(ni.uuid))
+        attrs = self._ensure_attributes()
+        ni_uuid = str(ni.uuid)
+        if ni_uuid not in attrs.networkinterfaces:
+            attrs.networkinterfaces.append(ni_uuid)
+            attrs.networkinterfaces_initialized = True
+            self._save_attributes()
+            self.add_event(EVENT_TYPE_MUTATE, 'add networkinterface',
+                           extra={'networkinterface': ni_uuid})
 
     def remove_networkinterface(self, ni):
         if ni.ipv4:
             self.remove_dhcp_lease(ni.ipv4, ni.macaddr)
-        attrs = self._load_attributes()
-        if attrs:
-            ni_uuid = str(ni.uuid)
-            if ni_uuid in attrs.networkinterfaces:
-                attrs.networkinterfaces.remove(ni_uuid)
-                self._save_attributes()
-        else:
-            self._remove_item_in_attribute_list(
-                'networkinterfaces', str(ni.uuid))
+        attrs = self._ensure_attributes()
+        ni_uuid = str(ni.uuid)
+        if ni_uuid in attrs.networkinterfaces:
+            attrs.networkinterfaces.remove(ni_uuid)
+            self._save_attributes()
+            self.add_event(EVENT_TYPE_MUTATE, 'remove networkinterface',
+                           extra={'networkinterface': ni_uuid})
 
     def _update_floating_gateway(self, gateway):
-        # Try MariaDB first
-        attrs = self._load_attributes()
-        if attrs:
-            if attrs.floating_gateway == gateway:
-                return True
-            if attrs.floating_gateway and gateway is not None:
-                return False
-            attrs.floating_gateway = gateway
-            self._save_attributes()
+        attrs = self._ensure_attributes()
+        if attrs.floating_gateway == gateway:
             return True
-
-        # Fall back to etcd for unmigrated objects
-        original_routing = self.routing
-        original_gateway = original_routing.get('floating_gateway')
-        if original_gateway == gateway:
-            return True
-        if original_gateway:
+        if attrs.floating_gateway and gateway is not None:
             return False
-
-        if not original_routing:
-            original_routing = None
-            updated_routing = {
-                'floating_gateway': gateway
-            }
-        else:
-            updated_routing = copy.copy(original_routing)
-            updated_routing['floating_gateway'] = gateway
-
-        return etcd.replace('attribute/network', self.uuid, 'routing',
-                            original_routing, updated_routing)
+        attrs.floating_gateway = gateway
+        self._save_attributes()
+        self.add_event(EVENT_TYPE_MUTATE, 'update floating gateway',
+                       extra={'floating_gateway': gateway})
+        return True
 
     def assign_floating_gateway(self):
         fn = floating_network()
@@ -482,12 +430,8 @@ class Network(dbowo):
 
         # Hosted DNS entries
         if self.provide_dns:
-            attrs = self._load_attributes()
-            if attrs:
-                retval['hosted_dns'] = attrs.hosteddns
-            else:
-                retval['hosted_dns'] = self._db_get_attribute(
-                    'hosteddns', {})
+            attrs = self._ensure_attributes()
+            retval['hosted_dns'] = attrs.hosteddns
         else:
             retval['hosted_dns'] = {}
 
@@ -817,16 +761,11 @@ class Network(dbowo):
         if not self.provide_dns:
             return
 
-        attrs = self._load_attributes()
-        if attrs:
-            attrs.hosteddns[name] = value
-            self._save_attributes()
-        else:
-            with self.get_lock_attr(
-                    'hosteddns', 'Update hosted DNS entry'):
-                entries = self._db_get_attribute('hosteddns', {})
-                entries[name] = value
-                self._db_set_attribute('hosteddns', entries)
+        attrs = self._ensure_attributes()
+        attrs.hosteddns[name] = value
+        self._save_attributes()
+        self.add_event(EVENT_TYPE_MUTATE, 'update dns entry',
+                       extra={'name': name, 'value': value})
 
         if config.NODE_IS_NETWORK_NODE:
             with self.get_lock(
@@ -845,18 +784,12 @@ class Network(dbowo):
         if not self.provide_dns:
             return
 
-        attrs = self._load_attributes()
-        if attrs:
-            if name in attrs.hosteddns:
-                del attrs.hosteddns[name]
-                self._save_attributes()
-        else:
-            with self.get_lock_attr(
-                    'hosteddns', 'Remove hosted DNS entry'):
-                entries = self._db_get_attribute('hosteddns', {})
-                if name in entries:
-                    del entries[name]
-                    self._db_set_attribute('hosteddns', entries)
+        attrs = self._ensure_attributes()
+        if name in attrs.hosteddns:
+            del attrs.hosteddns[name]
+            self._save_attributes()
+            self.add_event(EVENT_TYPE_MUTATE, 'remove dns entry',
+                           extra={'name': name})
 
         if config.NODE_IS_NETWORK_NODE:
             with self.get_lock(

--- a/shakenfist/operations/agentoperation.py
+++ b/shakenfist/operations/agentoperation.py
@@ -6,6 +6,7 @@ from shakenfist_utilities import logs  # noreorder
 from shakenfist import mariadb
 from shakenfist.baseobject import DatabaseBackedObject as dbo
 from shakenfist.baseobject import DatabaseBackedObjectIterator as dbo_iter
+from shakenfist.constants import EVENT_TYPE_MUTATE
 from shakenfist.operations.baseoperation import BaseOperation
 from shakenfist.schema.agentoperation_attributes import AgentOperationAttributesData
 from shakenfist.schema.agentoperation_data import AgentOperationData
@@ -153,17 +154,14 @@ class AgentOperation(BaseOperation):
 
     @property
     def results(self):
-        # Try MariaDB first
         _uuid = self.uuid if isinstance(self.uuid, UUID) else UUID(self.uuid)
         attrs = mariadb.get_agent_operation_attributes(_uuid)
-        if attrs:
-            return attrs.results
-
-        # Fall back to etcd for unmigrated objects
-        db_data = self._db_get_attribute('results')
-        if not db_data:
-            return {}
-        return db_data.get('results', {})
+        if not attrs:
+            attrs = AgentOperationAttributesData(uuid=_uuid, results={})
+            if not mariadb.create_agent_operation_attributes(attrs):
+                # Another thread created the record; re-read it
+                attrs = mariadb.get_agent_operation_attributes(_uuid)
+        return attrs.results
 
     def add_result(self, index, value):
         if 'command' in value:
@@ -174,20 +172,18 @@ class AgentOperation(BaseOperation):
         with self.get_lock_attr('results', op='add result'):
             _uuid = self.uuid if isinstance(self.uuid, UUID) else UUID(self.uuid)
             attrs = mariadb.get_agent_operation_attributes(_uuid)
-            if attrs:
-                # Update via MariaDB
-                results = dict(attrs.results)
-                results[str(index)] = value
-                updated = AgentOperationAttributesData(
-                    uuid=_uuid,
-                    results=results,
-                )
-                mariadb.update_agent_operation_attributes(updated)
-            else:
-                # Fall back to etcd for unmigrated objects
-                results = self.results
-                results[str(index)] = value
-                self._db_set_attribute('results', {'results': results})
+            if not attrs:
+                attrs = AgentOperationAttributesData(uuid=_uuid, results={})
+                if not mariadb.create_agent_operation_attributes(attrs):
+                    attrs = mariadb.get_agent_operation_attributes(_uuid)
+
+            results = dict(attrs.results)
+            results[str(index)] = value
+            updated = AgentOperationAttributesData(uuid=_uuid, results=results)
+            mariadb.update_agent_operation_attributes(updated)
+
+        self.add_event(EVENT_TYPE_MUTATE, 'add result',
+                       extra={'index': str(index)})
 
     def hard_delete(self):
         _uuid = self.uuid if isinstance(self.uuid, UUID) else UUID(self.uuid)


### PR DESCRIPTION
These three object types had MariaDB attribute tables at version 2 (data migrated) but code still fell back to etcd via _db_get_attribute/_db_set_attribute. This removes all etcd fallback paths so attributes are read/written exclusively through MariaDB:

- Network: floating_gateway, networkinterfaces, hosteddns
- NetworkInterface: floating_address
- AgentOperation: results

Also fixes ensure_data_migrations() to not bump the table version when objects fail to migrate, ensuring the migration retries on next restart. Previously failed objects would be permanently stranded without MariaDB records.

NetworkInterface initial_version bumped from 2 to 4, removing pre-MariaDB upgrade steps (2->3, 3->4).

Prompt: Let's find another etcd user to transition to mariadb.



Assisted-By: Claude Code