### PR TITLE
Write docker variant images to their own labels.

### DIFF
--- a/.github/workflows/ci-images.yml
+++ b/.github/workflows/ci-images.yml
@@ -50,7 +50,7 @@ jobs:
                 'name': 'debian-12-docker',
                 'baseimage': 'debian:12',
                 'baseuser': 'debian',
-                'outputlabel': 'ci-images/debian-12',
+                'outputlabel': 'ci-images/debian-12-docker',
                 'scheduled': True,
                 'runs_on': 'debian-12',
                 'extras': 'docker'
@@ -59,7 +59,7 @@ jobs:
                 'name': 'debian-13-docker',
                 'baseimage': 'debian:13',
                 'baseuser': 'debian',
-                'outputlabel': 'ci-images/debian-13',
+                'outputlabel': 'ci-images/debian-13-docker',
                 'scheduled': True,
                 'runs_on': 'debian-12',
                 'extras': 'docker'


### PR DESCRIPTION
The `debian-12-docker` and `debian-13-docker` entries in the ci-images matrix both set `outputlabel` to the plain non-docker label (`ci-images/debian-12` and
`ci-images/debian-13` respectively). Two problems:

- Whichever of the two builds (docker or non-docker) finishes last overwrites the other. The conductor's runner provisioner asks for `sf://label/ci-images/ debian-12` when a job requests a `debian-12` runner, so which actual rootfs it gets depends on last-writer- wins — not what we want from cache labels.
- No `ci-images/debian-12-docker` or `ci-images/debian-13-docker` label is ever created, so conductor/provisioner.py cannot satisfy a `debian-12-docker` queued job even once we teach the provisioner about the variant.

Give the docker variants distinct outputlabels so they cache independently. Follow-up change in
shakenfist/private-ci will add the matching `CI_IMAGES` entries so the conductor actually provisions them.

Prompt: Please fix both and then push in both repos.