### PR TITLE
Preserve binary payloads on cross-node API proxy hops.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -117,7 +117,7 @@ jobs:
           tox -eflake8
 
       - name: Type check with mypy
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: |
           . /tmp/venv-test/bin/activate
           tox -emypy

--- a/docs/operator_guide/upgrades.md
+++ b/docs/operator_guide/upgrades.md
@@ -74,6 +74,34 @@ Migrated table 'object_states' from version 1 to 2
 MariaDB schema verified.
 ```
 
+### Known migration notes
+
+#### cluster_operation_targets v1 to v2
+
+The v1 schema declared `operation_uuid` as a column-level `UNIQUE`,
+which prevented multi-target operations (e.g. the hot-plug interface
+op, which targets an instance, a network, and an interface) from
+recording more than one target row. The v2 migration replaces that
+constraint with a composite `UNIQUE(operation_uuid, target_object_type,
+target_uuid)` and adds a non-unique index `idx_cot_operation` for
+single-column lookups.
+
+Operations already in flight at the moment the migration runs will
+have only their first declared target row in the table; their
+remaining target rows were silently dropped under v1 and cannot be
+reconstructed. The practical effect is that
+`Network.is_okay()`'s pending-operation gate may transiently miss
+one in-flight op per affected network during the upgrade window,
+and the network maintainer can race the queue worker once -- which
+manifests as the "Recreating not okay network on hypervisor" event
+firing in syslog for that network. The recreate is idempotent with
+the queued operation's own `create_on_hypervisor`, so there is no
+functional breakage; only the audit event.
+
+Operations enqueued after the migration completes record all of
+their targets correctly, so the gate behaves as designed once the
+in-flight v1 ops drain.
+
 ### Database service architecture
 
 Only etcd_master nodes have direct access to MariaDB credentials. All other

--- a/docs/plans/PLAN-fix-cluster-operation-targets-unique-constraint.md
+++ b/docs/plans/PLAN-fix-cluster-operation-targets-unique-constraint.md
@@ -1,0 +1,254 @@
+# PLAN: Fix cluster_operation_targets UNIQUE constraint
+
+## Status
+
+Proposed. Root cause confirmed from CI artifact bundle for run
+`25727839217` (Guests job, 2026-05-12), with the diagnostic
+instrumentation added in commit `5d0bf73c`. See "Evidence" below.
+
+## Problem
+
+The forbidden-string scanner in CI has been intermittently failing on
+`Recreating not okay network on hypervisor` for months. The post-
+`86aacb19` change to `Network.is_okay()` was meant to close the
+last_cluster_operation race; commit `5d0bf73c` added instrumentation to
+distinguish "bridge was torn down unexpectedly" from "bridge create
+failed silently". The 2026-05-12 bundle shows neither -- the bridge was
+**never created on the affected hypervisor in the first place**, and
+the maintainer was the one creating it for the first time. The race is
+between `sf-net`'s maintainer and the `node_inst_net_iface_op`
+(hot-plug interface) cluster operation.
+
+## Root cause
+
+The `cluster_operation_targets` table is declared with
+`unique=True` on `operation_uuid`
+(`shakenfist/mariadb.py:639-640`):
+
+```python
+sa.Column('operation_uuid', sa.String(36),
+          nullable=False, unique=True),
+```
+
+This makes it physically impossible to record more than one target row
+per operation. But the design (commit message of `86aacb19` and the
+`target_fields: ClassVar[dict[str, ObjectType]]` declarations on
+operation schemas) explicitly **requires** multiple target rows per op
+for multi-target operations.
+
+`_direct_create_cluster_operation_target`
+(`shakenfist/mariadb.py:5327-5361`) catches `IntegrityError` and
+returns `True` silently:
+
+```python
+except IntegrityError:
+    # Duplicate operation_uuid — already recorded, which is fine.
+    # The UNIQUE constraint on operation_uuid ensures idempotency.
+    return True
+```
+
+So for any op with N>1 targets, only the **first** target row is
+persisted; the remaining N-1 are silently dropped. The comment claims
+idempotency; in reality it drops semantically-different rows because
+the column the design wants to be unique-per-target-row is
+`(operation_uuid, target_object_type, target_uuid)`, not just
+`operation_uuid`.
+
+### Affected operation schemas
+
+`grep -A6 'target_fields: ClassVar' shakenfist/schema/operations/`
+shows four multi-target ops. For each, only the **first** declared
+target is recorded; the rest are dropped:
+
+| Schema                       | Targets (dict order)                    | Recorded | Dropped                |
+| ---------------------------- | --------------------------------------- | -------- | ---------------------- |
+| `node_inst_net_iface_op`     | instance, network, interface            | instance | **network, interface** |
+| `artifact_fetch_op`          | artifact, instance                      | artifact | instance               |
+| `net_iface_ip_op`            | network, interface                      | network  | interface              |
+| `net_iface_op`               | network, interface                      | network  | interface              |
+
+The hot-plug op (`node_inst_net_iface_op`) is the one tripping the CI
+guard, because the **network** target row is the one
+`Network.is_okay()` reads to defer the maintainer. With that row
+missing, `has_pending_cluster_operation(network)` returns False, the
+maintainer falls through to `is_created()`, the bridge is genuinely
+absent on the target hypervisor (the hot-plug op hasn't reached
+`create_on_hypervisor` yet), and the forbidden-string event fires.
+
+The bridge is then created idempotently -- first by the maintainer at
+poll time, then later (no-op) by the hot-plug op's
+`create_on_hypervisor` once its `depends_on` net_op completes. There
+is no functional breakage of the hot-plug -- only the cosmetic
+forbidden-string trip. But the same schema bug would cause real bugs
+for `is_okay()` defers on the other three ops as well.
+
+## Evidence (CI run 25727839217)
+
+Timeline reconstructed from
+`bundle-functional-cluster-guests/bundle/t-SqLSw-{3,5}/var/log/syslog`:
+
+| Time         | Node | What                                                                                                            |
+| ------------ | ---- | --------------------------------------------------------------------------------------------------------------- |
+| 10:46:58.886 | sf-3 | API receives `POST /instances/ef251675.../interfaces` (hot-plug)                                                |
+| 10:46:59.478 | sf-3 | NetworkInterface `d17c9638` row written, state=initial                                                          |
+| 10:47:00.276 | sf-3 | net_op `c50f0867` (network_update_dnsmasq) enqueued                                                             |
+| 10:47:00.986 | sf-3 | node_inst_net_iface_op `7295cbee` enqueued, targets={instance,network,interface}                                |
+| 10:47:01.074 | sf-5 | Op `7295cbee` execution deferred 15s, `waiting_on=[net_op c50f0867]`                                            |
+| 10:47:13.014 | sf-5 | sf-net maintainer: `ip link show br-vxlan-35072f` → exit 1 "does not exist"                                     |
+| 10:47:13.111 | sf-5 | sf-net emits `network not ok, is not created` (proves `has_pending_cluster_operation` returned False)           |
+| 10:47:13.174 | sf-5 | sf-net emits **`recreating not okay network on hypervisor`** -- forbidden string                                |
+| 10:47:13.239 | sf-5 | sf-net runs `create_on_hypervisor`, bridge created cleanly                                                      |
+| 10:47:17.002 | sf-5 | Op `7295cbee` state→executing                                                                                   |
+| 10:47:17.063 | sf-5 | Hot-plug op runs `create_on_hypervisor` (idempotent, bridge already up)                                         |
+| 10:47:17.763 | sf-5 | Op `7295cbee` state→complete                                                                                    |
+
+The op was in `queued` state from 10:47:00.986 through 10:47:17.002 --
+a 16-second window in which `has_pending_cluster_operation(network)`
+**should** have returned True and made `Network.is_okay()` short-circuit
+to True. It returned False. The only consistent explanation is that
+the `cluster_operation_targets` row for `target_object_type=network,
+target_uuid=88eb4715...` was never persisted.
+
+The schema bug (`unique=True` on `operation_uuid`) is the proximate
+cause: `enqueue_cluster_operation` iterates `target_fields` in
+declaration order `{instance, network, interface}`, calls
+`mariadb.create_cluster_operation_target` three times for the same
+`operation_uuid=7295cbee...`, the second and third inserts raise
+`IntegrityError`, and the catch-and-return-True swallows them.
+
+## Test gap
+
+`shakenfist/tests/test_cluster_operation_targets.py:574`
+(`test_hot_plug_enqueue_writes_three_target_rows`) **passes** today
+because it mocks `mariadb.create_cluster_operation_target` directly --
+it asserts the function was called three times with the right args
+but never exercises the actual DB constraint. The constraint check
+must be moved to an integration test against a real engine (or at
+minimum an in-memory SQLAlchemy engine with the same table
+definition).
+
+## Fix
+
+### Schema change
+
+Replace the column-level `unique=True` on `operation_uuid` with a
+composite uniqueness over the three columns that together identify a
+unique target row:
+
+```python
+sa.Table(
+    'cluster_operation_targets', metadata,
+    sa.Column('sequence_number', sa.BigInteger(),
+              primary_key=True, autoincrement=True),
+    sa.Column('operation_uuid', sa.String(36), nullable=False),
+    sa.Column('operation_type', sa.String(64), nullable=False),
+    sa.Column('target_object_type', sa.Enum(ObjectType),
+              nullable=False),
+    sa.Column('target_uuid', sa.String(36), nullable=False),
+    sa.Column('created_at', sa.Double(), nullable=False),
+    sa.UniqueConstraint(
+        'operation_uuid', 'target_object_type', 'target_uuid',
+        name='uq_cot_op_target'),
+    sa.Index('idx_cot_target', 'target_object_type', 'target_uuid'),
+    sa.Index('idx_cot_operation', 'operation_uuid'),
+    sa.Index('idx_cot_created', 'created_at'),
+)
+```
+
+The new `idx_cot_operation` preserves the fast lookup that the old
+unique-on-`operation_uuid` constraint was providing as a side effect
+(comment at `shakenfist/mariadb.py:633`).
+
+### Migration
+
+Bump `CLUSTER_OPERATION_TARGETS_VERSION` and add a migration step
+that:
+1. Drops the existing UNIQUE constraint on `operation_uuid`.
+2. Adds the composite UNIQUE on `(operation_uuid, target_object_type,
+   target_uuid)`.
+3. Adds the new non-unique index on `operation_uuid`.
+
+The existing table will have at most one row per `operation_uuid`, so
+no data fix-up is required. The compound UNIQUE will accept any new
+rows after migration.
+
+### Insert path
+
+Keep the `IntegrityError → True` early-return for true duplicates (the
+composite UNIQUE only fires on actual duplicate `(op, target_type,
+target_uuid)` triples, which **is** idempotency). Update the comment to
+reflect the new constraint.
+
+### Backfill for in-flight operations
+
+Operations currently in flight at upgrade time will have only one
+target row each, so multi-target ops in flight at the moment of
+upgrade will continue to leak through the gate one more time. Two
+options:
+
+1. **Do nothing**: the next maintainer poll for any affected network
+   will see the bridge missing and recreate it -- exactly the
+   current bug, but only during the upgrade window.
+2. **Replay**: on startup of the database daemon after migration, scan
+   in-flight ops and re-call the `enqueue_cluster_operation` target-
+   write loop for them. Adds complexity for a one-time window.
+
+Recommend (1) for the upgrade. Document that the forbidden-string
+trip is expected during the upgrade window of this fix.
+
+### Test fix
+
+Add an integration-style test in `test_cluster_operation_targets.py`
+that uses a real SQLAlchemy engine (in-memory SQLite is fine for the
+shape, MariaDB in CI for the actual constraint) and asserts:
+
+1. Enqueuing `node_inst_net_iface_op` results in **three rows** in
+   `cluster_operation_targets`, one per declared target.
+2. `has_pending_cluster_operation_target(NETWORK, network_uuid)`
+   returns True while the op is queued/preflight/executing.
+3. Replays of the same op (idempotency check) do not produce
+   duplicate rows -- the composite UNIQUE handles this.
+
+The existing mock-based test is fine to keep as a unit test of the
+schema's `target_fields` declaration and the call-site fan-out; mark
+it as such in the docstring.
+
+## Why this didn't show up earlier
+
+* Single-target ops (the vast majority) are unaffected. The four
+  multi-target ops are all relatively recent additions in the
+  cluster_operation_targets era.
+* For `node_inst_net_iface_op` specifically, the **instance** target
+  *is* recorded -- so any gate that reads the instance's pending-op
+  list sees the op correctly. The bug is invisible from the instance
+  side and only manifests from the network/interface side.
+* The unit test asserts call counts, which pass regardless of what the
+  DB does with the writes.
+
+## Risk
+
+Low for the fix itself: removing an overly-strict constraint with a
+correct replacement, idempotency preserved, no callers depended on the
+old constraint outside the DB write helper.
+
+The only callers of `cluster_operation_targets` that read rows are:
+
+* `get_latest_cluster_operation_target` -- unaffected, picks one row.
+* `has_pending_cluster_operation_target` -- unaffected, EXISTS query.
+* `get_cluster_operation_targets_for_object` -- already designed to
+  return multiple rows (per-object history).
+* `delete_cluster_operation_targets_for_object` -- unaffected.
+* `delete_stale_cluster_operation_targets` -- unaffected.
+
+None assume one-row-per-operation_uuid; they all key on `target_uuid`
+or `operation_uuid` and tolerate multiple rows.
+
+## Out of scope
+
+* The 5d0bf73c instrumentation can stay for now; once this fix is in,
+  the next failure (if any) will be a genuinely different race and the
+  debug events still help.
+* The TOCTOU race in `_instance_delete` (host_networks snapshot vs
+  `delete_on_hypervisor`) that I initially suspected is **not** the
+  cause here, but it remains theoretically possible. Leave that for a
+  separate plan if it ever fires under the new constraint.

--- a/docs/plans/PLAN-network-facade.md
+++ b/docs/plans/PLAN-network-facade.md
@@ -1,0 +1,317 @@
+# Network operations facade and queue-only mutation
+
+## Prompt
+
+Before responding to questions or discussion points in this
+document, explore the shakenfist codebase thoroughly. Read
+relevant source files, understand existing patterns (object
+lifecycle, state machines, MariaDB storage via the three-layer
+direct/gRPC/public pattern, Pydantic schemas, daemon
+architecture, operation queue system, event logging), and
+ground your answers in what the code actually does today. Do
+not speculate about the codebase when you could read it
+instead. Where a question touches on external concepts
+(KVM/libvirt, VXLAN networking, MariaDB/Galera, gRPC/protobuf),
+research as needed to give a confident answer. Flag any
+uncertainty explicitly rather than guessing.
+
+All planning documents should go into `docs/plans/`.
+
+Consult `ARCHITECTURE.md` for the system architecture
+overview, object types, and daemon structure. Consult
+`CLAUDE.md` for build commands, project conventions, and
+database access patterns. Key references inside the repo
+include `shakenfist/network/network.py` (the `Network` class
+under discussion), `shakenfist/operations/net_op.py` (the
+worker dispatch), `shakenfist/daemons/network/workitem.py`
+(the single-threaded `net-worker`), `shakenfist/daemons/network/maintain.py` (the parallel `maintain` reconciliation
+thread), `shakenfist/daemons/privexec/main.py` (the
+privileged-execution daemon that actually mutates kernel
+network state), and `shakenfist/mariadb.py` (the existing
+three-layer database access pattern, which is the architectural
+precedent for the proposed change).
+
+When we get to detailed planning, I prefer a separate plan
+file per detailed phase. These separate files should be named
+for the master plan, in the same directory as the master
+plan, and simply have `-phase-NN-descriptive` appended before
+the `.md` file extension. Tracking of these sub-phases should
+be done via the table in the Execution section below.
+
+I prefer one commit per logical change, and at minimum one
+commit per phase. Do not batch unrelated changes into a
+single commit. Each commit should be self-contained: it
+should build, pass tests, and have a clear commit message
+explaining what changed and why.
+
+## Situation
+
+The `Network` class in `shakenfist/network/network.py` carries
+two distinct responsibilities in one type:
+
+1. The **intent API** that callers across the cluster reach
+   for when they want a network to change state — every
+   daemon and REST handler calls `n.create_on_hypervisor()`,
+   `n.ensure_mesh()`, `n.add_floating_ip(...)`, etc.
+
+2. The **worker API** that actually mutates host network
+   state on a given node — the same methods invoke
+   `util_concurrency.create_vxlan_interface`,
+   `util_concurrency.ensure_vxlan_mesh`,
+   `util_concurrency.add_floating_ip`, etc., which talk to
+   the local `sf-privexec` daemon and run `ip`/`bridge` /
+   `iptables` commands.
+
+Because both responsibilities live on the same class, any
+node-local caller can invoke the worker API directly without
+going through the queue. The `sf-net` daemon's `net-worker`
+job is single-threaded by design and processes one
+`net_op` work item at a time
+(`daemons/network/workitem.py:31` carries a comment from
+mikal to that effect), so two queued net-ops on one node
+are correctly serialised. But the same node typically runs
+`sf-net`'s separate `maintain` reconciliation thread plus
+`sf-queues`, `sf-api`, and the instance lifecycle paths in
+`instance.py`, and each of those can call `n.ensure_mesh()`
+(and friends) directly without coordinating with the
+net-worker. Today there are five call sites for
+`ensure_mesh` across `instance.py`,
+`operations/net_op.py`, `operations/node_inst_netdesc_op.py`,
+`daemons/queues/startup_tasks.py` and
+`daemons/network/maintain.py`, plus similar fan-out for
+floating-IP and route operations.
+
+This produced a concrete CI failure on PR #3182's merge-queue
+run (GitHub Actions run 25899623744, "Guests" job). Two
+threads inside `sf-privexec` ran `_ensure_mesh` for the same
+VXLAN interface within 2 ms of each other, both observed the
+same stale FDB entry from their initial `bridge fdb show`,
+and both issued `bridge fdb del` for it. The kernel served
+one and rejected the other with `RTNETLINK answers: No such
+file or directory`; the losing privexec request returned
+FAILURE, `network.ensure_mesh` raised `EnsureMeshFailed`, and
+the resulting `ERROR sf-net`/`ERROR sf-privexec`/`Traceback`
+lines tripped the post-test stable-log gate. The functional
+tests themselves all passed — only the log scrape caught the
+race.
+
+A short-term fix is being landed on the `stability` branch:
+wrap the six unlocked host-mutating methods on `Network`
+(`ensure_mesh`, `add_floating_ip`, `remove_floating_ip`,
+`route_address`, `unroute_address`, `remove_nat`) with the
+existing per-network `NodeLock` (the same primitive used by
+the already-locked methods). That fix is necessary but
+addresses the symptom, not the structural problem.
+
+The architectural precedent for the fix exists in this same
+codebase. `shakenfist/mariadb.py` (and the `sf-database`
+daemon at `daemons/database/main.py`) enforces that **every**
+daemon, including local ones, must reach MariaDB through the
+gRPC database service. Only `sf-database` has `MARIADB_HOST`
+set; all other daemons route through gRPC. This eliminates
+direct-vs-indirect access skew, gives the database service a
+single point to enforce metrics, throttling, and connection
+pooling, and lets the daemon evolve internally without
+touching every caller. The proposal in this plan is to apply
+the same shape to network operations: one daemon owns the
+host-state mutations, and every other caller addresses it
+through a typed API that enqueues intents.
+
+## Mission and problem statement
+
+Restructure `Network` so that all host-state mutations are
+performed by a single owner (the `sf-net` net-worker on each
+node), and every other caller — including local daemons on
+the same node — interacts via a typed facade that enqueues
+intents and (where appropriate) awaits the result. After the
+change:
+
+* There is no path by which `sf-queues`, `sf-api`,
+  `sf-cleaner`, the instance lifecycle code, or the
+  `maintain` reconciliation thread can directly call
+  `util_concurrency.ensure_vxlan_mesh`,
+  `util_concurrency.add_floating_ip`, or any other
+  host-mutating privexec helper for a network. They go
+  through the facade.
+* The single-threaded `net-worker` is the only mutator and
+  therefore naturally serialises all activity for a network
+  on a node — `NodeLock` becomes redundant for these methods
+  and the locks added by the stability-branch fix can be
+  removed.
+* The `maintain` reconciliation thread in `sf-net` no longer
+  calls the same methods as the net-worker; instead it
+  enqueues `net_op`s and lets the net-worker do the work.
+* The "queue-jumping" fairness concern (a node that's also
+  the network node, or just a node running both `sf-net`
+  and `sf-queues`, can bypass the work queue) disappears
+  because no caller has a bypass to take.
+
+Scope boundaries:
+
+* **In scope:** every `Network` method that currently invokes
+  `util_concurrency.*` host-mutating helpers, plus
+  `update_dnsmasq`, `remove_dnsmasq`, `remove_dhcp_lease`,
+  `update_dns_entry`, `remove_dns_entry` (which mutate the
+  dnsmasq process state for the network).
+* **In scope:** the `maintain` thread in `sf-net` — its
+  direct calls to `n.ensure_mesh()`,
+  `n.create_on_hypervisor()`, `n.add_floating_ip(...)`,
+  `n.route_address(...)` are precisely the bypasses we are
+  closing.
+* **In scope:** changing the call signature/contract of the
+  affected `Network` methods. Callers will need to handle
+  enqueue-and-wait semantics, and operation failures will
+  surface differently.
+* **Out of scope:** the `NetworkInterface` and `IPAM`
+  classes. Those have their own concerns (IP reservation,
+  interface attach/detach) that overlap with networks but
+  are not the same problem. They may benefit from the same
+  pattern later, but each has its own audit work.
+* **Out of scope:** the existing `nodelock`-based fix on the
+  `stability` branch. That fix stays in place until the
+  facade refactor lands and is proven; it can be removed in
+  the final phase as cleanup.
+* **Out of scope:** changing how `net_op`s are queued or how
+  the cluster decides which node owns a network. The work
+  queue, queue prioritisation, and network-node election are
+  unchanged.
+
+## Open questions
+
+1. **Synchronous-wait API.** Today
+   `n.create_on_hypervisor()` returns when the host change
+   is complete; many callers depend on that (e.g.
+   `node_inst_netdesc_op.py:243` calls `n.create_on_hypervisor()`
+   then `n.ensure_mesh()` then `n.update_dnsmasq()` in
+   sequence, relying on each having finished before the
+   next runs). The facade needs an equivalent
+   "enqueue-and-wait" idiom. Options: (a) a blocking
+   helper `facade.do_and_wait(...)` that polls the op state;
+   (b) an explicit two-step `op = facade.enqueue(...)`
+   followed by `facade.wait(op)`; (c) make every method a
+   coroutine and provide both sync and async variants.
+   **Current leaning:** (a). It preserves the call shape
+   callers expect today, surfaces errors via exception,
+   and concentrates the polling logic in one place. The
+   instance-start path is the largest beneficiary because
+   it composes several host changes back-to-back; pushing
+   the await pattern into every call site would be noisy.
+
+2. **Where the facade lives.** Three plausible locations:
+   (a) a new module `shakenfist/network/facade.py` exposing
+   module-level functions keyed by network UUID; (b) a new
+   `NetworkFacade` class that wraps a `Network` instance and
+   exposes the intent API; (c) keep the methods on `Network`
+   but have them dispatch to "do locally" or "enqueue"
+   based on whether the caller is the net-worker. Option (c)
+   re-creates the bypass we are trying to remove (the
+   net-worker now needs an explicit escape hatch), so it's
+   not really a separation. Between (a) and (b), the class
+   form is more discoverable because callers already hold a
+   `Network` reference. **Current leaning:** (b) — add
+   `NetworkFacade(network)` as the public surface and rename
+   the existing direct-call methods on `Network` to internal
+   helpers (e.g. `_apply_create_on_hypervisor`) that only the
+   net-worker invokes.
+
+3. **Error propagation.** Today exceptions like
+   `CreateVXLANInterfaceFailed`, `DeadNetwork`,
+   `EnsureMeshFailed`, `CannotAssignFloatingGateway` are
+   raised inline. With a queue indirection the exception
+   has to be serialised in the operation's failure record
+   and re-raised on the caller side. We already store
+   operation state and error messages on the `*_op`
+   classes, but not structured exception types. Options:
+   (a) re-raise a single generic `NetworkOperationFailed`
+   exception with the underlying message text; (b) include
+   the exception class name in the op record and dispatch
+   on it client-side; (c) keep exception fidelity for a
+   small whitelist and degrade the rest to the generic
+   form. **Current leaning:** (c). The caller-side switch
+   on `EnsureMeshFailed` in `net_op.py:89-94` and on
+   `DeadNetwork` in `node_inst_netdesc_op.py` are the
+   patterns worth preserving; the others are logging-only.
+
+4. **What happens to the `Network` class itself.** Two
+   shapes: (a) keep `Network` as the data carrier
+   (object_states, attributes, queries) and add a separate
+   `NetworkFacade` for intent; the worker code that lives
+   inside `net-worker` calls thin internal helpers on
+   `Network`. (b) split into `NetworkRecord` (data) and
+   `NetworkWorker` (intent target, used only inside
+   `net-worker`) with `NetworkFacade` as the public face. (a)
+   is a smaller change; (b) is cleaner. **Current leaning:**
+   (a), to keep the diff manageable and reduce the
+   migration surface.
+
+5. **Migration order.** The fan-out of direct call sites
+   is broad (instance.py, four operations modules, two
+   daemons). All-at-once migration is risky; doing it
+   per-method (`ensure_mesh` first, then `add_floating_ip`,
+   etc.) is safer but means `Network` carries both shapes
+   for a while. **Current leaning:** per-method migration,
+   with a temporary `Network` shim that calls the facade
+   for callers that haven't migrated yet. Each phase
+   removes one method's direct callers and removes the
+   shim line.
+
+6. **Behaviour of `maintain.py`.** The reconciliation
+   thread today walks all networks every interval and
+   re-applies host state where it has drifted. Under the
+   facade it would instead enqueue reconciliation ops. That
+   has two implications: (a) `maintain` becomes much
+   smaller, basically a scanner that compares observed vs.
+   desired and enqueues deltas; (b) the net-worker has to
+   absorb the resulting op rate, which today is mostly
+   idle. Need to make sure `maintain` does not enqueue
+   no-op ops on every interval. **Current leaning:** at
+   each pass, `maintain` does the discovery (e.g. `bridge
+   fdb show`) and only enqueues when something is actually
+   wrong, mirroring its current "Recreating not okay
+   network on hypervisor" logic.
+
+7. **Performance and latency.** The instance-start path
+   currently makes ~3-5 host changes back-to-back in the
+   POST `/instances` handler. Each change becomes
+   enqueue-plus-wait, with the queue round-trip dominated
+   by polling latency. We should measure the floor; if the
+   round-trip is >100 ms per op we'd be making
+   instance-start noticeably slower. **Current leaning:**
+   measure before designing the wait helper. If
+   round-trips are bad, batch the steps into a single
+   composite op (e.g. `instance_attach_network`) so the
+   net-worker performs the whole sequence under one queue
+   item.
+
+8. **What about `enable_nat`?** It's the one host-mutating
+   method already protected (it's only called from inside
+   `create_on_network_node`'s lock). Under the facade it
+   collapses into the implementation of
+   `create_on_network_node`'s queued op rather than being a
+   public method at all. **Current leaning:** make
+   `_enable_nat` an internal worker helper, not part of
+   the facade. Callers who today call `enable_nat()`
+   directly become callers of a higher-level intent.
+
+Please confirm the leanings above before phase 1 planning
+begins.
+
+## Execution
+
+| Phase | Plan | Status |
+|-------|------|--------|
+| 0. Stability-branch lock fix (separate, lands now) | (not a sub-plan — see commit on `stability`) | Complete |
+| 1. Facade scaffold and `ensure_mesh` migration | TBD | Planning |
+| 2. Floating-IP and route migration | TBD | Planning |
+| 3. dnsmasq operation migration | TBD | Planning |
+| 4. `create_on_*` and `delete_on_*` migration | TBD | Planning |
+| 5. `maintain.py` rewrite as discovery-only | TBD | Planning |
+| 6. Remove the temporary `NodeLock`s and the shim | TBD | Planning |
+| 7. Documentation and tests | TBD | Planning |
+
+Phase numbering reflects rough complexity ordering — small,
+isolated method first; the broad-fan-out lifecycle methods
+last. Each phase is expected to compile, pass CI, and leave
+the cluster in a runnable state; intermediate phases will
+have `Network` carrying both the old direct-call API and the
+new facade-routed API in parallel.

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -28,6 +28,7 @@ This section contains forward-looking roadmaps for Shaken Fist development. Thes
 | [Replace last_cluster_operation](PLAN-replace-last-cluster-operation.md) | Phase 4: Remove explicit setters | Complete | Drop redundant `set_last_cluster_operation` callers |
 | [Replace last_cluster_operation](PLAN-replace-last-cluster-operation.md) | Phase 5: Documentation and final audit | Complete | Update docs, verify CI |
 | [Fix cluster_operation_targets UNIQUE constraint](PLAN-fix-cluster-operation-targets-unique-constraint.md) | Schema fix | Complete | Replace column-level `UNIQUE(operation_uuid)` with composite `UNIQUE(operation_uuid, target_object_type, target_uuid)` so multi-target ops record all their target rows |
+| [Network operations facade](PLAN-network-facade.md) | Master plan | Planning | Split `Network` into a queue-enqueuing facade and a single-mutator worker so local daemons can no longer bypass `net-worker`'s serialisation |
 
 ### Status Definitions
 

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -27,6 +27,7 @@ This section contains forward-looking roadmaps for Shaken Fist development. Thes
 | [Replace last_cluster_operation](PLAN-replace-last-cluster-operation.md) | Phase 3: Auto-target tracking | Complete | `*_create_and_enqueue` writes target rows automatically |
 | [Replace last_cluster_operation](PLAN-replace-last-cluster-operation.md) | Phase 4: Remove explicit setters | Complete | Drop redundant `set_last_cluster_operation` callers |
 | [Replace last_cluster_operation](PLAN-replace-last-cluster-operation.md) | Phase 5: Documentation and final audit | Complete | Update docs, verify CI |
+| [Fix cluster_operation_targets UNIQUE constraint](PLAN-fix-cluster-operation-targets-unique-constraint.md) | Schema fix | Complete | Replace column-level `UNIQUE(operation_uuid)` with composite `UNIQUE(operation_uuid, target_object_type, target_uuid)` so multi-target ops record all their target rows |
 
 ### Status Definitions
 

--- a/docs/plans/order.yml
+++ b/docs/plans/order.yml
@@ -10,3 +10,4 @@
 - api-query-batching-roadmap.md: API query batching roadmap
 - PLAN-sql-pushdown-filtering.md: SQL-pushdown filtering
 - PLAN-replace-last-cluster-operation.md: Replace last_cluster_operation with cluster_operation_targets gating
+- PLAN-network-facade.md: Network operations facade and queue-only mutation

--- a/shakenfist/daemons/cleaner/main.py
+++ b/shakenfist/daemons/cleaner/main.py
@@ -200,6 +200,4 @@ def main():
 
     m.run()
 
-    # This is here because sometimes the grpc bits don't shut down cleanly
-    # by themselves.
-    raise SystemExit(0)
+    daemon.force_clean_exit()

--- a/shakenfist/daemons/cluster/main.py
+++ b/shakenfist/daemons/cluster/main.py
@@ -472,6 +472,4 @@ def main():
     m = Monitor('cluster')
     m.run()
 
-    # This is here because sometimes the grpc bits don't shut down cleanly
-    # by themselves.
-    raise SystemExit(0)
+    daemon.force_clean_exit()

--- a/shakenfist/daemons/daemon.py
+++ b/shakenfist/daemons/daemon.py
@@ -304,6 +304,30 @@ class Daemon:
                 break
 
 
+def force_clean_exit():
+    # Skip the interpreter's normal teardown and exit immediately.
+    #
+    # Some gRPC client channels (notably the thread-local eventlog channel
+    # in shakenfist.eventlog) leave C-level background threads alive that
+    # block ordinary interpreter shutdown when the server-side has already
+    # gone away. record_exit() has already flushed the audit state, so
+    # anything still running here is not productive work -- waiting for it
+    # only buys a systemd SIGKILL after TimeoutStopSec.
+    #
+    # Before exiting, log any non-daemon Python threads still alive. Those
+    # are leakers we control (the C++ gRPC event_engine threads we cannot)
+    # and naming them in syslog makes future regressions visible.
+    main_thread = threading.main_thread()
+    leakers = [
+        (t.name, t.ident) for t in threading.enumerate()
+        if t is not main_thread and not t.daemon
+    ]
+    if leakers:
+        LOG.warning(
+            f'Non-daemon Python threads still alive at exit: {leakers}')
+    os._exit(0)
+
+
 def _send_systemd_notification(message):
     # If running systemd and we are Type=notify...
     addr = os.environ.get('NOTIFY_SOCKET')

--- a/shakenfist/daemons/daemon.py
+++ b/shakenfist/daemons/daemon.py
@@ -86,7 +86,6 @@ def set_log_level(log, name):
 
 
 def write_pid_file(daemon_name):
-    os.makedirs('/run/sf/', exist_ok=True)
     with open(f'/run/sf/{daemon_name}.pid', 'w') as f:
         f.write(f'{os.getpid()}')
 
@@ -99,7 +98,6 @@ def clear_abort_path(abort_path):
 
 def set_abort_path(abort_path, source):
     LOG.info(f'Setting abort file: {abort_path} ({source})')
-    os.makedirs(os.path.basename(abort_path), exist_ok=True)
     with open(abort_path, 'w') as f:
         f.write('1')
 

--- a/shakenfist/daemons/database/main.py
+++ b/shakenfist/daemons/database/main.py
@@ -4937,6 +4937,4 @@ def main() -> None:
     m.run()
     server.stop(1).wait()
 
-    # This is here because sometimes the grpc bits don't shut down cleanly
-    # by themselves.
-    raise SystemExit(0)
+    daemon.force_clean_exit()

--- a/shakenfist/daemons/eventlog/main.py
+++ b/shakenfist/daemons/eventlog/main.py
@@ -381,6 +381,4 @@ def main():
     m.run()
     server.stop(1).wait()
 
-    # This is here because sometimes the grpc bits don't shut down cleanly
-    # by themselves.
-    raise SystemExit(0)
+    daemon.force_clean_exit()

--- a/shakenfist/daemons/network/main.py
+++ b/shakenfist/daemons/network/main.py
@@ -156,6 +156,4 @@ def main():
     m = Monitor('net')
     m.run()
 
-    # This is here because sometimes the grpc bits don't shut down cleanly
-    # by themselves.
-    raise SystemExit(0)
+    daemon.force_clean_exit()

--- a/shakenfist/daemons/nodelock/main.py
+++ b/shakenfist/daemons/nodelock/main.py
@@ -14,6 +14,7 @@ from google.protobuf.message import DecodeError
 import setproctitle
 from shakenfist_utilities import logs
 
+from shakenfist.daemons.daemon import force_clean_exit
 from shakenfist.daemons.daemon import send_systemd_ready
 from shakenfist.protos import nodelock_pb2
 from shakenfist.util import exceptions as util_exceptions
@@ -122,6 +123,4 @@ def main():
 
     LOG.info('Stopped')
 
-    # This is here because sometimes the grpc bits don't shut down cleanly
-    # by themselves.
-    raise SystemExit(0)
+    force_clean_exit()

--- a/shakenfist/daemons/privexec/main.py
+++ b/shakenfist/daemons/privexec/main.py
@@ -18,6 +18,7 @@ import setproctitle
 from shakenfist_utilities import random      # noreorder
 from shakenfist_utilities import logs        # noreorder
 
+from shakenfist.daemons.daemon import force_clean_exit
 from shakenfist.daemons.daemon import send_systemd_ready
 from shakenfist.daemons.daemon import send_systemd_stopping
 from shakenfist.daemons.privexec import util as privexec_util
@@ -609,6 +610,4 @@ def main():
     LOG.info(f'There are {len(workers)} remaining workers')
     LOG.info('Stopped')
 
-    # This is here because sometimes the grpc bits don't shut down cleanly
-    # by themselves.
-    raise SystemExit(0)
+    force_clean_exit()

--- a/shakenfist/daemons/queues/main.py
+++ b/shakenfist/daemons/queues/main.py
@@ -164,6 +164,4 @@ def main():
     m = Monitor('queues')
     m.run()
 
-    # This is here because sometimes the grpc bits don't shut down cleanly
-    # by themselves.
-    raise SystemExit(0)
+    daemon.force_clean_exit()

--- a/shakenfist/daemons/resources/main.py
+++ b/shakenfist/daemons/resources/main.py
@@ -504,6 +504,4 @@ def main():
 
     m.run()
 
-    # This is here because sometimes the grpc bits don't shut down cleanly
-    # by themselves.
-    raise SystemExit(0)
+    daemon.force_clean_exit()

--- a/shakenfist/daemons/sentinel_first/main.py
+++ b/shakenfist/daemons/sentinel_first/main.py
@@ -54,6 +54,4 @@ def main():
     n.state = Node.STATE_STOPPED
     LOG.info('Stopped')
 
-    # This is here because sometimes the grpc bits don't shut down cleanly
-    # by themselves.
-    raise SystemExit(0)
+    daemon.force_clean_exit()

--- a/shakenfist/daemons/sentinel_last/main.py
+++ b/shakenfist/daemons/sentinel_last/main.py
@@ -49,6 +49,4 @@ def main():
     n.state = Node.STATE_STOPPING
     LOG.info('Stopped')
 
-    # This is here because sometimes the grpc bits don't shut down cleanly
-    # by themselves.
-    raise SystemExit(0)
+    daemon.force_clean_exit()

--- a/shakenfist/daemons/sidechannel/main.py
+++ b/shakenfist/daemons/sidechannel/main.py
@@ -1021,6 +1021,4 @@ def main():
 
     m.run()
 
-    # This is here because sometimes the grpc bits don't shut down cleanly
-    # by themselves.
-    raise SystemExit(0)
+    daemon.force_clean_exit()

--- a/shakenfist/daemons/transfers/main.py
+++ b/shakenfist/daemons/transfers/main.py
@@ -144,6 +144,4 @@ def main():
 
     m.run()
 
-    # This is here because sometimes the grpc bits don't shut down cleanly
-    # by themselves.
-    raise SystemExit(0)
+    daemon.force_clean_exit()

--- a/shakenfist/deploy/ansible/files/sf-api.service
+++ b/shakenfist/deploy/ansible/files/sf-api.service
@@ -14,6 +14,8 @@ Group=root
 TimeoutStopSec=30s
 SuccessExitStatus=SIGTERM 143
 RestartPreventExitStatus=SIGTERM
+RuntimeDirectory=sf
+RuntimeDirectoryPreserve=yes
 
 EnvironmentFile=/etc/sf/config
 ExecStartPre=/bin/sh -c '/srv/shakenfist/venv/bin/sf-ctl verify-config'

--- a/shakenfist/deploy/ansible/files/sf.service
+++ b/shakenfist/deploy/ansible/files/sf.service
@@ -49,6 +49,8 @@ Group=root
 TimeoutStopSec=30s
 SuccessExitStatus=SIGTERM 143
 RestartPreventExitStatus=SIGTERM
+RuntimeDirectory=sf
+RuntimeDirectoryPreserve=yes
 
 EnvironmentFile=/etc/sf/config
 ExecStartPre=/srv/shakenfist/venv/bin/sf-ctl verify-config

--- a/shakenfist/deploy/ansible/roles/base/tasks/config.yml
+++ b/shakenfist/deploy/ansible/roles/base/tasks/config.yml
@@ -158,12 +158,3 @@
   changed_when: _.rc == 1
   failed_when: _.rc == 2
   notify: Reload systemd
-
-- name: Ensure /var/run/sf exists for gunicorn
-  file:
-    path: /var/run/sf
-    state: directory
-    owner: root
-    group: root
-    mode: u=rw,g=r,o=r
-  when: not config_stat_result.stat.exists

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -266,9 +266,11 @@ def redirect_instance_request(func):
                 'method': flask.request.environ['REQUEST_METHOD'],
                 'url': url,
                 'status_code': r.status_code,
-                'text': r.text
+                'body_bytes': len(r.content)
             }).info('Returning proxied request')
-            resp = flask.Response(r.text, mimetype='application/json')
+            resp = flask.Response(
+                r.content,
+                mimetype=r.headers.get('Content-Type', 'application/json'))
             resp.status_code = r.status_code
             return resp
 
@@ -352,9 +354,11 @@ def redirect_to_network_node(func):
                 'method': flask.request.environ['REQUEST_METHOD'],
                 'url': path,
                 'status_code': r.status_code,
-                'text': r.text
+                'body_bytes': len(r.content)
             }).info('Returning proxied request')
-            resp = flask.Response(r.text, mimetype='application/json')
+            resp = flask.Response(
+                r.content,
+                mimetype=r.headers.get('Content-Type', 'application/json'))
             resp.status_code = r.status_code
             return resp
 
@@ -455,9 +459,11 @@ def redirect_upload_request(func):
                 'method': flask.request.environ['REQUEST_METHOD'],
                 'url': url,
                 'status_code': r.status_code,
-                'text': r.text
+                'body_bytes': len(r.content)
             }).info('Returning proxied request')
-            resp = flask.Response(r.text,  mimetype='application/json')
+            resp = flask.Response(
+                r.content,
+                mimetype=r.headers.get('Content-Type', 'application/json'))
             resp.status_code = r.status_code
             return resp
 
@@ -486,9 +492,11 @@ def redirect_to_eventlog_node(func):
                 'method': flask.request.environ['REQUEST_METHOD'],
                 'url': path,
                 'status_code': r.status_code,
-                'text': r.text
+                'body_bytes': len(r.content)
             }).info('Returning proxied request')
-            resp = flask.Response(r.text, mimetype='application/json')
+            resp = flask.Response(
+                r.content,
+                mimetype=r.headers.get('Content-Type', 'application/json'))
             resp.status_code = r.status_code
             return resp
 

--- a/shakenfist/mariadb.py
+++ b/shakenfist/mariadb.py
@@ -716,17 +716,28 @@ def _ensure_cluster_operation_targets_schema(
             f'Upgrading {table_name} from v{current_ver} to v2: '
             'replacing UNIQUE(operation_uuid) with composite UNIQUE '
             '(operation_uuid, target_object_type, target_uuid).')
-        with engine.begin() as conn:
+        with engine.connect() as conn:
             conn.execute(sa.text(
                 f'ALTER TABLE {table_name} '
                 f'DROP INDEX IF EXISTS operation_uuid'))
-            conn.execute(sa.text(
-                f'ALTER TABLE {table_name} '
-                f'ADD CONSTRAINT uq_cot_op_target UNIQUE '
-                f'(operation_uuid, target_object_type, target_uuid)'))
+            # MariaDB has no ADD CONSTRAINT ... IF NOT EXISTS, so we
+            # tolerate an existing constraint of the same name. This
+            # mirrors the network_interfaces.macaddr migration and
+            # keeps the step restartable if a previous attempt
+            # crashed after the ALTER but before _set_table_version.
+            try:
+                conn.execute(sa.text(
+                    f'ALTER TABLE {table_name} '
+                    f'ADD CONSTRAINT uq_cot_op_target UNIQUE '
+                    f'(operation_uuid, target_object_type, target_uuid)'))
+            except (IntegrityError, OperationalError) as e:
+                LOG.debug(
+                    f'UNIQUE constraint uq_cot_op_target already '
+                    f'exists or could not be added: {e}')
             conn.execute(sa.text(
                 f'CREATE INDEX IF NOT EXISTS idx_cot_operation '
                 f'ON {table_name} (operation_uuid)'))
+            conn.commit()
         current_ver = 2
         _set_table_version(engine, table_name, current_ver)
 
@@ -5422,8 +5433,13 @@ def _direct_create_cluster_operation_target(
         # exists, which is the idempotency case. Any other integrity
         # violation (NOT NULL, type-check, foreign-key) is a real
         # bug and must surface.
+        #
+        # MariaDB names the constraint in the error text. SQLite does
+        # not, so we also accept its fixed "UNIQUE constraint failed"
+        # phrase; the table only carries this one composite UNIQUE so
+        # the fallback cannot misclassify a different uniqueness rule.
         msg = str(e).lower()
-        if 'uq_cot_op_target' in msg or 'unique' in msg or 'duplicate' in msg:
+        if 'uq_cot_op_target' in msg or 'unique constraint failed' in msg:
             return True
         LOG.warning(
             f'Non-uniqueness IntegrityError writing '

--- a/shakenfist/mariadb.py
+++ b/shakenfist/mariadb.py
@@ -165,7 +165,17 @@ AGENT_OPERATION_ATTRIBUTES_VERSION = 2
 INSTANCES_VERSION = 3
 INSTANCE_ATTRIBUTES_VERSION = 3
 OBJECT_METADATA_VERSION = 3
-CLUSTER_OPERATION_TARGETS_VERSION = 1
+# v1: schema creation.
+# v2: replace column-level UNIQUE on operation_uuid with a composite
+# UNIQUE on (operation_uuid, target_object_type, target_uuid). The v1
+# constraint made it impossible to record more than one target per
+# operation; multi-target ops (e.g. node_inst_net_iface_op) silently
+# dropped all but the first declared target via IntegrityError, which
+# the writer treated as idempotency. The replacement preserves real
+# idempotency (same target written twice) without truncating multi-
+# target ops. A non-unique idx_cot_operation index keeps lookups by
+# operation_uuid fast.
+CLUSTER_OPERATION_TARGETS_VERSION = 2
 NODE_METRICS_VERSION = 2
 # v1: schema creation. v2: data migration from node_attributes.daemon_states
 # JSON column.
@@ -627,24 +637,35 @@ def _get_cluster_operation_targets_table() -> sa.Table:
     global _cluster_operation_targets_table
     if _cluster_operation_targets_table is None:
         metadata = _get_metadata()
-        # sequence_number must be the primary key for MySQL/MariaDB to
-        # apply AUTO_INCREMENT. SQLAlchemy only generates AUTO_INCREMENT
-        # DDL for the first column of the primary key on MySQL backends.
-        # operation_uuid is made UNIQUE instead to preserve fast lookups.
+        # sequence_number is the primary key so MariaDB applies
+        # AUTO_INCREMENT (SQLAlchemy only emits AUTO_INCREMENT DDL for
+        # the first column of the primary key on MySQL backends).
+        #
+        # The unique constraint is on the triple (operation_uuid,
+        # target_object_type, target_uuid): one op can target many
+        # objects (e.g. node_inst_net_iface_op targets instance,
+        # network, and interface), but the same op-target pair must
+        # not appear twice. A column-level UNIQUE on operation_uuid
+        # alone (the v1 schema) silently truncated multi-target ops.
+        # idx_cot_operation keeps single-column operation_uuid
+        # lookups fast.
         _cluster_operation_targets_table = sa.Table(
             'cluster_operation_targets',
             metadata,
             sa.Column('sequence_number', sa.BigInteger(),
                       primary_key=True, autoincrement=True),
-            sa.Column('operation_uuid', sa.String(36),
-                      nullable=False, unique=True),
+            sa.Column('operation_uuid', sa.String(36), nullable=False),
             sa.Column('operation_type', sa.String(64), nullable=False),
             sa.Column('target_object_type', sa.Enum(ObjectType),
                       nullable=False),
             sa.Column('target_uuid', sa.String(36), nullable=False),
             sa.Column('created_at', sa.Double(), nullable=False),
+            sa.UniqueConstraint(
+                'operation_uuid', 'target_object_type', 'target_uuid',
+                name='uq_cot_op_target'),
             # Indexes for common query patterns
             sa.Index('idx_cot_target', 'target_object_type', 'target_uuid'),
+            sa.Index('idx_cot_operation', 'operation_uuid'),
             sa.Index('idx_cot_created', 'created_at'),
         )
     return _cluster_operation_targets_table
@@ -663,6 +684,50 @@ def _ensure_cluster_operation_targets_schema(
         LOG.info(f'Creating {table_name} table (version 1)')
         table.metadata.create_all(engine, tables=[table], checkfirst=True)
         current_ver = 1
+        _set_table_version(engine, table_name, current_ver)
+
+    if current_ver < 2:
+        # The v1 schema declared operation_uuid UNIQUE, which made
+        # multi-target operations impossible to represent: every
+        # target row after the first hit the UNIQUE constraint and
+        # was silently dropped by the writer's IntegrityError
+        # handler. The hot-plug interface op
+        # (node_inst_net_iface_op) is the path this bit hardest --
+        # the network target row was lost, so
+        # has_pending_cluster_operation(network) returned False
+        # while the op was queued, the network maintainer raced
+        # the queue worker, and the CI forbidden-string guard for
+        # "Recreating not okay network on hypervisor" tripped.
+        #
+        # The replacement is a composite UNIQUE on the triple
+        # (operation_uuid, target_object_type, target_uuid), which
+        # still gives idempotency (same op-target written twice is
+        # a no-op) without truncating multi-target ops. We also
+        # add idx_cot_operation to preserve the fast operation_uuid
+        # lookup the column-level UNIQUE was implicitly providing.
+        #
+        # SQLAlchemy's column-level unique=True on MariaDB creates
+        # an index named after the column. The drop is wrapped in
+        # IF EXISTS because some older deployments might already
+        # have it under a different auto-generated name -- the
+        # add-uniqueconstraint below is unconditional and will
+        # surface any leftover constraint as an error there.
+        LOG.info(
+            f'Upgrading {table_name} from v{current_ver} to v2: '
+            'replacing UNIQUE(operation_uuid) with composite UNIQUE '
+            '(operation_uuid, target_object_type, target_uuid).')
+        with engine.begin() as conn:
+            conn.execute(sa.text(
+                f'ALTER TABLE {table_name} '
+                f'DROP INDEX IF EXISTS operation_uuid'))
+            conn.execute(sa.text(
+                f'ALTER TABLE {table_name} '
+                f'ADD CONSTRAINT uq_cot_op_target UNIQUE '
+                f'(operation_uuid, target_object_type, target_uuid)'))
+            conn.execute(sa.text(
+                f'CREATE INDEX IF NOT EXISTS idx_cot_operation '
+                f'ON {table_name} (operation_uuid)'))
+        current_ver = 2
         _set_table_version(engine, table_name, current_ver)
 
     return {
@@ -5350,10 +5415,20 @@ def _direct_create_cluster_operation_target(
             conn.execute(stmt)
             conn.commit()
             return True
-    except IntegrityError:
-        # Duplicate operation_uuid — already recorded, which is fine.
-        # The UNIQUE constraint on operation_uuid ensures idempotency.
-        return True
+    except IntegrityError as e:
+        # The only IntegrityError we want to treat as success is the
+        # composite UNIQUE on (operation_uuid, target_object_type,
+        # target_uuid) tripping -- the same op-target pair already
+        # exists, which is the idempotency case. Any other integrity
+        # violation (NOT NULL, type-check, foreign-key) is a real
+        # bug and must surface.
+        msg = str(e).lower()
+        if 'uq_cot_op_target' in msg or 'unique' in msg or 'duplicate' in msg:
+            return True
+        LOG.warning(
+            f'Non-uniqueness IntegrityError writing '
+            f'cluster_operation_targets row for op {operation_uuid}: {e}')
+        return False
     except OperationalError as e:
         LOG.warning(
             f'MariaDB write failed for cluster_operation_targets '

--- a/shakenfist/network/network.py
+++ b/shakenfist/network/network.py
@@ -823,8 +823,9 @@ class Network(dbowo):
 
     def remove_nat(self):
         if config.NODE_IS_NETWORK_NODE:
-            if self.floating_gateway:
-                self.unassign_floating_gateway()
+            with self.get_lock(op='Network remove NAT', global_scope=False):
+                if self.floating_gateway:
+                    self.unassign_floating_gateway()
 
         else:
             net_create_and_enqueue(
@@ -882,49 +883,50 @@ class Network(dbowo):
 
     @_not_on_floating_network
     def ensure_mesh(self):
-        # Determine which IPs should be on this mesh and where
-        instances = []
-        for ni in self.networkinterfaces:
-            if ni.instance_uuid not in instances:
-                instances.append(ni.instance_uuid)
+        with self.get_lock(op='Network ensure mesh', global_scope=False):
+            # Determine which IPs should be on this mesh and where
+            instances = []
+            for ni in self.networkinterfaces:
+                if ni.instance_uuid not in instances:
+                    instances.append(ni.instance_uuid)
 
-        node_fqdns = []
-        for inst_uuid in instances:
-            inst = instance.Instance.from_db(inst_uuid)
-            if not inst:
-                continue
-            placement = inst.placement
-            if not placement:
-                continue
-            if not placement.get('node'):
-                continue
+            node_fqdns = []
+            for inst_uuid in instances:
+                inst = instance.Instance.from_db(inst_uuid)
+                if not inst:
+                    continue
+                placement = inst.placement
+                if not placement:
+                    continue
+                if not placement.get('node'):
+                    continue
 
-            if not placement.get('node') in node_fqdns:
-                node_fqdns.append(placement.get('node'))
+                if not placement.get('node') in node_fqdns:
+                    node_fqdns.append(placement.get('node'))
 
-        # NOTE(mikal): why not use DNS here? Well, DNS might be outside
-        # the control of the deployer if we're running in a public cloud
-        # as an overlay cloud... Also, we don't include ourselves in the
-        # mesh as that would cause duplicate packets to reflect back to us.
-        # (see bug #859).
-        node_ips = set()
-        if config.NETWORK_NODE_IP != config.NODE_MESH_IP:
-            # Always add Network node if it is not this node
-            node_ips.add(config.NETWORK_NODE_IP)
+            # NOTE(mikal): why not use DNS here? Well, DNS might be outside
+            # the control of the deployer if we're running in a public cloud
+            # as an overlay cloud... Also, we don't include ourselves in the
+            # mesh as that would cause duplicate packets to reflect back to us.
+            # (see bug #859).
+            node_ips = set()
+            if config.NETWORK_NODE_IP != config.NODE_MESH_IP:
+                # Always add Network node if it is not this node
+                node_ips.add(config.NETWORK_NODE_IP)
 
-        for fqdn in node_fqdns:
-            n = Node.from_db(fqdn)
-            if n and n.ip != config.NODE_MESH_IP:
-                node_ips.add(n.ip)
+            for fqdn in node_fqdns:
+                n = Node.from_db(fqdn)
+                if n and n.ip != config.NODE_MESH_IP:
+                    node_ips.add(n.ip)
 
-        added, removed = util_concurrency.ensure_vxlan_mesh(
-            self.uuid, self.vxid, node_ips)
-        if removed:
-            self.add_event(EVENT_TYPE_MUTATE, 'remove mesh elements',
-                           extra={'removed': removed})
-        if added:
-            self.add_event(EVENT_TYPE_MUTATE, 'add mesh elements',
-                           extra={'added': added})
+            added, removed = util_concurrency.ensure_vxlan_mesh(
+                self.uuid, self.vxid, node_ips)
+            if removed:
+                self.add_event(EVENT_TYPE_MUTATE, 'remove mesh elements',
+                               extra={'removed': removed})
+            if added:
+                self.add_event(EVENT_TYPE_MUTATE, 'add mesh elements',
+                               extra={'added': added})
 
     # NOTE(mikal): this call only works on the network node, the API
     # server redirects there.
@@ -937,8 +939,9 @@ class Network(dbowo):
                 'floating': floating_address,
                 'inner': inner_address
             })
-        util_concurrency.add_floating_ip(
-            str(self.uuid), floating_address, inner_address)
+        with self.get_lock(op='Network add floating IP', global_scope=False):
+            util_concurrency.add_floating_ip(
+                str(self.uuid), floating_address, inner_address)
 
     # NOTE(mikal): this call only works on the network node, the API
     # server redirects there.
@@ -951,7 +954,9 @@ class Network(dbowo):
                 'floating': floating_address,
                 'inner': inner_address
             })
-        util_concurrency.remove_floating_ip(str(self.uuid), floating_address)
+        with self.get_lock(op='Network remove floating IP', global_scope=False):
+            util_concurrency.remove_floating_ip(
+                str(self.uuid), floating_address)
 
     # NOTE(mikal): this call only works on the network node, the API
     # server redirects there.
@@ -961,8 +966,10 @@ class Network(dbowo):
             extra={'floating': floating_address})
         subst = self.subst_dict()
         subst['floating_address'] = floating_address
-        util_concurrency.execute(
-            'ip route add %(floating_address)s/32 dev %(vx_bridge)s' % subst)
+        with self.get_lock(op='Network route address', global_scope=False):
+            util_concurrency.execute(
+                'ip route add %(floating_address)s/32 dev %(vx_bridge)s'
+                % subst)
 
     # NOTE(mikal): this call only works on the network node, the API
     # server redirects there.
@@ -972,8 +979,10 @@ class Network(dbowo):
             extra={'floating': floating_address})
         subst = self.subst_dict()
         subst['floating_address'] = floating_address
-        util_concurrency.execute(
-            'ip route del %(floating_address)s/32 dev %(vx_bridge)s' % subst)
+        with self.get_lock(op='Network unroute address', global_scope=False):
+            util_concurrency.execute(
+                'ip route del %(floating_address)s/32 dev %(vx_bridge)s'
+                % subst)
 
 
 class Networks(dbo_iter):

--- a/shakenfist/scheduler.py
+++ b/shakenfist/scheduler.py
@@ -100,13 +100,16 @@ class Scheduler:
     def _has_reasonable_queue_state(self, log_ctx, node):
         waiting = self.metrics[node].get('node_queue_waiting', 0)
         if waiting > UNREASONABLE_QUEUE_LENGTH:
-            log_ctx.with_fields({
-                'node': node,
-                'node_queue_waiting': waiting
-            }).debug('Excluding node with many queued jobs')
-            return False
+            reason = {
+                'reason': 'queue too long',
+                'node_queue_waiting': waiting,
+                'unreasonable_threshold': UNREASONABLE_QUEUE_LENGTH,
+            }
+            log_ctx.with_fields({'node': node, **reason}).debug(
+                'Excluding node with many queued jobs')
+            return False, reason
 
-        return True
+        return True, None
 
     def _has_sufficient_cpu(self, log_ctx, cpus, node):
         hard_max_cpus = (self.metrics[node].get(
@@ -114,15 +117,17 @@ class Scheduler:
         current_cpu = self.metrics[node].get('cpu_total_instance_vcpus', 0)
 
         if current_cpu + cpus > hard_max_cpus:
-            log_ctx.with_fields({
-                'node': node,
+            reason = {
+                'reason': 'would exceed hard max CPUs',
                 'current_cpus': current_cpu,
                 'requested_cpus': cpus,
-                'hard_max_cpus': hard_max_cpus
-            }).debug('Scheduling on node would exceed hard maximum CPUs')
-            return False
+                'hard_max_cpus': hard_max_cpus,
+            }
+            log_ctx.with_fields({'node': node, **reason}).debug(
+                'Scheduling on node would exceed hard maximum CPUs')
+            return False, reason
 
-        return True
+        return True, None
 
     def _has_sufficient_ram(self, log_ctx, memory, node):
         # There are two things to track here... We must always have
@@ -132,28 +137,32 @@ class Scheduler:
         available = (self.metrics[node].get('memory_available', 0) -
                      (config.RAM_SYSTEM_RESERVATION * 1024))
         if available - memory < 0.0:
-            log_ctx.with_fields({
-                'node': node,
-                'available': available,
-                'requested_memory': memory
-            }).debug('Insufficient memory')
-            return False
+            reason = {
+                'reason': 'insufficient memory',
+                'available_mb': available,
+                'requested_memory_mb': memory,
+            }
+            log_ctx.with_fields({'node': node, **reason}).debug(
+                'Insufficient memory')
+            return False, reason
 
         # ...Secondly, if we're using KSM and over committing memory, we
         # shouldn't overcommit more than by RAM_OVERCOMMIT_RATIO
         instance_memory = (
             self.metrics[node].get('memory_total_instance_actual', 0) + memory)
-        if (instance_memory / self.metrics[node].get('memory_max', 0) >
-                config.RAM_OVERCOMMIT_RATIO):
-            log_ctx.with_fields({
-                'node': node,
-                'instance_memory': instance_memory,
-                'memory_max': self.metrics[node].get('memory_max', 0),
-                'overcommit_ratio': config.RAM_OVERCOMMIT_RATIO
-            }).debug('KSM overcommit ratio exceeded')
-            return False
+        memory_max = self.metrics[node].get('memory_max', 0)
+        if (instance_memory / memory_max > config.RAM_OVERCOMMIT_RATIO):
+            reason = {
+                'reason': 'KSM overcommit ratio exceeded',
+                'instance_memory_mb': instance_memory,
+                'memory_max_mb': memory_max,
+                'overcommit_ratio': config.RAM_OVERCOMMIT_RATIO,
+            }
+            log_ctx.with_fields({'node': node, **reason}).debug(
+                'KSM overcommit ratio exceeded')
+            return False, reason
 
-        return True
+        return True, None
 
     def _has_sufficient_disk(self, log_ctx, inst, node):
         requested_disk = 0
@@ -167,13 +176,16 @@ class Scheduler:
         disk_free = int(self.metrics[node].get('disk_free_instances', '0')) / GiB
         disk_free -= config.MINIMUM_FREE_DISK
         if requested_disk > disk_free:
-            log_ctx.with_fields({
-                'node': node,
+            reason = {
+                'reason': 'insufficient disk',
                 'requested_disk_gb': requested_disk,
                 'disk_free_gb': disk_free,
-            }).debug('Node has insufficient disk')
-            return False
-        return True
+                'minimum_free_disk_gb': config.MINIMUM_FREE_DISK,
+            }
+            log_ctx.with_fields({'node': node, **reason}).debug(
+                'Node has insufficient disk')
+            return False, reason
+        return True, None
 
     def _has_idle_disk_bandwidth(self, log_ctx, inst, node):
         # We also avoid starting new instances on hypervisors with busy disk.
@@ -183,26 +195,34 @@ class Scheduler:
         busy_time = int(
             self.metrics[node].get('disk_busy_time_delta_per_sec', '0'))
         if busy_time > 1200:
-            log_ctx.with_fields({
-                'node': node,
-                'busy_time_delta_per_sec': busy_time
-            }).debug('Scheduling on node would exceed maximum disk bandwidth')
-            return False
+            reason = {
+                'reason': 'disk bandwidth saturated',
+                'busy_time_delta_per_sec': busy_time,
+                'busy_time_threshold': 1200,
+            }
+            log_ctx.with_fields({'node': node, **reason}).debug(
+                'Scheduling on node would exceed maximum disk bandwidth')
+            return False, reason
 
-        return True
+        return True, None
 
-    def _log_and_raise_on_error(self, related_objects, stage, candidates):
+    def _log_and_raise_on_error(
+            self, related_objects, stage, candidates, dropped=None):
+        extra = {'candidates': candidates}
+        if dropped:
+            extra['dropped'] = dropped
+
         if not candidates:
             add_event_multi(
                 EVENT_TYPE_AUDIT, related_objects,
                 f'schedule has no candidates at stage {stage}, aborting',
-                extra={'candidates': candidates})
+                extra=extra)
             raise exceptions.LowResourceException(
                 f'No nodes remaining at scheduling stage {stage}')
 
         add_event_multi(
             EVENT_TYPE_AUDIT, related_objects,
-            f'schedule at stage {stage}', extra={'candidates': candidates})
+            f'schedule at stage {stage}', extra=extra)
 
     def find_candidates(self, inst, candidates=None):
         related_objects = [inst]
@@ -219,6 +239,26 @@ class Scheduler:
             diff = time.time() - self.metrics_updated
             if diff > config.SCHEDULER_CACHE_TIMEOUT or len(self.metrics) == 0:
                 self.refresh_metrics()
+
+            # Record the inputs to the scheduling decision so failures can be
+            # diagnosed from the event log alone.
+            requested_disk_gb = 0
+            for disk in inst.disk_spec:
+                if 'size' in disk and disk['size'] is not None:
+                    requested_disk_gb += int(disk['size'])
+            add_event_multi(
+                EVENT_TYPE_AUDIT, related_objects,
+                'schedule inputs',
+                extra={
+                    'requested_affinity': inst.affinity,
+                    'requested_cpus': inst.cpus,
+                    'requested_memory_mb': inst.memory,
+                    'requested_disk_gb': requested_disk_gb,
+                    'disk_spec': inst.disk_spec,
+                    'namespace': inst.namespace,
+                    'forced_candidates': bool(candidates),
+                    'metrics_age_seconds': diff,
+                })
 
             if candidates:
                 add_event_multi(
@@ -244,92 +284,176 @@ class Scheduler:
                 related_objects, 'pre_schedule', candidates)
 
             # Ensure all specified nodes are hypervisors
+            dropped = {}
             for c in list(candidates):
                 if not self.metrics[c].get('is_hypervisor', False):
+                    dropped[c] = {'reason': 'not a hypervisor'}
                     candidates.remove(c)
             self._log_and_raise_on_error(
-                related_objects, 'is_hypervisor', candidates)
+                related_objects, 'is_hypervisor', candidates, dropped=dropped)
 
             # Don't use nodes which aren't keeping up with queue jobs
+            dropped = {}
             for c in list(candidates):
-                if not self._has_reasonable_queue_state(log_ctx, c):
+                ok, reason = self._has_reasonable_queue_state(log_ctx, c)
+                if not ok:
+                    dropped[c] = reason
                     candidates.remove(c)
             self._log_and_raise_on_error(
-                related_objects, 'queue_state', candidates)
+                related_objects, 'queue_state', candidates, dropped=dropped)
 
             # Can we host that many vCPUs?
+            dropped = {}
             for c in list(candidates):
                 max_cpu = self.metrics[c].get('cpu_max_per_instance', 0)
                 if inst.cpus > max_cpu:
+                    dropped[c] = {
+                        'reason': 'requested vCPUs exceed per-instance max',
+                        'cpu_max_per_instance': max_cpu,
+                        'requested_cpus': inst.cpus,
+                    }
                     candidates.remove(c)
             self._log_and_raise_on_error(
-                related_objects, 'cpu_max_per_instance', candidates)
+                related_objects, 'cpu_max_per_instance', candidates,
+                dropped=dropped)
 
             # Do we have enough idle CPU?
+            dropped = {}
             for c in list(candidates):
-                if not self._has_sufficient_cpu(log_ctx, inst.cpus, c):
+                ok, reason = self._has_sufficient_cpu(log_ctx, inst.cpus, c)
+                if not ok:
+                    dropped[c] = reason
                     candidates.remove(c)
             self._log_and_raise_on_error(
-                related_objects, 'sufficient_idle_cpu', candidates)
+                related_objects, 'sufficient_idle_cpu', candidates,
+                dropped=dropped)
 
             # Do we have enough idle RAM?
+            dropped = {}
             for c in list(candidates):
-                if not self._has_sufficient_ram(log_ctx, inst.memory, c):
+                ok, reason = self._has_sufficient_ram(log_ctx, inst.memory, c)
+                if not ok:
+                    dropped[c] = reason
                     candidates.remove(c)
             self._log_and_raise_on_error(
-                related_objects, 'sufficient_idle_memory', candidates)
+                related_objects, 'sufficient_idle_memory', candidates,
+                dropped=dropped)
 
             # Do we have enough free disk?
+            dropped = {}
             for c in list(candidates):
-                if not self._has_sufficient_disk(log_ctx, inst, c):
+                ok, reason = self._has_sufficient_disk(log_ctx, inst, c)
+                if not ok:
+                    dropped[c] = reason
                     candidates.remove(c)
             self._log_and_raise_on_error(
-                related_objects, 'sufficient_free_disk', candidates)
+                related_objects, 'sufficient_free_disk', candidates,
+                dropped=dropped)
 
             # Are the disks really busy?
+            dropped = {}
             for c in list(candidates):
-                if not self._has_idle_disk_bandwidth(log_ctx, inst, c):
+                ok, reason = self._has_idle_disk_bandwidth(log_ctx, inst, c)
+                if not ok:
+                    dropped[c] = reason
                     candidates.remove(c)
             self._log_and_raise_on_error(
-                related_objects, 'sufficient_idle_disk', candidates)
+                related_objects, 'sufficient_idle_disk', candidates,
+                dropped=dropped)
 
-            # Filter by affinity, if any has been specified
+            # Filter by affinity, if any has been specified. We record the
+            # full per-candidate scoring breakdown so that incorrect placement
+            # decisions (e.g. a tagged neighbour being invisible) can be
+            # diagnosed from audit events.
             by_affinity = defaultdict(list)
             requested_affinity = inst.affinity
+            affinity_detail = {}
 
             for c in list(candidates):
                 n = Node.from_db(c)
-                if n:
-                    affinity = 0
-                    instances = n.instances
-                    for instance_uuid in instances:
-                        i = instance.Instance.from_db(instance_uuid)
-                        if not i:
-                            continue
-                        if i.uuid == inst.uuid:
-                            continue
-                        if not i.tags:
-                            continue
-                        if i.namespace != inst.namespace:
-                            continue
-
-                        for tag, val in requested_affinity.items():
-                            if tag in i.tags:
-                                affinity += int(val)
-
+                affinity = 0
+                considered = []
+                if n is None:
+                    affinity_detail[c] = {
+                        'score': 0,
+                        'reason': 'node row not found',
+                    }
                     by_affinity[affinity].append(c)
+                    continue
+
+                for instance_uuid in n.instances:
+                    i = instance.Instance.from_db(instance_uuid)
+                    if not i:
+                        considered.append({
+                            'instance_uuid': instance_uuid,
+                            'skipped': 'instance row not found',
+                        })
+                        continue
+                    if i.uuid == inst.uuid:
+                        considered.append({
+                            'instance_uuid': instance_uuid,
+                            'skipped': 'self',
+                        })
+                        continue
+                    if not i.tags:
+                        considered.append({
+                            'instance_uuid': instance_uuid,
+                            'skipped': 'no tags',
+                        })
+                        continue
+                    if i.namespace != inst.namespace:
+                        considered.append({
+                            'instance_uuid': instance_uuid,
+                            'skipped': 'different namespace',
+                            'namespace': i.namespace,
+                        })
+                        continue
+
+                    matched = {}
+                    contribution = 0
+                    for tag, val in requested_affinity.items():
+                        if tag in i.tags:
+                            matched[tag] = int(val)
+                            contribution += int(val)
+                    considered.append({
+                        'instance_uuid': instance_uuid,
+                        'tags': list(i.tags),
+                        'matched': matched,
+                        'contribution': contribution,
+                    })
+                    affinity += contribution
+
+                affinity_detail[c] = {
+                    'score': affinity,
+                    'instance_count': len(n.instances),
+                    'considered': considered,
+                }
+                by_affinity[affinity].append(c)
 
             highest_affinity = sorted(by_affinity, reverse=True)[0]
             candidates = by_affinity[highest_affinity]
             add_event_multi(
                 EVENT_TYPE_AUDIT, related_objects,
                 'schedule have highest affinity',
-                extra={'candidates': candidates})
+                extra={
+                    'candidates': candidates,
+                    'requested_affinity': requested_affinity,
+                    'highest_affinity': highest_affinity,
+                    'by_affinity': {
+                        str(k): v for k, v in by_affinity.items()},
+                    'affinity_detail': affinity_detail,
+                })
 
             # Order candidates by current CPU load
             by_load = defaultdict(list)
+            load_detail = {}
             for c in list(candidates):
-                load = math.floor(self.metrics[c].get('cpu_load_1', 0))
+                raw_load = self.metrics[c].get('cpu_load_1', 0)
+                load = math.floor(raw_load)
+                load_detail[c] = {
+                    'cpu_load_1': raw_load,
+                    'cpu_load_1_floor': load,
+                }
                 by_load[load].append(c)
 
             lowest_load = sorted(by_load)[0]
@@ -337,7 +461,11 @@ class Scheduler:
             add_event_multi(
                 EVENT_TYPE_AUDIT, related_objects,
                 'schedule have lowest cpu load',
-                extra={'candidates': candidates})
+                extra={
+                    'candidates': candidates,
+                    'lowest_load': lowest_load,
+                    'load_detail': load_detail,
+                })
 
             # Return a shuffled list of options
             random.shuffle(candidates)

--- a/shakenfist/schema/cluster_operation_target.py
+++ b/shakenfist/schema/cluster_operation_target.py
@@ -26,13 +26,18 @@ from pydantic import Field
 class ClusterOperationTargetData(BaseModel):
     """Schema for cluster operation targets in MariaDB.
 
-    Each row records one operation targeting one object. The combination
-    of (target_object_type, target_uuid) identifies the target, while
-    operation_uuid is the primary key. sequence_number is assigned by
-    the database via AUTO_INCREMENT for implicit ordering.
+    Each row records one operation targeting one object. The
+    combination of (target_object_type, target_uuid) identifies the
+    target. An operation with multiple declared targets writes one
+    row per target, so operation_uuid is NOT unique on its own; the
+    composite UNIQUE constraint uq_cot_op_target on (operation_uuid,
+    target_object_type, target_uuid) provides idempotency without
+    truncating multi-target ops. sequence_number is the actual
+    primary key, assigned by the database via AUTO_INCREMENT for
+    implicit ordering.
 
     Table: cluster_operation_targets
-    Primary key: operation_uuid
+    Primary key: sequence_number
 
     Attributes:
         operation_uuid: UUID of the cluster operation.

--- a/shakenfist/tests/test_cluster_operation_targets.py
+++ b/shakenfist/tests/test_cluster_operation_targets.py
@@ -631,6 +631,13 @@ class HotPlugTargetWriteIntegrationTestCase(base.ShakenFistTestCase):
     def setUp(self):
         super().setUp()
 
+        # Late imports: sqlalchemy is heavy at import time and only
+        # this test class needs it; pulling it in lazily keeps the
+        # rest of the test suite's import phase fast. The shakenfist
+        # mariadb module is rebound locally as ``mariadb_mod`` so
+        # test methods can call ``self._mariadb.<fn>()`` without
+        # shadowing the module-level ``mariadb`` import the file
+        # uses elsewhere.
         import sqlalchemy as sa
         from shakenfist import mariadb as mariadb_mod
 
@@ -672,6 +679,8 @@ class HotPlugTargetWriteIntegrationTestCase(base.ShakenFistTestCase):
 
         # SQLite :memory: databases are per-connection by default;
         # pool with StaticPool so every checkout shares one DB.
+        # Late import for the same reason sa is late above -- only
+        # this fixture needs the pool class.
         from sqlalchemy.pool import StaticPool
         self._engine = sa.create_engine(
             'sqlite:///:memory:',
@@ -817,6 +826,25 @@ class HotPlugTargetWriteIntegrationTestCase(base.ShakenFistTestCase):
                 'network', HOTPLUG_NETWORK_UUID))
         self.assertFalse(result)
 
+    def test_non_uniqueness_integrity_error_returns_false(self):
+        """A NOT NULL violation (or any non-uniqueness IntegrityError)
+        must surface as False, not be swallowed as idempotency.
+
+        Before the keyword-match was tightened, the writer's
+        IntegrityError handler returned True for any IntegrityError --
+        which hid bugs like passing None for a required column. The
+        narrowed match only forgives the composite UNIQUE we
+        actually want to be idempotent on.
+        """
+        ok = self._mariadb._direct_create_cluster_operation_target(
+            operation_uuid=None,
+            operation_type='node_inst_net_iface_op',
+            target_object_type='network',
+            target_uuid=HOTPLUG_NETWORK_UUID,
+            created_at=1000.0)
+        self.assertFalse(ok)
+        self.assertEqual(0, self._count_target_rows())
+
     def test_full_enqueue_persists_three_rows(self):
         """End-to-end: calling node_inst_net_iface_op.create_and_enqueue
         must result in three persisted cluster_operation_targets rows
@@ -827,6 +855,11 @@ class HotPlugTargetWriteIntegrationTestCase(base.ShakenFistTestCase):
         UNIQUE(operation_uuid) constraint silently dropped the
         network and interface rows after the instance row landed.
         """
+        # Late import to keep the schema module (and its transitive
+        # cluster-operation-target machinery) out of this test file's
+        # import path -- only this one method needs it, and pulling
+        # it at module scope would couple every test in the file to
+        # the operation-schema import chain.
         from shakenfist.schema.operations.node_inst_net_iface_op import (
             create_and_enqueue, model_tasks)
         from shakenfist.schema.operations.baseclusteroperation import PRIORITY

--- a/shakenfist/tests/test_cluster_operation_targets.py
+++ b/shakenfist/tests/test_cluster_operation_targets.py
@@ -543,14 +543,16 @@ HOTPLUG_NODE_UUID = 'bbbb3333-3333-4333-8333-333333333333'
 
 
 class HotPlugTripleTargetRegressionTestCase(base.ShakenFistTestCase):
-    """Regression test for the hot-plug triple-target bug (commit 8923391c).
+    """Unit-level regression for the hot-plug triple-target bug.
 
-    Enqueueing a node_inst_net_iface_op must write three
-    cluster_operation_targets rows (instance, network, interface) via
-    the auto-targeting path in enqueue_cluster_operation(). Before
-    3a/3b, the network target was written by an explicit
-    set_last_cluster_operation() call that was sometimes omitted,
-    causing the network maintainer to race the queue worker.
+    This test mocks mariadb.create_cluster_operation_target so it
+    only proves the schema's target_fields declaration and the
+    enqueue_cluster_operation() call-site fan-out are correct. It
+    does NOT exercise the actual database UNIQUE constraint --
+    see HotPlugTargetWriteIntegrationTestCase below for that.
+
+    Originally added for commit 8923391c. Kept for fast feedback;
+    the integration test catches the deeper bug.
     """
 
     def setUp(self):
@@ -607,3 +609,210 @@ class HotPlugTripleTargetRegressionTestCase(base.ShakenFistTestCase):
              HOTPLUG_INTERFACE_UUID},
             target_uuids,
         )
+
+
+class HotPlugTargetWriteIntegrationTestCase(base.ShakenFistTestCase):
+    """Integration regression: hot-plug must persist three target rows.
+
+    Drives _direct_create_cluster_operation_target() against a real
+    in-memory SQLite engine so the actual UNIQUE constraint is
+    exercised. The pre-fix schema (v1) declared operation_uuid UNIQUE,
+    which silently dropped every target row after the first --
+    masked by the IntegrityError-as-True handler in the writer. The
+    fixed schema (v2) replaces that with a composite UNIQUE on
+    (operation_uuid, target_object_type, target_uuid).
+
+    Also asserts has_pending_cluster_operation_target() sees the
+    network target while the op is queued -- the exact gate that
+    was being bypassed in the recurring "Recreating not okay
+    network on hypervisor" CI failure.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        import sqlalchemy as sa
+        from shakenfist import mariadb as mariadb_mod
+
+        # Build an isolated MetaData for this test so the global
+        # module-level metadata (which other tests share) isn't
+        # affected. We rebuild the two tables under test against it.
+        self._sa = sa
+        self._mariadb = mariadb_mod
+        self._metadata = sa.MetaData()
+
+        # Use Integer (not BigInteger) so SQLite's rowid alias kicks
+        # in for AUTOINCREMENT. Production runs on MariaDB which uses
+        # BigInteger; the column type isn't what we're testing here.
+        self._targets_table = sa.Table(
+            'cluster_operation_targets',
+            self._metadata,
+            sa.Column('sequence_number', sa.Integer(),
+                      primary_key=True, autoincrement=True),
+            sa.Column('operation_uuid', sa.String(36), nullable=False),
+            sa.Column('operation_type', sa.String(64), nullable=False),
+            sa.Column('target_object_type', sa.String(64),
+                      nullable=False),
+            sa.Column('target_uuid', sa.String(36), nullable=False),
+            sa.Column('created_at', sa.Double(), nullable=False),
+            sa.UniqueConstraint(
+                'operation_uuid', 'target_object_type', 'target_uuid',
+                name='uq_cot_op_target'),
+        )
+        self._states_table = sa.Table(
+            'object_states',
+            self._metadata,
+            sa.Column('object_uuid', sa.String(36), nullable=False),
+            sa.Column('object_type', sa.String(64), nullable=False),
+            sa.Column('state_value', sa.String(64), nullable=False),
+            sa.Column('update_time', sa.Double(), nullable=False),
+            sa.Column('message', sa.String(1024), nullable=True),
+            sa.PrimaryKeyConstraint('object_type', 'object_uuid'),
+        )
+
+        # SQLite :memory: databases are per-connection by default;
+        # pool with StaticPool so every checkout shares one DB.
+        from sqlalchemy.pool import StaticPool
+        self._engine = sa.create_engine(
+            'sqlite:///:memory:',
+            connect_args={'check_same_thread': False},
+            poolclass=StaticPool)
+        self._metadata.create_all(self._engine)
+
+        # Route the mariadb helpers at the real in-memory engine and
+        # tables. The helpers under test (_direct_create_cluster_
+        # operation_target, _direct_has_pending_cluster_operation_
+        # target) read these accessors and the table objects each
+        # invocation.
+        self._patches = [
+            mock.patch(
+                'shakenfist.mariadb._get_engine',
+                return_value=self._engine),
+            mock.patch(
+                'shakenfist.mariadb._get_cluster_operation_targets_table',
+                return_value=self._targets_table),
+            mock.patch(
+                'shakenfist.mariadb._get_object_states_table',
+                return_value=self._states_table),
+            mock.patch(
+                'shakenfist.mariadb._use_database_service',
+                return_value=False),
+        ]
+        for p in self._patches:
+            p.start()
+        self.addCleanup(mock.patch.stopall)
+
+    def _insert_op_state(self, op_uuid, state_value):
+        """Drop a row in the fake object_states table for an op."""
+        with self._engine.begin() as conn:
+            conn.execute(self._states_table.insert().values(
+                object_uuid=op_uuid,
+                object_type='node_inst_net_iface_op',
+                state_value=state_value,
+                update_time=1000.0,
+                message=None,
+            ))
+
+    def _count_target_rows(self):
+        with self._engine.connect() as conn:
+            return conn.execute(
+                self._sa.select(self._sa.func.count()).select_from(
+                    self._targets_table)).scalar()
+
+    def _target_rows(self):
+        with self._engine.connect() as conn:
+            return list(conn.execute(
+                self._sa.select(self._targets_table)).mappings())
+
+    def test_three_target_rows_persisted(self):
+        """All three (instance, network, interface) targets land in
+        the table -- the v1 schema dropped the latter two."""
+        op_uuid = 'cccc1111-1111-4111-8111-111111111111'
+        op_type = 'node_inst_net_iface_op'
+
+        for field, target_uuid, target_type in (
+                ('instance', HOTPLUG_INSTANCE_UUID, 'instance'),
+                ('network', HOTPLUG_NETWORK_UUID, 'network'),
+                ('interface', HOTPLUG_INTERFACE_UUID, 'interface')):
+            ok = self._mariadb._direct_create_cluster_operation_target(
+                operation_uuid=op_uuid,
+                operation_type=op_type,
+                target_object_type=target_type,
+                target_uuid=target_uuid,
+                created_at=1000.0)
+            self.assertTrue(ok, f'write for {field} target should succeed')
+
+        self.assertEqual(3, self._count_target_rows())
+
+        rows = self._target_rows()
+        target_uuids = {r['target_uuid'] for r in rows}
+        self.assertEqual(
+            {HOTPLUG_INSTANCE_UUID, HOTPLUG_NETWORK_UUID,
+             HOTPLUG_INTERFACE_UUID},
+            target_uuids)
+        target_types = {r['target_object_type'] for r in rows}
+        self.assertEqual({'instance', 'network', 'interface'},
+                         target_types)
+
+    def test_duplicate_op_target_pair_is_idempotent(self):
+        """Same (op_uuid, target_type, target_uuid) triple written
+        twice must not raise -- callers rely on idempotency."""
+        op_uuid = 'cccc1111-1111-4111-8111-111111111111'
+
+        ok = self._mariadb._direct_create_cluster_operation_target(
+            operation_uuid=op_uuid,
+            operation_type='node_inst_net_iface_op',
+            target_object_type='network',
+            target_uuid=HOTPLUG_NETWORK_UUID,
+            created_at=1000.0)
+        self.assertTrue(ok)
+
+        ok = self._mariadb._direct_create_cluster_operation_target(
+            operation_uuid=op_uuid,
+            operation_type='node_inst_net_iface_op',
+            target_object_type='network',
+            target_uuid=HOTPLUG_NETWORK_UUID,
+            created_at=2000.0)
+        self.assertTrue(ok)
+
+        self.assertEqual(1, self._count_target_rows())
+
+    def test_pending_network_target_visible_while_op_queued(self):
+        """has_pending_cluster_operation_target(NETWORK, uuid) must
+        return True while the op is in 'queued' state. This is the
+        gate Network.is_okay() uses to defer the maintainer. The
+        v1 schema bug dropped this target row, making the gate
+        useless for hot-plug.
+        """
+        op_uuid = 'cccc1111-1111-4111-8111-111111111111'
+
+        self._insert_op_state(op_uuid, 'queued')
+        ok = self._mariadb._direct_create_cluster_operation_target(
+            operation_uuid=op_uuid,
+            operation_type='node_inst_net_iface_op',
+            target_object_type='network',
+            target_uuid=HOTPLUG_NETWORK_UUID,
+            created_at=1000.0)
+        self.assertTrue(ok)
+
+        result = (
+            self._mariadb._direct_has_pending_cluster_operation_target(
+                'network', HOTPLUG_NETWORK_UUID))
+        self.assertTrue(result)
+
+    def test_pending_returns_false_after_op_completes(self):
+        """Once the op state moves to 'complete', the gate releases."""
+        op_uuid = 'cccc1111-1111-4111-8111-111111111111'
+
+        self._insert_op_state(op_uuid, 'complete')
+        self._mariadb._direct_create_cluster_operation_target(
+            operation_uuid=op_uuid,
+            operation_type='node_inst_net_iface_op',
+            target_object_type='network',
+            target_uuid=HOTPLUG_NETWORK_UUID,
+            created_at=1000.0)
+
+        result = (
+            self._mariadb._direct_has_pending_cluster_operation_target(
+                'network', HOTPLUG_NETWORK_UUID))
+        self.assertFalse(result)

--- a/shakenfist/tests/test_cluster_operation_targets.py
+++ b/shakenfist/tests/test_cluster_operation_targets.py
@@ -816,3 +816,48 @@ class HotPlugTargetWriteIntegrationTestCase(base.ShakenFistTestCase):
             self._mariadb._direct_has_pending_cluster_operation_target(
                 'network', HOTPLUG_NETWORK_UUID))
         self.assertFalse(result)
+
+    def test_full_enqueue_persists_three_rows(self):
+        """End-to-end: calling node_inst_net_iface_op.create_and_enqueue
+        must result in three persisted cluster_operation_targets rows
+        (instance, network, interface) in the real database, not just
+        three call-sites to create_cluster_operation_target.
+
+        This is the test the v1 schema bug would have failed: the
+        UNIQUE(operation_uuid) constraint silently dropped the
+        network and interface rows after the instance row landed.
+        """
+        from shakenfist.schema.operations.node_inst_net_iface_op import (
+            create_and_enqueue, model_tasks)
+        from shakenfist.schema.operations.baseclusteroperation import PRIORITY
+
+        # The op + state + work-queue write is its own MariaDB
+        # transaction; here we only care about the target writes,
+        # so stub it out as success.
+        with mock.patch(
+                'shakenfist.mariadb.create_and_enqueue_cluster_operation',
+                return_value=True):
+            _, op_uuid = create_and_enqueue(
+                HOTPLUG_NODE_UUID,
+                HOTPLUG_INSTANCE_UUID,
+                HOTPLUG_NETWORK_UUID,
+                HOTPLUG_INTERFACE_UUID,
+                [model_tasks.hot_plug_instance_interface],
+                PRIORITY.user_waiting,
+            )
+
+        self.assertEqual(3, self._count_target_rows())
+
+        rows = self._target_rows()
+        for r in rows:
+            self.assertEqual(op_uuid, r['operation_uuid'])
+            self.assertEqual('node_inst_net_iface_op', r['operation_type'])
+
+        target_uuids = {r['target_uuid'] for r in rows}
+        self.assertEqual(
+            {HOTPLUG_INSTANCE_UUID, HOTPLUG_NETWORK_UUID,
+             HOTPLUG_INTERFACE_UUID},
+            target_uuids)
+        target_types = {r['target_object_type'] for r in rows}
+        self.assertEqual({'instance', 'network', 'interface'},
+                         target_types)


### PR DESCRIPTION
The four proxy decorators in external_api/base.py
(redirect_instance_request, redirect_to_network_node, redirect_upload_request, redirect_to_eventlog_node) all forwarded the upstream response by passing r.text into flask.Response with a hard- coded application/json mimetype. For endpoints that return raw bytes across nodes (notably /instances/<uuid>/consoledata, which is application/octet-stream) this is wrong twice over: requests.text decodes the body to a str via the Content-Type / chardet guess, which for binary console-log bytes can insert lone surrogate codepoints, and flask then fails to UTF-8-encode the response body with UnicodeEncodeError('utf-8', ..., 'surrogates not allowed') -- returning HTTP 500 to the client. The forced application/json mimetype also hid the upstream Content-Type from the caller.

Forward r.content (bytes) and the upstream Content-Type instead, so binary payloads survive the proxy hop unchanged and JSON responses still work because UTF-8-encoded JSON bytes are valid WSGI body.

Also replace the 'text': r.text field on the "Returning proxied request" log line with 'body_bytes': len(r.content) in all four decorators. Logging the full body on every proxied request bloated the journal, and for binary bodies the structured-log encoder could itself trip on surrogates.

Caught by the Debian 12 cluster functional test
cluster_ci_tests.test_console_log.TestConsoleLog.test_console_log, which fetches 2000 bytes of console log -- the slice that pulls in cloud-init's binary SSH host-key dump. The Ubuntu 24.04 single-node job did not hit it because there is no proxy hop on a one-node cluster.

Prompt: Mikal asked me to investigate the Debian 12 cluster CI failure in run 25656006610 and propose a fix, then to apply and commit it. I traced the 500 from a UnicodeEncodeError back to the proxy decorators in external_api/base.py and fixed all four sibling decorators with the same pattern rather than only the one the failing test happened to exercise.


Assisted-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>