### PR TITLE
Unblock PLAN-remove-etcd; move it ahead of remove-primary.

### DIFF
--- a/docs/plans/PLAN-remove-etcd.md
+++ b/docs/plans/PLAN-remove-etcd.md
@@ -39,15 +39,23 @@ service `DATA_MIGRATIONS` entries which drain leftover
 etcd keys from older clusters" and "will be removed in the
 next minor version."
 
-There is exactly one known SF deployment still running on
-the etcd-era shape (Mikal's own production cluster). The
-plan to rebuild that deployment against the new BYO-
-infrastructure shape established by `PLAN-remove-primary.md`
-is in flight. Once that rebuild is complete, the etcd
-drain code is unambiguously dead weight: no remaining
-cluster can ever exercise it, and keeping it around clouds
-the codebase with stale references that have to be re-
-explained to every new contributor.
+The one known SF deployment still running on the etcd-era
+shape (Mikal's own production cluster) is going to be
+**wiped and reinstalled**, not upgraded in place, against
+the new BYO-infrastructure shape established by
+`PLAN-remove-primary.md`. Once that decision is made, the
+drain code is dead weight forever — there is no scenario
+in which it executes against a real cluster.
+
+The mitigation for any *unknown* etcd-era deployment is
+modest: pin the last release that still carries the drain
+code (the release immediately before this plan lands), and
+note in the changelog that anyone still on etcd-era SF
+must upgrade through that pinned release first or rebuild
+from scratch. Operators who have not surfaced their
+deployments to the project are accepting the
+responsibility to either follow the pinned-release path or
+do the rebuild themselves.
 
 ## Mission and problem statement
 
@@ -58,25 +66,31 @@ mechanical, and well-bounded; its only real complexity is
 
 ## Preconditions
 
-This plan **must not start** until all of the following are
-true:
+This plan needs only one thing to be true: **a recorded
+decision that in-place upgrade from etcd-era Shaken Fist
+is no longer supported.** The decision was made during
+the planning conversation that produced this document and
+its sibling plans. Operationally, that means:
 
-1. **`PLAN-remove-primary.md` is complete** through at
-   least phase 7 (the `etcd_master` → `database_node`
-   rename and final cleanup). Phase 7 removes the stale
-   *naming* throughout the deployer; this plan removes the
-   stale *code* and the genuine etcd-era references that
-   remain after the rename.
-2. **The last known etcd-era SF deployment has been
-   wiped and redeployed** against the new BYO shape. This
-   is the real gating condition: as long as one cluster
-   still needs the drain functions on next boot, the drain
-   code stays in the tree.
-3. **No new etcd-era SF clusters have appeared.** Confirm
-   on the day of by asking in the project's normal
-   channels.
+1. The PR that lands this deletion sweep notes the
+   pinned-release upgrade path in its description, so the
+   changelog / release notes for the release containing
+   this deletion can point at the prior release as the
+   intermediate-upgrade target for anyone still on
+   etcd-era SF.
+2. `CLAUDE.md`'s claim that the shim is "retained only to
+   service `DATA_MIGRATIONS` entries which drain leftover
+   etcd keys from older clusters" is updated as part of
+   the same PR, since it is no longer true.
 
-If any of these is not yet true, this plan does not start.
+This plan is **not** gated on `PLAN-remove-primary.md`
+landing. The two are independent: this plan removes the
+drain *code* in `shakenfist/`; phase 7 of remove-primary
+removes the stale `etcd_master` *naming* in the deployer.
+Either can land first. Practically, this plan is small and
+mechanical and should land **early in the sequence** so the
+remove-primary work is not navigating misleading etcd
+references while it tries to rename the ansible group.
 
 ## Scope
 

--- a/docs/plans/PLAN-remove-primary.md
+++ b/docs/plans/PLAN-remove-primary.md
@@ -317,10 +317,14 @@ Phase notes:
   consumers.
 - **Phase 7** is mostly mechanical: rename `etcd_master` →
   `database_node` across `deploy.py`, `deploy.yml`, all
-  roles, and comments. Delete dead `etcd_host` default and
-  `ETCDCTL_API=3` line in `sfrc`. Leaves
-  `shakenfist/etcd.py` alone (handled separately, per
-  CLAUDE.md).
+  roles, and comments. By the time phase 7 runs,
+  `PLAN-remove-etcd.md` will already have landed and the
+  drain code, `etcd_host` default, `ETCDCTL_API=3` line in
+  `sfrc`, and `etcd3gw` dependency will be gone. Phase 7's
+  scope is therefore *only* the deployer-level naming and
+  comments — the ansible group rename, the inventory.yaml
+  `etcd:` children-group rename, and the residual
+  `etcd_master` mentions in role comments.
 
 ## Agent guidance
 
@@ -483,10 +487,14 @@ because the following statements will be true:
   Tracked in `PLAN-embrace-tls.md`. This plan establishes the
   operator-provides-PKI surface that the TLS plan consumes.
 - **Retiring `shakenfist/etcd.py` and the `DATA_MIGRATIONS`
-  drain code.** Tracked in `PLAN-remove-etcd.md`. Blocked
-  on this plan completing (through phase 7) and on a
-  subsequent wipe-and-redeploy of the last known etcd-era
-  SF deployment against the new BYO shape.
+  drain code.** Tracked in `PLAN-remove-etcd.md`. No longer
+  blocked on this plan landing: the decision to close
+  in-place upgrade from etcd-era SF means the drain code
+  is dead weight forever and can be deleted at any time.
+  Sequenced *before* this plan in `index.md` so the
+  remove-primary work is not navigating misleading etcd
+  references while it does the `etcd_master` rename in
+  phase 7.
 - **Health checks, readiness, and graceful drain semantics.**
   A precondition for the BYO-LB story being operationally
   honest: operators need a `/healthz` (or equivalent) that

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -10,9 +10,9 @@ This section contains forward-looking roadmaps for Shaken Fist development. Thes
 The set of incomplete plans has grown to the point where the order they land in matters. The intended sequencing is:
 
 1. **[Network operations facade](PLAN-network-facade.md)** — in progress in a separate work session. Lands first.
-2. **[Health checks, readiness, and graceful drain](PLAN-health-checks.md)** — a precondition for the BYO load-balancer story in remove-primary being operationally honest. The plan is partial: a phase 0 decisions pass resolves the open questions before the implementation phases are re-cut.
-3. **[Remove the primary node](PLAN-remove-primary.md)** — the BYO-infrastructure scope reduction. Naturally followed by a wipe-and-redeploy of the last known etcd-era SF deployment against the new shape.
-4. **[Retire etcd](PLAN-remove-etcd.md)** — a small, mechanical deletion sweep gated on remove-primary completing and the redeploy having happened.
+2. **[Retire etcd](PLAN-remove-etcd.md)** — a small, mechanical deletion sweep. Originally gated on the etcd-era cluster redeploy; that gating has been dropped because the in-place upgrade path is being closed deliberately. Lands early in the sequence so the remove-primary work below is not navigating misleading etcd references while it renames the ansible group.
+3. **[Health checks, readiness, and graceful drain](PLAN-health-checks.md)** — a precondition for the BYO load-balancer story in remove-primary being operationally honest. The plan is partial: a phase 0 decisions pass resolves the open questions before the implementation phases are re-cut.
+4. **[Remove the primary node](PLAN-remove-primary.md)** — the BYO-infrastructure scope reduction. Phase 7 finishes the deployer-level `etcd_master` → `database_node` rename, by which point the drain code itself is long gone. Naturally followed by a wipe-and-redeploy of Mikal's production cluster against the new shape.
 
 The remaining incomplete plans — [Embrace TLS](PLAN-embrace-tls.md), [Sticky blob transfers](PLAN-sticky-transfers.md), and the not-yet-drafted threads for eventlog-into-MariaDB, network-node failover, and OpenTelemetry instrumentation — are intentionally **not ordered relative to each other** here. They each have specific dependencies on remove-primary having established the BYO shape (the operator-provides-PKI surface for TLS, the streaming-proxy baseline for sticky transfers, the sf-database election pattern for the others), but among themselves the order is a triage decision best made when remove-primary is close to landing rather than now.
 
@@ -54,7 +54,7 @@ The blob-storage and SQL-pushdown roadmaps and the network-facade plan run on th
 | [Remove the primary node](PLAN-remove-primary.md) | Phase 5: Elect sf-database | Not started | Candidate-list discovery and leader election for sf-database |
 | [Remove the primary node](PLAN-remove-primary.md) | Phase 6: Galaxy role | Not started | Repackage deployer as a per-node ansible-galaxy-style role |
 | [Remove the primary node](PLAN-remove-primary.md) | Phase 7: Rename and cleanup | Not started | `etcd_master` → `database_node`; final dead-code sweep |
-| [Retire etcd](PLAN-remove-etcd.md) | Single sweep | Blocked on preconditions | Delete `shakenfist/etcd.py`, the `DATA_MIGRATIONS` drain code, residual etcd references and dependencies once remove-primary lands and the last etcd-era deployment is redeployed |
+| [Retire etcd](PLAN-remove-etcd.md) | Single sweep | Not started | Delete `shakenfist/etcd.py`, the `DATA_MIGRATIONS` drain code, residual etcd references and the `etcd3gw` dependency in one coordinated sweep |
 | [Embrace TLS](PLAN-embrace-tls.md) | Phase 0: Research and decisions | Not started | Resolve open TLS questions into a decisions document |
 | [Embrace TLS](PLAN-embrace-tls.md) | Phase 1: Cert reload | Not started | Graceful TLS material reload across daemons |
 | [Embrace TLS](PLAN-embrace-tls.md) | Phase 2: sf-database mTLS | Not started | Canary mTLS path for the highest-traffic gRPC channel |

--- a/docs/plans/order.yml
+++ b/docs/plans/order.yml
@@ -11,8 +11,8 @@
 - PLAN-sql-pushdown-filtering.md: SQL-pushdown filtering
 - PLAN-replace-last-cluster-operation.md: Replace last_cluster_operation with cluster_operation_targets gating
 - PLAN-network-facade.md: Network operations facade and queue-only mutation
+- PLAN-remove-etcd.md: Retire etcd from the Shaken Fist codebase
 - PLAN-health-checks.md: Health checks, readiness, and graceful drain for SF daemons
 - PLAN-remove-primary.md: Remove the primary node and adopt a BYO-infrastructure deployer
-- PLAN-remove-etcd.md: Retire etcd from the Shaken Fist codebase
 - PLAN-embrace-tls.md: Embrace TLS across Shaken Fist
 - PLAN-sticky-transfers.md: Sticky session affinity for SF blob transfers


### PR DESCRIPTION
The drain code in shakenfist/etcd.py and the DATA_MIGRATIONS machinery only matters if some cluster will exercise it on first boot of a new release. Mikal's production cluster -- the only known etcd-era SF deployment -- is going to be wiped and reinstalled against the new BYO shape rather than upgraded in place. That decision closes the last scenario in which the drain code could ever execute, so the code is dead weight forever and there is no reason to keep waiting.

Rewrite PLAN-remove-etcd's Preconditions section. The old gating (remove-primary complete + the production redeploy done) is replaced by a single recorded decision: in-place upgrade from etcd-era SF is no longer supported. The mitigation for any unknown deployment is modest -- pin the last release that still carries the drain code and document it in the changelog as the intermediate-upgrade target. Operators who have not surfaced their deployments to the project are accepting the responsibility to either follow that pinned-release path or rebuild from scratch.

Update PLAN-remove-primary's phase 7 notes to reflect that by the time phase 7 runs, the drain code, etcd_host default, ETCDCTL_API=3 line and etcd3gw dependency will already be gone via PLAN-remove-etcd. Phase 7's scope shrinks to *only* the deployer-level naming work -- the ansible group rename, the inventory.yaml etcd children-group rename, and the residual etcd_master mentions in role comments. Update the matching future-work bullet to note the new sequencing.

Reorder the Plan sequencing section in docs/plans/index.md to put Retire etcd at position 2 (after network-facade, before health-checks and remove-primary). Update the etcd plan's row in the Plan Status table from "Blocked on preconditions" to "Not started". Reshuffle order.yml so the docs navigation matches the new sequence.

Prompt: Mikal observed that if his production cluster is going to be wiped and reinstalled rather than upgraded in place, the drain code is dead weight forever and there is no reason for PLAN-remove-etcd to wait on remove-primary landing. He accepted the tradeoff that any unknown etcd-era deployment must either upgrade through a pinned intermediate release or rebuild from scratch -- if they have not told the project they exist they get to carry some of the work for resolving this. He asked me to update the preconditions section of PLAN-remove-etcd, the phase 7 note in PLAN-remove-primary, and the index sequencing
accordingly.