### PR TITLE
Add spicedebug VDI type for verbose SPICE logging.

### DIFF
--- a/docs/developer_guide/api_reference/instances.md
+++ b/docs/developer_guide/api_reference/instances.md
@@ -119,10 +119,12 @@ passed as a list. You only have one `videospec` per instance. Once again, a
   options include: vga; cirrus (the default); and qxl.
 * memory (integer): the amount of video RAM the video card should have, in
   kibibytes (blocks of 1024 bytes).
-* vdi (string): the VDI protocol to use. Options are "vnc", "spice" (the default), or
-  "spiceconcurrent". spice and spiceconcurrent are the same except that spiceconcurrent
-  allows limited multi-user sessions, with subsequent sessions not experiencing
-  full VDI functionality.
+* vdi (string): the VDI protocol to use. Options are "vnc", "spice" (the default),
+  "spiceconcurrent", or "spicedebug". spice and spiceconcurrent are the same except
+  that spiceconcurrent allows limited multi-user sessions, with subsequent sessions
+  not experiencing full VDI functionality. spicedebug behaves like spice but also
+  sets `G_MESSAGES_DEBUG=all` in the qemu environment so the SPICE server emits
+  verbose logs to the qemu log, which is useful for diagnosing connectivity issues.
 
 ???+ tip "REST API calls"
 

--- a/docs/user_guide/consoles.md
+++ b/docs/user_guide/consoles.md
@@ -84,6 +84,11 @@ experimental support for multiple users accessing the same SPICE console at the
 same time is enabled. For more details about the experimental nature of concurrent
 SPICE consoles, see https://www.spice-space.org/multiple-clients.html.
 
+If you set `vdi=spicedebug`, the SPICE console behaves like `spice` but the qemu
+process is started with `G_MESSAGES_DEBUG=all` so the SPICE server emits verbose
+debug logs to the qemu log. This is useful when diagnosing SPICE connectivity
+issues but is otherwise too noisy for normal use.
+
 And example video specification would be:
 
 ```

--- a/shakenfist/deploy/templates/libvirt.tmpl
+++ b/shakenfist/deploy/templates/libvirt.tmpl
@@ -217,6 +217,9 @@
   {%- if spice_concurrent -%}
     <qemu:env name='SPICE_DEBUG_ALLOW_MC' value='1'/>
   {%- endif -%}
+  {%- if spice_debug -%}
+    <qemu:env name='G_MESSAGES_DEBUG' value='all'/>
+  {%- endif -%}
   {%- for extra in extracommands %}
     <qemu:arg value='{{extra}}'/>
   {%- endfor %}

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -1493,6 +1493,7 @@ class Instance(dbowo):
             machine_type=self.machine_type,
             vdi_type=vdi_type,
             spice_concurrent=(vdi_type == 'spiceconcurrent'),
+            spice_debug=(vdi_type == 'spicedebug'),
             extradevices=extradevices
         )
 


### PR DESCRIPTION
Introduces a new value for the videospec "vdi" field. When set to "spicedebug" the qemu process is started with G_MESSAGES_DEBUG=all in its environment, which makes the SPICE server emit verbose debug logs to the qemu log. The new value behaves identically to "spice" in all other respects (including TLS port allocation, which already keyed off `vdi.startswith('spice')`).

The plumbing mirrors the existing "spiceconcurrent" path: a spice_debug template variable is passed in from instance.py and a new conditional in libvirt.tmpl emits the qemu:env entry. No API side validation was required because the vdi field is free-form today.

This is useful for diagnosing SPICE connectivity issues, and is modelled on a patch I previously carried against OpenStack Nova (kerbside-patches/_patches/patch017-enable-spice-debug-logging.patch).

Prompt: I asked Claude to check whether we still had support for putting the qemu SPICE server into debug mode via an env var on the libvirt domain XML. After confirming the code we have today is the SPICE_DEBUG_ALLOW_MC concurrency flag (not a debug verbosity flag) and that the verbosity flag I was thinking of lived in a Nova patch rather than Shaken Fist, I asked Claude to create a new branch and implement debug logging as a new VDI type modelled on spiceconcurrent.


Assisted-By: Claude Opus 4.7 (1M context, low effort) <noreply@anthropic.com>