### PR TITLE
Honour explicit False for network boolean flags.

### DIFF
--- a/shakenfist/external_api/network.py
+++ b/shakenfist/external_api/network.py
@@ -250,11 +250,15 @@ class NetworksEndpoint(api_base.Resource):
     @api_base.log_token_use
     def post(self, netblock=None, provide_dhcp=None, provide_nat=None, name=None,
              namespace=None, provide_dns=None):
-        if not provide_dhcp:
+        # NOTE(mikal): these defaults must distinguish "the caller omitted
+        # the field" (None) from "the caller explicitly asked for False".
+        # Using `if not provide_nat` collapses both cases and silently
+        # re-enables NAT (and DHCP) when --no-nat / --no-dhcp was requested.
+        if provide_dhcp is None:
             provide_dhcp = True
-        if not provide_nat:
+        if provide_nat is None:
             provide_nat = True
-        if not provide_dns:
+        if provide_dns is None:
             provide_dns = False
 
         try:

--- a/shakenfist/tests/external_api/test_network.py
+++ b/shakenfist/tests/external_api/test_network.py
@@ -325,6 +325,103 @@ class NetworkDeleteAlreadyDeletedTestCase(base.ShakenFistTestCase):
         self.assertIn('error', body)
 
 
+class NetworkCreateBooleanDefaultsTestCase(base.ShakenFistTestCase):
+    """Regression tests for the POST /networks boolean flag defaults.
+
+    The create handler must distinguish "the caller omitted the field"
+    (None -> apply the default) from "the caller explicitly asked for
+    False". A previous `if not provide_nat: provide_nat = True` idiom
+    collapsed both cases, so --no-nat / --no-dhcp silently created a
+    network with NAT / DHCP still enabled.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        external_api.TESTING = True
+        external_api.app.testing = True
+        external_api.app.debug = False
+
+        external_api.app.logger.addHandler(logging.StreamHandler(sys.stdout))
+        external_api.app.logger.setLevel(logging.DEBUG)
+        logging.root.setLevel(logging.DEBUG)
+
+        # We need to pretend to be the network node
+        fake_config = SFConfig(
+            NODE_NAME='seriously',
+            NODE_EGRESS_IP='127.0.0.1',
+            NETWORK_NODE_IP='127.0.0.1',
+            NODE_EGRESS_NIC='eth0',
+            NODE_MESH_NIC='eth1',
+            NODE_IS_NETWORK_NODE=True,
+        )
+        self.config = mock.patch(
+            'shakenfist.external_api.base.config', fake_config)
+        self.mock_config = self.config.start()
+        self.addCleanup(self.config.stop)
+
+        self.mock_etcd = MockEtcd(self, node_count=4)
+        self.mock_etcd.setup()
+
+        self.client = external_api.app.test_client()
+
+        self.mock_etcd.create_namespace('system', 'key1', 'bar')
+
+        resp = self.client.post(
+            '/auth', data=json.dumps({'namespace': 'system', 'key': 'bar'}))
+        self.assertEqual(200, resp.status_code)
+        self.auth_token = 'Bearer %s' % resp.get_json()['access_token']
+
+    def _create_network(self, body):
+        body.setdefault('name', 'boolnet')
+        body.setdefault('netblock', '10.0.2.0/24')
+        body.setdefault('namespace', 'system')
+        return self.client.post(
+            '/networks',
+            headers={'Authorization': self.auth_token},
+            data=json.dumps(body))
+
+    @mock.patch('shakenfist.network.network.net_create_and_enqueue')
+    def test_explicit_false_is_honoured(self, _mock_enqueue):
+        """--no-dhcp / --no-nat / --no-dns send explicit False and must be
+        stored as False, not coerced back to the default."""
+        resp = self._create_network({
+            'provide_dhcp': False,
+            'provide_nat': False,
+            'provide_dns': False,
+        })
+        self.assertEqual(200, resp.status_code)
+        n = resp.get_json()
+        self.assertFalse(n['provide_dhcp'])
+        self.assertFalse(n['provide_nat'])
+        self.assertFalse(n['provide_dns'])
+
+    @mock.patch('shakenfist.network.network.net_create_and_enqueue')
+    def test_omitted_fields_use_defaults(self, _mock_enqueue):
+        """When the flags are omitted, DHCP and NAT default to enabled and
+        DNS defaults to disabled."""
+        resp = self._create_network({})
+        self.assertEqual(200, resp.status_code)
+        n = resp.get_json()
+        self.assertTrue(n['provide_dhcp'])
+        self.assertTrue(n['provide_nat'])
+        self.assertFalse(n['provide_dns'])
+
+    @mock.patch('shakenfist.network.network.net_create_and_enqueue')
+    def test_explicit_true_is_honoured(self, _mock_enqueue):
+        """Explicitly requesting the non-default (DNS on) must also work."""
+        resp = self._create_network({
+            'provide_dhcp': True,
+            'provide_nat': True,
+            'provide_dns': True,
+        })
+        self.assertEqual(200, resp.status_code)
+        n = resp.get_json()
+        self.assertTrue(n['provide_dhcp'])
+        self.assertTrue(n['provide_nat'])
+        self.assertTrue(n['provide_dns'])
+
+
 class NetworkDNSAddressEndpointTestCase(base.ShakenFistTestCase):
     """Regression tests for step 4f: REST handlers call raise_for_error()
     after update_dns_entry / remove_dns_entry."""


### PR DESCRIPTION
The POST /networks handler defaulted its boolean flags with the idiom `if not provide_nat: provide_nat = True` (and likewise for provide_dhcp and provide_dns). This collapses two distinct cases: the caller omitting the field (arrives as None) and the caller explicitly requesting False. As a result `sf-client network create --no-nat` (and --no-dhcp) silently created networks with NAT/DHCP still enabled -- there was no value the client could send to disable them, because False was coerced straight back to the default.

Switch the defaulting to explicit `is None` checks so an omitted field takes the default while an explicit True/False is honoured as sent.

Add NetworkCreateBooleanDefaultsTestCase covering all three flags for the explicit-False, omitted, and explicit-True cases. The explicit-False test fails against the previous code and passes with the fix.

Prompt: While using the Python client I noticed `sf-client network create --no-nat` produced a network with NAT still enabled. We traced it through the client (correct) to the server's create handler, confirmed the bug still exists at HEAD, then fixed this class of falsy-vs-None defaulting bug for provide_dhcp, provide_nat and provide_dns and added covering unit tests to detect regressions.


Assisted-By: Claude Opus 4.8 (1M context, medium effort) <noreply@anthropic.com>