### PR TITLE
Remove the duplicated shakenfist checkout.

### DIFF
--- a/.github/workflows/ci-images-test.yml
+++ b/.github/workflows/ci-images-test.yml
@@ -98,12 +98,6 @@ jobs:
             fetch-depth: 0
 
         - name: Checkout the shakenfist repository
-          uses: actions/checkout@v6
-          with:
-            path: shakenfist
-            fetch-depth: 1
-
-        - name: Checkout the shakenfist repository
           # No explicit repository: an explicit one pins the checkout to that
           # repo's default branch, but this job tests the proposed change, so
           # it must check out the triggering sha.


### PR DESCRIPTION
The image test job already checked out the shakenfist repository at the triggering sha; the collection-install series added a second checkout of the same repository to the same path without noticing. The pinned first version of that duplicate is what originally broke every matrix entry (it re-checked-out develop over the correct working tree); now that both steps are identical it is merely redundant. Keep the commented one.

Prompt: While fixing the image-test failures we noticed the checkout added for the collection install duplicated a pre-existing step; remove the duplicate.


Assisted-By: Claude Opus 4.8 (200K context, high effort)