### PR TITLE
Fix greenfield collection deploy blockers.

### DIFF
--- a/examples/cluster/README.md
+++ b/examples/cluster/README.md
@@ -56,7 +56,19 @@ or set `ANSIBLE_COLLECTIONS_PATH` to a tree containing
 Ansible must be able to reach each host (the sample uses `ansible_host` = the
 mesh IP) and `become` root there.
 
-### 3. Bring your own MariaDB
+### 3. Control node packages
+
+The internal CA plays generate certificates on the control node with
+`certtool`, from the `gnutls-bin` package (Debian/Ubuntu). The role installs
+it via apt when the control-node plays run with root; if you run the deploy
+rootless (overriding `ansible_become` for localhost and pointing `ca_path` at
+a user-writable directory), install it beforehand:
+
+```bash
+apt-get install gnutls-bin
+```
+
+### 4. Bring your own MariaDB
 
 Provision MariaDB on (or reachable by) the database tier and point
 `mariadb_host` / `mariadb_user` / `mariadb_password` / `mariadb_database` in

--- a/shakenfist/client/backup.py
+++ b/shakenfist/client/backup.py
@@ -23,7 +23,9 @@ if os.path.exists('/etc/sf/config'):
             if line == '':
                 continue
 
-            key, value = line.split('=')
+            # Values may legitimately contain '=' (base64 padding, URLs
+            # with query strings), so split on the first one only.
+            key, value = line.split('=', 1)
             value = value.strip('\'"')
 
             if key not in os.environ:

--- a/shakenfist/client/ctl.py
+++ b/shakenfist/client/ctl.py
@@ -111,7 +111,9 @@ if os.path.exists('/etc/sf/config'):
             if line == '':
                 continue
 
-            key, value = line.split('=')
+            # Values may legitimately contain '=' (base64 padding, URLs
+            # with query strings), so split on the first one only.
+            key, value = line.split('=', 1)
             value = value.strip('\'"')
 
             if key not in os.environ:

--- a/shakenfist/daemons/sentinel_last/main.py
+++ b/shakenfist/daemons/sentinel_last/main.py
@@ -36,6 +36,16 @@ def main():
 
     n = Node.from_db(config.NODE_NAME)
     n.set_daemon_state('sentinel-last', Node.DAEMON_STATE_RUNNING)
+
+    # sentinel-last starts after every other daemon (the systemd ordering
+    # contract), so reaching here means the node is fully up: declare it
+    # created, mirroring how our shutdown declares it stopping. Without
+    # this a restarted node is stranded in stopping or degraded -- the
+    # only other path back to created is the cluster daemon's
+    # missing-node recovery, which never fires while checkins stay
+    # fresh. Being the last daemon to start also makes this the final
+    # state write in any restart interleaving.
+    n.state = Node.STATE_CREATED
     send_systemd_ready()
 
     while daemon.check_abort_path(ABORT_PATH):

--- a/shakenfist/deploy/collection/README.md
+++ b/shakenfist/deploy/collection/README.md
@@ -53,6 +53,11 @@ pip install shakenfist-client
 node never needs the Shaken Fist server package. The roles additionally
 require `ansible >= 2.15` (see `meta/runtime.yml`).
 
+The `internal_ca` role generates certificates on the control node with
+`certtool` from the `gnutls-bin` package (Debian/Ubuntu). The role installs it
+via apt when its control-node tasks run with root; rootless deploys must
+install it beforehand.
+
 ## Consuming the collection
 
 Install the published collection on your Ansible control node:

--- a/shakenfist/deploy/collection/roles/hypervisor/tasks/validate_kvm.yml
+++ b/shakenfist/deploy/collection/roles/hypervisor/tasks/validate_kvm.yml
@@ -2,6 +2,21 @@
 # Preflight check: confirm this host can actually run KVM. The consuming
 # playbook runs this via:
 #   include_role: { name: shakenfist.shakenfist.hypervisor, tasks_from: validate_kvm }
+
+# The node role's bootstrap also installs cpu-checker, but this preflight
+# runs before bootstrap in the example playbooks -- on a greenfield host
+# kvm-ok does not exist yet, so the preflight must own its tool.
+- name: Install cpu-checker for kvm-ok
+  ansible.builtin.apt:
+    name: cpu-checker
+    state: present
+  register: apt_action
+  retries: 100
+  until: >-
+    apt_action is success or
+    ('Failed to lock apt for exclusive operation' not in apt_action.msg and
+     '/var/lib/dpkg/lock' not in apt_action.msg)
+
 - name: Check that we can run KVM
   ansible.builtin.command: kvm-ok
   changed_when: false

--- a/shakenfist/deploy/collection/roles/internal_ca/tasks/bootstrap.yml
+++ b/shakenfist/deploy/collection/roles/internal_ca/tasks/bootstrap.yml
@@ -29,7 +29,9 @@
   ansible.builtin.template:
     src: ca_template.tmpl
     dest: "{{ ca_template_path }}"
-    owner: root
+    # No owner: the invoking user owns the CA material. A root-run
+    # creates root-owned files anyway, and hardcoding owner: root
+    # breaks rootless control nodes (chown as non-root fails).
     mode: u=r
   when: not ca_cert.stat.exists
 

--- a/shakenfist/deploy/collection/roles/internal_ca/tasks/host_certificate.yml
+++ b/shakenfist/deploy/collection/roles/internal_ca/tasks/host_certificate.yml
@@ -51,7 +51,8 @@
       encryption_key
       signing_key
     dest: "{{ host_template_path }}"
-    owner: root
+    # No owner: see bootstrap.yml -- rootless control nodes cannot
+    # chown, and a root-run creates root-owned files anyway.
     mode: u=r
   delegate_to: localhost
   delegate_facts: true


### PR DESCRIPTION
The first from-scratch deploy of the collection against freshly installed hosts (the sfcbr rebuild) hit three issues CI never sees because its images come pre-baked:

- validate_kvm ran before the node role's bootstrap installs cpu-checker, so kvm-ok did not exist on greenfield hypervisors and the preflight always failed. The preflight now installs its own tool (with the usual apt-lock retry), keeping it a true preflight.
- The internal CA's control-node writes hardcoded owner: root, which breaks rootless control nodes (chown as non-root fails) and is redundant when running as root (created files are root-owned anyway). Dropped from the CA template and host certificate template tasks; the remote-host certificate installs keep their explicit root ownership.
- certtool (gnutls-bin) was not documented as a control-node dependency anywhere. It is now listed in the cluster example's prerequisites and the collection README, including the rootless case where the role's apt fallback cannot run.

Prompt: While running the first sfcbr rebuild deploy, Mikal asked for certtool to be tracked as a shakenfist deploy node dependency if it was not already; the kvm-ok and CA ownership fixes are the other two greenfield blockers that same deploy surfaced. He asked for the fixes to be committed and pushed.

Assisted-By: Claude Code