### PR TITLE
Apply configured log levels in all daemons.

### DIFF
--- a/shakenfist/config.py
+++ b/shakenfist/config.py
@@ -559,14 +559,23 @@ class SFConfig(BaseSettings):
         description='Path to libvirt logs.'
     )
 
-    # Logging
+    # Logging. One entry per daemon; daemon.apply_log_level() applies
+    # the value to the whole shakenfist logger namespace at daemon
+    # startup, so a single daemon can be turned up to debug without
+    # drowning the cluster's syslog and Loki streams in every
+    # daemon's debug records.
     LOGLEVEL_API: str = 'info'
     LOGLEVEL_CLEANER: str = 'info'
+    LOGLEVEL_CLUSTER: str = 'info'
+    LOGLEVEL_DATABASE: str = 'info'
     LOGLEVEL_MAIN: str = 'info'
     LOGLEVEL_NET: str = 'info'
+    LOGLEVEL_NODELOCK: str = 'info'
+    LOGLEVEL_PRIVEXEC: str = 'info'
+    LOGLEVEL_QUEUES: str = 'info'
     LOGLEVEL_RESOURCES: str = 'info'
     LOGLEVEL_SIDECHANNEL: str = 'info'
-    LOGLEVEL_QUEUES: str = 'info'
+    LOGLEVEL_TRANSFERS: str = 'info'
 
     # MariaDB
     MARIADB_HOST: str = Field(

--- a/shakenfist/daemons/daemon.py
+++ b/shakenfist/daemons/daemon.py
@@ -74,23 +74,46 @@ def set_syslog_ident(procname):
                 handler.ident = ident
 
 
+def _configured_log_level(name):
+    # Check for configuration override
+    level = getattr(config, 'LOGLEVEL_' + name.upper(), None)
+    if not level:
+        return logging.INFO
+    numeric_level = getattr(logging, level.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError('Invalid log level: %s' % level)
+    return numeric_level
+
+
 def set_log_level(log, name):
     # Check that id is a valid name
     process_name(name)
 
-    # Check for configuration override
-    level = getattr(config, 'LOGLEVEL_' + name.upper(), None)
-    if level:
-        numeric_level = getattr(logging, level.upper(), None)
-        if not isinstance(numeric_level, int):
-            raise ValueError('Invalid log level: %s' % level)
-    else:
-        numeric_level = logging.INFO
+    log.setLevel(_configured_log_level(name))
 
-    log.setLevel(numeric_level)
+
+def apply_log_level(daemon_name):
+    """Apply this daemon's configured log level to every shakenfist logger.
+
+    ``logs.setup()`` leaves the root logger at DEBUG and gives each
+    module its own child logger with no explicit level, so until a
+    level is set on the *package* logger every module ships debug
+    records (privexec command dumps, concurrency output captures, ...)
+    to syslog and Loki no matter what ``LOGLEVEL_*`` says --
+    ``set_log_level()`` only quiets the single module logger it is
+    handed. Setting the level once here makes every ``shakenfist.*``
+    logger inherit it. Daemons without a ``LOGLEVEL_*`` config field
+    default to info.
+    """
+    logging.getLogger('shakenfist').setLevel(
+        _configured_log_level(daemon_name))
 
 
 def write_pid_file(daemon_name):
+    # The one universal per-daemon startup hook (see below), so this
+    # is also where the configured log level is enforced.
+    apply_log_level(daemon_name)
+
     with open(f'/run/sf/{daemon_name}.pid', 'w') as f:
         f.write(f'{os.getpid()}')
 

--- a/shakenfist/daemons/nodelock/main.py
+++ b/shakenfist/daemons/nodelock/main.py
@@ -14,6 +14,7 @@ from google.protobuf.message import DecodeError
 import setproctitle
 from shakenfist_utilities import logs
 
+from shakenfist.daemons.daemon import apply_log_level
 from shakenfist.daemons.daemon import force_clean_exit
 from shakenfist.daemons.daemon import send_systemd_ready
 from shakenfist.protos import nodelock_pb2
@@ -42,6 +43,10 @@ def write_pid_file():
 def main():
     util_exceptions.install_exception_tracking()
     write_pid_file()
+    # This daemon has its own minimal write_pid_file rather than the
+    # universal hook in daemons.daemon, so the configured log level
+    # must be applied explicitly.
+    apply_log_level('nodelock')
     setproctitle.setproctitle('sf-nodelock')
 
     if os.path.exists(SOCKET_PATH):

--- a/shakenfist/daemons/privexec/main.py
+++ b/shakenfist/daemons/privexec/main.py
@@ -18,6 +18,7 @@ import setproctitle
 from shakenfist_utilities import random      # noreorder
 from shakenfist_utilities import logs        # noreorder
 
+from shakenfist.daemons.daemon import apply_log_level
 from shakenfist.daemons.daemon import force_clean_exit
 from shakenfist.daemons.daemon import send_systemd_ready
 from shakenfist.daemons.daemon import send_systemd_stopping
@@ -533,6 +534,10 @@ def write_pid_file():
 def main():
     util_exceptions.install_exception_tracking()
     write_pid_file()
+    # This daemon has its own minimal write_pid_file rather than the
+    # universal hook in daemons.daemon, so the configured log level
+    # must be applied explicitly.
+    apply_log_level('privexec')
     setproctitle.setproctitle('sf-privexec')
 
     if os.path.exists(SOCKET_PATH):

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -50,6 +50,11 @@ from shakenfist.util import general as util_general
 
 LOG, HANDLER = logs.setup(__name__)
 daemon.set_log_level(LOG, 'api')
+# The api runs under gunicorn rather than via write_pid_file(), so
+# the package-wide level (which quiets the modules the per-module
+# set_log_level calls cannot reach, like util.concurrency) is
+# applied here at worker import time instead.
+daemon.apply_log_level('api')
 
 
 app = flask.Flask(__name__)

--- a/shakenfist/tests/test_daemon_loglevel.py
+++ b/shakenfist/tests/test_daemon_loglevel.py
@@ -1,0 +1,52 @@
+# Copyright 2019 Michael Still and contributors
+import logging
+from unittest import mock
+
+from shakenfist.config import BaseSettings
+from shakenfist.daemons import daemon
+from shakenfist.tests import base
+
+
+class FakeConfig(BaseSettings):
+    # error rather than debug so the tests can tell package-level
+    # inheritance apart from the DEBUG root logger logs.setup()
+    # leaves behind.
+    LOGLEVEL_NET: str = 'error'
+    LOGLEVEL_QUEUES: str = 'bogus'
+
+
+fake_config = FakeConfig()
+
+
+class ApplyLogLevelTestCase(base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+        self.config = mock.patch(
+            'shakenfist.daemons.daemon.config', fake_config)
+        self.config.start()
+        self.addCleanup(self.config.stop)
+
+        pkg = logging.getLogger('shakenfist')
+        self.addCleanup(pkg.setLevel, pkg.level)
+
+    def test_configured_level_applies_to_package(self):
+        daemon.apply_log_level('net')
+        self.assertEqual(
+            logging.ERROR, logging.getLogger('shakenfist').level)
+
+        # Module loggers have no explicit level, so they must inherit
+        # the package level rather than the root logger's DEBUG.
+        self.assertEqual(
+            logging.ERROR,
+            logging.getLogger(
+                'shakenfist.util.concurrency').getEffectiveLevel())
+
+    def test_unconfigured_daemon_defaults_to_info(self):
+        # FakeConfig has no LOGLEVEL_PRIVEXEC.
+        daemon.apply_log_level('privexec')
+        self.assertEqual(
+            logging.INFO, logging.getLogger('shakenfist').level)
+
+    def test_invalid_level_raises(self):
+        self.assertRaises(
+            ValueError, daemon.apply_log_level, 'queues')


### PR DESCRIPTION
shakenfist_utilities.logs.setup() leaves the root logger at DEBUG and gives every module its own child logger with no explicit level. The LOGLEVEL_* configuration (default info) was only ever applied by daemon.set_log_level(), which sets the level on the single module logger it is handed -- and which is only called by the external_api modules. The result: sf-api was the only quiet daemon, and every other daemon shipped every debug record (privexec command dumps, util.concurrency output captures, ...) to syslog and the Loki shipper regardless of configuration, burying real signal. This was found while diagnosing a MariaDB stall on sfcbr, where the debug flood made the incident window hard to see.

daemon.apply_log_level() now sets the configured level once on the 'shakenfist' package logger so every module logger inherits it. It is called from write_pid_file() -- the existing universal per-daemon startup hook -- and explicitly by privexec and nodelock (which have their own minimal write_pid_file) and the gunicorn-hosted api at worker import. Config gains the previously missing per-daemon fields (cluster, database, nodelock, privexec, transfers), so a single daemon can still be turned up to debug deliberately without drowning the cluster's log streams.

Prompt: While reviewing overnight sfcbr Loki logs, Mikal noted that overly verbose debug log messages are themselves a bug that should be fixed, especially when they obscure our view of what is really happening in the cluster. Diagnosis found LOGLEVEL_* was never applied outside sf-api; he asked for the fix to be committed and pushed.

Assisted-By: Claude Code