### PR TITLE
Make docs-only CI skip actually work.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -67,6 +67,12 @@ jobs:
         id: filter
         if: github.event_name != 'workflow_dispatch'
         with:
+          # By default a file matches the filter if it matches ANY listed
+          # pattern, which makes '**' match everything and silently
+          # defeats the '!docs/**' exclusions. 'every' requires a file to
+          # match ALL patterns, which is the correct semantics for an
+          # "everything except docs" filter.
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'
@@ -294,7 +300,10 @@ jobs:
   # can_merge.
   functional_matrix_merge_collection:
     name: "${{ matrix.merge.name }} (collection)"
-    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    if: >-
+      (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
+      && needs.check_paths.outputs.code_changed != 'false'
+    needs: [check_paths]
     strategy:
       fail-fast: false
       matrix:
@@ -363,7 +372,10 @@ jobs:
   # shakenfist.shakenfist collection. Gated by can_merge.
   ansible_modules_collection:
     name: "Ansible modules (collection)"
-    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    if: >-
+      (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
+      && needs.check_paths.outputs.code_changed != 'false'
+    needs: [check_paths]
     uses: shakenfist/actions/.github/workflows/smoke-cluster.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
dorny/paths-filter ORs its patterns by default, so the '**' entry matched every file and the '!docs/**' exclusions never subtracted anything -- code_changed always evaluated true and the existing docs-only gates never fired. Set predicate-quantifier to 'every' so a file must match all patterns to count as a code change.

Also gate the two remaining ungated merge-queue collection jobs (functional_matrix_merge_collection and ansible_modules_collection) on check_paths.outputs.code_changed, matching their sibling node_lifecycle_collection.

Prompt: While cleaning up stale worktrees and branches we found this uncommitted fix in the no-ci-for-docs worktree: the merged branch landed the code_changed gating but not the paths-filter semantics fix that makes it effective. Mikal asked to rebase the worktree onto develop, then commit and push the surviving work.