### PR TITLE
Collect memory and disk capacity statistics.

### DIFF
--- a/shakenfist/deploy/collection/roles/hypervisor/files/libvirt.tmpl
+++ b/shakenfist/deploy/collection/roles/hypervisor/files/libvirt.tmpl
@@ -200,6 +200,10 @@
       <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
     </video>
     <memballoon model='virtio'>
+      <!-- The stats period makes the balloon driver report guest internal
+           memory statistics (unused, available, swap activity) every 10
+           seconds, which surface in instance usage events. -->
+      <stats period='10'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
     </memballoon>
 

--- a/shakenfist/deploy/templates/libvirt.tmpl
+++ b/shakenfist/deploy/templates/libvirt.tmpl
@@ -200,6 +200,10 @@
       <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
     </video>
     <memballoon model='virtio'>
+      <!-- The stats period makes the balloon driver report guest internal
+           memory statistics (unused, available, swap activity) every 10
+           seconds, which surface in instance usage events. -->
+      <stats period='10'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
     </memballoon>
 

--- a/shakenfist/tests/test_util_libvirt.py
+++ b/shakenfist/tests/test_util_libvirt.py
@@ -1,0 +1,156 @@
+from unittest import mock
+
+from shakenfist.tests import base
+from shakenfist.util import libvirt as util_libvirt
+
+
+DOMAIN_XML = """<domain type='kvm'>
+  <devices>
+    <disk type='file' device='disk'>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+    <interface type='bridge'>
+      <mac address='02:00:00:12:34:56'/>
+      <target dev='vnet0'/>
+    </interface>
+  </devices>
+</domain>"""
+
+
+class FakeLibvirtError(Exception):
+    ...
+
+
+class FakeLibvirtModule:
+    libvirtError = FakeLibvirtError
+
+
+class FakeDomain:
+    def __init__(self, memory_stats=None, block_info=None):
+        self._memory_stats = memory_stats
+        self._block_info = block_info
+
+    def XMLDesc(self):
+        return DOMAIN_XML
+
+    def getCPUStats(self, total):
+        return [{'cpu_time': 1000, 'system_time': 300, 'user_time': 700}]
+
+    def blockStats(self, device):
+        return (10, 4096, 20, 8192, 0)
+
+    def interfaceStats(self, device):
+        return (100, 1, 0, 0, 200, 2, 0, 0)
+
+    def memoryStats(self):
+        if self._memory_stats is None:
+            raise FakeLibvirtError('balloon not available')
+        return self._memory_stats
+
+    def blockInfo(self, device):
+        if self._block_info is None:
+            raise FakeLibvirtError('no media')
+        return self._block_info
+
+
+class UtilLibvirtStatistics(base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+        fake_libvirt = mock.patch.object(
+            util_libvirt, 'LIBVIRT', FakeLibvirtModule())
+        fake_libvirt.start()
+        self.addCleanup(fake_libvirt.stop)
+
+    def test_extract_statistics_full(self):
+        domain = FakeDomain(
+            memory_stats={
+                'actual': 2097152,
+                'rss': 1048576,
+                'unused': 524288,
+                'available': 2000000,
+                'swap_in': 0,
+                'swap_out': 12,
+                'major_fault': 3,
+                'minor_fault': 400,
+            },
+            block_info=(107374182400, 2147483648, 1073741824))
+
+        stats = util_libvirt.extract_statistics(domain)
+
+        self.assertEqual(
+            {
+                'cpu time ns': 1000,
+                'system time ns': 300,
+                'user time ns': 700,
+            },
+            stats['cpu usage'])
+        self.assertEqual(
+            {
+                'actual kb': 2097152,
+                'rss kb': 1048576,
+                'unused kb': 524288,
+                'available kb': 2000000,
+                'swap in kb': 0,
+                'swap out kb': 12,
+                'major fault': 3,
+                'minor fault': 400,
+            },
+            stats['memory usage'])
+        self.assertEqual(
+            {
+                'read requests': 10,
+                'read bytes': 4096,
+                'write requests': 20,
+                'write bytes': 8192,
+                'errors': 0,
+                'capacity bytes': 107374182400,
+                'allocation bytes': 2147483648,
+                'physical bytes': 1073741824,
+            },
+            stats['disk usage']['vda'])
+        self.assertEqual(
+            {
+                'read bytes': 100,
+                'read packets': 1,
+                'read errors': 0,
+                'read drops': 0,
+                'write bytes': 200,
+                'write packets': 2,
+                'write errors': 0,
+                'write drops': 0,
+            },
+            stats['network usage']['02:00:00:12:34:56'])
+
+    def test_extract_statistics_partial_memory_stats(self):
+        # Without a balloon stats period (or a guest driver reporting
+        # them), memoryStats() only returns host side values. The guest
+        # internal values must default to zero, not KeyError.
+        domain = FakeDomain(
+            memory_stats={'actual': 2097152, 'rss': 1048576},
+            block_info=(1, 1, 1))
+
+        stats = util_libvirt.extract_statistics(domain)
+
+        self.assertEqual(2097152, stats['memory usage']['actual kb'])
+        self.assertEqual(1048576, stats['memory usage']['rss kb'])
+        self.assertEqual(0, stats['memory usage']['unused kb'])
+        self.assertEqual(0, stats['memory usage']['swap out kb'])
+
+    def test_extract_statistics_collection_failures(self):
+        # A failing memoryStats() or blockInfo() call must not prevent
+        # collection of the other statistics.
+        domain = FakeDomain(memory_stats=None, block_info=None)
+
+        stats = util_libvirt.extract_statistics(domain)
+
+        self.assertEqual({}, stats['memory usage'])
+        self.assertEqual(
+            {
+                'read requests': 10,
+                'read bytes': 4096,
+                'write requests': 20,
+                'write bytes': 8192,
+                'errors': 0,
+            },
+            stats['disk usage']['vda'])
+        self.assertIn('02:00:00:12:34:56', stats['network usage'])

--- a/shakenfist/util/libvirt.py
+++ b/shakenfist/util/libvirt.py
@@ -169,6 +169,7 @@ def extract_hypervisor_devices(domain: Any) -> dict[str, list[Any]]:
 
 
 def extract_statistics(domain: Any) -> dict[str, Any]:
+    libvirt = get_libvirt()
     devices = extract_hypervisor_devices(domain)
     raw_stats = domain.getCPUStats(True)
 
@@ -178,9 +179,30 @@ def extract_statistics(domain: Any) -> dict[str, Any]:
             'system time ns': raw_stats[0]['system_time'],
             'user time ns': raw_stats[0]['user_time']
         },
+        'memory usage': {},
         'disk usage': {},
         'network usage': {}
     }
+
+    # Memory statistics come from the balloon driver. The host side
+    # values (actual, rss) are always available, but the guest internal
+    # values (unused, available, swap in/out, faults) require a virtio
+    # memballoon with a stats collection period in the domain XML and a
+    # guest driver which reports them, so default anything missing.
+    try:
+        mem_stats = domain.memoryStats()
+        out['memory usage'] = {
+            'actual kb': mem_stats.get('actual', 0),
+            'rss kb': mem_stats.get('rss', 0),
+            'unused kb': mem_stats.get('unused', 0),
+            'available kb': mem_stats.get('available', 0),
+            'swap in kb': mem_stats.get('swap_in', 0),
+            'swap out kb': mem_stats.get('swap_out', 0),
+            'major fault': mem_stats.get('major_fault', 0),
+            'minor fault': mem_stats.get('minor_fault', 0),
+        }
+    except libvirt.libvirtError as e:
+        LOG.debug(f'Failed to collect memory statistics: {e}')
 
     for disk_device in devices['disk']:
         raw_stats = domain.blockStats(disk_device)
@@ -191,6 +213,22 @@ def extract_statistics(domain: Any) -> dict[str, Any]:
             'write bytes': raw_stats[3],
             'errors': raw_stats[4],
         }
+
+        # Capacity is the logical disk size the guest sees, allocation
+        # is the space used within the image, and physical is the host
+        # disk space consumed (sparse files and qcow2 images can make
+        # these differ). Media-less devices (an empty cdrom) have no
+        # block info.
+        try:
+            block_info = domain.blockInfo(disk_device)
+            out['disk usage'][disk_device].update({
+                'capacity bytes': block_info[0],
+                'allocation bytes': block_info[1],
+                'physical bytes': block_info[2],
+            })
+        except libvirt.libvirtError as e:
+            LOG.debug(
+                f'Failed to collect block info for {disk_device}: {e}')
 
     for mac_address, hypervisor_interface in devices['network']:
         raw_stats = domain.interfaceStats(hypervisor_interface)


### PR DESCRIPTION
extract_statistics() now includes two new metric groups in the per-instance usage events emitted by the billing collector:

- 'memory usage' from domain.memoryStats(): balloon allocation (actual), host RSS, guest-internal unused/available, swap activity, and fault counts. Guest-internal values depend on the balloon driver reporting them, so missing keys default to zero.
- Per-device disk capacity from domain.blockInfo(): capacity (logical size), allocation (used within the image), and physical (host space consumed). The allocation/capacity ratio identifies instances whose disks are running near full.

Both collectors are individually guarded against libvirtError so a failing balloon query or a media-less device cannot suppress the CPU, disk I/O, and network statistics collected alongside them.

The libvirt domain templates gain <stats period='10'/> on the memballoon element, without which the balloon driver never reports guest-internal memory statistics. Existing instances pick this up on their next restart; new instances have it from first boot.

This is step 1a of the workflow cost tracking plan in shakenfist/private-ci docs/plans/PLAN-workflow-cost-tracking.md: the conductor will harvest these usage events at CI runner teardown to build an archive of per-workflow resource consumption.

Prompt: While implementing runtime cost tracking for the private CI conductor, Mikal asked me to implement step 1a of the workflow cost tracking plan -- extending Shaken Fist's per-instance usage events with memory and disk capacity statistics -- in a fresh worktree and branch created from develop.

Assisted-By: Claude Code