### PR TITLE
Roll the database gateway tier one node at a time.

### DIFF
--- a/examples/_shared/site.yml
+++ b/examples/_shared/site.yml
@@ -469,11 +469,23 @@
 # Play 6b: register the database tier (starts sf-database and the gRPC gateway)
 # BEFORE the remaining nodes register over that gateway. The ordering contract
 # in the node role's register.yml requires this.
+#
+# serial: 1 rolls the tier one node at a time. Every SF client round-robins
+# across all gateways in MARIADB_GATEWAY_HOSTS, so restarting them in parallel
+# (ansible's default) takes the whole tier down at once -- the ~5s cluster-wide
+# DatabaseUnavailable window seen on the 2026-07-15 sfcbr deploy, harmless with
+# one gateway but an outage with several. Rolling one at a time keeps a gateway
+# serving throughout; register.yml waits for each node's gateway to accept
+# connections again before this play moves on, so the next restart never begins
+# while a peer is still down. Database nodes reach MariaDB directly (not through
+# the gateway), so a node can always register itself even while its own gateway
+# is mid-restart.
 # ---------------------------------------------------------------------------
 - name: Register the database tier and start its daemons
   hosts: database_node:etcd_master
   become: true
   gather_facts: false
+  serial: 1
   tasks:
     - name: Register the database-tier node
       ansible.builtin.include_role:

--- a/shakenfist/deploy/collection/roles/node/tasks/register.yml
+++ b/shakenfist/deploy/collection/roles/node/tasks/register.yml
@@ -49,6 +49,25 @@
     daemon_reload: false
   when: node_is_database_node
 
+# Confirm this node's gRPC gateway is accepting connections again before we
+# return. When the example playbook rolls the database tier one node at a time
+# (site.yml play 6b, serial: 1), this gate is what keeps a gateway serving
+# throughout the roll: the next node's restart cannot begin until this one is
+# back up. sf-database binds the gateway to the mesh IP; a listening socket is
+# exactly the signal round_robin failover keys on (subchannel connectivity),
+# and systemd reports the unit started before the port is bound, so the service
+# restart above is not sufficient on its own.
+- name: Wait for this node's database gateway to accept connections
+  ansible.builtin.wait_for:
+    host: "{{ node_mesh_ip }}"
+    # The gateway port is hardcoded to 13005 across the collection (see the
+    # config template's SHAKENFIST_MARIADB_GATEWAY_PORT); match that here.
+    port: 13005
+    state: started
+    delay: 2
+    timeout: 60
+  when: node_is_database_node
+
 # Start the remaining daemons. The ordering here matches the order they must
 # start in, not alphabetical order.
 - name: Base daemons everywhere


### PR DESCRIPTION
Every SF client round-robins across all gateways in MARIADB_GATEWAY_HOSTS, so restarting the sf-database daemons in parallel -- ansible's default for a play targeting the whole database_node group -- takes the entire gateway tier down at once. With a single gateway that is the harmless ~5 second cluster-wide DatabaseUnavailable window seen on the 2026-07-15 sfcbr deploy; with two or more it is a real outage every time the tier is rolled.

Add serial: 1 to site.yml's play 6b so the tier registers and restarts one node at a time, and gate register.yml on the just-started gateway accepting connections again (wait_for the mesh IP on 13005) before the play moves on. Together these keep at least one gateway serving throughout the roll: the next node's restart cannot begin until the previous node's gateway is back up. A listening socket is exactly the signal round_robin failover keys on via subchannel connectivity, and systemd reports sf-database started before the port binds, so the service restart alone is not a sufficient readiness signal. Database nodes reach MariaDB directly rather than through the gateway, so a node can always register itself even while its own gateway is mid-restart -- no chicken-and-egg.

serial: 1 is a no-op with one database node, so existing single-DB deploys (including today's sfcbr, which lists only sf-1) are unchanged; the rolling behaviour engages once a second node joins the database_node group. The config play (play 4) is deliberately left alone: it does not restart the gateway today. When restart-on-change lands and introduces a config-triggered sf-database handler, that path will need the same serialisation.

Prompt: The 2026-07-15 in-flight sfcbr upgrade showed a brief cluster-wide DatabaseUnavailable window while the sole sf-database gateway restarted. Michael wants to run the database tier on more than one node (sf-1 and sf-2) to remove that deploy-time outage, while keeping it a deliberate subset so deploys keep validating a separate database tier. The client already supports a multi-gateway tier; the only gap was that the deploy restarted all gateways in parallel. This implements the rolling restart that closes that gap.


Assisted-By: Claude Code