### PR TITLE
Restart node daemons only on change.

### DIFF
--- a/docs/operator_guide/upgrades.md
+++ b/docs/operator_guide/upgrades.md
@@ -35,6 +35,19 @@ Which will pull in all the relevant other python packages it requires.
 Then simply re-run your deployment playbook as you did when you first
 installed (see [Installation](installation.md)) and the cluster will upgrade.
 
+If you deploy with the [`shakenfist.shakenfist` Ansible
+collection](https://github.com/shakenfist/shakenfist/tree/develop/deploy/collection),
+re-running the playbook is **restart-on-change**: the `node` role restarts a
+node's `sf-*` daemons only when the installed code, `/etc/sf/config`, or a
+systemd unit actually changed on that node. A redeploy on a day nothing moved
+leaves the running cluster undisturbed, so it is safe to run the deploy on a
+schedule; on a day the code did move, the daemons restart to pick it up (a
+built-in daily upgrade-path test). Code changes are detected by hashing the
+installed package files, not the wheel, so a rebuilt-but-identical wheel does
+not trigger a spurious restart. See the collection's *Idempotence and
+restart-on-change* section for details. This automates, per node, the same
+restart the manual procedure below performs by hand.
+
 ## MariaDB schema migrations
 
 Starting with v0.8, Shaken Fist uses MariaDB to store object state data. The

--- a/shakenfist/deploy/collection/README.md
+++ b/shakenfist/deploy/collection/README.md
@@ -15,10 +15,47 @@ another host's facts, so the roles compose cleanly with any inventory layout.
 
 | Role | Purpose |
 |------|---------|
-| `shakenfist.shakenfist.node` | Core per-node setup: OS packages, `/etc/sf/config`, `sfrc`, the global auth file, all `sf-*` systemd units, and registration of the node and its daemons. Folds in the database capability: when `node_is_database_node` is true it also writes, registers and starts `sf-database`. Has `bootstrap`, `config` and `register` entry points (run them as separate plays to order database-tier hosts first). The `bootstrap` entry point creates the `/srv/shakenfist` virtualenv and installs the `shakenfist` server and client packages (override `server_package`/`client_package`/`pip_extra` to install local wheels for local/CI). |
+| `shakenfist.shakenfist.node` | Core per-node setup: OS packages, `/etc/sf/config`, `sfrc`, the global auth file, all `sf-*` systemd units, and registration of the node and its daemons. Folds in the database capability: when `node_is_database_node` is true it also writes, registers and starts `sf-database`. Has `bootstrap`, `config` and `register` entry points (run them as separate plays to order database-tier hosts first). The `bootstrap` entry point creates the `/srv/shakenfist` virtualenv and installs the `shakenfist` server and client packages (override `server_package`/`client_package`/`pip_extra` to install local wheels for local/CI). Re-running the role is **restart-on-change**: it only restarts a node's daemons when the installed code, `/etc/sf/config`, or a systemd unit actually changed (see [Idempotence and restart-on-change](#idempotence-and-restart-on-change)). |
 | `shakenfist.shakenfist.hypervisor` | Hypervisor host preparation: nested KVM detection/enable, KSM, `vhost_vsock`, SPICE TLS, and the libvirt AppArmor/config tweaks. Apply only to hosts where `node_is_hypervisor` is true. |
 | `shakenfist.shakenfist.network` | Network node preparation: removes the distro `dnsmasq` unit, installs the DHCP/DNS templates, enables IPv4 forwarding, and validates the mesh interface MTU. Apply only to hosts where `node_is_network_node` is true. |
 | `shakenfist.shakenfist.internal_ca` | Internal certificate authority: generates a CA on the control node, issues a per-host SPICE TLS certificate, and distributes the certificates to each host. |
+
+## Idempotence and restart-on-change
+
+Re-running the `node` role is safe to do routinely — for example from a daily
+`manage.yml`-style rotation that keeps every node on the tip of a branch. The
+role restarts a node's `sf-*` daemons **only when something they depend on
+actually changed**, so a redeploy on a day nothing moved leaves the running
+cluster completely undisturbed. A daemon is restarted when any of the following
+changed on its node:
+
+* **The installed Shaken Fist code.** The `bootstrap` entry point hashes the
+  *installed* `shakenfist` / `shakenfist_client` package files into a marker
+  (`/srv/shakenfist/.deployed-code.sha256`) after each install and restarts if
+  the hash moved. It deliberately hashes the installed files rather than the
+  wheel: the wheels are rebuilt from source every deploy and embed build
+  timestamps, so their bytes differ every run even when the source did not,
+  whereas identical source always installs byte-identical files. This detects a
+  real code change on a branch bump, on a same-version dirty rebuild (CI), and
+  on a first install (marker absent), while staying quiet on a genuine no-op.
+* **`/etc/sf/config`.** It is the daemons' shared systemd `EnvironmentFile`, so
+  a change to it restarts every daemon on the node. The config is re-rendered
+  every run and changes when a value moved or the node's role did (most
+  importantly joining or leaving the database tier).
+* **A systemd unit file.** A rewritten `sf-*.service`/`sf.target`, or removal of
+  an obsolete unit, restarts the affected daemons. `systemctl daemon-reload`
+  runs in the same play that writes the units, before any restart.
+
+The decision is per node and is logged during `register` as a
+`restart_needed=… (code=… config=… units=…)` line. Granularity is
+node-wide: because the code and config are shared by every daemon on the host,
+any change restarts all of that node's daemons rather than a subset. On a
+database-tier node the restart still honours the ordering the role guarantees —
+`sf-database` first, then a wait until its gRPC gateway (port 13005) is
+accepting connections, then the remaining daemons — so a rolling redeploy of a
+redundant database tier stays outage-free. Registration of the node and its
+daemons is idempotent and runs every time regardless, which is what heals a
+node whose database rows have drifted.
 
 ## Modules
 

--- a/shakenfist/deploy/collection/roles/node/tasks/bootstrap.yml
+++ b/shakenfist/deploy/collection/roles/node/tasks/bootstrap.yml
@@ -188,6 +188,55 @@
     VIRTUAL_ENV: /srv/shakenfist/venv
   changed_when: true
 
+# Restart-on-change (1 of 2): decide whether the installed Shaken Fist CODE
+# actually changed this run. The install above always reports changed (--reinstall
+# rewrites the venv unconditionally), and the wheels themselves are rebuilt from
+# source on every deploy -- python3 -m build embeds build timestamps, so the wheel
+# BYTES differ every morning even when the source did not. Neither is a faithful
+# "did the code change" signal. What IS faithful is the content of the INSTALLED
+# package files: identical source produces byte-identical installed .py files
+# regardless of how the wheel was packed. We hash those files into a marker; the
+# marker changing is the signal register.yml gates daemon restarts on. This fires
+# whenever the code that actually runs changed -- a develop bump that touched the
+# Python source, a CI dirty rebuild (same version string, changed source), or a
+# first install (marker absent) -- and stays quiet otherwise, so folding the
+# deploy into a daily rotation no longer bounces every daemon every morning.
+# Deliberately narrow in two ways. The .dist-info metadata directories are not
+# under these package paths, so a bump that changes only the version string (a
+# docs- or CI-only commit) leaves the hash untouched and correctly restarts
+# nothing. And a pure runtime-dependency bump with no SF source change is not
+# caught either -- acceptable, because uv does not upgrade already-satisfied
+# dependencies on --reinstall, so in practice a dependency only moves alongside a
+# source change this hash already sees. __pycache__ is excluded because .pyc
+# files carry their own embedded timestamps.
+- name: Compute the installed Shaken Fist code signature
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail;
+      find /srv/shakenfist/venv/lib/python3*/site-packages/shakenfist
+      /srv/shakenfist/venv/lib/python3*/site-packages/shakenfist_client
+      -type f -not -path '*__pycache__*' -print0
+      | sort -z | xargs -0 sha256sum | sha256sum | awk '{print $1}'
+    executable: /bin/bash
+  register: sf_code_signature
+  changed_when: false
+
+- name: Record the deployed code signature
+  ansible.builtin.copy:
+    dest: /srv/shakenfist/.deployed-code.sha256
+    content: "{{ sf_code_signature.stdout }}\n"
+    owner: root
+    group: root
+    mode: u=rw,go=r
+  register: sf_code_marker
+
+# Persist the decision as a host fact: register.yml runs in a SEPARATE, later
+# play (the example playbook rolls the database tier serial: 1), and registered
+# results do not survive a play boundary but set_fact host facts do.
+- name: Remember whether the installed code changed this run
+  ansible.builtin.set_fact:
+    sf_code_changed: "{{ sf_code_marker is changed }}"
+
 - name: Enable desired services
   ansible.builtin.service:
     name: "{{ item }}.service"

--- a/shakenfist/deploy/collection/roles/node/tasks/config.yml
+++ b/shakenfist/deploy/collection/roles/node/tasks/config.yml
@@ -66,6 +66,13 @@
 # the sudo group matches the global auth file above, letting the daemons read
 # it as root via systemd EnvironmentFile while administrators (and the CI test
 # scripts) read it as sudo-group users.
+# The config file and the systemd units below are each registered so that
+# register.yml can restart daemons ONLY when something they depend on actually
+# changed (restart-on-change, 2 of 2). The config is the daemons' shared systemd
+# EnvironmentFile, so a change to it requires restarting every daemon; a changed
+# unit requires restarting that daemon. The `notify: Reload systemd` handlers
+# still run at the end of THIS play, so systemd has already re-read any changed
+# unit before register.yml (a later play) restarts anything.
 - name: Write config file on remote host
   ansible.builtin.template:
     src: config
@@ -73,6 +80,7 @@
     owner: root
     group: sudo
     mode: u=r,g=r,o=
+  register: sf_config_result
   notify: Reload systemd
 
 - name: Remove obsolete systemd units
@@ -82,6 +90,7 @@
   with_items:
     - sf.service
     - sf-checksums.service
+  register: sf_obsolete_units_result
   notify: Reload systemd
 
 - name: Write systemd target unit on remote host
@@ -91,6 +100,7 @@
     owner: root
     group: root
     mode: ugo+r
+  register: sf_target_unit_result
   notify: Reload systemd
 
 - name: Write systemd units on remote host
@@ -112,6 +122,7 @@
     - resources
     - sidechannel
     - transfers
+  register: sf_service_units_result
   notify: Reload systemd
 
 - name: Write systemd unit for API daemon
@@ -121,6 +132,7 @@
     owner: root
     group: root
     mode: ugo+r
+  register: sf_api_unit_result
   notify: Reload systemd
 
 - name: Write systemd unit for database daemon
@@ -133,6 +145,7 @@
   vars:
     item: database
   when: node_is_database_node
+  register: sf_db_unit_result
   notify: Reload systemd
 
 # Symmetric teardown: when a node is NOT a database node, remove any database
@@ -181,3 +194,23 @@
   changed_when: set_default_result.rc == 1
   failed_when: set_default_result.rc == 2
   notify: Reload systemd
+
+# Restart-on-change (2 of 2): fold the config- and unit-file results into two
+# host facts that register.yml (a later play) reads to decide whether to restart
+# daemons. sf_config_changed forces a restart of every daemon, because the config
+# is their shared systemd EnvironmentFile; sf_units_changed forces it when any
+# unit file was rewritten or an obsolete one removed. Every result referenced
+# here is always defined -- the database unit task registers a skipped result on
+# non-database nodes rather than leaving the variable unset -- so no default
+# guards are needed. The database-teardown path (a node leaving the tier) does
+# not need to be captured here: that transition also rewrites /etc/sf/config, so
+# sf_config_changed already forces the restart.
+- name: Remember which configuration changes require a daemon restart
+  ansible.builtin.set_fact:
+    sf_config_changed: "{{ sf_config_result is changed }}"
+    sf_units_changed: >-
+      {{ (sf_obsolete_units_result is changed)
+         or (sf_target_unit_result is changed)
+         or (sf_service_units_result is changed)
+         or (sf_api_unit_result is changed)
+         or (sf_db_unit_result is changed) }}

--- a/shakenfist/deploy/collection/roles/node/tasks/register.yml
+++ b/shakenfist/deploy/collection/roles/node/tasks/register.yml
@@ -17,6 +17,34 @@
 #      it, because non-database hosts register over that gRPC gateway. The
 #      example playbook orders its plays so database hosts converge first.
 
+# Restart-on-change decision. sf_code_changed (bootstrap.yml) and
+# sf_config_changed / sf_units_changed (config.yml) are host facts set in the
+# earlier bootstrap+config play; here we OR them into a single gate. When nothing
+# a daemon depends on has changed, the service tasks below use state: started (a
+# no-op for an already-running daemon) rather than restarted, so an idempotent
+# redeploy -- for instance a daily manage.yml rotation on a morning develop did
+# not move -- leaves the running cluster completely undisturbed. Registration
+# (initialise-node, register-daemon) still runs every time: it is idempotent and
+# cheap, and it is what heals a node whose daemon rows drifted. Each fact
+# defaults to true so any unexpected gap in the earlier plays fails safe to the
+# old always-restart behaviour rather than silently skipping a needed restart;
+# on a first deploy the facts are genuinely true (config and units are freshly
+# written, code freshly installed), so the initial bring-up is a full start.
+- name: Decide whether SF daemons need a restart this run
+  ansible.builtin.set_fact:
+    sf_restart_needed: >-
+      {{ (sf_code_changed | default(true))
+         or (sf_config_changed | default(true))
+         or (sf_units_changed | default(true)) }}
+
+- name: Report the restart decision
+  ansible.builtin.debug:
+    msg: >-
+      restart_needed={{ sf_restart_needed }}
+      (code={{ sf_code_changed | default('?') }},
+      config={{ sf_config_changed | default('?') }},
+      units={{ sf_units_changed | default('?') }})
+
 # Initialise this node in the database.
 - name: Ensure the node exists in the database
   ansible.builtin.shell: |
@@ -45,18 +73,20 @@
   ansible.builtin.service:
     name: sf-database
     enabled: true
-    state: restarted
+    state: "{{ 'restarted' if sf_restart_needed else 'started' }}"
     daemon_reload: false
   when: node_is_database_node
 
-# Confirm this node's gRPC gateway is accepting connections again before we
-# return. When the example playbook rolls the database tier one node at a time
-# (site.yml play 6b, serial: 1), this gate is what keeps a gateway serving
-# throughout the roll: the next node's restart cannot begin until this one is
-# back up. sf-database binds the gateway to the mesh IP; a listening socket is
-# exactly the signal round_robin failover keys on (subchannel connectivity),
-# and systemd reports the unit started before the port is bound, so the service
-# restart above is not sufficient on its own.
+# Confirm this node's gRPC gateway is accepting connections before we return.
+# This runs whether or not the task above actually restarted sf-database: when
+# the example playbook rolls the database tier one node at a time (site.yml play
+# 6b, serial: 1), this gate is what keeps a gateway serving throughout the roll
+# -- the next node's restart cannot begin until this one is back up -- and on a
+# no-op redeploy it simply confirms the already-running gateway is healthy.
+# sf-database binds the gateway to the mesh IP; a listening socket is exactly the
+# signal round_robin failover keys on (subchannel connectivity), and systemd
+# reports the unit started before the port is bound, so a service restart is not
+# sufficient on its own.
 - name: Wait for this node's database gateway to accept connections
   ansible.builtin.wait_for:
     host: "{{ node_mesh_ip }}"
@@ -74,7 +104,7 @@
   ansible.builtin.service:
     name: "sf-{{ item }}"
     enabled: true
-    state: restarted
+    state: "{{ 'restarted' if sf_restart_needed else 'started' }}"
     daemon_reload: false
   with_items:
     - sentinel-first
@@ -84,11 +114,11 @@
 # TODO(mikal): this is a bit wrong. Some of these should only come up
 # on nodes which are either a network node, hypervisor, or storage
 # node...
-- name: Restart the other SF daemons
+- name: Start or restart the other SF daemons
   ansible.builtin.service:
     name: "sf-{{ item }}"
     enabled: true
-    state: restarted
+    state: "{{ 'restarted' if sf_restart_needed else 'started' }}"
     daemon_reload: false
   with_items:
     - net


### PR DESCRIPTION
The node role restarted every sf-* daemon on every run. That is fine for a greenfield CI bring-up, but it makes an idempotent redeploy -- for instance folding the deploy into a daily manage.yml rotation -- bounce the whole cluster every morning, even on days nothing changed. Make the role restart-on-change: restart a node's daemons only when the installed code, /etc/sf/config, or a systemd unit actually changed on that node.

Detecting a real code change is the crux. The install always reports changed (--reinstall rewrites the venv), and the wheels are rebuilt from source every deploy -- python3 -m build embeds timestamps, so the wheel bytes differ every run even when the source did not -- so neither is a faithful signal. Instead bootstrap.yml hashes the installed shakenfist/shakenfist_client package files into /srv/shakenfist/.deployed-code.sha256 after the install; identical source installs byte-identical files regardless of how the wheel was packed. The marker changing is sf_code_changed. This fires on a develop bump that touched the Python source, a CI dirty rebuild (same version string, changed source), and a first install, and stays quiet otherwise. It is deliberately narrow: the dist-info metadata is not under these paths, so a version-string-only bump (docs- or CI-only commit) restarts nothing, and __pycache__ is excluded.

config.yml registers the config- and unit-file tasks and folds them into sf_config_changed (the config is the daemons' shared systemd EnvironmentFile, so a change restarts every daemon) and sf_units_changed. register.yml ORs the three host facts into sf_restart_needed -- persisted via set_fact because register runs in a later, serial play where registered results would not survive -- and each service task becomes
state: {{ 'restarted' if sf_restart_needed else 'started' }}, a no-op for an already-running daemon. The database-first ordering and the wait-for-gateway health gate are unchanged, so a rolling redeploy of a redundant database tier stays outage-free. The decision is logged per node as restart_needed=... (code=... config=... units=...). Each fact defaults to true so any unexpected gap in the earlier plays fails safe to the old always-restart behaviour; on a first deploy the facts are genuinely true, so the initial bring-up is a full start.

The first deploy after this lands re-renders no config on an established cluster but writes the code marker for the first time, so it restarts every node's daemons once as a one-time catch-up; subsequent no-op deploys are quiet.

This is the last shakenfist-side prerequisite before sfcbr.yml can fold into the daily rotation (PLAN-sfcbr-rebuild phase 8). It lands entirely in the shakenfist.shakenfist collection, so every consumer benefits, not just sfcbr. Documented in the collection README (Idempotence and restart-on-change) and the operator upgrades guide.

Prompt: Implement restart-on-change in the collection's node role -- the last gate before enabling daily sfcbr deploys. Michael agreed to the design (gated conditional restarts keyed on code/config/unit change, code detected by hashing installed files rather than the non-reproducible wheel, preserving the database ordering and gateway gate) and asked that it land in the collection so others benefit and that docs/ cover how it works.


Assisted-By: Claude Code