### PR TITLE
Fix duplicate typing-extensions pin and its root cause.

### DIFF
--- a/.github/workflows/pin-indirect-dependencies.yml
+++ b/.github/workflows/pin-indirect-dependencies.yml
@@ -75,10 +75,18 @@ jobs:
           datestamp=$(date "+%Y%m%d")
           git checkout -b pin-dependencies-${datestamp}
 
+          # NOTE(mikal): compare dependency names in their PEP 503 canonical
+          # form so a dep already pinned with one spelling (e.g.
+          # "typing-extensions") is not re-added under pip freeze's canonical
+          # spelling ("typing_extensions"). Treating "-" and "_" as distinct
+          # here silently created duplicate pins that only diverged -- and
+          # broke resolution -- once Renovate bumped one spelling (see the
+          # duplicate PRs #3398/#3399 for typing-extensions).
           for depver in $(${GITHUB_WORKSPACE}/ci-venv/bin/pip freeze --local); do
             dep=$(echo ${depver} | sed 's/==.*//')
+            depre=$(echo ${dep} | sed -E 's/[-_.]+/[-_.]/g')
 
-            if [ $(egrep -ic "${dep}==" pyproject.toml) -lt 1 ]; then
+            if [ $(egrep -ic "\"${depre}==" pyproject.toml) -lt 1 ]; then
               sed -i "s/    # END_OF_INDIRECT_DEPS/    \"${depver}\",\n    # END_OF_INDIRECT_DEPS/" pyproject.toml
             fi
           done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ dependencies = [
     "sniffio==1.3.1",
     "solus==1.2.2",
     "typing-aliases==1.10.1",
-    "typing-extensions==4.15.0",
+    "typing-extensions==4.16.0",
     "verboselogs==1.7",
     "zipp==3.23.1",
     "zope.event==6.2",
@@ -148,11 +148,8 @@ dependencies = [
     "tzdata==2025.3",
     "wrapt==2.2.2",
     "gunicorn==25.3.0",
-    "prometheus_client==0.24.1",
     "psutil==7.2.2",
-    "pydantic_core==2.46.3",
     "typing-inspection==0.4.2",
-    "typing_extensions==4.15.0",
     "uv==0.11.28",
     # END_OF_INDIRECT_DEPS
 ]


### PR DESCRIPTION
pyproject.toml pinned typing-extensions twice -- once as "typing-extensions" (hyphen) and once as "typing_extensions" (underscore). This was dormant while both sat at 4.15.0, but when Renovate bumped one spelling to 4.16.0 the two diverged and uv, which canonicalises both to the same package, reported the requirements as unsatisfiable. Renovate also saw the two spellings as separate packages and opened duplicate PRs (#3398, #3399), neither of which could pass CI on its own.

The duplicates originated in the pin-indirect-dependencies workflow, whose "already pinned?" check compared pip freeze's canonical (underscore) names against pyproject.toml literally, so a dep pinned with a hyphen was re-added under its underscore spelling. The same trap had already produced duplicate pins for prometheus-client and pydantic-core.

Remove the three underscore duplicate pins, bump the surviving typing-extensions to 4.16.0, and normalise dependency names to their PEP 503 canonical form (collapsing "-", "_" and ".") in the workflow's dedup check so already-pinned deps are recognised regardless of spelling.

Prompt: Investigate why the repo had two open Renovate PRs (#3398/#3399) both bumping typing-extensions, de-duplicate them, and find and fix the root cause of the resulting CI failure. Mikal chose the full root-cause fix: consolidate the duplicate pins and fix the pin-indirect-dependencies workflow so the duplication cannot recur.


Assisted-By: Claude Opus 4.8 (200K context, medium effort) <noreply@anthropic.com>