### PR TITLE
Make daemon re-registration idempotent.

### DIFF
--- a/shakenfist/node.py
+++ b/shakenfist/node.py
@@ -371,9 +371,19 @@ class Node(dbo):
         with self.get_lock_attr('daemons', 'Register daemon'):
             self._invalidate_attributes()
             attrs = self._ensure_attributes()
-            if daemon not in attrs.daemons:
-                attrs.daemons.append(daemon)
-                self._save_attributes()
+            if daemon in attrs.daemons:
+                # Already registered: re-registering must be a true no-op. In
+                # particular it must NOT reset the daemon state. A deploy runs
+                # register-daemon on every pass, and with restart-on-change the
+                # daemon is not restarted when nothing changed -- so resetting a
+                # running daemon's state to STOPPED here would leave it stuck
+                # stopped (nothing re-asserts a running daemon's state without a
+                # restart) and wrongly report the whole node degraded.
+                return
+            attrs.daemons.append(daemon)
+            self._save_attributes()
+        # Only reached for a genuinely new registration: initialise the state to
+        # STOPPED (the daemon has not started yet) and record the event.
         self.set_daemon_state(daemon, self.DAEMON_STATE_STOPPED)
         self.add_event(EVENT_TYPE_AUDIT, f'{daemon} daemon registered')
 

--- a/shakenfist/tests/test_node.py
+++ b/shakenfist/tests/test_node.py
@@ -459,6 +459,46 @@ class NodeDaemonStateTestCase(base.ShakenFistTestCase):
         self.assertIn('api', attrs.daemons)
         mock_set_daemon_state.assert_called_once()
 
+    @mock.patch('shakenfist.node.mariadb.get_all_node_daemon_states',
+                return_value=[])
+    @mock.patch('shakenfist.node.mariadb.set_node_daemon_state',
+                return_value=True)
+    @mock.patch('shakenfist.node.mariadb.update_node_attributes')
+    @mock.patch('shakenfist.node.mariadb.create_node_attributes')
+    @mock.patch('shakenfist.node.mariadb.get_node_attributes')
+    @mock.patch('shakenfist.node.add_event')
+    @mock.patch('shakenfist.baseobject.DatabaseBackedObject.get_lock_attr')
+    @mock.patch('shakenfist.mariadb.set_state')
+    @mock.patch(
+        'shakenfist.mariadb.get_state',
+        return_value=State(
+            value='created', update_time=1234567890.0))
+    def test_register_daemon_already_registered_is_noop(
+            self, mock_get_state, mock_set_state,
+            mock_lock, mock_add_event, mock_get_attrs,
+            mock_create_attrs, mock_update_attrs,
+            mock_set_daemon_state, mock_get_all_states):
+        """Re-registering an existing daemon must not reset its state.
+
+        A deploy re-runs register-daemon every pass; with restart-on-change the
+        daemon is not restarted when nothing changed. Resetting a running
+        daemon's state to STOPPED here would leave it stuck stopped and the node
+        wrongly degraded, so re-registration must be a true no-op.
+        """
+        attrs = NodeAttributesData(uuid=TEST_UUID)
+        attrs.daemons.append('api')
+        mock_get_attrs.return_value = attrs
+        mock_lock.return_value = mock.MagicMock()
+        mock_update_attrs.return_value = True
+
+        n = self._make_node()
+        n.register_daemon('api')
+
+        # Still registered exactly once, and no state reset / event emitted.
+        self.assertEqual(['api'], attrs.daemons)
+        mock_set_daemon_state.assert_not_called()
+        mock_add_event.assert_not_called()
+
     def test_register_invalid_daemon(self):
         """Test registering invalid daemon raises."""
         n = self._make_node()


### PR DESCRIPTION
register_daemon() reset the daemon's state to STOPPED on every call, even for a daemon that was already registered and running -- the existing guard only protected appending to the daemon list, not the state write. A deploy runs sf-ctl register-daemon on every pass, so every daemon's state was reset to STOPPED each time.

The old deploy masked this because it also restarted every daemon, which made each one re-report running. With restart-on-change (#3415) a no-op deploy no longer restarts anything, so the reset stuck: the running sentinels re-report the worker daemons, but nothing re-asserts a sentinel's OWN state without a restart, leaving sentinel-first/sentinel-last (and the cluster daemon on the maintenance leader) stuck STOPPED and the whole node wrongly reported degraded -- with every process healthy and NRestarts=0.

Only initialise the state to STOPPED when the daemon is genuinely new; re-registering an already-registered daemon now returns early as a true no-op, touching neither its state nor emitting a duplicate registration event. A new daemon is still initialised to STOPPED, since it has not started yet. Add a regression test asserting re-registration does not reset state or emit an event.

Prompt: Onboarding two new hypervisors to the sfcbr cluster ran a no-op redeploy on the existing nodes (restart-on-change correctly did not bounce them), which left them degraded. Michael and I traced it to register_daemon() unconditionally resetting daemon state, asked for the root-cause fix (make re-registration idempotent) with a regression test, recognising this blocks folding sfcbr.yml into the daily rotation.


Assisted-By: Claude Code