### PR TITLE
eventlog: persist suppressed events again.

### DIFF
--- a/shakenfist/eventlog.py
+++ b/shakenfist/eventlog.py
@@ -42,9 +42,6 @@ def add_event_multi(
         suppress_event_logging: bool = False,
         log_as_error: bool = False
 ) -> None:
-    if suppress_event_logging:
-        return
-
     if not objects:
         return
 
@@ -86,11 +83,13 @@ def add_event_multi(
 
     # The 'Added event' diagnostic line is what flows to the log stream
     # (Loki). It is gated by LOG_EVENTS_TO_LOKI so an operator can mute
-    # the event echo without affecting the authoritative MariaDB write
-    # below. The 'fqdn' field is intentionally omitted here -- it would
-    # duplicate the host label on the log stream -- but is kept in the
-    # MariaDB payload below, which is the authoritative record.
-    if config.LOG_EVENTS_TO_LOKI:
+    # the event echo, and by suppress_event_logging so high-volume
+    # callers (billing statistics, object creation) can mute their own
+    # echo per-event. Neither gate affects the authoritative MariaDB
+    # write below. The 'fqdn' field is intentionally omitted here -- it
+    # would duplicate the host label on the log stream -- but is kept in
+    # the MariaDB payload below, which is the authoritative record.
+    if config.LOG_EVENTS_TO_LOKI and not suppress_event_logging:
         log = LOG.with_fields({
             'event_type': event_type,
             'duration': duration,

--- a/shakenfist/tests/test_eventlog.py
+++ b/shakenfist/tests/test_eventlog.py
@@ -124,6 +124,42 @@ class AddEventMultiSpoolPayloadTestCase(
         self.assertEqual('network', objects[1]['object_type'])
         self.assertEqual('net-uuid-5', objects[1]['object_uuid'])
 
+    def test_suppressed_event_still_reaches_spool(self):
+        """suppress_event_logging mutes the log echo, not the store.
+
+        Billing statistics (and other high-volume callers) add their
+        events with suppress_event_logging=True. The flag must only
+        skip the 'Added event' Loki echo; the event itself still has
+        to reach the spool, and from there the events table. A
+        regression here silently discards all instance usage data.
+        """
+        self.mock_config.LOG_EVENTS_TO_LOKI = True
+        with mock.patch.object(eventlog, 'LOG') as mock_log:
+            eventlog.add_event_multi(
+                'usage', [('instance', 'inst-uuid-6')], 'usage',
+                extra={'cpu usage': {'cpu time ns': 12345}},
+                suppress_event_logging=True)
+            mock_log.with_fields.assert_not_called()
+
+        payload = self._dequeue_one()
+        self.assertEqual('usage', payload['event_type'])
+        self.assertEqual(
+            'inst-uuid-6', payload['objects'][0]['object_uuid'])
+        self.assertEqual(
+            {'cpu usage': {'cpu time ns': 12345}},
+            json.loads(payload['extra']))
+
+    def test_unsuppressed_event_is_echoed_to_log(self):
+        """Without the flag the 'Added event' echo is emitted."""
+        self.mock_config.LOG_EVENTS_TO_LOKI = True
+        with mock.patch.object(eventlog, 'LOG') as mock_log:
+            eventlog.add_event_multi(
+                'audit', [('instance', 'inst-uuid-7')], 'echoed event')
+            mock_log.with_fields.assert_called()
+
+        payload = self._dequeue_one()
+        self.assertEqual('audit', payload['event_type'])
+
     def test_uuid_object_uuid_is_logged_as_str(self):
         """A uuid.UUID object uuid must be stringified before it is logged.
 


### PR DESCRIPTION
Commit bf1e7ba4c (events: delete DLQ table, suppress-grpc paths, legacy fallbacks) changed the semantics of the suppress_event_logging flag. It previously only muted the 'Added event' echo to the log stream while the event was still written to the event store; the rewrite turned it into an early return at the top of add_event_multi, silently discarding the event before the spool enqueue.

Every caller of the flag is a high-volume "quiet" event, and all of them have been dropped on the floor since then:

- instance billing statistics from node_inst_op (CPU, memory, disk and network usage events), which the private-ci conductor harvests at namespace teardown for its workflow cost tables. This is how the regression was noticed: every metric column has been NULL since the sfcbr cluster was deployed from post-bf1e7ba4c code.
- network NAT interface usage from the resources daemon.
- artifact storage usage events.
- 'object created' events from baseobject.

Restore the original semantics: the flag now combines with the LOG_EVENTS_TO_LOKI gate to mute only the log echo, and the spool write is unconditional again. Add regression tests asserting that a suppressed event still reaches the spool without being echoed, and that an unsuppressed event is echoed.

1468 unit tests pass; pre-commit fully green.

Prompt: Mikal reported that the private-ci conductor's workflow cost tables tracked runtime but never populated their CPU/RAM/disk/network columns. Diagnosis traced the NULLs through the conductor to the sfcbr cluster, which emits no instance usage events at all, and then to the suppress_event_logging early return introduced by the eventlog DLQ removal. Mikal asked for the fix to be made on a new branch of shakenfist/shakenfist and committed.


Assisted-By: Claude Fable 5 (200K context, low effort) <noreply@anthropic.com>