### PR TITLE
Point CodeQL workflow at develop, not master.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,10 +6,10 @@ permissions:
 
 on:
   push:
-    branches: [master, ]
+    branches: [develop]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [develop]
   schedule:
     - cron: '0 17 * * 2'
 


### PR DESCRIPTION
The codeql-analysis.yml workflow triggered on pushes and pull requests targeting master, but the default branch is develop, so the workflow silently never ran except on its weekly cron. Update both trigger branch lists to develop, matching the client-python copy of this workflow.

Fixes #3168

Prompt: Asked to fix shakenfist issue 3168, where the CodeQL workflow watches master although the repository's default branch is develop.


Assisted-By: Claude Code