### PR TITLE
Stop pinning pydantic-core as an indirect dependency.

### DIFF
--- a/.github/workflows/pin-indirect-dependencies.yml
+++ b/.github/workflows/pin-indirect-dependencies.yml
@@ -88,9 +88,28 @@ jobs:
           # duplicates into a single update and patches only one of them,
           # which leaves the two pins disagreeing and makes dependency
           # resolution unsatisfiable (see PR #3462 for gunicorn v26).
+          #
+          # NOTE(mikal): some packages have their exact version chosen by a
+          # parent's "==" pin (e.g. pydantic X.Y.Z depends on
+          # pydantic-core==A.B.C). Pinning such a package here as an indirect
+          # dependency lets Renovate bump it out from under its parent, which
+          # makes dependency resolution unsatisfiable (see PR #3469 for
+          # pydantic-core 2.47.0 against pydantic 2.13.4). Never pin these;
+          # the parent determines them. Names are compared in PEP 503
+          # canonical form (lowercase, dashes).
+          never_pin="pydantic-core"
+
           for depver in $(${GITHUB_WORKSPACE}/ci-venv/bin/pip freeze --local); do
             dep=$(echo ${depver} | sed 's/==.*//')
             depre=$(echo ${dep} | sed -E 's/[-_.]+/[-_.]/g')
+            depcanon=$(echo ${dep} | tr '[:upper:]' '[:lower:]' | sed -E 's/[-_.]+/-/g')
+
+            case " ${never_pin} " in
+              *" ${depcanon} "*)
+                echo "Skipping ${dep}: version is determined by a parent pin."
+                continue
+                ;;
+            esac
 
             if [ $(egrep -ic "\"${depre}(\[[a-z0-9,_.-]+\])?==" pyproject.toml) -lt 1 ]; then
               sed -i "s/    # END_OF_INDIRECT_DEPS/    \"${depver}\",\n    # END_OF_INDIRECT_DEPS/" pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,6 @@ dependencies = [
     "typing-inspection==0.4.2",
     "uv==0.11.29",
     "iso8601==2.1.0",
-    "pydantic_core==2.46.4",
     # END_OF_INDIRECT_DEPS
 ]
 


### PR DESCRIPTION
pydantic pins pydantic-core exactly (pydantic 2.13.4 depends on pydantic-core==2.46.4), so an explicit pin of pydantic-core in pyproject.toml can only ever agree with that pin or break resolution. The nightly pin-indirect-dependencies job added such a pin from pip freeze, and Renovate then bumped it to 2.47.0 (PR #3469), which made dependency resolution unsatisfiable because no pydantic release yet pairs with pydantic-core 2.47.0.

Remove the pydantic-core pin (its version is fully determined by the pydantic pin) and teach the pinning automation to never re-add it via a never_pin skip-list matched in PEP 503 canonical form. This is the same failure family as the typing-extensions (#3398/#3399) and gunicorn (#3462) duplicate-pin incidents.

Prompt: Fix the failed CI on the Renovate PRs. Two were infra-flaked "Can enqueue" jobs (re-run to green); the third, pydantic_core 2.47.0, was an unsatisfiable dependency bump. Apply the full root-cause fix: remove the stray pin and stop the automation from regenerating it, so the broken Renovate PR does not recur.


Assisted-By: Claude Opus 4.8 (200K context, medium effort) <noreply@anthropic.com>