### PR TITLE
Fix gRPC method-name parse crashing every database call.

### DIFF
--- a/shakenfist/mariadb.py
+++ b/shakenfist/mariadb.py
@@ -483,15 +483,23 @@ def _grpc_call(method: Any, request: Any) -> Any:
         grpc.StatusCode.UNAVAILABLE,
         grpc.StatusCode.DEADLINE_EXCEEDED,
     }
-    # grpcio's ``_UnaryUnaryMultiCallable`` (returned by ``stub.X``) uses
-    # ``__slots__`` and exposes no ``__name__``; the wire method name lives
-    # in ``self._method`` as bytes shaped like
-    # ``b'/shakenfist.protos.DatabaseService/GetNodeByFqdn'``. Take the part
-    # after the last ``/`` -- that matches the attribute name set on the
-    # stub in the generated ``_pb2_grpc`` module, so ``getattr(stub, name)``
-    # resolves cleanly on the retry path.
+    # grpcio's multicallable (returned by ``stub.X``) uses ``__slots__`` and
+    # exposes no ``__name__``; the wire method name lives in ``self._method``
+    # shaped like ``/shakenfist.protos.DatabaseService/GetNodeByFqdn``. Its
+    # type varies across grpcio releases and stub flavours: the older
+    # unregistered multicallable stored it as ``bytes``, while the current
+    # registered multicallable (our generated stubs pass
+    # ``_registered_method=True``) stores it as ``str``. Normalise to ``str``
+    # before splitting -- calling ``.decode()`` unconditionally raised
+    # ``AttributeError: 'str' object has no attribute 'decode'`` against
+    # current grpcio, breaking every gRPC database call. Take the part after
+    # the last ``/`` -- that matches the attribute name set on the stub in the
+    # generated ``_pb2_grpc`` module, so ``getattr(stub, name)`` resolves
+    # cleanly on the retry path.
     raw_method = getattr(method, '_method', b'') or b''
-    method_name = raw_method.decode().rsplit('/', 1)[-1] or None
+    if isinstance(raw_method, bytes):
+        raw_method = raw_method.decode()
+    method_name = raw_method.rsplit('/', 1)[-1] or None
 
     last_error: BaseException = grpc.RpcError()
     for attempt in range(GRPC_RETRIES):

--- a/shakenfist/tests/test_database_unavailable.py
+++ b/shakenfist/tests/test_database_unavailable.py
@@ -131,6 +131,44 @@ class GrpcCallRetryExhaustionTestCase(base.ShakenFistTestCase):
             mariadb.get_node_by_fqdn, 'sf-1')
 
 
+class GrpcCallMethodNameTestCase(base.ShakenFistTestCase):
+    # The wire method name is read from the private ``_method`` attribute of
+    # grpcio's multicallable so the retry path can re-resolve a fresh bound
+    # method by name. That attribute's type differs across grpcio releases and
+    # stub flavours -- older unregistered multicallables expose ``bytes``,
+    # current registered multicallables (our generated stubs use
+    # ``_registered_method=True``) expose ``str``. Both must work; assuming
+    # ``bytes`` and calling ``.decode()`` unconditionally crashed every gRPC
+    # database call with ``AttributeError`` against current grpcio.
+    @mock.patch('shakenfist.mariadb.time')
+    @mock.patch('shakenfist.mariadb._reset_database_stub')
+    @mock.patch('shakenfist.mariadb._get_database_stub')
+    def _assert_retry_reresolves(
+            self, wire_method, mock_stub, mock_reset, mock_time):
+        # First attempt fails DEADLINE_EXCEEDED (which rebuilds the channel),
+        # so the retry must re-resolve the method by name off a fresh stub --
+        # the code path that depends on parsing ``_method``.
+        failing = mock.MagicMock(
+            side_effect=FakeRpcError(grpc.StatusCode.DEADLINE_EXCEEDED))
+        failing._method = wire_method
+        succeeding = mock.MagicMock(return_value='ok')
+        mock_stub.return_value.GetNode = succeeding
+
+        self.assertEqual(
+            'ok', mariadb._grpc_call(failing, mock.MagicMock()))
+        # The retry resolved GetNode by name from the fresh stub and called it.
+        succeeding.assert_called_once()
+
+    def test_method_name_from_bytes(self):
+        self._assert_retry_reresolves(
+            b'/shakenfist.protos.DatabaseService/GetNode')
+
+    def test_method_name_from_str(self):
+        # The regression: current grpcio hands us a ``str`` here.
+        self._assert_retry_reresolves(
+            '/shakenfist.protos.DatabaseService/GetNode')
+
+
 class CheckDaemonStateTestCase(base.ShakenFistTestCase):
     NODE_UUID = '11111111-1111-1111-1111-111111111111'
 


### PR DESCRIPTION
_grpc_call read the wire method name from grpcio's private ``_method`` attribute and called ``.decode()`` on it unconditionally, assuming it was always ``bytes``. Current grpcio's registered multicallable -- which our generated stubs select via ``_registered_method=True`` -- exposes ``_method`` as a ``str`` instead, so every gRPC database call died with ``AttributeError: 'str' object has no attribute 'decode'``. This surfaced as the sfcbr deploy failing on sf-3/sf-4/sf-5 at "Ensure the node exists in the database" (sf-ctl initialise-node).

Normalise ``_method`` to ``str`` before splitting so both the older ``bytes`` and current ``str`` shapes work, and rewrite the comment that asserted it is always bytes.

The existing _grpc_call tests all hardcoded ``_method`` as bytes, which is exactly why CI never caught this. Add GrpcCallMethodNameTestCase covering both the ``bytes`` and ``str`` shapes, driving the retry path that actually parses ``_method``.

Prompt: While triaging an sfcbr deploy failure, we traced the fatal traceback (AttributeError on ``str``.decode in mariadb._grpc_call) to a grpcio version assumption, confirmed it was the only fragile grpc-internal access in the tree, and prepared a type-tolerant fix plus regression tests in a fresh worktree off develop.



Assisted-By: Claude Opus 4.8 (200K context, high effort) <noreply@anthropic.com>