### PR TITLE
Plan phase 5: next-tier DB reductions and load ratchet

### DIFF
--- a/docs/plans/PLAN-database-load-reduction-phase-05-next-tier.md
+++ b/docs/plans/PLAN-database-load-reduction-phase-05-next-tier.md
@@ -1,0 +1,104 @@
+# Phase 5 — next-tier reductions, diagnosed and ratcheted
+
+Master plan: [PLAN-database-load-reduction.md](PLAN-database-load-reduction.md)
+
+**Status: Planned.** Phase 4 attribution has now been deployed on `sfcbr`
+for several days, so the next-tier targets are diagnosed from real
+per-caller data rather than guessed. This phase splits into two threads:
+(a) the individual reductions, filed as GitHub issues so they can be fixed
+opportunistically and owned separately; and (b) a durable ratchet — teaching
+the nightly infra report to mine per-caller sf-database load so these signals
+are watched going forward and cannot silently regress.
+
+## What the attribution data actually said
+
+Measured on the Prometheus at `maui.home.stillhq.com:9099` against the
+`database_requests_total{operation, caller_daemon}` counter added in phase 4
+(#3473). Total steady-state sf-database load is **~174/s over 24h** (down from
+the ~527/s that started this whole effort — phases 1-2 removed ~two thirds).
+
+A 1h snapshot initially made `GetIPAM` look like the dominant cost (~48/s,
+~22% of that window). The 24h average corrected this: `GetIPAM` is
+workload-correlated and *bursts* under load but averages only ~14/s at rest.
+The real steady-state floor is **fixed-rate polling that runs even when the
+cluster is completely idle**:
+
+| Operation | 24h steady | Caller(s) | Nature |
+|-----------|-----------|-----------|--------|
+| Dequeue | 38.8/s | net 19.6, queues 19.2 | fixed-rate poll |
+| GetExistingLocks | 19.2/s | queues | lock-check paired with each dequeue |
+| GetBlobTransfersForNode | 19.5/s | transfers | fixed-rate poll |
+| **idle-poll subtotal** | **~78/s** | | **~45% of load, workload-independent** |
+| GetIPAM | 14.4/s (peaks ~48) | cluster | workload-correlated burst |
+| GetInstanceAttributes | 15.0/s | spread (cluster 4.2) | mutable |
+| GetReferencesFrom | 9.1/s | cluster 5.8, api 3.2 | mutable |
+
+The lesson — recorded here deliberately — is that the ratchet baseline must be
+taken from a 24h (or longer) window, never a single busy hour, or it both
+overstates bursty operations and would enshrine reducible idle-poll cost as
+the defended floor.
+
+## Thread A — the reductions (filed as issues)
+
+Each next-tier reduction is a separate change in a different daemon loop, so
+each is a standalone GitHub issue rather than a single monolithic phase:
+
+* **#3499 — queue-worker idle polling (~58/s, highest).** `Dequeue` +
+  `GetExistingLocks` fire as a lockstep pair on every fixed tick in the
+  `queues` daemon, and `net` polls `Dequeue` the same way. Fix: adaptive
+  backoff on empty dequeue, with a latency cap. Backing off the dequeue
+  collapses the paired lock check too.
+* **#3500 — transfers idle polling (~20/s).** `GetBlobTransfersForNode`
+  polls at a fixed rate even with no pending transfers. Fix: back off / wake
+  on enqueue.
+* **#3501 — cluster IPAM re-reads (~14/s steady, ~48/s burst).** IPAM is
+  mutable so it cannot use the phase 2 static cache; fix is loop
+  restructuring / event-driven invalidation in the cluster sweep.
+* **#3502 — cluster sweep attribute/reference re-reads (~10/s, lowest).**
+  Mutable reads re-hydrated per-check; fix is batching within the sweep.
+
+These are deliberately *not* bundled into this phase's PR. #3499 and #3500 are
+behaviour changes (backoff trades a little first-task latency for a large load
+reduction) and each deserves its own review. The correct order by
+value-per-risk is #3499, then #3500, then #3501, then #3502.
+
+## Thread B — the ratchet (this phase's actual deliverable)
+
+Fixing the four issues above is necessary but not sufficient: without a
+standing check, load creeps back as new loops are added. Phase 5's own work is
+to make per-caller sf-database load a mined, watched signal, consistent with
+the existing practice of moving hand-computation into the nightly report
+precompute.
+
+* **Where.** The nightly infra report precompute
+  (`tools/infra-report-precompute.py` in the private `33fl` ops repo, not this
+  repo). This phase's code change lands there; this plan documents the intent
+  and the honest baseline it must encode.
+* **What it computes.** Per `(operation, caller_daemon)` 24h-averaged QPS from
+  `database_requests_total`, plus the cluster total, straight from the same
+  Prometheus the numbers above came from.
+* **What it flags.** Any caller/operation that climbs materially above the
+  recorded baseline, and specifically any regression on the four operations
+  the issues target — so a fix that lands and then rots is caught, and a new
+  fixed-rate poll added elsewhere shows up as a new high-rate `(operation,
+  caller_daemon)` pair.
+* **Baseline honesty.** The ratchet records today's 24h numbers as the
+  starting baseline *and* the expected post-fix floors for #3499/#3500, so it
+  defends the improved target rather than the current wasteful number. Until a
+  fix lands, its operation sits at "known-reducible", not "healthy".
+
+## Success criteria
+
+1. The nightly report emits a per-caller sf-database load section with the 24h
+   baseline and flags regressions against it.
+2. The four reduction issues are filed with attributed numbers and a repro
+   query (done: #3499-#3502).
+3. When #3499/#3500 land, the report's flagged "known-reducible" items clear
+   and the defended floor drops accordingly — verifiable in the nightly output
+   rather than by ad-hoc PromQL.
+
+## Out of scope
+
+The individual daemon-loop fixes (#3499-#3502) — tracked separately. mTLS and
+OpenTelemetry span propagation, which reuse phase 4's caller-identity plumbing,
+remain their own plans.

--- a/docs/plans/PLAN-database-load-reduction.md
+++ b/docs/plans/PLAN-database-load-reduction.md
@@ -274,7 +274,7 @@ so the phase plans do not reopen them:
 | 2. Static object value caching | [PLAN-database-load-reduction-phase-02-static-cache.md](PLAN-database-load-reduction-phase-02-static-cache.md) | Complete |
 | 3. Consolidate the gRPC client stacks | PLAN-database-load-reduction-phase-03-client-consolidation.md | Complete |
 | 4. Caller attribution on counters | [PLAN-database-load-reduction-phase-04-attribution.md](PLAN-database-load-reduction-phase-04-attribution.md) | Complete |
-| 5. Next-tier reductions | PLAN-database-load-reduction-phase-05-next-tier.md | Not started |
+| 5. Next-tier reductions | [PLAN-database-load-reduction-phase-05-next-tier.md](PLAN-database-load-reduction-phase-05-next-tier.md) | Planned (issues #3499-#3502 filed; ratchet pending) |
 
 Phase summaries:
 
@@ -350,14 +350,26 @@ the peer SAN) rather than duplicate it. Detailed design,
 including the label-cardinality resolution of open question 4,
 is in the phase 4 plan file.
 
-**Phase 5 — next-tier reductions.** With per-caller data
-from phase 4, attack the remaining table: `dequeue` (38/s,
-likely adaptive backoff in the queues/transfers daemon
-loops), `get_ipam` (34/s), `get_existing_locks` (19/s),
-`get_blob_transfers_for_node` (19/s). This phase's plan is
-written after phase 4 has been deployed for long enough to
-have real attribution numbers; the reductions here are
-diagnosed, not guessed.
+**Phase 5 — next-tier reductions, diagnosed and ratcheted.**
+Phase 4 has now been deployed on `sfcbr` for several days,
+so the targets are diagnosed from 24h per-caller data. That
+data corrected the guess: total steady-state load is ~174/s
+(down from ~527/s), and the floor is dominated not by
+`GetIPAM` (which averages ~14/s but bursts to ~48/s under
+load) but by fixed-rate idle polling — `Dequeue` (38.8/s:
+net + queues), `GetExistingLocks` (19.2/s: queues) and
+`GetBlobTransfersForNode` (19.5/s: transfers), ~78/s of
+workload-independent cost. The phase splits in two: the
+individual reductions are filed as issues #3499 (queue-poll
+backoff, highest), #3500 (transfer-poll backoff), #3501
+(cluster IPAM re-reads) and #3502 (cluster sweep re-reads),
+to be fixed and reviewed separately; and phase 5's own
+deliverable is a ratchet — teaching the nightly infra report
+precompute (in the 33fl ops repo) to mine per-caller
+sf-database load, encode the honest 24h baseline, and flag
+regressions so the gains cannot silently rot. Detail,
+including the baseline-honesty argument, is in the phase 5
+plan file.
 
 ## Agent guidance
 


### PR DESCRIPTION
## What

Reframes phase 5 of the database load reduction plan now that phase 4
attribution (#3473) has been deployed on `sfcbr` for several days and we have
real per-caller data. Docs-only: adds the phase 5 plan file and updates the
master plan's status table and phase 5 summary.

## What the 24h data said

Total steady-state sf-database load is **~174/s** (down from the ~527/s that
started this effort). A 1h snapshot made `GetIPAM` look dominant (~48/s); the
24h average corrected that — `GetIPAM` bursts under load but averages ~14/s.
The real floor is **fixed-rate idle polling** that runs even when the cluster
is idle:

| Operation | 24h steady | Caller(s) |
|-----------|-----------|-----------|
| Dequeue | 38.8/s | net 19.6, queues 19.2 |
| GetExistingLocks | 19.2/s | queues |
| GetBlobTransfersForNode | 19.5/s | transfers |
| **idle-poll subtotal** | **~78/s (~45%)** | workload-independent |

## Two threads

**A — reductions, filed as issues** (fixed/reviewed separately):
- #3499 queue-worker idle polling (~58/s, highest)
- #3500 transfers idle polling (~20/s)
- #3501 cluster IPAM re-reads (~14/s steady, ~48/s burst)
- #3502 cluster sweep attribute/reference re-reads (~10/s)

**B — the ratchet (this phase's deliverable):** teach the nightly infra report
precompute (in the `33fl` ops repo) to mine per-caller sf-database load, encode
the honest 24h baseline, and flag regressions so the gains cannot silently rot.
The baseline must come from a 24h+ window, not a busy hour, or it would
enshrine reducible idle-poll cost as the defended floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhXZHkKSx52ZoRcd8u3FP2
