### PR TITLE
Back off idle blob-transfer polling (#3500)

### DIFF
--- a/shakenfist/daemons/daemon.py
+++ b/shakenfist/daemons/daemon.py
@@ -49,6 +49,19 @@ WATCHDOG_PET_INTERVAL = 10
 DAEMON_STATE_POLL_INTERVAL = 2
 
 
+# Adaptive backoff for the idle dequeue loops (the queues and net
+# dispatchers). Those loops slept a flat IDLE_POLL_FAST_SECONDS whenever a
+# dequeue came back empty, so a completely idle cluster still issued ~5
+# Dequeue calls per second per node. IdlePollBackoff grows the empty-poll
+# sleep geometrically towards IDLE_POLL_MAX_SECONDS and snaps back to the
+# fast interval the moment any work is found, so a burst is still drained at
+# full speed and only the idle->work transition pays the extra latency. See
+# PLAN-database-load-reduction-phase-05-next-tier.md and issue #3499.
+IDLE_POLL_FAST_SECONDS = 0.2
+IDLE_POLL_MAX_SECONDS = 2.0
+IDLE_POLL_BACKOFF_FACTOR = 2.0
+
+
 DAEMON_NAMES = {
     'api': 'sf-api',
     'checksums': 'sf-checksums',
@@ -218,6 +231,35 @@ def health_check_api():
     except requests.exceptions.RequestException as e:
         LOG.warning(f'api daemon is unhealthy ({e})!')
         return False
+
+
+class IdlePollBackoff:
+    """Adaptive sleep for idle dequeue loops.
+
+    Call reset() whenever a poll finds work (returns to fast polling) and
+    next_empty_interval() whenever a poll comes back empty (returns the sleep
+    to use this time and grows the next one, capped at the maximum). The first
+    empty poll still sleeps the fast interval, so a brief lull is cheap; only a
+    sustained idle period reaches the cap.
+    """
+
+    def __init__(self, fast=IDLE_POLL_FAST_SECONDS,
+                 maximum=IDLE_POLL_MAX_SECONDS,
+                 factor=IDLE_POLL_BACKOFF_FACTOR):
+        self._fast = fast
+        self._max = maximum
+        self._factor = factor
+        self._current = fast
+
+    def reset(self):
+        """A poll found work; return to the fast polling interval."""
+        self._current = self._fast
+
+    def next_empty_interval(self):
+        """A poll was empty; return this sleep and grow the next one."""
+        interval = self._current
+        self._current = min(self._current * self._factor, self._max)
+        return interval
 
 
 class Daemon:
@@ -407,7 +449,11 @@ class Daemon:
             self._last_watchdog = now
 
     def idle(self, seconds):
-        for _ in range(int(seconds / 0.2)):
+        # round(), not int(): the loop sleeps in 0.2s chunks, and truncating
+        # dropped fractional chunks (idle(0.8) slept 0.6s) -- harmless for the
+        # integer callers but wrong for the adaptive backoff intervals, which
+        # are fractional multiples of 0.2.
+        for _ in range(max(1, round(seconds / 0.2))):
             time.sleep(0.2)
             self.check_daemon_state()
             self.pet_watchdog()

--- a/shakenfist/daemons/network/workitem.py
+++ b/shakenfist/daemons/network/workitem.py
@@ -10,6 +10,7 @@ from shakenfist.constants import EVENT_TYPE_AUDIT
 from shakenfist.constants import EVENT_TYPE_USAGE
 from shakenfist.constants import get_object_class
 from shakenfist.daemons import daemon
+from shakenfist.daemons.daemon import IdlePollBackoff
 from shakenfist import mariadb
 from shakenfist.exceptions import DatabaseUnavailable
 from shakenfist.exceptions import InvalidStateException
@@ -201,6 +202,10 @@ class Job(util_concurrency.Job):
             # runtime). The first entry is highest priority -- the MariaDB
             # query honours that order via FIELD().
             util_concurrency.set_thread_name('net-dispatcher')
+            # Adaptive backoff so an idle dispatcher stops issuing ~5 empty
+            # Dequeue/s per node; snaps back to fast polling on any work. See
+            # issue #3499.
+            poll_backoff = IdlePollBackoff()
             while daemon.check_abort_path(self.abort_path):
                 try:
                     # One round trip claims up to BATCH_SIZE items in
@@ -216,9 +221,17 @@ class Job(util_concurrency.Job):
                             util_concurrency.set_thread_name('idle')
                             LOG.debug('This network thread is now idle')
                             was_previously_idle = True
-                        time.sleep(0.2)
+                        # Sleep the backoff interval in short chunks so
+                        # shutdown stays responsive even at the cap.
+                        remaining = poll_backoff.next_empty_interval()
+                        while (remaining > 0
+                               and daemon.check_abort_path(self.abort_path)):
+                            chunk = min(0.2, remaining)
+                            time.sleep(chunk)
+                            remaining -= chunk
                         continue
 
+                    poll_backoff.reset()
                     if was_previously_idle:
                         util_concurrency.set_thread_name('net-dispatcher')
                         was_previously_idle = False

--- a/shakenfist/daemons/queues/main.py
+++ b/shakenfist/daemons/queues/main.py
@@ -19,6 +19,12 @@ from shakenfist.util import exceptions as util_exceptions
 LOG, _ = logs.setup(__name__)
 
 
+# Seconds between stray-lock housekeeping scans. Locks left by a dead process
+# are a slow-changing condition, so this scan (a GetExistingLocks read) is
+# rate-limited rather than run on every poll of the queue loop. See issue #3499.
+STRAY_LOCK_CHECK_INTERVAL = 30
+
+
 def _check_other_daemon(n, daemon_name, override_daemon_name=None):
     health_checks = {
         'gunicorn': daemon.health_check_api,
@@ -116,6 +122,8 @@ class Monitor(daemon.WorkerPoolDaemon):
 
         warned_locks = {}
         last_third_party_health_check = 0
+        last_stray_lock_check = 0.0
+        poll_backoff = daemon.IdlePollBackoff()
 
         while daemon.check_abort_path(self.abort_path):
             try:
@@ -132,26 +140,37 @@ class Monitor(daemon.WorkerPoolDaemon):
                 #
                 # NOTE(mikal): this doesn't really make sense with threads, but
                 # given we want to get rid of locks anyways...
-                existing_locks = sf_locks.get_existing_locks()
-                for lock in existing_locks:
-                    lock_details = existing_locks[lock]
-                    if lock_details.get('node') != config.NODE_NAME:
-                        continue
+                #
+                # Rate-limited: stray locks are slow-changing housekeeping, so
+                # there is no need to re-read every lock on every poll (that was
+                # ~19 GetExistingLocks/s cluster-wide at idle). See issue #3499.
+                if time.time() - last_stray_lock_check > STRAY_LOCK_CHECK_INTERVAL:
+                    existing_locks = sf_locks.get_existing_locks()
+                    for lock in existing_locks:
+                        lock_details = existing_locks[lock]
+                        if lock_details.get('node') != config.NODE_NAME:
+                            continue
 
-                    pid = lock_details.get('pid')
-                    if psutil.pid_exists(pid):
-                        continue
-                    if pid not in warned_locks:
-                        LOG.with_fields(lock_details).warning(
-                            'Lock held by missing process on this node')
-                        warned_locks[pid] = time.time()
-                    elif time.time() - warned_locks[pid] > 30:
-                        LOG.with_fields(lock_details).error(
-                            'Lock held by missing process on this node for more '
-                            'than 30 seconds')
+                        pid = lock_details.get('pid')
+                        if psutil.pid_exists(pid):
+                            continue
+                        if pid not in warned_locks:
+                            LOG.with_fields(lock_details).warning(
+                                'Lock held by missing process on this node')
+                            warned_locks[pid] = time.time()
+                        elif time.time() - warned_locks[pid] > 30:
+                            LOG.with_fields(lock_details).error(
+                                'Lock held by missing process on this node for '
+                                'more than 30 seconds')
+                    last_stray_lock_check = time.time()
 
-                if not self.dequeue_job(workitem.Job):
-                    self.idle(0.2)
+                # Adaptive backoff: poll fast while there is work, back off
+                # towards IDLE_POLL_MAX_SECONDS while idle so an empty cluster
+                # stops issuing ~5 Dequeue/s per node. See issue #3499.
+                if self.dequeue_job(workitem.Job):
+                    poll_backoff.reset()
+                else:
+                    self.idle(poll_backoff.next_empty_interval())
 
             except exceptions.DatabaseUnavailable:
                 # Not an error to be ignored noisily: the database will

--- a/shakenfist/daemons/transfers/main.py
+++ b/shakenfist/daemons/transfers/main.py
@@ -102,9 +102,16 @@ class TransferJob(util_concurrency.Job):
 
 class Monitor(daemon.WorkerPoolDaemon):
     def _run_inner(self):
+        # Adaptive backoff: poll fast while there are transfers to run, back
+        # off towards IDLE_POLL_MAX_SECONDS while idle so a node with nothing
+        # to transfer stops issuing ~5 GetBlobTransfersForNode/s. See issue
+        # #3500.
+        poll_backoff = daemon.IdlePollBackoff()
+
         while daemon.check_abort_path(self.abort_path):
             self.wait_for_nodelock()
 
+            transfers = []
             try:
                 self.reap_workers()
 
@@ -126,7 +133,11 @@ class Monitor(daemon.WorkerPoolDaemon):
             except Exception as e:
                 util_exceptions.ignore_exception('transfer worker', e)
 
-            self.idle(0.2)
+            if transfers:
+                poll_backoff.reset()
+                self.idle(daemon.IDLE_POLL_FAST_SECONDS)
+            else:
+                self.idle(poll_backoff.next_empty_interval())
 
 
 def main():

--- a/shakenfist/tests/test_daemon_idle_poll_backoff.py
+++ b/shakenfist/tests/test_daemon_idle_poll_backoff.py
@@ -1,0 +1,61 @@
+# Copyright 2019 Michael Still and contributors
+
+from unittest import mock
+
+from shakenfist.daemons import daemon
+from shakenfist.tests import base
+
+
+class IdlePollBackoffTestCase(base.ShakenFistTestCase):
+    def test_starts_fast(self):
+        b = daemon.IdlePollBackoff(fast=0.2, maximum=2.0, factor=2.0)
+        # The first empty poll still sleeps the fast interval so a brief lull
+        # is cheap.
+        self.assertEqual(0.2, b.next_empty_interval())
+
+    def test_grows_geometrically_and_caps(self):
+        b = daemon.IdlePollBackoff(fast=0.2, maximum=2.0, factor=2.0)
+        self.assertEqual(
+            [0.2, 0.4, 0.8, 1.6, 2.0, 2.0],
+            [b.next_empty_interval() for _ in range(6)])
+
+    def test_reset_returns_to_fast(self):
+        b = daemon.IdlePollBackoff(fast=0.2, maximum=2.0, factor=2.0)
+        for _ in range(4):
+            b.next_empty_interval()
+        b.reset()
+        # After work is found the next empty poll is fast again.
+        self.assertEqual(0.2, b.next_empty_interval())
+
+    def test_defaults_match_module_constants(self):
+        b = daemon.IdlePollBackoff()
+        self.assertEqual(daemon.IDLE_POLL_FAST_SECONDS, b.next_empty_interval())
+
+
+class IdleRoundingTestCase(base.ShakenFistTestCase):
+    def _make_daemon(self):
+        d = daemon.Daemon.__new__(daemon.Daemon)
+        d._last_watchdog = 0.0
+        d.abort_path = '/run/sf/_test.abort'
+        return d
+
+    @mock.patch('shakenfist.daemons.daemon.os.path.exists', return_value=False)
+    @mock.patch('shakenfist.daemons.daemon.Daemon.pet_watchdog')
+    @mock.patch('shakenfist.daemons.daemon.Daemon.check_daemon_state')
+    @mock.patch('shakenfist.daemons.daemon.time.sleep')
+    def test_fractional_interval_rounds_to_nearest_chunk(
+            self, mock_sleep, _state, _watchdog, _exists):
+        d = self._make_daemon()
+        # 0.8s is four 0.2s chunks; int() truncation used to yield three.
+        d.idle(0.8)
+        self.assertEqual(4, mock_sleep.call_count)
+
+    @mock.patch('shakenfist.daemons.daemon.os.path.exists', return_value=False)
+    @mock.patch('shakenfist.daemons.daemon.Daemon.pet_watchdog')
+    @mock.patch('shakenfist.daemons.daemon.Daemon.check_daemon_state')
+    @mock.patch('shakenfist.daemons.daemon.time.sleep')
+    def test_fast_interval_sleeps_one_chunk(
+            self, mock_sleep, _state, _watchdog, _exists):
+        d = self._make_daemon()
+        d.idle(0.2)
+        self.assertEqual(1, mock_sleep.call_count)

--- a/shakenfist/tests/test_daemon_transfers_backoff.py
+++ b/shakenfist/tests/test_daemon_transfers_backoff.py
@@ -1,0 +1,58 @@
+# Copyright 2019 Michael Still and contributors
+
+from unittest import mock
+
+from shakenfist.daemons import daemon
+from shakenfist.daemons.transfers import main as transfers_main
+from shakenfist.tests import base
+
+
+class TransfersBackoffTestCase(base.ShakenFistTestCase):
+    def _make_monitor(self):
+        # Construct a Monitor without running __init__ (which touches
+        # setproctitle, logging and the filesystem). _run_inner only reads the
+        # attributes and instance methods stubbed below.
+        m = transfers_main.Monitor.__new__(transfers_main.Monitor)
+        m.abort_path = '/run/sf/_test.abort'
+        m.workers = {}
+        m.wait_for_nodelock = mock.MagicMock()
+        m.reap_workers = mock.MagicMock()
+        return m
+
+    def _run_n_iterations(self, m, transfers, iterations):
+        idle_calls = []
+        m.idle = mock.MagicMock(side_effect=lambda s: idle_calls.append(s))
+
+        polls = {'n': 0}
+
+        def fake_abort(path):
+            polls['n'] += 1
+            return polls['n'] <= iterations
+
+        with mock.patch.object(
+                daemon, 'check_abort_path', side_effect=fake_abort), \
+                mock.patch(
+                    'shakenfist.daemons.transfers.main.mariadb') as mock_mdb, \
+                mock.patch('shakenfist.daemons.transfers.main.config'):
+            mock_mdb.get_blob_transfers_for_node.return_value = transfers
+            m._run_inner()
+
+        return idle_calls
+
+    def test_backs_off_when_idle(self):
+        m = self._make_monitor()
+        # No transfers on every poll: the sleep grows geometrically to the cap.
+        idle_calls = self._run_n_iterations(m, [], 5)
+        self.assertEqual([0.2, 0.4, 0.8, 1.6, 2.0], idle_calls)
+
+    def test_stays_fast_while_work_present(self):
+        m = self._make_monitor()
+        # A transfer whose worker already exists, so no thread is spawned but
+        # the poll is non-empty: the loop keeps polling at the fast interval.
+        transfer = mock.MagicMock()
+        transfer.transfer_name = 't1'
+        m.workers = {'t1': {'object': None, 'thread': None}}
+
+        idle_calls = self._run_n_iterations(m, [transfer], 4)
+        self.assertEqual(
+            [daemon.IDLE_POLL_FAST_SECONDS] * 4, idle_calls)


### PR DESCRIPTION
Closes #3500.

**Stacked on #3506** (depends on `daemon.IdlePollBackoff` from that PR). Base is
`database-load-reduction-queue-backoff`; retarget to `develop` once #3506 merges.

## What

The sf-transfers monitor loop polled `get_blob_transfers_for_node` every `0.2s`
regardless of whether any transfers were pending, so a node with nothing to
transfer still issued ~5 `GetBlobTransfersForNode` calls/second. On `sfcbr` that
was **19.5/s cluster-wide over 24h — ~11% of steady-state sf-database traffic**,
entirely at idle.

## Change

Reuse `daemon.IdlePollBackoff` (added for the queue/net dispatchers in #3499):
poll fast while there are transfers to run, grow the empty-poll sleep
geometrically to the 2s cap while idle, and snap back to fast the moment a
transfer appears. A newly enqueued transfer on a fully idle node is picked up
within at most the cap.

## Expected effect

Idle `GetBlobTransfersForNode` load (~19.5/s) drops ~85–90% at rest, verifiable
via the phase 4 `database_requests_total` counter. New-transfer latency on a
fully idle node rises to ≤2s and resets to 0.2s while transfers are active.

## Testing

New `test_daemon_transfers_backoff.py` covers backing off across idle polls and
staying fast while work is present. Full `pre-commit run --all-files` green
(flake8, mypy, unit tests).

Second of the phase 5 next-tier reductions (see the plan in #3504).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhXZHkKSx52ZoRcd8u3FP2
