### PR TITLE
Cache the immutable IPAM static record (#3501)

### DIFF
--- a/shakenfist/mariadb.py
+++ b/shakenfist/mariadb.py
@@ -13589,9 +13589,20 @@ def get_ipam(ipam_uuid: UUID) -> Optional[IPAMData]:
     Returns:
         An IPAMData object, or None if not found.
     """
+    # The IPAM record read here is the immutable static block definition
+    # (uuid/namespace/network_uuid/ipblock/version); the mutable allocations
+    # live in the ipam_reservations table and are read by other functions. So
+    # this is a phase 2 immutable-tier cache candidate -- update_ipam (the
+    # version-upgrade persist path) and delete_ipam evict it. See issue #3501.
+    cached: Optional[IPAMData] = _object_cache_get('ipam', ipam_uuid)
+    if cached is not None:
+        return cached
     if _use_database_service():
-        return _grpc_get_ipam(ipam_uuid)
-    return _direct_get_ipam(ipam_uuid)
+        row = _grpc_get_ipam(ipam_uuid)
+    else:
+        row = _direct_get_ipam(ipam_uuid)
+    _object_cache_put('ipam', ipam_uuid, row, config.OBJECT_CACHE_TTL_IMMUTABLE)
+    return row
 
 
 def delete_ipam(ipam_uuid: UUID) -> bool:
@@ -13604,8 +13615,11 @@ def delete_ipam(ipam_uuid: UUID) -> bool:
         True if deleted, False if not found or error.
     """
     if _use_database_service():
-        return _grpc_delete_ipam(ipam_uuid)
-    return _direct_delete_ipam(ipam_uuid)
+        result = _grpc_delete_ipam(ipam_uuid)
+    else:
+        result = _direct_delete_ipam(ipam_uuid)
+    _object_cache_evict('ipam', ipam_uuid)
+    return result
 
 
 def update_ipam(data: IPAMData) -> bool:
@@ -13620,8 +13634,11 @@ def update_ipam(data: IPAMData) -> bool:
         True if updated, False if not found or error.
     """
     if _use_database_service():
-        return _grpc_update_ipam(data)
-    return _direct_update_ipam(data)
+        result = _grpc_update_ipam(data)
+    else:
+        result = _direct_update_ipam(data)
+    _object_cache_evict('ipam', data.uuid)
+    return result
 
 
 # =============================================================================

--- a/shakenfist/tests/test_object_cache.py
+++ b/shakenfist/tests/test_object_cache.py
@@ -120,6 +120,31 @@ class ObjectCacheWiringTestCase(base.ShakenFistTestCase):
         self.assertEqual(3, mock_get.call_count)
 
     @mock.patch('shakenfist.mariadb._use_database_service', return_value=False)
+    @mock.patch('shakenfist.mariadb._direct_get_ipam')
+    def test_ipam_reader_caches_then_writers_evict(self, mock_get, _mock_use):
+        # The static IPAM record is immutable (block definition), so get_ipam
+        # is cached; update_ipam (version-upgrade persist) and delete_ipam must
+        # evict. See issue #3501.
+        model = mock.Mock(uuid=self.uuid)
+        mock_get.return_value = model
+
+        self.assertIs(model, mariadb.get_ipam(self.uuid))
+        self.assertIs(model, mariadb.get_ipam(self.uuid))
+        self.assertEqual(1, mock_get.call_count)
+
+        with mock.patch('shakenfist.mariadb._direct_update_ipam',
+                        return_value=True):
+            mariadb.update_ipam(model)
+        mariadb.get_ipam(self.uuid)
+        self.assertEqual(2, mock_get.call_count)
+
+        with mock.patch('shakenfist.mariadb._direct_delete_ipam',
+                        return_value=True):
+            mariadb.delete_ipam(self.uuid)
+        mariadb.get_ipam(self.uuid)
+        self.assertEqual(3, mock_get.call_count)
+
+    @mock.patch('shakenfist.mariadb._use_database_service', return_value=False)
     @mock.patch('shakenfist.mariadb._direct_get_blob', return_value=None)
     def test_missing_row_is_not_cached(self, mock_get, _mock_use):
         # A None result must not be cached, or a later create would be masked.


### PR DESCRIPTION
Closes #3501.

## The premise changed on investigation

The issue (and the phase 5 plan) assumed IPAM is mutable and would need
cluster-daemon **loop restructuring**. It turns out the record `get_ipam`
returns is only the **immutable static block definition**
(`uuid`/`namespace`/`network_uuid`/`ipblock`/`version`). The *mutable*
allocations live in the separate `ipam_reservations` table and are read by
different functions. `update_ipam`'s own docstring says it exists only "to
persist version upgrades," and it has no application callers.

So this is the **phase 2 immutable-tier cache pattern**, not loop surgery.

## Change

- `get_ipam` now reads through the existing object cache at
  `OBJECT_CACHE_TTL_IMMUTABLE` (same wiring as `get_network` /
  `get_networkinterface`).
- `update_ipam` (the version-upgrade persist path) and `delete_ipam` evict, so
  the cache self-heals on upgrade and never resurrects a deleted record.
- `None` is never cached, so a later create isn't masked (existing cache
  invariant).

## Why this is better than the planned approach

It removes the redundant reads for **every** `get_ipam` caller cluster-wide (via
`ipam.py`), not just the cluster daemon, and reuses proven, already-reviewed
cache machinery instead of restructuring a hot control-plane loop.

## Expected effect

Steady-state `GetIPAM` (~14/s, cluster) and its ~48/s activity bursts should
drop toward zero at rest, verifiable via the phase 4 `database_requests_total`
counter.

## Testing

New wiring test in `test_object_cache.py` (read caches; update and delete
evict). Full `pre-commit run --all-files` green (flake8, mypy, unit tests).

Third of the phase 5 next-tier reductions (see the plan in #3504).

Note: the phase 5 plan text in #3504 still describes #3501 as "loop
restructuring" — that one line should be corrected to "immutable-tier cache";
happy to update it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhXZHkKSx52ZoRcd8u3FP2
