### PR TITLE
Purge expired nonced keys on namespace key writes.

### DIFF
--- a/shakenfist/namespace.py
+++ b/shakenfist/namespace.py
@@ -25,6 +25,18 @@ from shakenfist.util import callstack as util_callstack
 LOG, _ = logs.setup(__name__)
 
 
+def _prune_expired_keys(nonced_keys):
+    # Expired keys must be dropped whenever the keys attribute is
+    # written, not just filtered on read: get_api_token() mints a
+    # short-lived _service_key_* every few minutes per daemon, and
+    # without pruning the stored blob grows without bound until it
+    # crosses gRPC's maximum message size and namespace reads start
+    # failing cluster-wide (issue #3521).
+    now = time.time()
+    return {k: v for k, v in nonced_keys.items()
+            if 'expiry' not in v or v['expiry'] >= now}
+
+
 class Namespace(dbo):
     object_type = ObjectType.NAMESPACE
     initial_version = 6
@@ -176,13 +188,7 @@ class Namespace(dbo):
         if not attrs:
             return {'nonced_keys': {}}
 
-        nonced_keys = dict(attrs.keys.get('nonced_keys', {}))
-        for k in list(nonced_keys.keys()):
-            if 'expiry' in nonced_keys[k]:
-                if time.time() > nonced_keys[k]['expiry']:
-                    del nonced_keys[k]
-
-        return {'nonced_keys': nonced_keys}
+        return {'nonced_keys': _prune_expired_keys(attrs.keys.get('nonced_keys', {}))}
 
     def add_key(self, name, value, expiry=None):
         encoded = str(base64.b64encode(bcrypt.hashpw(value.encode('utf-8'), bcrypt.gensalt())), 'utf-8')
@@ -192,7 +198,7 @@ class Namespace(dbo):
             self._invalidate_attributes()
             attrs = self._ensure_attributes()
             k = dict(attrs.keys)
-            nk = dict(k.get('nonced_keys', {}))
+            nk = _prune_expired_keys(k.get('nonced_keys', {}))
             nk[name] = {'key': encoded, 'nonce': nonce}
             if expiry:
                 nk[name]['expiry'] = expiry
@@ -207,9 +213,9 @@ class Namespace(dbo):
             self._invalidate_attributes()
             attrs = self._ensure_attributes()
             k = dict(attrs.keys)
-            nk = dict(k.get('nonced_keys', {}))
-            if name in nk:
-                del nk[name]
+            nk = _prune_expired_keys(k.get('nonced_keys', {}))
+            if name in nk or len(nk) != len(k.get('nonced_keys', {})):
+                nk.pop(name, None)
                 k['nonced_keys'] = nk
                 attrs.keys = k
                 self._save_attributes(fields=['keys'])

--- a/shakenfist/tests/test_namespace_key_pruning.py
+++ b/shakenfist/tests/test_namespace_key_pruning.py
@@ -1,0 +1,64 @@
+import time
+
+from shakenfist.namespace import Namespace
+from shakenfist.tests import base
+from shakenfist.tests.mock_mariadb import MockMariaDB
+
+
+class NamespaceKeyPruningTestCase(base.ShakenFistTestCase):
+    """Expired nonced keys must be pruned from storage on write.
+
+    get_api_token() mints a short-lived _service_key_* every few
+    minutes per daemon. Filtering expired keys only on read lets the
+    stored blob grow without bound until it crosses gRPC's maximum
+    message size and namespace reads fail cluster-wide (issue #3521).
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.mock_mariadb = MockMariaDB(self, node_count=1)
+        self.mock_mariadb.setup()
+
+    def _stored_keys(self, namespace):
+        return self.mock_mariadb.namespace_attributes[namespace].keys['nonced_keys']
+
+    def test_add_key_prunes_expired_keys(self):
+        ns = Namespace.new('banana')
+        ns.add_key('permanent', 'cheese')
+        ns.add_key('_service_key_aaaaa', 'stale', expiry=time.time() - 10)
+
+        # The expired key survives its own write...
+        self.assertEqual(
+            {'permanent', '_service_key_aaaaa'},
+            set(self._stored_keys('banana')))
+
+        # ... but the next write must purge it from storage, not just
+        # filter it from the read.
+        ns.add_key('_service_key_bbbbb', 'fresh', expiry=time.time() + 300)
+        self.assertEqual(
+            {'permanent', '_service_key_bbbbb'},
+            set(self._stored_keys('banana')))
+
+    def test_remove_key_prunes_expired_keys(self):
+        ns = Namespace.new('banana')
+        ns.add_key('permanent', 'cheese')
+        ns.add_key('doomed', 'bacon')
+        ns.add_key('_service_key_aaaaa', 'stale', expiry=time.time() - 10)
+
+        ns.remove_key('doomed')
+        self.assertEqual({'permanent'}, set(self._stored_keys('banana')))
+
+    def test_remove_key_prunes_even_when_name_absent(self):
+        ns = Namespace.new('banana')
+        ns.add_key('permanent', 'cheese')
+        ns.add_key('_service_key_aaaaa', 'stale', expiry=time.time() - 10)
+
+        ns.remove_key('no-such-key')
+        self.assertEqual({'permanent'}, set(self._stored_keys('banana')))
+
+    def test_keys_property_filters_expired_keys(self):
+        ns = Namespace.new('banana')
+        ns.add_key('permanent', 'cheese')
+        ns.add_key('_service_key_aaaaa', 'stale', expiry=time.time() - 10)
+
+        self.assertEqual({'permanent'}, set(ns.keys['nonced_keys']))


### PR DESCRIPTION
get_api_token() mints a short-lived _service_key_* roughly every five minutes per daemon, but expired keys were only ever filtered on read — the stored nonced_keys blob grew without bound. On the sfcbr cluster the system namespace accumulated 24,263 expired service keys (~4.21MB), crossing gRPC's default 4MiB maximum message size. From that point GetNamespaceAttributes failed RESOURCE_EXHAUSTED on every node using the sf-database gRPC gateway, which broke API authentication on those nodes and stopped the private CI conductor from starting workers.

Prune expired entries whenever the keys attribute is written (add_key and remove_key, inside the existing attribute lock), so the blob is self-limiting: every namespace that services mint tokens against is rewritten within minutes of the fix deploying, which also heals already-bloated rows without a separate migration. The keys property now shares the same pruning helper.

Fixes #3521

Prompt: While investigating why the conductor had stopped starting CI workers, we root-caused the 401s to the system namespace keys blob crossing the 4MiB gRPC message cap. Mikal asked me to purge the expired keys on the live cluster, then land a fix in shakenfist/shakenfist on a new worktree and branch, with the commit message referencing the bug so it autocloses on merge.


Assisted-By: Claude Code