### PR TITLE
Deflake heartbeat test: join leaked probe thread.

### DIFF
--- a/shakenfist/tests/test_resource_health.py
+++ b/shakenfist/tests/test_resource_health.py
@@ -164,7 +164,12 @@ class PathCheckTestCase(base.ShakenFistTestCase):
             opened = []
 
             def counting_open(path, *a, **kw):
-                if path.endswith(resource_health.HEARTBEAT_FILENAME):
+                # Only count heartbeat opens under this test's own tempdir:
+                # os.open is patched process-wide, and a probe thread leaked
+                # by another test in this worker could otherwise open its own
+                # heartbeat inside our patch window and inflate the count.
+                if (isinstance(path, str) and path.startswith(d) and
+                        path.endswith(resource_health.HEARTBEAT_FILENAME)):
                     opened.append(path)
                 return real_open(path, *a, **kw)
 
@@ -197,3 +202,10 @@ class PathCheckTestCase(base.ShakenFistTestCase):
             self.assertEqual(
                 resource_health.HealthStatus.TIMEOUT, result.status)
         release.set()
+        # Join the probe's daemon thread before finishing. Once released it
+        # resumes _probe_once with do_write=True and opens its heartbeat
+        # file; unjoined, that open races into whichever test runs next in
+        # this worker (seen as test_write_interval_gates_the_heartbeat
+        # counting a stray os.open under its process-wide patch).
+        check._probe._thread.join(5)
+        self.assertFalse(check._probe._thread.is_alive())


### PR DESCRIPTION
test_write_interval_gates_the_heartbeat kept failing in CI (1 != 2) even after the stateful-clock deflake in 8f0b6386d. This is a second, distinct mechanism: cross-test pollution from a leaked daemon thread.

test_timeout_when_probe_hangs blocks its probe in a mocked os.statvfs, asserts TIMEOUT, then calls release.set() without joining the probe thread. The released thread resumes _probe_once with do_write=True and opens '/does/not/matter/_heartbeat'. stestr runs that test immediately before the write-interval test in the same worker, and the latter patches os.open process-wide with a counter matching any path ending in the heartbeat filename -- so on a loaded runner the stray open lands inside the patch window and inflates the count to 2.

Fix both ends: join the probe thread before the timeout test returns, and scope the write-interval test's os.open counter to its own tempdir so no unrelated thread can ever inflate it.

Prompt: Mikal reported test_write_interval_gates_the_heartbeat failing repeatedly in CI (e.g. PR #3529) and asked whether it was a new flake; after root-causing it to the leaked probe thread from the neighbouring timeout test, he asked for the fix as a standalone deflake commit.