### PR TITLE
Treat nodelock connection refusal as unhealthy.

### DIFF
--- a/shakenfist/daemons/daemon.py
+++ b/shakenfist/daemons/daemon.py
@@ -22,6 +22,7 @@ from shakenfist.constants import OBJECT_NAMES_TO_CLASSES
 from shakenfist import mariadb
 from shakenfist.exceptions import DatabaseUnavailable
 from shakenfist.exceptions import InvalidStateException
+from shakenfist.exceptions import MissingNodeLockSocket
 from shakenfist.exceptions import ProcessExecutionError
 from shakenfist.node import Node
 from shakenfist.operations.baseoperation import get_all_user_facing_node_queues
@@ -210,6 +211,13 @@ def health_check_nodelock():
             ...
     except ConnectionResetError:
         LOG.warning('nodelock daemon is unhealthy (connection reset)!')
+        return False
+    except (ConnectionRefusedError, MissingNodeLockSocket):
+        # nodelock only unlinks its socket at startup, so while it is
+        # restarting (for example during a deploy) the stale socket file
+        # from the previous incarnation remains on disk and connections
+        # are refused rather than failing with a missing socket.
+        LOG.warning('nodelock daemon is unhealthy (not listening)!')
         return False
 
     return True

--- a/shakenfist/daemons/sidechannel/main.py
+++ b/shakenfist/daemons/sidechannel/main.py
@@ -1204,6 +1204,7 @@ class Monitor(daemon.Daemon):
 
             except Exception as e:
                 util_exceptions.ignore_exception('side channel monitor', e)
+                time.sleep(1)
 
         LOG.info('Stopping')
         send_systemd_stopping()

--- a/shakenfist/tests/test_daemon_nodelock_health.py
+++ b/shakenfist/tests/test_daemon_nodelock_health.py
@@ -1,0 +1,34 @@
+# Copyright 2026 Michael Still and contributors
+
+from unittest import mock
+
+from shakenfist.daemons import daemon
+from shakenfist.exceptions import MissingNodeLockSocket
+from shakenfist.tests import base
+
+
+class HealthCheckNodelockTestCase(base.ShakenFistTestCase):
+    # health_check_nodelock() must report "unhealthy" rather than raise for
+    # the connection failures seen while the nodelock daemon restarts. In
+    # particular a stale socket file (nodelock only unlinks its socket at
+    # startup) surfaces as ConnectionRefusedError; letting that escape
+    # bypasses wait_for_nodelock()'s calm 1Hz retry loop and callers like
+    # the sidechannel monitor busy-spin logging tracebacks instead.
+
+    def _check_with_lock_error(self, exc):
+        with mock.patch.object(
+                daemon.util_concurrency, 'NodeLock', side_effect=exc):
+            return daemon.health_check_nodelock()
+
+    def test_healthy(self):
+        with mock.patch.object(daemon.util_concurrency, 'NodeLock'):
+            self.assertTrue(daemon.health_check_nodelock())
+
+    def test_connection_reset_is_unhealthy(self):
+        self.assertFalse(self._check_with_lock_error(ConnectionResetError()))
+
+    def test_connection_refused_is_unhealthy(self):
+        self.assertFalse(self._check_with_lock_error(ConnectionRefusedError()))
+
+    def test_missing_socket_is_unhealthy(self):
+        self.assertFalse(self._check_with_lock_error(MissingNodeLockSocket()))


### PR DESCRIPTION
During a deploy the nodelock daemon restarts, and because it only unlinks its Unix socket at startup, the stale socket file from the previous incarnation remains on disk while it is down. Clients then see ConnectionRefusedError from connect() rather than a missing socket file. health_check_nodelock() only caught
ConnectionResetError, so the refusal escaped wait_for_nodelock()'s calm 1Hz retry loop and landed in the sidechannel monitor's catch-all exception handler, which had no sleep. The result was a busy-loop emitting ~500 ERROR tracebacks per second on every hypervisor during every deploy (observed as 1,500-3,400 ConnectionRefusedError tracebacks per day on the sfcbr cluster).

Catch ConnectionRefusedError and MissingNodeLockSocket in health_check_nodelock(), and add a one second sleep to the sidechannel monitor's exception path as defence in depth against any future exception storm.

Prompt: Investigate the climbing ConnectionRefusedError traceback count reported by the sfcbr error reporter (previously misattributed to sf-6's absence), find the root cause in the sidechannel monitor, and fix it in a shakenfist worktree.

Assisted-By: Claude Code