### PR TITLE
Raise the nodelock listen() backlog.

### DIFF
--- a/shakenfist/daemons/nodelock/main.py
+++ b/shakenfist/daemons/nodelock/main.py
@@ -58,7 +58,13 @@ def main():
 
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     s.bind(SOCKET_PATH)
-    s.listen(1)
+    # Every daemon on the node health checks this socket about once a
+    # second, as well as making real locking requests, and they arrive
+    # in a herd after a deploy restarts everything. Connections are
+    # serviced one at a time, so a full backlog on a Unix socket means
+    # connect() fails immediately with ECONNREFUSED instead of queueing.
+    # A deep backlog converts those refusals into short waits.
+    s.listen(128)
     s.settimeout(0.2)
     LOG.info('Listening for incoming requests')
     send_systemd_ready()


### PR DESCRIPTION
The nodelock daemon services connections one at a time from a single thread, but listened with a backlog of one. On a Unix socket a full backlog means connect() fails immediately with ECONNREFUSED rather than queueing. Every daemon on the node health checks this socket about once a second in addition to making real locking requests, and they arrive in a herd after a deploy restarts everything, so concurrent connection attempts are routine. Requests are serviced in well under a millisecond, so a deeper backlog converts those refusals into short waits.

Prompt: While diagnosing the deploy-time ConnectionRefusedError traceback storm on the sfcbr cluster, the listen(1) backlog was identified as a remaining fragility against the post-deploy reconnect herd; harden it as a separate PR from the health check and sidechannel backoff fixes.

Assisted-By: Claude Code