### PR TITLE
Add PUSH-AUDIT.md; make README links absolute.

### DIFF
--- a/PUSH-AUDIT.md
+++ b/PUSH-AUDIT.md
@@ -243,8 +243,24 @@ Report findings as a bullet list grouped by file.
 Check that documentation matches the current code state.
 Read the diff (`git diff develop...HEAD`) and verify:
 
-- `README.md` reflects any new features, changed usage, or
-  updated project structure.
+<!-- shared-block: readme-discipline v1 -->
+README discipline (shared block; do not edit -- the canonical
+copy lives in shakenfist/development at
+`templates/shared-blocks/readme-discipline.md`):
+
+- New user-visible features are documented in `docs/` (and
+  `ARCHITECTURE.md` / `AGENTS.md` where appropriate), not by
+  adding bullets to `README.md`.
+- `README.md` is a pitch: what the project is, who it is for,
+  minimal installation instructions, a small number of usage
+  examples, and curated absolute links into `docs/`. It only
+  changes when the pitch, the install story, or the
+  documentation links change.
+- README growth is itself a finding: if the diff adds README
+  content that belongs in `docs/`, flag it as blocking and
+  move it.
+<!-- shared-block-end -->
+
 - `ARCHITECTURE.md` reflects any new or modified modules,
   daemons, object types, or gRPC services.
 - `AGENTS.md` reflects any new dependencies, build

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
 ## Deployment
 
 Shaken Fist is deployed with the `shakenfist.shakenfist` Ansible collection
-(which lives in [`shakenfist/deploy/collection/`](shakenfist/deploy/collection/)
+(which lives in [`shakenfist/deploy/collection/`](https://github.com/shakenfist/shakenfist/tree/develop/shakenfist/deploy/collection)
 in this repository and is published to Ansible Galaxy). You write an inventory
 describing your machines, set a handful of variables, and run a playbook.
-Ready-to-use examples ship in [`examples/`](examples/) —
+Ready-to-use examples ship in [`examples/`](https://github.com/shakenfist/shakenfist/tree/develop/examples) —
 `examples/single-node/` is the recommended quickstart. See
-[`docs/operator_guide/installation.md`](docs/operator_guide/installation.md)
+[`docs/operator_guide/installation.md`](https://github.com/shakenfist/shakenfist/blob/develop/docs/operator_guide/installation.md)
 for the full walkthrough.
 
 ## Prerequisites
@@ -23,18 +23,18 @@ for the full walkthrough.
 Shaken Fist requires an operator-provided MariaDB 10.6.0+ server. Before
 deploying, provision a MariaDB instance and apply the bootstrap snippet
 (`tools/bootstrap-mariadb.sql`). See
-[`docs/operator_guide/database.md`](docs/operator_guide/database.md) for the
+[`docs/operator_guide/database.md`](https://github.com/shakenfist/shakenfist/blob/develop/docs/operator_guide/database.md) for the
 complete setup workflow.
 
 Shaken Fist emits structured JSON logs and can ship them to an
 operator-provided [Loki](https://grafana.com/oss/loki/), or log locally to the
 systemd journal if you prefer your own log agent. See
-[`docs/operator_guide/logging.md`](docs/operator_guide/logging.md).
+[`docs/operator_guide/logging.md`](https://github.com/shakenfist/shakenfist/blob/develop/docs/operator_guide/logging.md).
 
 Shaken Fist monitors the storage each node depends on and takes a node with
 failed storage (a dead disk or a hung NFS mount) out of scheduling
 automatically. See
-[`docs/operator_guide/node_health.md`](docs/operator_guide/node_health.md).
+[`docs/operator_guide/node_health.md`](https://github.com/shakenfist/shakenfist/blob/develop/docs/operator_guide/node_health.md).
 
 ## Claude Code Skills
 

--- a/docs/plans/PLAN-sql-pushdown-filtering-phase-06-tests-docs.md
+++ b/docs/plans/PLAN-sql-pushdown-filtering-phase-06-tests-docs.md
@@ -14,7 +14,7 @@ land the guardrail.
 Before responding to questions or discussion points in
 this document, read the four earlier phase plans to
 understand what has been delivered (phases 1 through 5,
-all complete), the existing shape of `PUSH-TEMPLATE.md`
+all complete), the existing shape of `PUSH-AUDIT.md`
 and `docs/operator_guide/database.md` and
 `ARCHITECTURE.md`, the test file
 `shakenfist/tests/test_mariadb_find.py` that covers the
@@ -36,7 +36,7 @@ Close out the SQL-pushdown work:
    `docs/operator_guide/database.md` and
    `ARCHITECTURE.md` so a future contributor knows when
    to use `find_*` vs `.filter()` vs the iterator.
-3. Land the `PUSH-TEMPLATE.md` guardrail — a wave-1
+3. Land the `PUSH-AUDIT.md` guardrail — a wave-1
    mechanical grep that catches new `mariadb.get_all_*(`
    additions outside the established call sites, and a
    wave-2a brief bullet that promotes SQL-pushdown
@@ -130,7 +130,7 @@ Target: ~20-40 lines of prose.
 
 No new diagrams.
 
-### 6c — PUSH-TEMPLATE.md guardrail
+### 6c — PUSH-AUDIT.md guardrail
 
 The template's wave-1 style-check block at lines 46-48
 today runs three greps (line length, stray `print()`,
@@ -184,7 +184,7 @@ explanation.
 |------|--------|--------|-----------|---------------------|
 | 6a   | medium | sonnet | none      | Extend `shakenfist/tests/test_mariadb_find.py` with Direct / Public / Grpc test classes for `find_network_interfaces` per the design above. Mirror the existing trio's structure; drop `namespace`/`name` filter-only tests (they are no-ops for this type) and add explicit "silently ignored" tests for those two criteria. Run `tox -e py3 -- shakenfist.tests.test_mariadb_find` to confirm. |
 | 6b   | medium | sonnet | none      | Add the filter-pushdown subsection to `docs/operator_guide/database.md` under the "Access Pattern" section, and a short "SQL filter-pushdown discipline" paragraph or two to the Database Layer section of `ARCHITECTURE.md`. Match existing prose voice — terse, single-sentence paragraphs, no emoji. Reference files by relative path with markdown link syntax. |
-| 6c   | medium | sonnet | none      | Edit `PUSH-TEMPLATE.md`: add the new `mariadb.get_all_*` grep as the fourth bullet in the wave-1 style-check block at lines 46-48, including the `# nopushdown:` allowlist filter and a one-line inline comment. Promote the wave-2a "SQL pushdown discipline" bullet at line 83 from advisory ("does any new code materialise...") to blocking ("Blocking: any new `mariadb.get_all_*(` call that is not on an existing line and not tagged `# nopushdown:` must be rewritten as a `find_*` call or as a bulk-scan helper with explicit justification."). |
+| 6c   | medium | sonnet | none      | Edit `PUSH-AUDIT.md`: add the new `mariadb.get_all_*` grep as the fourth bullet in the wave-1 style-check block at lines 46-48, including the `# nopushdown:` allowlist filter and a one-line inline comment. Promote the wave-2a "SQL pushdown discipline" bullet at line 83 from advisory ("does any new code materialise...") to blocking ("Blocking: any new `mariadb.get_all_*(` call that is not on an existing line and not tagged `# nopushdown:` must be rewritten as a `find_*` call or as a bulk-scan helper with explicit justification."). |
 | 6d   | low    | haiku  | none      | Mark phase 6 complete in `docs/plans/index.md`. Add a "Bugs fixed" paragraph to the master plan listing the four bugs caught during rollout (stability-branch KeyError, mock_etcd state-filter, phase-4 `_resolve_prefilter_to_states` regression, namespace alphabetical-ordering regression). Leave phase 7 at Planning. |
 | 6e   | low    | haiku  | none      | Run `pre-commit run --all-files`. Fix anything flagged. Commit as needed. |
 
@@ -202,7 +202,7 @@ with:
   `test_mariadb_find.py` test-class layout matches the
   expected "one class per direct / public / gRPC" shape.
 * For 6c: confirmation of the exact current lines of
-  `PUSH-TEMPLATE.md` that need editing (line numbers
+  `PUSH-AUDIT.md` that need editing (line numbers
   have almost certainly shifted since the plan was
   written).
 * Any design decision not explicit in the plan.
@@ -230,7 +230,7 @@ After each step:
   entry point.
 * `ARCHITECTURE.md` references the pattern briefly in
   its Database Layer section.
-* `PUSH-TEMPLATE.md` wave-1 has the new grep with an
+* `PUSH-AUDIT.md` wave-1 has the new grep with an
   `# nopushdown:` allowlist and wave-2a has the
   SQL-pushdown discipline bullet promoted to blocking.
 * `docs/plans/index.md` shows phase 6 Complete and

--- a/docs/plans/PLAN-sql-pushdown-filtering-phase-07-denorm-lists.md
+++ b/docs/plans/PLAN-sql-pushdown-filtering-phase-07-denorm-lists.md
@@ -200,7 +200,7 @@ Column drop is safe because the stored list is pure
 cache: every UUID in the list is derivable from the
 `network_interfaces` table via an indexed query.
 
-### PUSH-TEMPLATE.md guardrail
+### PUSH-AUDIT.md guardrail
 
 The phase-6 guardrail catches new `mariadb.get_all_*(`
 call sites; phase 7's work exposes a second pattern worth
@@ -231,7 +231,7 @@ append/remove from such a list) get the same flag.
 | 7c   | medium | sonnet | none      | Network side. Rewrite `Network.networkinterfaces` as a query-backed property returning `list[NetworkInterface]`. Remove `add_networkinterface`, `remove_networkinterface`, references to `networkinterfaces_initialized` from the getter/setter paths. Migrate all Network-side callers identified in 7a. This includes `network/interface.py:195` and `:299` (which called `add/remove_networkinterface`), `network/network.py:861` (delete loop), and the external_api / daemons paths. Adapt helpers that previously took a list of UUIDs. Be vigilant about the circular-import network<->interface (use a late import inside the property; document). One commit. |
 | 7d   | medium | sonnet | none      | Instance side. Rewrite `Instance.interfaces` as a query-backed property returning `list[NetworkInterface]`. Remove the setter, `interfaces_append`, and all writer call sites. Readers migrate from UUIDs to objects. One commit. |
 | 7e   | medium | sonnet | none      | Schema cleanup. Drop `networkinterfaces` and `networkinterfaces_initialized` fields from `schema/network_attributes.py:NetworkAttributesData` and `interfaces` from `schema/instance_attributes.py:InstanceAttributesData`. Add idempotent v-bump migrations to `_ensure_network_attributes_schema` and `_ensure_instance_attributes_schema` in `mariadb.py` that drop the columns (CREATE-INDEX-IF-NOT-EXISTS-style pattern with try/except). Bump the VERSION constants. One commit. |
-| 7f   | low    | haiku  | none      | Add a wave-2a code-quality bullet to `PUSH-TEMPLATE.md` directing the reviewer to flag new `list[str]` / `list[UUID4]` fields on `shakenfist/schema/*_attributes.py` as a potential cached FK list — prompt the reviewer to ask "is this a list of child-object UUIDs that a `WHERE <fk> = ?` query could provide live?" — and to apply the same flag to any new `add_*` / `remove_*` mutator pair on an attributes object. Place the bullet adjacent to the phase-6 "SQL pushdown (blocking)" bullet. Wording should match the tone and structure of the adjacent bullets. One commit. |
+| 7f   | low    | haiku  | none      | Add a wave-2a code-quality bullet to `PUSH-AUDIT.md` directing the reviewer to flag new `list[str]` / `list[UUID4]` fields on `shakenfist/schema/*_attributes.py` as a potential cached FK list — prompt the reviewer to ask "is this a list of child-object UUIDs that a `WHERE <fk> = ?` query could provide live?" — and to apply the same flag to any new `add_*` / `remove_*` mutator pair on an attributes object. Place the bullet adjacent to the phase-6 "SQL pushdown (blocking)" bullet. Wording should match the tone and structure of the adjacent bullets. One commit. |
 | 7g   | low    | haiku  | none      | Run `pre-commit run --all-files`. Fix anything flagged (most likely a stale import after removing add/remove mutators). Mark phase 7 complete in `docs/plans/index.md`. Commit as needed. |
 
 ## Back brief
@@ -291,7 +291,7 @@ After each step:
   iterate objects, writer call sites deleted.
 * `pre-commit run --all-files` passes; `test_mariadb_find`
   gains at least two new tests for the FK filters.
-* `PUSH-TEMPLATE.md` wave-2a brief has a new bullet
+* `PUSH-AUDIT.md` wave-2a brief has a new bullet
   directing the reviewer to flag new attribute-list-of-FK
   patterns, so a future contributor does not re-introduce
   a denormalised cache that phase 7 just removed.

--- a/docs/plans/PLAN-sql-pushdown-filtering.md
+++ b/docs/plans/PLAN-sql-pushdown-filtering.md
@@ -216,7 +216,7 @@ transitions during lookup, cross-namespace lookups under
 `system`), and update `docs/operator_guide/database.md` and
 `ARCHITECTURE.md` to describe the new pattern.
 
-Also add a guardrail in `PUSH-TEMPLATE.md` to keep this
+Also add a guardrail in `PUSH-AUDIT.md` to keep this
 regression from sneaking back in: a wave-1 mechanical grep
 that flags new additions of `mariadb.get_all_*(` in the diff
 (excluding `shakenfist/mariadb.py`, admin tooling under
@@ -394,7 +394,7 @@ because the following statements will be true:
   primitive and the SQL pushdown rule.
 * `ARCHITECTURE.md` mentions the three-layer pattern's
   filter-pushdown discipline.
-* `PUSH-TEMPLATE.md` has a wave-1 mechanical grep that
+* `PUSH-AUDIT.md` has a wave-1 mechanical grep that
   flags new `mariadb.get_all_*(` additions outside the
   allowlist, and the wave-2a brief marks SQL-pushdown
   discipline as blocking.
@@ -451,7 +451,7 @@ creep:
 
 #### Items raised by the phase 7 pre-push audit
 
-The `PUSH-TEMPLATE.md` audit on the post-phase-7 branch
+The `PUSH-AUDIT.md` audit on the post-phase-7 branch
 flagged a handful of items that are real but not phase-7
 specific. Capturing them here so the next contributor in
 this area has a punch list rather than re-discovering


### PR DESCRIPTION
PUSH-TEMPLATE.md is renamed to PUSH-AUDIT.md (it is a runbook, not a template) and its documentation-review brief now embeds the v1 readme-discipline shared block from shakenfist/development, replacing the "README.md reflects any new features" instruction. The repo-specific documentation-review bullets (state machine docs, operator guide sync) are unchanged. References updated in the SQL pushdown filtering plan documents; the mirrored plan copies under docs/components/ are left for their sync process.

The README was already pitch-sized, so this sweep only converts its six relative links (operator guide pages, examples/, the deploy collection) to absolute URLs so they render off the repository landing page, closing the readme-absolute-links non-compliance.

Prompt: Mikal asked me to continue the README-as-pitch sweeps across the shakenfist repos one at a time, applying the policy landed in shakenfist/development: rename PUSH-TEMPLATE.md to PUSH-AUDIT.md, embed the versioned readme-discipline shared block, and bring the README into audit compliance.


Assisted-By: Claude Code