### PR TITLE
Drop apt steps from Claude fix workflows.

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -320,11 +320,12 @@ jobs:
           git branch -D "issue-fix-${ISSUE_NUMBER}" 2>/dev/null || true
           git checkout -b "issue-fix-${ISSUE_NUMBER}"
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libmariadb-dev python3-dev python3-mysqldb
-
+      # No apt step here: the claude-code runners have no passwordless
+      # sudo, and none is needed -- the unit tests mock the database, so
+      # the mariadb driver is never imported (see the sanity_checks
+      # comment in functional-tests.yml). If system packages are ever
+      # genuinely required, add them to the runner image in
+      # mach33labs/33fl rather than apt-installing here.
       - name: Install project dependencies
         run: |
           python3 -mvenv ~/sf-venv

--- a/.github/workflows/test-drift-fix.yml
+++ b/.github/workflows/test-drift-fix.yml
@@ -106,11 +106,12 @@ jobs:
           git branch -D test-drift-fix-${DATESTAMP} 2>/dev/null || true
           git checkout -b test-drift-fix-${DATESTAMP}
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libmariadb-dev python3-dev python3-mysqldb
-
+      # No apt step here: the claude-code runners have no passwordless
+      # sudo, and none is needed -- the unit tests mock the database, so
+      # the mariadb driver is never imported (see the sanity_checks
+      # comment in functional-tests.yml). If system packages are ever
+      # genuinely required, add them to the runner image in
+      # mach33labs/33fl rather than apt-installing here.
       - name: Install project dependencies
         run: |
           python3 -mvenv ~/sf-venv


### PR DESCRIPTION
The first live run of issue-fix.yml (run 30340227385) failed at the "Install system dependencies" step: the claude-code runners have no passwordless sudo, so "sudo apt-get install" cannot work. test-drift-fix.yml carries the identical step (issue-fix copied it from there), so it has the same latent failure.

The step is unnecessary as well as impossible: as documented in the sanity_checks comment in functional-tests.yml, the unit tests mock the database and never import the mariadb driver, and system packages belong in the runner image built in mach33labs/33fl rather than being apt-installed by workflows. Replace the step with a comment recording that policy.

Everything before the apt step worked in the smoke test run: triage found 25 eligible issues, selected #3532 with sound reasoning, and the fix job applied the attempt label and comment before failing.

Prompt: Mikal dispatched the new issue-fix workflow as a smoke test and asked me to watch whether smoke came out. It failed at the apt step on the claude-code runner; this removes the unneeded apt steps from both Claude fix workflows.


Assisted-By: Claude Code