### PR TITLE
Surface unreadable namespace key sets as 503.

### DIFF
--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -663,6 +663,31 @@ def handle_authorization_exceptions(func):
     return wrapper
 
 
+def handle_database_unavailable(func):
+    # An unreachable or failing database must surface to clients as a
+    # 503, never as an authentication or "object not found" failure:
+    # the auth path treating an unreadable namespace key set as a 401
+    # 'JWT token uses non-existent key' sent clients into
+    # re-authentication loops and misdirected diagnosis towards key
+    # rotation (issue 3522, the auth-path variant of issue 3373). This
+    # sits below record_exception in the decorator stack so a database
+    # outage answers each request with a clean 503 rather than
+    # recording a server exception per request for the duration.
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except exceptions.DatabaseUnavailable as e:
+            LOG.with_fields({
+                'method': flask.request.method,
+                'path': flask.request.path,
+                'error': str(e)}).error(
+                'Database unavailable while handling API request')
+            return sf_api.error(503, 'database unavailable, please retry',
+                                suppress_traceback=True)
+
+    return wrapper
+
+
 def record_exception(func):
     def wrapper(*args, **kwargs):
         try:
@@ -709,6 +734,7 @@ class Resource(flask_restful.Resource):
     method_decorators = [
         log_request,
         handle_authorization_exceptions,
+        handle_database_unavailable,
         record_exception,
         suppress_exceptions_to_client
         ]

--- a/shakenfist/mariadb.py
+++ b/shakenfist/mariadb.py
@@ -10875,8 +10875,13 @@ def _direct_get_namespace_attributes(name: str) -> Optional[NamespaceAttributesD
                 trust=result.trust if result.trust else ['system'],
             )
     except OperationalError as e:
+        # As with the gRPC path above, a database failure must not read
+        # as "no attributes row". Raising here also means the database
+        # daemon's GetNamespaceAttributes servicer returns INTERNAL to
+        # its clients instead of found=False (issue 3522).
         LOG.warning(f'MariaDB get failed for namespace_attributes {name}: {e}')
-        return None
+        raise exceptions.DatabaseUnavailable(
+            f'namespace attributes for {name} could not be read: {e}') from e
 
 
 def _namespace_attributes_column_values(
@@ -11029,8 +11034,15 @@ def _grpc_get_namespace_attributes(name: str) -> Optional[NamespaceAttributesDat
             trust=json.loads(reply.data.trust_json) if reply.data.trust_json else ['system'],
         )
     except grpc.RpcError as e:
+        # None from this function means "no attributes row exists" and the
+        # auth path treats that as an authoritative empty key set, so a
+        # transport or server failure here must raise instead: mapping it
+        # to None turned a RESOURCE_EXHAUSTED on an oversized keys blob
+        # into cluster-wide 401s (issue 3522, the auth-path variant of
+        # issue 3373).
         LOG.error(f'gRPC GetNamespaceAttributes failed for {name}: {e}')
-        return None
+        raise exceptions.DatabaseUnavailable(
+            f'namespace attributes for {name} could not be read: {e}') from e
 
 
 def _grpc_update_namespace_attributes(
@@ -11623,8 +11635,8 @@ def _direct_get_namespace_key_by_name(
         name: The key name, unique within that namespace.
 
     Returns:
-        A (static, attributes) pair, or None if there is no such key
-        or on error.
+        A (static, attributes) pair, or None if there is no such key.
+        Raises DatabaseUnavailable if the database cannot be read.
     """
     engine = _get_engine()
     table = _get_namespace_keys_table()
@@ -11668,10 +11680,15 @@ def _direct_get_namespace_key_by_name(
                 )
             )
     except OperationalError as e:
+        # As with the gRPC path, a database failure must not read as
+        # "no such key". Raising here also means the database daemon's
+        # GetNamespaceKeyByName servicer returns INTERNAL to its
+        # clients instead of found=False (issue 3522).
         LOG.warning(
             f'MariaDB get failed for namespace_key '
             f'(namespace={namespace!r}, name={name!r}): {e}')
-        return None
+        raise exceptions.DatabaseUnavailable(
+            f'namespace key {namespace}:{name} could not be read: {e}') from e
 
 
 def _direct_delete_namespace_key(key_uuid: UUID) -> bool:
@@ -11718,7 +11735,8 @@ def _direct_find_namespace_keys(
             include_expired is True.
 
     Returns:
-        A list of (static, attributes) pairs, empty on error.
+        A list of (static, attributes) pairs. Raises
+        DatabaseUnavailable if the database cannot be read.
     """
     engine = _get_engine()
     table = _get_namespace_keys_table()
@@ -11769,11 +11787,17 @@ def _direct_find_namespace_keys(
                 for row in rows
             ]
     except OperationalError as e:
+        # As with the gRPC path, a database failure must not read as
+        # "the namespace has no usable keys". Raising here also means
+        # the database daemon's FindNamespaceKeys servicer returns
+        # INTERNAL to its clients instead of an empty listing
+        # (issue 3522).
         LOG.warning(
             f'MariaDB find failed for namespace_keys '
             f'(namespace={namespace!r}, '
             f'include_expired={include_expired!r}): {e}')
-        return []
+        raise exceptions.DatabaseUnavailable(
+            f'namespace keys for {namespace} could not be listed: {e}') from e
 
 
 def _direct_delete_expired_namespace_keys(older_than: float) -> int:
@@ -12038,10 +12062,15 @@ def _grpc_get_namespace_key_by_name(
             _namespace_key_attrs_from_proto(reply.key.attributes)
         )
     except grpc.RpcError as e:
+        # None from this function means "no such key" and token
+        # validation treats that as an authoritative 401, so a
+        # transport or server failure here must raise instead
+        # (issue 3522).
         LOG.error(
             f'gRPC GetNamespaceKeyByName failed for '
             f'{namespace}:{name}: {e}')
-        return None
+        raise exceptions.DatabaseUnavailable(
+            f'namespace key {namespace}:{name} could not be read: {e}') from e
 
 
 def _grpc_delete_namespace_key(key_uuid: UUID) -> bool:
@@ -12076,9 +12105,14 @@ def _grpc_find_namespace_keys(
             for k in reply.keys
         ]
     except grpc.RpcError as e:
+        # An empty list from this function means "the namespace has no
+        # usable keys" and /auth treats that as an authoritative 401,
+        # so a transport or server failure here must raise instead
+        # (issue 3522).
         LOG.error(
             f'gRPC FindNamespaceKeys failed for {namespace}: {e}')
-        return []
+        raise exceptions.DatabaseUnavailable(
+            f'namespace keys for {namespace} could not be listed: {e}') from e
 
 
 def _grpc_delete_expired_namespace_keys(older_than: float) -> int:

--- a/shakenfist/tests/external_api/test_auth.py
+++ b/shakenfist/tests/external_api/test_auth.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import bcrypt
 
+from shakenfist import exceptions
 from shakenfist.baseobject import DatabaseBackedObject as dbo
 from shakenfist.config import config
 from shakenfist.config import SFConfig
@@ -150,6 +151,77 @@ class AuthTestCase(base.ShakenFistTestCase):
             },
             _clean_traceback(resp.get_json()))
         self.assertEqual(401, resp.status_code)
+
+
+class AuthDatabaseUnavailableTestCase(base.ShakenFistTestCase):
+    """Issue 3522: an unreadable namespace key set must surface as a 503,
+    not as a 401 telling the client its credentials are bad."""
+
+    def setUp(self):
+        super().setUp()
+
+        external_api.TESTING = True
+        external_api.app.testing = True
+        external_api.app.debug = False
+
+        external_api.app.logger.addHandler(logging.StreamHandler(sys.stdout))
+        external_api.app.logger.setLevel(logging.DEBUG)
+        logging.root.setLevel(logging.DEBUG)
+
+        self.mock_mariadb = MockMariaDB(self, node_count=4)
+        self.mock_mariadb.setup()
+
+        self.mock_mariadb.create_namespace('banana', 'key1', 'bacon')
+
+        # The client must be created after all the mocks, or the mocks are not
+        # correctly applied.
+        self.client = external_api.app.test_client()
+
+    def _get_token(self):
+        resp = self.client.post(
+            '/auth', data=json.dumps({'namespace': 'banana', 'key': 'bacon'}))
+        self.assertEqual(200, resp.status_code)
+        return 'Bearer %s' % resp.get_json()['access_token']
+
+    def test_token_verification_surfaces_outage_as_503(self):
+        auth_token = self._get_token()
+
+        # Token verification point reads the JWT's key via
+        # get_namespace_key_by_name (auth federation phase 2), so that
+        # is the read which must not conflate an outage with "no such
+        # key".
+        with mock.patch(
+                'shakenfist.mariadb.get_namespace_key_by_name',
+                side_effect=exceptions.DatabaseUnavailable('keys unreadable')):
+            resp = self.client.get(
+                '/auth/namespaces', headers={'Authorization': auth_token})
+
+        self.assertEqual(503, resp.status_code)
+        self.assertEqual(
+            {
+                'error': 'database unavailable, please retry',
+                'status': 503
+            },
+            _clean_traceback(resp.get_json()))
+
+    def test_login_surfaces_outage_as_503(self):
+        # /auth lists the namespace's keys via find_namespace_keys
+        # (auth federation phase 2), so that is the read which must not
+        # conflate an outage with "the namespace has no usable keys".
+        with mock.patch(
+                'shakenfist.mariadb.find_namespace_keys',
+                side_effect=exceptions.DatabaseUnavailable('keys unreadable')):
+            resp = self.client.post(
+                '/auth',
+                data=json.dumps({'namespace': 'banana', 'key': 'bacon'}))
+
+        self.assertEqual(503, resp.status_code)
+
+    def test_token_verification_works_once_database_recovers(self):
+        auth_token = self._get_token()
+        resp = self.client.get(
+            '/auth/namespaces', headers={'Authorization': auth_token})
+        self.assertEqual(200, resp.status_code)
 
 
 class AuthWithServiceKeyTestCase(base.ShakenFistTestCase):

--- a/shakenfist/tests/test_database_unavailable.py
+++ b/shakenfist/tests/test_database_unavailable.py
@@ -12,6 +12,7 @@ import uuid
 from unittest import mock
 
 import grpc
+from sqlalchemy.exc import OperationalError
 
 from shakenfist import exceptions
 from shakenfist import locks
@@ -170,6 +171,92 @@ class GrpcCallRetryExhaustionTestCase(base.ShakenFistTestCase):
         self.assertRaises(
             exceptions.DatabaseUnavailable,
             mariadb.get_node_by_fqdn, 'sf-1')
+
+
+class NamespaceAttributesFetchFailureTestCase(base.ShakenFistTestCase):
+    """Issue 3522: a failed namespace key set fetch must raise, not read
+    as an authoritative "no attributes row" (which the auth path treats
+    as an empty key set and answers with a 401)."""
+
+    @mock.patch('shakenfist.mariadb._grpc_call',
+                side_effect=FakeRpcError(grpc.StatusCode.RESOURCE_EXHAUSTED))
+    @mock.patch('shakenfist.mariadb._get_database_stub')
+    @mock.patch('shakenfist.mariadb._use_database_service',
+                return_value=True)
+    def test_grpc_error_raises_database_unavailable(
+            self, mock_use, mock_stub, mock_call):
+        # The trigger from issue 3521: a keys blob over the 4MiB message
+        # cap fails RESOURCE_EXHAUSTED, which is not retryable and so
+        # reaches the wrapper as a raw RpcError rather than as a
+        # DatabaseUnavailable from _grpc_call's retry exhaustion.
+        self.assertRaises(
+            exceptions.DatabaseUnavailable,
+            mariadb.get_namespace_attributes, 'banana')
+
+    @mock.patch('shakenfist.mariadb._get_engine')
+    @mock.patch('shakenfist.mariadb._use_database_service',
+                return_value=False)
+    def test_direct_operational_error_raises_database_unavailable(
+            self, mock_use, mock_engine):
+        # The direct path feeds the database daemon's servicer: swallowing
+        # an OperationalError there made the daemon reply found=False, so
+        # a MariaDB outage read as "namespace has no keys" cluster-wide.
+        mock_engine.return_value.connect.side_effect = OperationalError(
+            'SELECT', {}, Exception('server has gone away'))
+        self.assertRaises(
+            exceptions.DatabaseUnavailable,
+            mariadb.get_namespace_attributes, 'banana')
+
+
+class NamespaceKeyFetchFailureTestCase(base.ShakenFistTestCase):
+    """Issue 3522, post auth federation phase 2: the auth path reads
+    keys via find_namespace_keys (/auth) and get_namespace_key_by_name
+    (token validation), so those reads must also raise on failure
+    rather than conflating an outage with "no such key"."""
+
+    @mock.patch('shakenfist.mariadb._grpc_call',
+                side_effect=FakeRpcError(grpc.StatusCode.RESOURCE_EXHAUSTED))
+    @mock.patch('shakenfist.mariadb._get_database_stub')
+    @mock.patch('shakenfist.mariadb._use_database_service',
+                return_value=True)
+    def test_grpc_find_error_raises_database_unavailable(
+            self, mock_use, mock_stub, mock_call):
+        self.assertRaises(
+            exceptions.DatabaseUnavailable,
+            mariadb.find_namespace_keys, 'banana', False, 0.0)
+
+    @mock.patch('shakenfist.mariadb._grpc_call',
+                side_effect=FakeRpcError(grpc.StatusCode.RESOURCE_EXHAUSTED))
+    @mock.patch('shakenfist.mariadb._get_database_stub')
+    @mock.patch('shakenfist.mariadb._use_database_service',
+                return_value=True)
+    def test_grpc_point_read_error_raises_database_unavailable(
+            self, mock_use, mock_stub, mock_call):
+        self.assertRaises(
+            exceptions.DatabaseUnavailable,
+            mariadb.get_namespace_key_by_name, 'banana', 'key1')
+
+    @mock.patch('shakenfist.mariadb._get_engine')
+    @mock.patch('shakenfist.mariadb._use_database_service',
+                return_value=False)
+    def test_direct_find_operational_error_raises_database_unavailable(
+            self, mock_use, mock_engine):
+        mock_engine.return_value.connect.side_effect = OperationalError(
+            'SELECT', {}, Exception('server has gone away'))
+        self.assertRaises(
+            exceptions.DatabaseUnavailable,
+            mariadb.find_namespace_keys, 'banana', False, 0.0)
+
+    @mock.patch('shakenfist.mariadb._get_engine')
+    @mock.patch('shakenfist.mariadb._use_database_service',
+                return_value=False)
+    def test_direct_point_read_operational_error_raises_database_unavailable(
+            self, mock_use, mock_engine):
+        mock_engine.return_value.connect.side_effect = OperationalError(
+            'SELECT', {}, Exception('server has gone away'))
+        self.assertRaises(
+            exceptions.DatabaseUnavailable,
+            mariadb.get_namespace_key_by_name, 'banana', 'key1')
 
 
 class GrpcCallMethodNameTestCase(base.ShakenFistTestCase):


### PR DESCRIPTION
A failure to fetch namespace attributes was conflated with the attributes row not existing: both gRPC and direct MariaDB fetch paths mapped infrastructure errors to None, which Namespace.keys treats as an authoritative empty key set. When a namespace's keys blob crossed the 4MiB gRPC message cap (RESOURCE_EXHAUSTED, issue 3521), the API auth path therefore rejected every request 401 'JWT token uses non-existent key', sending clients into re-authentication loops and misdirecting diagnosis towards key rotation. This is the auth-path variant of the error conflation fixed for retryable failures in issue 3373.

Both _grpc_get_namespace_attributes and
_direct_get_namespace_attributes now raise DatabaseUnavailable instead of returning None, so "not found" return values again always mean genuine absence. Raising in the direct path also makes the database daemon's servicer return INTERNAL to its clients instead of found=False during a MariaDB outage.

A new handle_database_unavailable decorator in the external API Resource stack maps DatabaseUnavailable to a 503 'database unavailable, please retry' with request context in the ERROR log, placed below record_exception so an outage does not record a server exception per request for its duration.

Fixes #3522

Triggered-By: issue-fix workflow, https://github.com/shakenfist/shakenfist/actions/runs/30344320363


Assisted-By: Claude Code