### PR TITLE
Fix stale eventlog plan phase statuses.

### DIFF
--- a/docs/plans/PLAN-eventlog-direct-mariadb.md
+++ b/docs/plans/PLAN-eventlog-direct-mariadb.md
@@ -439,12 +439,12 @@ post-decisions plan.
 | Phase | Plan | Status |
 |-------|------|--------|
 | -1. Local sqlite spool + batched-RPC drainer (caller side) | _(delivered in the network-facade branch ahead of this plan)_ | Complete |
-| 1. `events`/`event_objects` schema, accessors, the `RecordEventBatch` RPC on sf-database, and the events-row-count gauge | PLAN-eventlog-direct-mariadb-phase-01-schema.md | Not started |
-| 2. Swap the drainer's RPC target from sf-eventlog to sf-database; promote `event_uuid` and `request_id` to first-class fields; wire spool-depth, drop, and insert metrics | PLAN-eventlog-direct-mariadb-phase-02-write.md | Not started |
-| 3. Move prune sweep into the cluster daemon's scheduled tasks, with prune-delete counter | PLAN-eventlog-direct-mariadb-phase-03-prune.md | Not started |
-| 4. REST API direct-read path via a new `GetObjectEvents` RPC on sf-database | PLAN-eventlog-direct-mariadb-phase-04-read.md | Not started |
-| 5. Delete `sf-eventlog` daemon, gRPC protos, systemd unit, config, the MariaDB `event_dlq`, and the on-disk sqlite chunks | PLAN-eventlog-direct-mariadb-phase-05-remove.md | Not started |
-| 6. Documentation (operator guide for the new eventlog, ARCHITECTURE/README/AGENTS updates, cut-over loss called out in release notes) | PLAN-eventlog-direct-mariadb-phase-06-docs.md | Not started |
+| 1. `events`/`event_objects` schema, accessors, the `RecordEventBatch` RPC on sf-database, and the events-row-count gauge | PLAN-eventlog-direct-mariadb-phase-01-schema.md | Complete |
+| 2. Swap the drainer's RPC target from sf-eventlog to sf-database; promote `event_uuid` and `request_id` to first-class fields; wire spool-depth, drop, and insert metrics | PLAN-eventlog-direct-mariadb-phase-02-write.md | Complete |
+| 3. Move prune sweep into the cluster daemon's scheduled tasks, with prune-delete counter | PLAN-eventlog-direct-mariadb-phase-03-prune.md | Complete |
+| 4. REST API direct-read path via a new `GetObjectEvents` RPC on sf-database | PLAN-eventlog-direct-mariadb-phase-04-read.md | Complete |
+| 5. Delete `sf-eventlog` daemon, gRPC protos, systemd unit, config, the MariaDB `event_dlq`, and the on-disk sqlite chunks | PLAN-eventlog-direct-mariadb-phase-05-remove.md | Complete |
+| 6. Documentation (operator guide for the new eventlog, ARCHITECTURE/README/AGENTS updates, cut-over loss called out in release notes) | PLAN-eventlog-direct-mariadb-phase-06-docs.md | Complete |
 
 Sequencing constraints between phases:
 


### PR DESCRIPTION
The Execution table in PLAN-eventlog-direct-mariadb.md still listed phases 1 through 6 as "Not started", although all six phases have landed: the sf-eventlog daemon is deleted, events flow through the local spool and RecordEventBatch to MariaDB, and the plan is marked Complete for every phase in docs/plans/index.md. Update the master plan's table to match reality so the two status sources agree.

Prompt: While reviewing the 2026 technical goals against the state of the codebase, an automated audit noticed that this master plan contradicted docs/plans/index.md and the tree itself. Mikal asked for a PR to be proposed from a fresh worktree and branch correcting the stale plan file.


Assisted-By: Claude Code