### PR TITLE
Widen MariaDB ENUM columns as Python enums grow.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -569,6 +569,43 @@ jobs:
           if-no-files-found: error
           path: /srv/github/artifacts/bundle.zip
 
+  # MariaDB ENUM columns freeze their permitted values at CREATE TABLE
+  # time, so a Python enum gaining a member silently breaks existing
+  # databases while greenfield CI deploys keep passing -- which is how
+  # ObjectType.NAMESPACE_KEY shipped without a widening migration and
+  # broke namespace key writes on upgraded clusters. The functional
+  # matrix cannot catch this class of bug because it always deploys a
+  # fresh schema. This job installs a real MariaDB on an ephemeral VM
+  # runner, builds the schema, shrinks each ENUM column back one member
+  # (what a pre-upgrade database looks like), and verifies the
+  # ensure_schema() reconciliation pass widens them and the newest
+  # values become writable. Gated by can_merge.
+  schema_enum_widening:
+    name: "Schema ENUM widening"
+    if: >-
+      (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
+      && needs.check_paths.outputs.code_changed != 'false'
+    needs: [check_paths]
+    runs-on: [self-hosted, vm, debian-12]
+    timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-schema-enum-widening
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install MariaDB
+        timeout-minutes: 10
+        run: |
+          sudo bash tools/ci-install-mariadb.sh \
+              tools/bootstrap-mariadb.sql '' ci-test-password
+
+      - name: Run live ENUM widening tests
+        timeout-minutes: 15
+        run: bash tools/ci-enum-widening-test.sh ci-test-password
+
   can_see_status:
     name: "Can see status"
     runs-on: [self-hosted, static]
@@ -601,6 +638,7 @@ jobs:
       - functional_matrix_merge_collection
       - ansible_modules_collection
       - node_lifecycle_collection
+      - schema_enum_widening
       - check_paths
     if: always() && github.event_name == 'merge_group'
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,22 @@ belongs in a table with per-row inserts and deletes — see the
 `instance_location` rows in `object_references` — never in a JSON list
 on an attributes row.
 
+### Native ENUM columns and Python enums
+
+A handful of columns are native MariaDB `ENUM` types built with
+`sa.Enum(SomePythonEnum)` (e.g. `object_states.object_type`). MariaDB
+freezes an `ENUM`'s value list at `CREATE TABLE` time, so adding a
+member to the Python enum works on fresh installs but breaks existing
+databases ("Data truncated for column", error 1265) — greenfield CI
+will not catch this. You do NOT need to write a migration when adding
+an enum member: `ensure_schema()` ends with a reconciliation pass
+(`_ensure_native_enum_columns()` in `shakenfist/mariadb.py`) that
+discovers every `sa.Enum` column from the SQLAlchemy metadata and
+widens stale columns automatically. Unit coverage lives in
+`shakenfist/tests/test_mariadb_enum_columns.py`; the live upgrade path
+is exercised against a real MariaDB by the "Schema ENUM widening" CI
+job in `functional-tests.yml` (`tools/ci-enum-widening-test.sh`).
+
 ### Documentation
 
 - When a change adds, renames, or removes a user-visible concept

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -93,6 +93,18 @@ startup, not a runtime health signal.
 See [`docs/operator_guide/database.md`](docs/operator_guide/database.md) —
 "MARIADB_HOST vs MARIADB_GATEWAY_HOSTS" — for the operator-facing detail.
 
+Schema management (`ensure_schema()` in `mariadb.py`, run via `sf-ctl
+ensure-mariadb-schema`) is version-gated per table, plus one un-gated
+pass: native MariaDB `ENUM` columns are reconciled against their Python
+enums on every run, because a MariaDB `ENUM` freezes its value list at
+`CREATE TABLE` time and a new Python enum member changes no table
+version. Without this pass, an upgrade adding an enum member (e.g.
+`ObjectType.NAMESPACE_KEY`) works on fresh installs but breaks existing
+databases with "Data truncated for column" errors. Enum columns are
+discovered from the SQLAlchemy metadata, so new `sa.Enum(...)` columns
+are covered automatically; the live upgrade path is exercised by the
+"Schema ENUM widening" CI job (`tools/ci-enum-widening-test.sh`).
+
 #### Static object value cache
 
 The database client in `mariadb.py` carries a small read-through cache for

--- a/docs/operator_guide/upgrades.md
+++ b/docs/operator_guide/upgrades.md
@@ -100,6 +100,40 @@ Migrated table 'object_states' from version 1 to 2
 MariaDB schema verified.
 ```
 
+### ENUM value reconciliation
+
+Some columns (for example `object_states.object_type`) are native MariaDB
+`ENUM` types whose permitted values mirror a Python enum in the code. A
+MariaDB `ENUM` freezes its value list when the table is created, so a code
+upgrade that adds a new enum member leaves existing databases unable to
+store the new value — inserts fail with MariaDB error 1265 ("Data
+truncated for column ..."). Fresh installs are unaffected, which makes
+this failure mode easy to miss in greenfield testing; it is exactly what
+broke namespace key writes when the `NAMESPACE_KEY` object type shipped
+in July 2026.
+
+To close this class of problem, `sf-ctl ensure-mariadb-schema` ends with
+a reconciliation pass that compares every native `ENUM` column against
+its Python enum and widens the column in place when the code has grown
+new values. Appending values to an `ENUM` is a metadata-only change in
+MariaDB and does not rewrite the table. Values removed from the code are
+deliberately retained in the column (existing rows may still hold them)
+and logged. The pass reports its work in the command output:
+
+```
+Widened ENUM column(s): object_states.object_type
+```
+
+or, on an up-to-date database:
+
+```
+Native ENUM columns are up to date
+```
+
+Because enum growth does not change any table version, this pass runs on
+every invocation rather than being version-gated. It is idempotent and
+cheap (one `information_schema` query per `ENUM` column).
+
 ### Known migration notes
 
 #### cluster_operation_targets v1 to v2

--- a/shakenfist/client/ctl.py
+++ b/shakenfist/client/ctl.py
@@ -277,7 +277,13 @@ def ensure_mariadb_schema() -> None:
     results = mariadb.ensure_schema()
 
     for r in results:
-        if r['migrated']:
+        if 'altered_columns' in r:
+            if r['migrated']:
+                click.echo('Widened ENUM column(s): '
+                           f"{', '.join(r['altered_columns'])}")
+            else:
+                click.echo('Native ENUM columns are up to date')
+        elif r['migrated']:
             if r['start_version'] <= 0:
                 click.echo(f"Created table '{r['table']}' at version "
                            f"{r['end_version']}")

--- a/shakenfist/mariadb.py
+++ b/shakenfist/mariadb.py
@@ -17,6 +17,10 @@
 # Each table has a version number tracked in the schema_versions table.
 # When ensure_schema() is called, it checks the current version and applies
 # any necessary migrations. This follows the same pattern as eventlog.py.
+# Native ENUM columns are additionally reconciled against their Python
+# enums on every ensure_schema() run (see _ensure_native_enum_columns),
+# because enum growth changes no table version and so cannot be caught by
+# the version gate.
 
 from ipaddress import IPv4Address
 import json
@@ -1040,13 +1044,135 @@ def _get_object_states_table() -> sa.Table:
     return _object_states_table
 
 
-def _build_object_type_enum_values() -> str:
-    """Build the ENUM values string for ObjectType.
+def _native_enum_columns() -> list[tuple[str, sa.Column[Any]]]:
+    """List every column rendered as a native MariaDB ENUM.
 
-    Returns a comma-separated list of quoted enum values for use in
-    ALTER TABLE statements.
+    Discovers (table name, column) pairs directly from the registered
+    SQLAlchemy metadata rather than from a hand-maintained list, so a new
+    ``sa.Enum(...)`` column -- or a new member added to an existing Python
+    enum -- is automatically covered by _ensure_native_enum_columns()
+    without anyone remembering to write a migration.
     """
-    return ', '.join(f"'{ot.value}'" for ot in ObjectType)
+    register_all_tables()
+    found = []
+    for table in _get_metadata().tables.values():
+        for column in table.columns:
+            if (isinstance(column.type, sa.Enum) and
+                    column.type.enum_class is not None):
+                found.append((table.name, column))
+    return sorted(found, key=lambda entry: (entry[0], entry[1].name))
+
+
+def _parse_enum_column_type(column_type: str) -> Optional[list[str]]:
+    """Parse the value list out of an information_schema COLUMN_TYPE.
+
+    Returns None if the column is not an ENUM. Values are single quoted
+    with embedded quotes doubled, e.g. enum('A','B','it''s').
+    """
+    if not column_type.lower().startswith('enum('):
+        return None
+    inner = column_type[column_type.index('(') + 1:column_type.rindex(')')]
+
+    values: list[str] = []
+    current: list[str] = []
+    in_string = False
+    i = 0
+    while i < len(inner):
+        ch = inner[i]
+        if in_string:
+            if ch == "'":
+                if i + 1 < len(inner) and inner[i + 1] == "'":
+                    current.append("'")
+                    i += 1
+                else:
+                    in_string = False
+                    values.append(''.join(current))
+                    current = []
+            else:
+                current.append(ch)
+        elif ch == "'":
+            in_string = True
+        i += 1
+    return values
+
+
+def _render_enum_ddl(values: list[str]) -> str:
+    """Render an ENUM(...) type clause for the given values."""
+    quoted = ', '.join("'" + v.replace("'", "''") + "'" for v in values)
+    return f'ENUM({quoted})'
+
+
+def _ensure_native_enum_columns(engine: sa.Engine) -> dict[str, Any]:
+    """Widen native ENUM columns whose Python enum has grown.
+
+    A MariaDB ENUM column stores its permitted values in the table
+    definition, frozen at CREATE TABLE time. Adding a member to the Python
+    enum therefore only takes effect on fresh installs; existing databases
+    reject the new value with "Data truncated for column ..." (error 1265).
+    That is exactly what broke every API request touching namespace keys
+    when ObjectType.NAMESPACE_KEY shipped without a widening migration.
+
+    This reconciles every native ENUM column against its Python enum on
+    each ensure_schema() run: values present in Python but not in the
+    database trigger an ALTER TABLE ... MODIFY COLUMN with the full value
+    list. Appending values to an ENUM is an in-place metadata-only change
+    on MariaDB. Values present in the database but no longer in the Python
+    enum are retained (rows may still reference them) and logged.
+    """
+    altered: list[str] = []
+    with engine.connect() as conn:
+        for table_name, column in _native_enum_columns():
+            row = conn.execute(
+                sa.text(
+                    'SELECT COLUMN_TYPE FROM information_schema.COLUMNS '
+                    'WHERE TABLE_SCHEMA = DATABASE() '
+                    'AND TABLE_NAME = :table_name '
+                    'AND COLUMN_NAME = :column_name'),
+                {'table_name': table_name, 'column_name': column.name}
+            ).first()
+            if row is None:
+                LOG.debug(
+                    f'ENUM reconciliation skipping {table_name}.'
+                    f'{column.name}: column not present in database')
+                continue
+
+            db_values = _parse_enum_column_type(row[0])
+            if db_values is None:
+                LOG.warning(
+                    f'ENUM reconciliation skipping {table_name}.'
+                    f'{column.name}: database type is not an ENUM '
+                    f'({row[0]})')
+                continue
+
+            # column.type.enums is the exact value list SQLAlchemy renders
+            # at CREATE TABLE time (enum member names, not values).
+            expected = list(cast(sa.Enum, column.type).enums)
+            missing = [v for v in expected if v not in db_values]
+            if not missing:
+                continue
+
+            stale = [v for v in db_values if v not in expected]
+            if stale:
+                LOG.warning(
+                    f'ENUM column {table_name}.{column.name} retains '
+                    f'values no longer in the Python enum: {stale}')
+
+            nullability = 'NULL' if column.nullable else 'NOT NULL'
+            LOG.info(
+                f'Widening ENUM column {table_name}.{column.name} '
+                f'with new values: {missing}')
+            conn.execute(sa.text(
+                f'ALTER TABLE {table_name} '
+                f'MODIFY COLUMN {column.name} '
+                f'{_render_enum_ddl(expected + stale)} {nullability}'))
+            conn.commit()
+            altered.append(f'{table_name}.{column.name}')
+
+    return {
+        'table': 'native-enum-columns',
+        'altered_columns': altered,
+        'migrated': bool(altered),
+    }
 
 
 def _build_object_filter_query(
@@ -1976,15 +2102,6 @@ def _get_ipam_reservations_table() -> sa.Table:
     return _ipam_reservations_table
 
 
-def _build_reservation_type_enum_values() -> str:
-    """Build the ENUM values string for ReservationType.
-
-    Returns a comma-separated list of quoted enum values for use in
-    ALTER TABLE statements.
-    """
-    return ', '.join(f"'{rt.value}'" for rt in ReservationType)
-
-
 def _ensure_ipam_reservations_schema(engine: sa.Engine) -> dict[str, Any]:
     """Ensure the ipam_reservations table schema is up to date.
 
@@ -2844,6 +2961,13 @@ def ensure_schema() -> list[dict[str, Any]]:
     results.append(_ensure_cluster_config_schema(engine))
     results.append(_ensure_events_schema(engine))
     results.append(_ensure_event_objects_schema(engine))
+
+    # Widen any native ENUM column whose Python enum has grown since the
+    # table was created. This runs after the per-table ensures so every
+    # table exists, and must not be skipped: the version-gated migrations
+    # above cannot see enum drift because adding an enum member changes no
+    # table version.
+    results.append(_ensure_native_enum_columns(engine))
 
     # Log summary
     migrated = [r for r in results if r['migrated']]

--- a/shakenfist/tests/test_mariadb_enum_columns.py
+++ b/shakenfist/tests/test_mariadb_enum_columns.py
@@ -1,0 +1,301 @@
+# Copyright 2026 Michael Still and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for native ENUM column reconciliation.
+
+MariaDB ENUM columns freeze their permitted values at CREATE TABLE time,
+so adding a member to a Python enum silently breaks existing databases:
+inserts of the new value fail with "Data truncated for column ..." (error
+1265). This is exactly what happened when ObjectType.NAMESPACE_KEY shipped
+without a widening migration and every API request touching namespace keys
+started returning 500s.
+
+_ensure_native_enum_columns() reconciles the database ENUMs against the
+Python enums on every ensure_schema() run. These tests exercise it against
+a mocked engine; tools/ci-enum-widening-test.sh proves the live behaviour
+against a real MariaDB in CI.
+"""
+
+from unittest import mock
+
+from pydantic_settings import BaseSettings
+
+from shakenfist import mariadb
+from shakenfist.tests import base
+
+
+class FakeConfig(BaseSettings):
+    MARIADB_HOST: str = 'localhost'
+
+
+fake_config = FakeConfig()
+
+
+# The (table, column) pairs we know are rendered as native MariaDB ENUMs.
+# Discovery is automatic, so a new sa.Enum(...) column does not need to be
+# added here to be reconciled -- this list only anchors the assertion that
+# discovery keeps finding the columns that exist today.
+KNOWN_ENUM_COLUMNS = {
+    ('cluster_operation_targets', 'target_object_type'),
+    ('ipam_reservations', 'reservation_type'),
+    ('ipam_reservations', 'user_type'),
+    ('object_metadata', 'object_type'),
+    ('object_states', 'object_type'),
+}
+
+
+def _current_column_types() -> dict:
+    """Build information_schema COLUMN_TYPE strings matching the Python enums.
+
+    This is what a fully up-to-date database would report: the exact enum
+    member list, rendered the way MariaDB does (lowercase keyword, no space
+    after commas).
+    """
+    column_types = {}
+    for table_name, column in mariadb._native_enum_columns():
+        rendered = ','.join(f"'{v}'" for v in column.type.enums)
+        column_types[(table_name, column.name)] = f'enum({rendered})'
+    return column_types
+
+
+class _FakeConnection:
+    """A connection double that answers information_schema queries.
+
+    Serves COLUMN_TYPE values from a dict keyed by (table, column) and
+    records every executed statement so tests can assert on emitted DDL.
+    """
+
+    def __init__(self, column_types: dict):
+        self.column_types = column_types
+        self.executed = []
+
+    def execute(self, statement, params=None):
+        sql = str(statement)
+        self.executed.append((sql, params))
+        result = mock.MagicMock()
+        if 'information_schema' in sql:
+            column_type = self.column_types.get(
+                (params['table_name'], params['column_name']))
+            result.first.return_value = (
+                None if column_type is None else (column_type,))
+        return result
+
+    def commit(self):
+        pass
+
+    def alters(self):
+        return [sql for sql, _ in self.executed if sql.startswith('ALTER')]
+
+
+def _engine_with(column_types: dict):
+    conn = _FakeConnection(column_types)
+    engine = mock.MagicMock()
+    engine.connect.return_value.__enter__.return_value = conn
+    return engine, conn
+
+
+class NativeEnumDiscoveryTestCase(base.ShakenFistTestCase):
+    """Tests for _native_enum_columns() discovery."""
+
+    def test_discovers_known_enum_columns(self):
+        """Discovery finds every ENUM column that exists today.
+
+        This is a superset assertion: a future sa.Enum(...) column is
+        covered automatically and must not break this test, but losing
+        discovery of an existing column must.
+        """
+        discovered = {
+            (table_name, column.name)
+            for table_name, column in mariadb._native_enum_columns()}
+        self.assertTrue(
+            KNOWN_ENUM_COLUMNS.issubset(discovered),
+            f'ENUM column discovery lost columns: '
+            f'{KNOWN_ENUM_COLUMNS - discovered}')
+
+    def test_discovered_columns_use_member_names(self):
+        """The canonical value list is enum member names, not values.
+
+        The removed _build_object_type_enum_values() helper quoted enum
+        *values* ('namespace_key'), but SQLAlchemy renders member *names*
+        ('NAMESPACE_KEY') into the DDL. Guard against that bug returning.
+        """
+        for table_name, column in mariadb._native_enum_columns():
+            if column.type.enum_class is mariadb.ObjectType:
+                self.assertIn('NAMESPACE_KEY', column.type.enums)
+                self.assertNotIn('namespace_key', column.type.enums)
+
+
+class ParseEnumColumnTypeTestCase(base.ShakenFistTestCase):
+    """Tests for _parse_enum_column_type()."""
+
+    def test_non_enum_returns_none(self):
+        self.assertIsNone(mariadb._parse_enum_column_type('varchar(36)'))
+        self.assertIsNone(mariadb._parse_enum_column_type('bigint(20)'))
+
+    def test_simple_enum(self):
+        self.assertEqual(
+            ['A', 'B', 'C'],
+            mariadb._parse_enum_column_type("enum('A','B','C')"))
+
+    def test_uppercase_keyword_and_spaces(self):
+        self.assertEqual(
+            ['A', 'B'],
+            mariadb._parse_enum_column_type("ENUM('A', 'B')"))
+
+    def test_embedded_quote(self):
+        self.assertEqual(
+            ["it's", 'B'],
+            mariadb._parse_enum_column_type("enum('it''s','B')"))
+
+    def test_round_trips_render(self):
+        values = ['A', "it's", 'B-2']
+        rendered = mariadb._render_enum_ddl(values)
+        self.assertEqual(
+            values,
+            mariadb._parse_enum_column_type(rendered))
+
+
+class EnsureNativeEnumColumnsTestCase(base.ShakenFistTestCase):
+    """Tests for _ensure_native_enum_columns() against a mocked engine."""
+
+    def test_up_to_date_database_is_noop(self):
+        engine, conn = _engine_with(_current_column_types())
+
+        result = mariadb._ensure_native_enum_columns(engine)
+
+        self.assertEqual([], conn.alters())
+        self.assertFalse(result['migrated'])
+        self.assertEqual([], result['altered_columns'])
+
+    def test_namespace_key_regression(self):
+        """An object_states ENUM predating NAMESPACE_KEY is widened.
+
+        Regression test for the 2026-07-28 outage: clusters deployed
+        before ObjectType.NAMESPACE_KEY existed rejected namespace key
+        state writes with "Data truncated for column 'object_type'",
+        which turned every request touching namespace keys into a 500.
+        """
+        column_types = _current_column_types()
+        for key in [('object_states', 'object_type'),
+                    ('object_metadata', 'object_type'),
+                    ('cluster_operation_targets', 'target_object_type'),
+                    ('ipam_reservations', 'user_type')]:
+            column_types[key] = column_types[key].replace(
+                ",'NAMESPACE_KEY'", '')
+            self.assertNotIn('NAMESPACE_KEY', column_types[key])
+        engine, conn = _engine_with(column_types)
+
+        result = mariadb._ensure_native_enum_columns(engine)
+
+        self.assertTrue(result['migrated'])
+        self.assertEqual(
+            ['cluster_operation_targets.target_object_type',
+             'ipam_reservations.user_type',
+             'object_metadata.object_type',
+             'object_states.object_type'],
+            result['altered_columns'])
+
+        alters = conn.alters()
+        self.assertEqual(4, len(alters))
+        for alter in alters:
+            self.assertIn("'NAMESPACE_KEY'", alter)
+            self.assertIn('MODIFY COLUMN', alter)
+
+    def test_nullability_is_preserved(self):
+        """user_type is nullable and must stay so; object_type must not."""
+        column_types = _current_column_types()
+        for key in [('object_states', 'object_type'),
+                    ('ipam_reservations', 'user_type')]:
+            column_types[key] = column_types[key].replace(
+                ",'NAMESPACE_KEY'", '')
+        engine, conn = _engine_with(column_types)
+
+        mariadb._ensure_native_enum_columns(engine)
+
+        by_table = {}
+        for alter in conn.alters():
+            by_table[alter.split(' ')[2]] = alter
+        self.assertTrue(by_table['object_states'].endswith(' NOT NULL'))
+        self.assertTrue(by_table['ipam_reservations'].endswith(' NULL'))
+        self.assertFalse(
+            by_table['ipam_reservations'].endswith(' NOT NULL'))
+
+    def test_stale_values_are_retained(self):
+        """Values removed from the Python enum stay in the column.
+
+        Rows may still hold the old value; dropping it from the ENUM would
+        corrupt them. The stale value is appended after the canonical list
+        so canonical ordinals stay stable.
+        """
+        column_types = _current_column_types()
+        key = ('object_states', 'object_type')
+        column_types[key] = column_types[key].replace(
+            ",'NAMESPACE_KEY'", '').replace(
+            "enum(", "enum('LEGACY_TYPE',")
+        engine, conn = _engine_with(column_types)
+
+        mariadb._ensure_native_enum_columns(engine)
+
+        alters = conn.alters()
+        self.assertEqual(1, len(alters))
+        self.assertIn("'NAMESPACE_KEY'", alters[0])
+        self.assertIn("'LEGACY_TYPE'", alters[0])
+        # The stale value comes after every canonical value.
+        self.assertGreater(
+            alters[0].index("'LEGACY_TYPE'"),
+            alters[0].index("'NAMESPACE_KEY'"))
+
+    def test_missing_column_is_skipped(self):
+        """A table not present in the database is skipped without DDL."""
+        column_types = _current_column_types()
+        del column_types[('object_states', 'object_type')]
+        engine, conn = _engine_with(column_types)
+
+        result = mariadb._ensure_native_enum_columns(engine)
+
+        self.assertEqual([], conn.alters())
+        self.assertFalse(result['migrated'])
+
+    def test_non_enum_database_column_is_skipped(self):
+        """A column that is not an ENUM in the database is left alone."""
+        column_types = _current_column_types()
+        column_types[('object_states', 'object_type')] = 'varchar(64)'
+        engine, conn = _engine_with(column_types)
+
+        result = mariadb._ensure_native_enum_columns(engine)
+
+        self.assertEqual([], conn.alters())
+        self.assertFalse(result['migrated'])
+
+
+class EnsureSchemaWiringTestCase(base.ShakenFistTestCase):
+    """ensure_schema() must run the ENUM reconciliation pass."""
+
+    def test_ensure_schema_calls_enum_reconciliation(self):
+        ensure_fns = [
+            name for name in dir(mariadb)
+            if name.startswith('_ensure_') and name.endswith('_schema')]
+        patchers = []
+        for name in ensure_fns:
+            p = mock.patch.object(
+                mariadb, name,
+                return_value={'table': name, 'migrated': False})
+            p.start()
+            patchers.append(p)
+        self.addCleanup(lambda: [p.stop() for p in patchers])
+
+        with mock.patch.object(mariadb, '_ensure_schema_versions_table'), \
+                mock.patch.object(mariadb, '_get_engine'), \
+                mock.patch.object(
+                    mariadb, '_ensure_native_enum_columns',
+                    return_value={'table': 'native-enum-columns',
+                                  'altered_columns': [],
+                                  'migrated': False}) as mock_reconcile, \
+                mock.patch('shakenfist.mariadb.config', fake_config):
+            results = mariadb.ensure_schema()
+
+        mock_reconcile.assert_called_once()
+        self.assertEqual(
+            'native-enum-columns', results[-1]['table'])

--- a/shakenfist/tests/test_mariadb_enum_columns_live.py
+++ b/shakenfist/tests/test_mariadb_enum_columns_live.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Michael Still and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Live-MariaDB test for native ENUM column widening.
+
+These tests run only when SF_MARIADB_TEST_DSN points at a disposable
+MariaDB database (CI provides one via tools/ci-enum-widening-test.sh;
+developers can point at a local instance). They simulate the failure
+mode that broke the sfcbr cluster on 2026-07-28: a database created
+before ObjectType.NAMESPACE_KEY existed rejected namespace key state
+writes with "Data truncated for column 'object_type'" (error 1265),
+because a MariaDB ENUM column freezes its value list at CREATE TABLE
+time and no migration widened it.
+
+The test creates the real schema, shrinks every native ENUM column back
+one member (what a pre-upgrade database looks like), then runs the
+reconciliation and proves both that the column definitions are restored
+and that the incident's exact write -- a namespace_key state row -- now
+succeeds.
+
+DESTRUCTIVE: tables in the target database are dropped during cleanup.
+Never point SF_MARIADB_TEST_DSN at a real deployment.
+"""
+
+import os
+import time
+import unittest
+from uuid import uuid4
+
+import sqlalchemy as sa
+
+from shakenfist import mariadb
+from shakenfist.schema.object_types import ObjectType
+from shakenfist.tests import base
+
+
+DSN_ENV = 'SF_MARIADB_TEST_DSN'
+
+# Every table an enum-bearing ensure function touches, for cleanup.
+TEST_TABLES = [
+    'object_states',
+    'object_metadata',
+    'cluster_operation_targets',
+    'ipam_reservations',
+    'schema_versions',
+]
+
+
+@unittest.skipUnless(
+    os.environ.get(DSN_ENV),
+    f'{DSN_ENV} not set; requires a disposable MariaDB database')
+class NativeEnumWideningLiveTestCase(base.ShakenFistTestCase):
+    """Prove ENUM widening works against a real MariaDB."""
+
+    def setUp(self):
+        super().setUp()
+        self.engine = sa.create_engine(os.environ[DSN_ENV])
+        self.addCleanup(self._drop_tables)
+        self.addCleanup(self.engine.dispose)
+
+        mariadb._ensure_schema_versions_table(self.engine)
+        mariadb._ensure_object_states_schema(self.engine)
+        mariadb._ensure_object_metadata_schema(self.engine)
+        mariadb._ensure_cluster_operation_targets_schema(self.engine)
+        mariadb._ensure_ipam_reservations_schema(self.engine)
+
+    def _drop_tables(self):
+        with self.engine.connect() as conn:
+            for table in TEST_TABLES:
+                conn.execute(sa.text(f'DROP TABLE IF EXISTS {table}'))
+            conn.commit()
+
+    def _column_enum_values(self, table_name, column_name):
+        with self.engine.connect() as conn:
+            row = conn.execute(
+                sa.text(
+                    'SELECT COLUMN_TYPE FROM information_schema.COLUMNS '
+                    'WHERE TABLE_SCHEMA = DATABASE() '
+                    'AND TABLE_NAME = :table_name '
+                    'AND COLUMN_NAME = :column_name'),
+                {'table_name': table_name, 'column_name': column_name}
+            ).first()
+        self.assertIsNotNone(row)
+        values = mariadb._parse_enum_column_type(row[0])
+        self.assertIsNotNone(values)
+        return values
+
+    def _shrink_enum_columns(self):
+        """Rewrite every native ENUM column without its newest member.
+
+        This is exactly what a database created from an older release
+        looks like after a code upgrade: the Python enum has a member
+        the column definition has never heard of.
+        """
+        shrunk = []
+        with self.engine.connect() as conn:
+            for table_name, column in mariadb._native_enum_columns():
+                values = list(column.type.enums)
+                if len(values) < 2:
+                    continue
+                nullability = 'NULL' if column.nullable else 'NOT NULL'
+                conn.execute(sa.text(
+                    f'ALTER TABLE {table_name} '
+                    f'MODIFY COLUMN {column.name} '
+                    f'{mariadb._render_enum_ddl(values[:-1])} '
+                    f'{nullability}'))
+                shrunk.append((table_name, column.name, values[-1]))
+            conn.commit()
+        return shrunk
+
+    def test_widening_restores_all_enum_columns(self):
+        shrunk = self._shrink_enum_columns()
+        self.assertNotEqual([], shrunk)
+        for table_name, column_name, newest in shrunk:
+            self.assertNotIn(
+                newest, self._column_enum_values(table_name, column_name))
+
+        result = mariadb._ensure_native_enum_columns(self.engine)
+
+        self.assertTrue(result['migrated'])
+        self.assertEqual(len(shrunk), len(result['altered_columns']))
+        for table_name, column_name, newest in shrunk:
+            self.assertIn(
+                newest, self._column_enum_values(table_name, column_name))
+
+        # Reconciliation is idempotent: a second run changes nothing.
+        result = mariadb._ensure_native_enum_columns(self.engine)
+        self.assertFalse(result['migrated'])
+
+    def test_namespace_key_state_write_succeeds_after_widening(self):
+        """The incident's exact failing write works after reconciliation.
+
+        On the broken cluster this INSERT raised DataError 1265 ("Data
+        truncated for column 'object_type'"), which surfaced as 500s on
+        every API request that touched namespace keys. First reproduce
+        that failure against the shrunken schema, then prove the
+        reconciliation fixes it.
+        """
+        self._shrink_enum_columns()
+
+        table = mariadb._get_object_states_table()
+        key_uuid = str(uuid4())
+        with self.engine.connect() as conn:
+            self.assertRaises(
+                sa.exc.DBAPIError,
+                conn.execute,
+                table.insert().values(
+                    object_uuid=key_uuid,
+                    object_type=ObjectType.NAMESPACE_KEY,
+                    state_value='initial',
+                    update_time=time.time(),
+                    message=None))
+
+        mariadb._ensure_native_enum_columns(self.engine)
+        with self.engine.connect() as conn:
+            conn.execute(table.insert().values(
+                object_uuid=key_uuid,
+                object_type=ObjectType.NAMESPACE_KEY,
+                state_value='initial',
+                update_time=time.time(),
+                message=None))
+            conn.commit()
+
+            row = conn.execute(
+                sa.select(table).where(
+                    table.c.object_uuid == key_uuid)).first()
+        self.assertIsNotNone(row)
+        self.assertEqual('initial', row.state_value)

--- a/tools/ci-enum-widening-test.sh
+++ b/tools/ci-enum-widening-test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Copyright 2026 Michael Still and contributors
+#
+# ci-enum-widening-test.sh -- run the live ENUM widening tests against
+# a local MariaDB. The caller must have installed MariaDB first (see
+# tools/ci-install-mariadb.sh), with the shakenfist database and user
+# from tools/bootstrap-mariadb.sql.
+#
+# The tests simulate a database created before the newest member of
+# each Python enum existed (the failure mode that broke namespace key
+# writes when ObjectType.NAMESPACE_KEY shipped without a widening
+# migration), then verify ensure_schema()'s reconciliation pass widens
+# the ENUM columns and the new values become writable.
+#
+# Usage:
+#
+#   bash tools/ci-enum-widening-test.sh <mariadb-password>
+#
+# Arguments:
+#
+#   $1   the MariaDB password for the shakenfist user (required)
+#
+# The tests are DESTRUCTIVE to the shakenfist database (tables are
+# dropped during cleanup), which is fine on the ephemeral CI VM this
+# script targets. Do not run against a real deployment.
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <mariadb-password>" >&2
+    exit 1
+fi
+
+DB_PASSWORD="$1"
+
+# The mariadb+mysqldb SQLAlchemy dialect (the one production uses, and
+# the only one that supports MariaDB-specific types like INET4) needs
+# the system python3-mysqldb bindings, hence --system-site-packages.
+echo "Installing system MySQLdb bindings..."
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3-mysqldb
+
+echo "Building test venv..."
+rm -rf /tmp/venv-enum-widening
+python3 -mvenv --system-site-packages /tmp/venv-enum-widening
+# shellcheck disable=SC1091
+. /tmp/venv-enum-widening/bin/activate
+pip3 install uv
+uv pip install -e '.[test]'
+
+export SF_MARIADB_TEST_DSN="mariadb+mysqldb://shakenfist:${DB_PASSWORD}@127.0.0.1:3306/shakenfist"
+
+echo "Running live ENUM widening tests..."
+stestr run --serial test_mariadb_enum_columns_live
+
+echo "Live ENUM widening tests passed."


### PR DESCRIPTION
MariaDB freezes an ENUM column's value list at CREATE TABLE time, so adding a member to a Python enum works on fresh installs but breaks existing databases: inserts of the new value fail with "Data truncated for column" (error 1265). This is how ObjectType.NAMESPACE_KEY broke namespace key state writes on upgraded clusters on 2026-07-28 -- every API request touching namespace keys returned 500, while greenfield CI kept passing.

ensure_schema() now ends with a reconciliation pass that discovers every native sa.Enum column from the SQLAlchemy metadata and widens stale columns in place, so future enum members (and future enum columns) need no hand-written migration. The previous helpers for this were dead code and quoted enum values where the DDL stores member names. Coverage: mock unit tests including a named regression test for the outage; live tests that reproduce the failing insert against a real MariaDB and prove recovery; and a new "Schema ENUM widening" CI job on an ephemeral VM runner gating the merge queue.

Prompt: After diagnosing why CI jobs were queueing (the sfcbr cluster API was returning 500s following the auth-federation deploy), Mikal asked for the shakenfist bug to be fixed on a new worktree/branch, with unit and CI test coverage to ensure this class of failure cannot recur.

Assisted-By: Claude Code