### PR TITLE
Align SPICE graphics settings with ryll findings.

### DIFF
--- a/shakenfist/deploy/collection/roles/hypervisor/files/libvirt.tmpl
+++ b/shakenfist/deploy/collection/roles/hypervisor/files/libvirt.tmpl
@@ -181,11 +181,17 @@
       <channel name='smartcard' mode='secure'/>
       <channel name='usbredir' mode='secure'/>
 
-      <image compression="auto_glz"/>
-      <jpeg compression="always"/>
-      <zlib compression="always"/>
+      <!-- NOTE(mikal): auto_lz over auto_glz because glz payloads are slow
+           to decode client-side; auto (not always) for jpeg/zlib so the
+           server honours client capability advertisements like LZ4; and
+           streaming mode filter because mode all causes rapid stream
+           create/destroy flapping on cursor blinks and window drags. See
+           https://github.com/shakenfist/ryll/blob/develop/docs/libvirt-spice-recommendations.md -->
+      <image compression="auto_lz"/>
+      <jpeg compression="auto"/>
+      <zlib compression="auto"/>
       <playback compression="on"/>
-      <streaming mode="all"/>
+      <streaming mode="filter"/>
     </graphics>
     {%- endif %}
 

--- a/shakenfist/deploy/templates/libvirt.tmpl
+++ b/shakenfist/deploy/templates/libvirt.tmpl
@@ -181,11 +181,17 @@
       <channel name='smartcard' mode='secure'/>
       <channel name='usbredir' mode='secure'/>
 
-      <image compression="auto_glz"/>
-      <jpeg compression="always"/>
-      <zlib compression="always"/>
+      <!-- NOTE(mikal): auto_lz over auto_glz because glz payloads are slow
+           to decode client-side; auto (not always) for jpeg/zlib so the
+           server honours client capability advertisements like LZ4; and
+           streaming mode filter because mode all causes rapid stream
+           create/destroy flapping on cursor blinks and window drags. See
+           https://github.com/shakenfist/ryll/blob/develop/docs/libvirt-spice-recommendations.md -->
+      <image compression="auto_lz"/>
+      <jpeg compression="auto"/>
+      <zlib compression="auto"/>
       <playback compression="on"/>
-      <streaming mode="all"/>
+      <streaming mode="filter"/>
     </graphics>
     {%- endif %}
 


### PR DESCRIPTION
Ryll dogfooding sessions produced concrete evidence against our current SPICE server settings: auto_glz produces large payloads that are slow to decode client-side; jpeg/zlib "always" forces the WAN path and ignores client capability advertisements like LZ4; and streaming mode "all" causes rapid stream create/destroy flapping on cursor blinks and window drags. Switch to auto_lz / auto / auto / filter in both copies of libvirt.tmpl, per https://github.com/shakenfist/ryll/blob/develop/docs/libvirt-spice-recommendations.md

Prompt: Mikal asked how the recommendations in ryll's libvirt-spice-recommendations.md align with what shakenfist actually sets today, and for libvirt.tmpl edits in a new worktree and branch to match current best practice. The compression and streaming settings were the only misalignments; TLS channels, the vdagent channel, and USB redirection already matched.


Assisted-By: Claude Code