### PR TITLE
Bound database calls upstream of watchdog pets.

### DIFF
--- a/docs/operator_guide/events.md
+++ b/docs/operator_guide/events.md
@@ -166,7 +166,7 @@ daemon's own metrics port.
 
 | Metric | Type | Source daemon | Description |
 |--------|------|---------------|-------------|
-| `database_events_rows` | Gauge | sf-database | Current row count in the `events` table, sampled roughly every 60 seconds. Use this to watch for unchecked growth if pruning stops. |
+| `database_events_rows` | Gauge | sf-database | Estimated row count of the `events` table (the statistics-based `information_schema` estimate, matching what mysqld-exporter reports), sampled roughly every 60 seconds. It can be off by tens of percent between statistics refreshes but tracks growth trends; use it to watch for unchecked growth if pruning stops. An exact `COUNT(*)` is deliberately not used: on a large events table the full scan churns the InnoDB buffer pool and can stall the daemon's watchdog loop (issue 3586). |
 | `database_events_inserted_total` | Counter | sf-database | Events inserted, labelled by `event_type`. Watch the per-label rate for unexpected spikes. |
 | `database_events_pruned_total` | Counter | sf-database | `event_objects` rows pruned per prune run, labelled by `event_type`. The synthetic label `event_type='api-request'` covers the object-type-override sweep. |
 | `database_orphan_events_pruned_total` | Counter | sf-database | `events` rows removed by the orphan sweep. A non-zero rate here is normal after each daily prune. |

--- a/shakenfist/daemons/daemon.py
+++ b/shakenfist/daemons/daemon.py
@@ -420,12 +420,18 @@ class Daemon:
         # avoid a get_node round trip just to reach a daemon-state accessor. An
         # unreachable database must not propagate from here -- we just can't
         # check right now, and will again shortly.
+        #
+        # bounded=True because this poll runs inside idle(), upstream of the
+        # systemd watchdog pet: a slow database must make the poll fail fast,
+        # not block past WatchdogSec and get the daemon SIGABRT-killed. That
+        # was the coredump mechanism in issue 3586, on both the database
+        # daemon's direct path and other daemons' gRPC path.
         node_uuid = config.NODE_UUID
         if not node_uuid:
             return
         try:
             row = mariadb.get_node_daemon_state(
-                uuid.UUID(node_uuid), self.daemon_name)
+                uuid.UUID(node_uuid), self.daemon_name, bounded=True)
         except DatabaseUnavailable:
             return
         daemon_state = row.value if row is not None else None

--- a/shakenfist/daemons/database/main.py
+++ b/shakenfist/daemons/database/main.py
@@ -5541,7 +5541,12 @@ class Monitor(daemon.WorkerPoolDaemon):
                 # The database daemon doesn't have background work to do,
                 # it just serves gRPC requests. We check health periodically
                 # and refresh the events row-count gauge every ~60s (every
-                # 6 ticks of the 10s idle).
+                # 6 ticks of the 10s idle). Everything in this loop must be
+                # bounded well inside the unit's WatchdogSec: the watchdog is
+                # only petted from idle(), so an unbounded database call here
+                # gets the daemon SIGABRT-killed when MariaDB stalls -- on
+                # both gateways at once, since they run the same loop against
+                # the same server (issue 3586).
                 self._update_health()
 
                 refresh_tick += 1

--- a/shakenfist/mariadb.py
+++ b/shakenfist/mariadb.py
@@ -450,6 +450,16 @@ GRPC_RETRIES = 3
 GRPC_UNAVAILABLE_RETRIES = 6
 GRPC_RETRY_DELAY = 0.5
 
+# Ceiling for database work performed upstream of a daemon's systemd
+# watchdog pet (the check_daemon_state() poll inside Daemon.idle(), and
+# the database daemon's events-rows gauge refresh). Every such call must
+# complete or fail well inside WatchdogSec (60s in sf.service): issue
+# 3586 traced simultaneous SIGABRT coredumps of sf-database on both
+# gateways to an InnoDB stall holding these calls -- and with them the
+# watchdog pet -- hostage. Used as the connect/read/write timeout on the
+# bounded direct engine and as the gRPC deadline for bounded calls.
+BOUNDED_QUERY_TIMEOUT = 10
+
 
 def _get_database_stub() -> Any:
     """Get or create a gRPC stub for the database service.
@@ -477,8 +487,21 @@ def _reset_database_stub() -> None:
     _local.database_stub = None
 
 
-def _grpc_call(method: Any, request: Any) -> Any:
+def _grpc_call(
+    method: Any, request: Any,
+    timeout: Optional[int] = None,
+    max_slow_failures: Optional[int] = None,
+) -> Any:
     """Call a gRPC method with timeout and retry.
+
+    ``timeout`` and ``max_slow_failures`` default to GRPC_TIMEOUT and
+    GRPC_RETRIES. Callers running upstream of a systemd watchdog pet
+    pass BOUNDED_QUERY_TIMEOUT and 1 instead, capping the worst case
+    (one full deadline plus the fast-failing UNAVAILABLE attempts and
+    their sleeps) well inside WatchdogSec -- the default worst case of
+    GRPC_RETRIES * GRPC_TIMEOUT plus sleeps exceeds it, which is how a
+    stalled database tier SIGABRTed non-database daemons via their
+    check_daemon_state() poll (issue 3586).
 
     Retries on UNAVAILABLE and DEADLINE_EXCEEDED with a short delay
     between attempts. On DEADLINE_EXCEEDED it rebuilds the channel
@@ -520,6 +543,11 @@ def _grpc_call(method: Any, request: Any) -> Any:
     so the retry path here -- which closes and rebuilds the channel
     -- never fires. Fail-fast plus retry recovers; fail-slow does not.
     """
+    if timeout is None:
+        timeout = GRPC_TIMEOUT
+    if max_slow_failures is None:
+        max_slow_failures = GRPC_RETRIES
+
     retryable_codes = {
         grpc.StatusCode.UNAVAILABLE,
         grpc.StatusCode.DEADLINE_EXCEEDED,
@@ -550,7 +578,7 @@ def _grpc_call(method: Any, request: Any) -> Any:
             if attempt > 0 and method_name:
                 stub = _get_database_stub()
                 method = getattr(stub, method_name)
-            return method(request, timeout=GRPC_TIMEOUT)
+            return method(request, timeout=timeout)
         except grpc.RpcError as e:
             last_error = e
             if e.code() not in retryable_codes:
@@ -560,7 +588,7 @@ def _grpc_call(method: Any, request: Any) -> Any:
                 # cap them separately so the fast-failing UNAVAILABLE budget
                 # cannot stretch the caller's worst case to minutes.
                 slow_failures += 1
-                if slow_failures >= GRPC_RETRIES:
+                if slow_failures >= max_slow_failures:
                     break
             if attempt < GRPC_UNAVAILABLE_RETRIES - 1:
                 # Whether to rebuild the channel depends on *why* we failed.
@@ -752,6 +780,48 @@ def _get_engine() -> sa.Engine:
             _log_slow_query)
         LOG.debug('Created new MariaDB engine for thread')
     engine: sa.Engine = _local.engine
+    return engine
+
+
+def _get_bounded_engine() -> sa.Engine:
+    """Get or create a thread-local engine whose calls cannot stall.
+
+    The pooled engine from _get_engine() carries no timeouts: a query
+    against a stalled server blocks indefinitely. That is tolerable for
+    gRPC worker threads, but fatal for code running upstream of a
+    daemon's systemd watchdog pet -- issue 3586 traced simultaneous
+    watchdog SIGABRTs of sf-database on both gateways to an InnoDB
+    buffer-pool stall wedging exactly such calls. This engine sets
+    connect, read and write timeouts of BOUNDED_QUERY_TIMEOUT seconds
+    so the worst case stays well inside WatchdogSec (60s); a timed-out
+    call surfaces as OperationalError, which the bounded callers
+    already treat as 'cannot check right now'.
+
+    Configuration otherwise mirrors _get_engine() (pool_recycle, JSON
+    serializer, slow-query listeners); see that docstring for the
+    reasoning behind those values.
+    """
+    if not hasattr(_local, 'bounded_engine') or _local.bounded_engine is None:
+        url = _get_connection_url()
+        _local.bounded_engine = sa.create_engine(
+            url,
+            pool_recycle=1800,
+            echo=False,
+            connect_args={
+                'connect_timeout': BOUNDED_QUERY_TIMEOUT,
+                'read_timeout': BOUNDED_QUERY_TIMEOUT,
+                'write_timeout': BOUNDED_QUERY_TIMEOUT,
+            },
+            json_serializer=_json_dumps,
+        )
+        sa_event.listen(
+            _local.bounded_engine, 'before_cursor_execute',
+            _record_query_start_time)
+        sa_event.listen(
+            _local.bounded_engine, 'after_cursor_execute',
+            _log_slow_query)
+        LOG.debug('Created new bounded MariaDB engine for thread')
+    engine: sa.Engine = _local.bounded_engine
     return engine
 
 
@@ -4746,19 +4816,33 @@ def _direct_record_event_batch(events: list[EventRecord]) -> bool:
 
 
 def _direct_get_events_count() -> int:
-    """Return the current row count of the events table.
+    """Return an estimate of the events table row count.
 
     Used by the database daemon to refresh the database_events_rows
-    Prometheus gauge. Returns 0 on database error so a transient
-    failure does not crash the gauge-refresh loop.
-    """
-    engine = _get_engine()
-    events_table = _get_events_table()
+    Prometheus gauge from its watchdog-petting main loop, so this must
+    be cheap and bounded. It reads the statistics-based
+    information_schema TABLE_ROWS estimate rather than an exact
+    COUNT(*): with millions of event rows the full scan takes unbounded
+    time under I/O pressure and cycles the entire table -- larger than
+    the InnoDB buffer pool on real deployments -- through it on every
+    refresh. Issue 3586 traced simultaneous watchdog SIGABRTs of
+    sf-database on both gateways to exactly that. The estimate can be
+    off by tens of percent between statistics refreshes, which is fine
+    for a growth-trend gauge (and matches what mysqld-exporter reports
+    for the same quantity).
 
+    Runs on the bounded engine so a stalled server cannot hold the
+    daemon's main loop -- and with it the systemd watchdog pet --
+    hostage. Returns 0 on database error so a transient failure does
+    not crash the gauge-refresh loop.
+    """
     try:
-        with engine.connect() as conn:
-            stmt = sa.select(sa.func.count()).select_from(events_table)
-            return conn.execute(stmt).scalar() or 0
+        with _get_bounded_engine().connect() as conn:
+            stmt = sa.text(
+                'SELECT table_rows FROM information_schema.tables '
+                'WHERE table_schema = DATABASE() AND table_name = :name')
+            return int(conn.execute(
+                stmt, {'name': 'events'}).scalar() or 0)
     except OperationalError as e:
         LOG.warning(f'MariaDB read failed for events count: {e}')
         return 0
@@ -10148,10 +10232,18 @@ def _direct_set_node_daemon_state(
 
 
 def _direct_get_node_daemon_state(
-    node_uuid: UUID, daemon: str,
+    node_uuid: UUID, daemon: str, bounded: bool = False,
 ) -> Optional[NodeDaemonStateData]:
-    """Read one (node, daemon) state row, or None if absent."""
-    engine = _get_engine()
+    """Read one (node, daemon) state row, or None if absent.
+
+    With bounded=True the read runs on the bounded engine: the caller
+    is upstream of a systemd watchdog pet (Daemon.check_daemon_state's
+    poll on the database daemon) and must not block on a stalled
+    server. A timeout surfaces as OperationalError and, as with any
+    database error here, returns None -- the poll just cannot check
+    right now and will again shortly.
+    """
+    engine = _get_bounded_engine() if bounded else _get_engine()
     table = _get_node_daemon_states_table()
 
     try:
@@ -10782,14 +10874,28 @@ def _grpc_set_node_daemon_state(
 
 
 def _grpc_get_node_daemon_state(
-    node_uuid: UUID, daemon: str,
+    node_uuid: UUID, daemon: str, bounded: bool = False,
 ) -> Optional[NodeDaemonStateData]:
-    """Read one (node, daemon) state row via the database service."""
+    """Read one (node, daemon) state row via the database service.
+
+    With bounded=True the call uses a short deadline and a single slow
+    attempt: the caller is upstream of a systemd watchdog pet
+    (Daemon.check_daemon_state's poll inside idle()) and the default
+    retry budget of GRPC_RETRIES * GRPC_TIMEOUT plus sleeps exceeds
+    WatchdogSec, so a stalled database tier would SIGABRT the polling
+    daemon (issue 3586). Exhausted retries still raise
+    DatabaseUnavailable, which the poll already catches.
+    """
     try:
         stub = _get_database_stub()
         request = database_pb2.GetNodeDaemonStateRequest(
             node_uuid=str(node_uuid), daemon=daemon)
-        reply = _grpc_call(stub.GetNodeDaemonState, request)
+        if bounded:
+            reply = _grpc_call(
+                stub.GetNodeDaemonState, request,
+                timeout=BOUNDED_QUERY_TIMEOUT, max_slow_failures=1)
+        else:
+            reply = _grpc_call(stub.GetNodeDaemonState, request)
         if not reply.found:
             return None
         d = reply.data
@@ -10868,12 +10974,18 @@ def set_node_daemon_state(
 
 
 def get_node_daemon_state(
-    node_uuid: UUID, daemon: str,
+    node_uuid: UUID, daemon: str, bounded: bool = False,
 ) -> Optional[NodeDaemonStateData]:
-    """Read one (node, daemon) state row, or None if absent."""
+    """Read one (node, daemon) state row, or None if absent.
+
+    bounded=True promises the caller a bounded worst-case wall time
+    (well inside the systemd WatchdogSec) on both the direct and gRPC
+    paths, at the cost of giving up sooner when the database is slow.
+    Pass it from any code path that runs upstream of a watchdog pet.
+    """
     if _use_database_service():
-        return _grpc_get_node_daemon_state(node_uuid, daemon)
-    return _direct_get_node_daemon_state(node_uuid, daemon)
+        return _grpc_get_node_daemon_state(node_uuid, daemon, bounded=bounded)
+    return _direct_get_node_daemon_state(node_uuid, daemon, bounded=bounded)
 
 
 def get_all_node_daemon_states(

--- a/shakenfist/tests/test_database_unavailable.py
+++ b/shakenfist/tests/test_database_unavailable.py
@@ -330,8 +330,10 @@ class CheckDaemonStateTestCase(base.ShakenFistTestCase):
         with mock.patch.object(daemon.config, 'NODE_UUID', self.NODE_UUID):
             self._daemon().check_daemon_state()
         mock_this_node.assert_not_called()
+        # bounded=True: the poll runs upstream of the systemd watchdog pet
+        # and must not block past WatchdogSec on a stalled database (3586).
         mock_get_state.assert_called_once_with(
-            uuid.UUID(self.NODE_UUID), 'queues')
+            uuid.UUID(self.NODE_UUID), 'queues', bounded=True)
 
     @mock.patch('shakenfist.daemons.daemon.set_abort_path')
     @mock.patch('shakenfist.daemons.daemon.mariadb.get_node_daemon_state')

--- a/shakenfist/tests/test_events_storage.py
+++ b/shakenfist/tests/test_events_storage.py
@@ -463,44 +463,49 @@ class RecordEventBatchRoutingTestCase(base.ShakenFistTestCase):
 class DirectGetEventsCountTestCase(base.ShakenFistTestCase):
     """Tests for _direct_get_events_count()."""
 
-    @mock.patch('shakenfist.mariadb._get_events_table')
-    @mock.patch('shakenfist.mariadb._get_engine')
-    def test_returns_scalar_from_connection(
-            self, mock_get_engine, mock_get_events_table):
-        """The row count returned by the DB is forwarded unchanged."""
-        import sqlalchemy as sa
-        metadata = sa.MetaData()
-        events_table = sa.Table(
-            'events', metadata,
-            sa.Column('event_uuid', sa.CHAR(36), nullable=False),
-        )
-        mock_get_events_table.return_value = events_table
+    @mock.patch('shakenfist.mariadb._get_bounded_engine')
+    def test_returns_estimate_from_information_schema(
+            self, mock_get_bounded_engine):
+        """The information_schema TABLE_ROWS estimate is forwarded as an int.
 
+        The gauge refresh must not run an exact COUNT(*) -- the full scan
+        of a table larger than the buffer pool is what starved the systemd
+        watchdog in issue 3586 -- and must use the bounded engine so it
+        cannot stall the database daemon's main loop.
+        """
         conn = _MockConnection(result=_MockResult(scalar_val=42))
-        mock_get_engine.return_value = _MockEngine(conn)
+        mock_get_bounded_engine.return_value = _MockEngine(conn)
 
         count = mariadb._direct_get_events_count()
         self.assertEqual(count, 42)
 
-    @mock.patch('shakenfist.mariadb._get_events_table')
-    @mock.patch('shakenfist.mariadb._get_engine')
-    def test_returns_zero_on_database_error(
-            self, mock_get_engine, mock_get_events_table):
-        """OperationalError during the count query returns 0 without raising."""
+        self.assertEqual(1, len(conn.executed))
+        self.assertIn('information_schema.tables', str(conn.executed[0]))
+        self.assertNotIn('count', str(conn.executed[0]).lower())
+
+    @mock.patch('shakenfist.mariadb._get_bounded_engine')
+    def test_returns_zero_when_table_absent(self, mock_get_bounded_engine):
+        """No information_schema row (scalar None) is reported as 0."""
+        conn = _MockConnection(result=_MockResult(scalar_val=None))
+        mock_get_bounded_engine.return_value = _MockEngine(conn)
+
+        count = mariadb._direct_get_events_count()
+        self.assertEqual(count, 0)
+
+    @mock.patch('shakenfist.mariadb._get_bounded_engine')
+    def test_returns_zero_on_database_error(self, mock_get_bounded_engine):
+        """OperationalError during the estimate query returns 0 without raising.
+
+        This includes the read/connect timeouts the bounded engine raises
+        as OperationalError when the server stalls.
+        """
         from sqlalchemy.exc import OperationalError
-        import sqlalchemy as sa
-        metadata = sa.MetaData()
-        events_table = sa.Table(
-            'events', metadata,
-            sa.Column('event_uuid', sa.CHAR(36), nullable=False),
-        )
-        mock_get_events_table.return_value = events_table
 
         conn = _MockConnection()
         conn.execute = mock.Mock(
             side_effect=OperationalError('stmt', {}, Exception('db error'))
         )
-        mock_get_engine.return_value = _MockEngine(conn)
+        mock_get_bounded_engine.return_value = _MockEngine(conn)
 
         count = mariadb._direct_get_events_count()
         self.assertEqual(count, 0)

--- a/shakenfist/tests/test_mariadb_node_daemon_states.py
+++ b/shakenfist/tests/test_mariadb_node_daemon_states.py
@@ -117,6 +117,71 @@ class GetNodeDaemonStateTestCase(base.ShakenFistTestCase):
 
         self.assertIsNone(result)
 
+    @mock.patch('shakenfist.mariadb._get_engine')
+    @mock.patch('shakenfist.mariadb._get_bounded_engine')
+    def test_bounded_read_uses_bounded_engine(
+            self, mock_get_bounded_engine, mock_get_engine):
+        """bounded=True must route the read via the timeout-bearing engine.
+
+        The bounded path exists so Daemon.check_daemon_state()'s poll --
+        which runs upstream of the systemd watchdog pet -- cannot block
+        past WatchdogSec on a stalled server (issue 3586).
+        """
+        mock_engine = mock.MagicMock()
+        mock_conn = mock.MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = None
+        mock_engine.connect.return_value.__enter__ = mock.Mock(
+            return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = mock.Mock(
+            return_value=False)
+        mock_get_bounded_engine.return_value = mock_engine
+
+        result = mariadb._direct_get_node_daemon_state(
+            NODE_UUID, 'net', bounded=True)
+
+        self.assertIsNone(result)
+        mock_get_bounded_engine.assert_called_once()
+        mock_get_engine.assert_not_called()
+
+    @mock.patch('shakenfist.mariadb._direct_get_node_daemon_state',
+                return_value=None)
+    @mock.patch('shakenfist.mariadb._use_database_service',
+                return_value=False)
+    def test_public_accessor_plumbs_bounded_direct(
+            self, mock_use_service, mock_direct):
+        mariadb.get_node_daemon_state(NODE_UUID, 'net', bounded=True)
+        mock_direct.assert_called_once_with(NODE_UUID, 'net', bounded=True)
+
+    @mock.patch('shakenfist.mariadb._grpc_get_node_daemon_state',
+                return_value=None)
+    @mock.patch('shakenfist.mariadb._use_database_service',
+                return_value=True)
+    def test_public_accessor_plumbs_bounded_grpc(
+            self, mock_use_service, mock_grpc):
+        mariadb.get_node_daemon_state(NODE_UUID, 'net', bounded=True)
+        mock_grpc.assert_called_once_with(NODE_UUID, 'net', bounded=True)
+
+    @mock.patch('shakenfist.mariadb._grpc_call')
+    @mock.patch('shakenfist.mariadb._get_database_stub')
+    def test_grpc_bounded_read_uses_short_deadline_single_slow_attempt(
+            self, mock_get_stub, mock_grpc_call):
+        """The bounded gRPC read caps its worst-case wall time.
+
+        The default retry budget (GRPC_RETRIES full deadlines plus
+        sleeps) exceeds WatchdogSec, which is how a stalled database
+        tier SIGABRTed non-database daemons via their
+        check_daemon_state() poll (issue 3586).
+        """
+        mock_grpc_call.return_value = mock.Mock(found=False)
+
+        result = mariadb._grpc_get_node_daemon_state(
+            NODE_UUID, 'net', bounded=True)
+
+        self.assertIsNone(result)
+        _, kwargs = mock_grpc_call.call_args
+        self.assertEqual(kwargs['timeout'], mariadb.BOUNDED_QUERY_TIMEOUT)
+        self.assertEqual(kwargs['max_slow_failures'], 1)
+
 
 class GetAllNodeDaemonStatesTestCase(base.ShakenFistTestCase):
     """``_direct_get_all_node_daemon_states`` returns rows for one node."""


### PR DESCRIPTION
sf-database on both sfcbr gateways hit its 60s systemd watchdog and was SIGABRT-killed near-simultaneously three times in seven days (2026-07-28 17:33, 2026-07-31 05:58 and 06:01 AEST), each time causing an ~8s cluster-wide DatabaseUnavailable window. The trigger was an InnoDB buffer-pool exhaustion stall on the backing MariaDB; the daemon-side defect is that calls made upstream of the systemd watchdog pet had unbounded worst-case wall time, so a stalled (but reachable) database held the pet hostage past WatchdogSec:

- The events row-count gauge ran an exact COUNT(*) full scan of the events table (~6.4M rows, ~4.4 GiB with indexes on sfcbr -- larger than the buffer pool) every ~60s per gateway on the timeout-less pooled engine. It was simultaneously a major cause of buffer-pool churn and the main victim of the resulting stall.

- Daemon.check_daemon_state(), polled every 2s inside idle() before the pet, reads the daemon-state row with no bound: directly on the pooled engine on the database daemon, and via _grpc_call() -- whose worst case of GRPC_RETRIES full GRPC_TIMEOUT deadlines plus backoff sleeps exceeds 90s -- everywhere else. The gRPC variant is how a stalled database tier also SIGABRTed queues, transfers, sidechannel and resources daemons on 2026-07-25.

Introduce BOUNDED_QUERY_TIMEOUT (10s) and a bounded thread-local engine carrying connect/read/write timeouts, and route both paths through it: the gauge now reads the statistics-based information_schema TABLE_ROWS estimate (no scan, accuracy is fine for a growth-trend gauge and matches mysqld-exporter), and get_node_daemon_state() grows a bounded flag that picks the bounded engine directly or a short gRPC deadline with a single slow attempt. A timed-out check degrades to "cannot check right now, will retry shortly", which both callers already handle; slow-database health is still reported via the gRPC health protocol rather than by coredumping the entire gateway tier at once.

Fixes #3586

Prompt: Investigate the nightly infra report finding of repeated sf-database watchdog SIGABRT coredumps on both sf-1 and sf-2. The investigation traced them to InnoDB buffer-pool exhaustion on the backing MariaDB stalling unbounded database calls in the daemons' watchdog-pet loops. Mikal asked for the resulting daemon hardening to be proposed on a new worktree and branch, with the matching infrastructure fix committed separately to 33fl.


Assisted-By: Claude Code