### PR TITLE
Stop re-eventing undeletable expired namespace keys.

### DIFF
--- a/docs/operator_guide/authentication.md
+++ b/docs/operator_guide/authentication.md
@@ -16,7 +16,11 @@ no window during which it still works because a cleanup task has not run yet.
 Tidying up expired keys is a separate, purely cosmetic concern. The cluster
 daemon sweeps every fifteen minutes and soft-deletes keys which expired more
 than `NAMESPACE_KEY_REAP_GRACE` seconds ago; the standard object reaper then
-hard-deletes them once they have been soft-deleted for `CLEANER_DELAY`.
+hard-deletes them once they have been soft-deleted for `CLEANER_DELAY`. A key
+whose static row has no state row at all (a "zombie", see the orphan
+reconciliation section of the [database guide](database.md)) is skipped by
+this sweep — the hourly orphan reconciliation repairs it, after which the
+normal reap path removes it.
 
 | Setting | Default | Effect |
 |---------|---------|--------|

--- a/shakenfist/daemons/cluster/scheduled_tasks.py
+++ b/shakenfist/daemons/cluster/scheduled_tasks.py
@@ -361,6 +361,7 @@ def reap_expired_namespace_keys() -> None:
 
     cutoff = time.time() - grace
     reaped = 0
+    zombies = 0
 
     for ns in Namespaces(filters=[], prefilter='active'):
         # include_expired is the whole point of the sweep, and the
@@ -370,19 +371,26 @@ def reap_expired_namespace_keys() -> None:
             if attrs.expiry is None or attrs.expiry >= cutoff:
                 continue
 
+            state_value = key.state.value
+
             # Already soft deleted by an earlier sweep, and now waiting
             # on the hard delete reaper.
-            if key.state.value in FINAL_OBJECT_STATES:
+            if state_value in FINAL_OBJECT_STATES:
+                continue
+
+            # A static row with no state row at all cannot be soft
+            # deleted: the state machine has no transition from None to
+            # deleted, so delete() would raise on every sweep forever.
+            # These zombies are reconcile_orphaned_objects' problem --
+            # it writes them a deleted state row and the hard delete
+            # reaper takes it from there. Count them for one aggregate
+            # log line rather than logging (or worse, eventing) each.
+            if state_value is None:
+                zombies += 1
                 continue
 
             try:
-                key.add_event(
-                    EVENT_TYPE_AUDIT,
-                    'the cluster wide cleanup daemon is deleting this '
-                    'namespace key because it expired',
-                    extra={'expiry': attrs.expiry})
                 key.delete()
-                reaped += 1
             except InvalidStateException as e:
                 # Raced with something else deleting the key. Not an
                 # error, the key is going away either way.
@@ -390,9 +398,26 @@ def reap_expired_namespace_keys() -> None:
                     'namespace': key.namespace,
                     'key': key.name
                 }).info(f'Expired namespace key already transitioning: {e}')
+                continue
+
+            # The audit event records only a successful delete. Eventing
+            # before the attempt meant a key whose delete always failed
+            # was re-evented every fifteen minutes forever -- 4,151
+            # zombie keys generated ~380k junk audit events/day, two
+            # thirds of the cluster's entire event volume (issue 3588).
+            key.add_event(
+                EVENT_TYPE_AUDIT,
+                'the cluster wide cleanup daemon is deleting this '
+                'namespace key because it expired',
+                extra={'expiry': attrs.expiry})
+            reaped += 1
 
     if reaped:
         LOG.info(f'Soft deleted {reaped} expired namespace keys')
+    if zombies:
+        LOG.with_fields({'zombies': zombies}).warning(
+            'Expired namespace keys with no state row skipped; '
+            'reconcile_orphaned_objects repairs these')
 
 
 def prune_events() -> None:

--- a/shakenfist/mariadb.py
+++ b/shakenfist/mariadb.py
@@ -20688,6 +20688,12 @@ _STATIC_TABLE_GETTERS: dict[str, tuple[Callable[[], sa.Table], str]] = {
     ObjectType.INTERFACE.value: (_get_network_interfaces_table, 'uuid'),
     ObjectType.IPAM.value: (_get_ipams_table, 'uuid'),
     ObjectType.NAMESPACE.value: (_get_namespaces_table, 'name'),
+    # namespace_key was missing from this map from the day the object
+    # landed, so the reconciler never repaired zombie keys: 4,151
+    # stateless keys from the cutover deploy's mixed-version window sat
+    # unrepairable while the expiry sweep re-evented every one of them
+    # every pass, ~380k junk audit events/day (issue 3588).
+    ObjectType.NAMESPACE_KEY.value: (_get_namespace_keys_table, 'uuid'),
     ObjectType.NETWORK.value: (_get_networks_table, 'uuid'),
     ObjectType.NODE.value: (_get_nodes_table, 'uuid'),
     ObjectType.UPLOAD.value: (_get_uploads_table, 'uuid'),

--- a/shakenfist/tests/test_daemon_cluster_scheduled_tasks.py
+++ b/shakenfist/tests/test_daemon_cluster_scheduled_tasks.py
@@ -480,8 +480,28 @@ class ReapExpiredNamespaceKeysTestCase(base.ShakenFistTestCase):
         key = FakeNamespaceKey('racing')
         key.delete = mock.Mock(side_effect=InvalidStateException('raced'))
 
-        # Must not raise -- the key is going away either way.
+        # Must not raise -- the key is going away either way. And no
+        # audit event: the event records a delete that happened, and
+        # this one did not. Eventing before the attempt is how 4,151
+        # undeletable keys generated ~380k junk events/day (issue 3588).
         self._sweep([(key, _attrs(1000.0))])
+
+        self.assertEqual([], key.events)
+
+    def test_skips_a_zombie_key_with_no_state_row(self):
+        # A static row with no object_states row (a mixed-version deploy
+        # artifact) has no legal transition to deleted, so delete()
+        # raises on every sweep forever. The sweep must leave these to
+        # reconcile_orphaned_objects: no delete attempt, and above all
+        # no per-key audit event per pass (issue 3588).
+        key = FakeNamespaceKey('zombie', state=None)
+        key.delete = mock.Mock(
+            side_effect=AssertionError('zombie must not be deleted here'))
+
+        self._sweep([(key, _attrs(1000.0))])
+
+        self.assertEqual([], key.events)
+        key.delete.assert_not_called()
 
     def test_does_nothing_when_reaping_is_disabled(self):
         key = FakeNamespaceKey('stale')

--- a/shakenfist/tests/test_mariadb_orphans.py
+++ b/shakenfist/tests/test_mariadb_orphans.py
@@ -205,3 +205,19 @@ class OrphanQueryTestCase(base.ShakenFistTestCase):
             ObjectType.UNKNOWN, updated_before=200.0))
         self.assertEqual([], mariadb._direct_get_stateless_object_uuids(
             ObjectType.UNKNOWN))
+
+    def test_namespace_keys_are_reconcilable(self):
+        # namespace_key was missing from _STATIC_TABLE_GETTERS from the
+        # day the object landed, so zombie keys (static row, no state
+        # row) were invisible to the reconciler while the expiry sweep
+        # re-evented every one of them every pass (issue 3588). Pin the
+        # membership so the reconciler keeps covering keys.
+        self.assertIn(ObjectType.NAMESPACE_KEY.value,
+                      mariadb.ORPHAN_RECONCILABLE_OBJECT_TYPES)
+
+        entry = mariadb._static_table_for_object_type(
+            ObjectType.NAMESPACE_KEY)
+        self.assertIsNotNone(entry)
+        table, pk = entry
+        self.assertEqual('namespace_keys', table.name)
+        self.assertEqual('uuid', pk)


### PR DESCRIPTION
Two thirds of all events written on sfcbr (~380k/day, ~4.4/second) were one audit message: "the cluster wide cleanup daemon is deleting this namespace key because it expired". 4,151 service keys minted in the ~18.5 hour mixed-version window following the NamespaceKey cutover deploy have static and attributes rows but no object_states row. The expiry sweep evented each of them BEFORE calling delete(), which then raised InvalidStateException every time (there is no legal transition from None to deleted), and the exception handler mislogged that as a benign already-transitioning race -- so every fifteen minute sweep re-evented all 4,151 keys, forever. The junk added over a million rows to events/event_objects, feeding the events-table growth implicated in issue 3586's buffer-pool exhaustion.

The reconciler added in bf23811c7 repairs exactly this zombie shape (static row, no state row) by writing a deleted state row -- but ObjectType.NAMESPACE_KEY was missing from _STATIC_TABLE_GETTERS, so namespace keys were never iterated. Two features that landed a day apart never learned about each other.

Three changes:

- Add NAMESPACE_KEY to _STATIC_TABLE_GETTERS. The hourly reconciler now sees namespace keys and drains the zombie backlog through the designed repair-then-hard-delete path; no manual data surgery is needed.

- The expiry sweep skips keys whose state is None, counting them into one aggregate warning per pass instead of eventing each key each time. Zombie repair is the reconciler's job.

- The sweep emits its audit event only after a successful delete(). An event describing an action must not be written before the action has happened; that inversion is what turned a stuck delete into an event storm. A delete lost to a genuine race is now also no longer evented.

Fixes #3588

Prompt: Mikal was concerned about the event emission rate on sfcbr and asked for the chattiest events to be identified (read-only queries, credentials from 33fl sops). The investigation found one message was two thirds of all volume and root-caused it to the zombie key loop above; he then asked for an issue plus this fix on a new worktree and branch, following the same pattern as the issue 3586 hardening.


Assisted-By: Claude Code