### PR TITLE
Rate limit idle sidechannel dispatch checks.

### DIFF
--- a/shakenfist/daemons/sidechannel/main.py
+++ b/shakenfist/daemons/sidechannel/main.py
@@ -1052,11 +1052,14 @@ class Monitor(daemon.Daemon):
                     if instance_uuid in self.executors:
                         continue
 
-                    # Rate limit executor starts per instance. A failed
+                    # Rate limit dispatch checks per instance. A failed
                     # dispatch (the executor couldn't connect, or the
                     # agent never welcomed us) leaves the operation at
                     # the head of the queue, so we would otherwise retry
-                    # every loop iteration.
+                    # every loop iteration. The idle case matters just as
+                    # much: agent_operation_next() costs an uncached
+                    # instance attributes read per call, so an unthrottled
+                    # check polls the database at 1Hz per ready instance.
                     last_attempt = self.executor_attempts.get(
                         instance_uuid, 0)
                     if time.time() - last_attempt < 5:
@@ -1072,6 +1075,7 @@ class Monitor(daemon.Daemon):
                                      constants.AGENT_READY_DEGRADED]:
                         continue
 
+                    self.executor_attempts[instance_uuid] = time.time()
                     inst = instance.Instance.from_db(instance_uuid)
                     if not inst:
                         continue


### PR DESCRIPTION
The sidechannel dispatcher's per-instance rate limit stamped `executor_attempts` only in `start_instance_executor()`, so it only engaged after an operation was actually dispatched. For an idle instance the stamp stayed at zero forever and the dispatcher called `agent_operation_next()` — one uncached full-row `GetInstanceAttributes` gRPC read — every one-second pass. That made this the top query pair on sfcbr: 31 qps at ~31 agent-ready instances, exactly 1 Hz each, and the single largest reducible line in the cluster's database load.

The fix stamps the attempt time when the dispatcher checks an instance, not only when it starts an executor, so the existing five-second limit covers the idle case the way its comment already implied (the comment is updated to say so explicitly). The stamp is placed after the ready check, so instances the dispatcher skips without touching the database are not stamped.

Trade-off: a newly queued agent operation may now wait up to five seconds for dispatch rather than one — the same latency the rate limit already accepted for failed-dispatch retries. Expected effect on sfcbr is an ~80% cut to `GetInstanceAttributes/sidechannel` (~25 qps at current instance counts); the before/after will be visible in the nightly `shakenfist_db_load` facts.

Fixes #3595

Prompt: While closing a bottom-up accounting gap in the 33fl hunt 2026-01 database-load investigation, Mikal and Claude found the sidechannel dispatcher polling instance attributes at 1 Hz per ready instance because the intended 5 s throttle never engaged when the agent-operations queue was empty. Mikal asked for the issue to be filed and this one-line fix proposed as a PR that closes it on merge.

Assisted-By: Claude Code
