### PR TITLE
Use the shared automated review workflow

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -223,6 +223,10 @@ jobs:
   automated_delinter:
     name: "Automated delinter"
     runs-on: [self-hosted, claude-code]
+    # Without this the job inherits the six hour GitHub default, so a
+    # wedged Claude run would hold a scarce claude-code runner for the
+    # rest of the day.
+    timeout-minutes: 60
     needs: [sanity_checks, check_bot_commit]
     # The same-repo check keeps fork PRs from running their own copy of the
     # delinter script on the credential-bearing claude-code runners.
@@ -277,32 +281,21 @@ jobs:
 
   automated_reviewer:
     name: "Automated reviewer"
+    # The needs: list is the "review only once CI has passed" gate:
+    # a job skipped because a dependency failed never starts the
+    # reusable workflow. Everything else about the reviewer --
+    # runner, timeout, fork restriction, bot-commit check --
+    # lives in the shared workflow so it stays in step with the
+    # rest of the fleet.
+    needs: [sanity_checks, smoke_collection]
+    # A cross-repository reusable workflow cannot grant itself more
+    # token scope than its caller has, so the permissions go here.
     permissions:
       contents: read
       pull-requests: write
       issues: write
-    runs-on: [self-hosted, claude-code]
-    needs: [sanity_checks, smoke_collection, check_bot_commit]
-    # The same-repo check keeps fork PRs off the credential-bearing
-    # claude-code runners.
-    if: |
-      github.event_name == 'pull_request' &&
-      needs.check_bot_commit.outputs.is_bot != 'true' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-reviewer
-      cancel-in-progress: true
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Run automated reviewer
-        uses: shakenfist/actions/review-pr-with-claude@main
-        with:
-          pr-number: ${{ github.event.pull_request.number }}
+    uses: shakenfist/actions/.github/workflows/pr-auto-review.yml@main
+    secrets: inherit
 
   # Multi-node merge-queue functional coverage: each matrix entry deploys a
   # topology (slim-primary / slim-tier) via the shakenfist.shakenfist collection

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -32,6 +32,11 @@ jobs:
     name: "Check bot commit"
     if: github.event_name == 'pull_request'
     runs-on: [self-hosted, static]
+    # A checkout and one git command. These small jobs are not on the
+    # scarce claude-code runners, but a wedged one still occupies a
+    # static runner for GitHub's six hour default, and a gate job which
+    # has not finished in minutes is never going to.
+    timeout-minutes: 10
     outputs:
       is_bot: ${{ steps.check.outputs.is_bot }}
     steps:
@@ -58,6 +63,7 @@ jobs:
   check_paths:
     name: "Check paths"
     runs-on: [self-hosted, static]
+    timeout-minutes: 10
     outputs:
       code_changed: ${{ steps.filter.outputs.code || 'true' }}
     steps:
@@ -101,6 +107,10 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: [self-hosted, static]
+    # The steps below carry their own timeouts, which add up to forty
+    # minutes; this is the backstop for the checkout and for any step
+    # added later without one.
+    timeout-minutes: 45
     needs: [check_paths]
     if: needs.check_paths.outputs.code_changed != 'false'
     outputs:
@@ -283,10 +293,30 @@ jobs:
     name: "Automated reviewer"
     # The needs: list is the "review only once CI has passed" gate:
     # a job skipped because a dependency failed never starts the
-    # reusable workflow. Everything else about the reviewer --
-    # runner, timeout, fork restriction, bot-commit check --
-    # lives in the shared workflow so it stays in step with the
-    # rest of the fleet.
+    # reusable workflow. Everything else about the reviewer lives in
+    # the shared workflow, so it stays in step with the rest of the
+    # fleet instead of drifting per project. Specifically, the review
+    # job there:
+    #
+    #   * runs on [self-hosted, claude-code] with timeout-minutes: 60,
+    #   * is guarded by "github.event_name == 'pull_request' &&
+    #     github.event.pull_request.head.repo.full_name ==
+    #     github.repository", so merge_group, workflow_dispatch and
+    #     fork PRs never reach it,
+    #   * declares its own concurrency group
+    #     "pr-auto-review-<repo>-<pr number>" with
+    #     cancel-in-progress: true, which is a narrower group than the
+    #     per-workflow one this job used to carry,
+    #   * checks the head commit's author over the API (by head SHA,
+    #     not the paged commits list) and skips when it is
+    #     bot@shakenfist.com or noreply@anthropic.com, before it even
+    #     checks the repository out. That is the same loop protection
+    #     check_bot_commit gives automated_delinter below, done
+    #     without a runner and matching one more address.
+    #
+    # Those guards are deliberately not repeated here: the shared
+    # workflow owns them so no project can lose one by editing its own
+    # CI.
     needs: [sanity_checks, smoke_collection]
     # A cross-repository reusable workflow cannot grant itself more
     # token scope than its caller has, so the permissions go here.
@@ -294,8 +324,13 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+    # No "secrets: inherit": neither this workflow nor the
+    # review-pr-with-claude action it calls reads a secret -- both
+    # authenticate with github.token, which comes from the permissions
+    # above. Inheriting would hand every secret this repository has,
+    # including DEPENDENCIES_TOKEN, to a workflow in another
+    # repository for no benefit.
     uses: shakenfist/actions/.github/workflows/pr-auto-review.yml@main
-    secrets: inherit
 
   # Multi-node merge-queue functional coverage: each matrix entry deploys a
   # topology (slim-primary / slim-tier) via the shakenfist.shakenfist collection
@@ -403,6 +438,10 @@ jobs:
       && needs.check_paths.outputs.code_changed != 'false'
     needs: [check_paths]
     runs-on: [self-hosted, vm, debian-12]
+    # The deploy and test steps below are capped at 90 and 60 minutes;
+    # this is the backstop for the setup and teardown around them, and
+    # is still far short of GitHub's six hour default.
+    timeout-minutes: 180
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-nodelifecycle-collection
       cancel-in-progress: true
@@ -602,6 +641,8 @@ jobs:
   can_see_status:
     name: "Can see status"
     runs-on: [self-hosted, static]
+    # Runs "true", so five minutes is generous even on a busy runner.
+    timeout-minutes: 5
     steps:
       - name: "Immediate success"
         run: true
@@ -616,6 +657,8 @@ jobs:
     permissions:
       actions: read
     runs-on: [self-hosted, static]
+    # A jq expression over the needs context.
+    timeout-minutes: 5
     steps:
       - env:
           NEEDS_JSON: "${{toJSON(needs)}}"
@@ -637,6 +680,8 @@ jobs:
     permissions:
       actions: read
     runs-on: [self-hosted, static]
+    # A jq expression over the needs context.
+    timeout-minutes: 5
     steps:
       - env:
           NEEDS_JSON: "${{toJSON(needs)}}"

--- a/.github/workflows/pr-address-comments.yml
+++ b/.github/workflows/pr-address-comments.yml
@@ -45,6 +45,8 @@ jobs:
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@shakenfist-bot please address comments')
     runs-on: [self-hosted, static]
+    # Just a few gh API calls, so anything beyond this is a hang.
+    timeout-minutes: 10
     outputs:
       authorized: ${{ steps.trigger.outputs.authorized }}
       pr_ref: ${{ steps.trigger.outputs.pr-ref }}

--- a/.github/workflows/pr-fix-tests.yml
+++ b/.github/workflows/pr-fix-tests.yml
@@ -24,6 +24,8 @@ jobs:
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@shakenfist-bot please attempt to fix')
     runs-on: [self-hosted, static]
+    # Just a few gh API calls, so anything beyond this is a hang.
+    timeout-minutes: 10
     outputs:
       authorized: ${{ steps.trigger.outputs.authorized }}
       pr_ref: ${{ steps.trigger.outputs.pr-ref }}

--- a/.github/workflows/pr-re-review.yml
+++ b/.github/workflows/pr-re-review.yml
@@ -22,6 +22,10 @@ jobs:
       contains(github.event.comment.body, '@shakenfist-bot please re-review')
     runs-on: [self-hosted, claude-code]
     name: "Re-review PR"
+    # A review typically takes a handful of minutes. Without this the
+    # job inherits the six hour GitHub default, so a wedged Claude run
+    # would hold a scarce claude-code runner for the rest of the day.
+    timeout-minutes: 60
 
     steps:
       - name: Check commenter permissions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,8 +65,22 @@ issues.
 
 ### Automated Reviewer
 
-After successful tests, the `automated_reviewer` job uses the shared
-`shakenfist/actions/review-pr-with-claude@main` action to review the PR.
+After successful tests, the `automated_reviewer` job calls the shared
+`shakenfist/actions/.github/workflows/pr-auto-review.yml@main` reusable
+workflow, which reviews the PR with the `review-pr-with-claude` action.
+All the gating other than "CI passed" lives in that shared workflow: the
+runner, the 60 minute timeout, the pull-request-event and
+same-repository restrictions, its own concurrency group, and the
+bot-commit check which keeps a bot push from triggering a review which
+triggers another bot push. What this repository supplies is the `needs:`
+list naming the test jobs and the token `permissions`, which a
+cross-repository reusable workflow cannot grant itself.
+
+The `@shakenfist-bot please re-review` command in `pr-re-review.yml`
+still uses the `shakenfist/actions/review-pr-with-claude@main` action
+directly, because it deliberately passes `force` to review a PR the bot
+has already reviewed.
+
 The reviewer produces structured JSON reviews, creates GitHub issues for
 actionable items, and embeds the JSON in the PR comment for automation.
 

--- a/docs/components/development/ci-review-automation.md
+++ b/docs/components/development/ci-review-automation.md
@@ -109,15 +109,39 @@ cp /path/to/development/templates/test-drift-fix/test-drift-fix.yml \
 
 ### Step 2: Add Automated Reviewer to CI
 
-Modify your main CI workflow (e.g. `functional-tests.yml`) to add:
+Modify your main CI workflow (e.g. `functional-tests.yml`) to add an
+`automated_reviewer` job which calls the shared reusable workflow:
 
-1. A top-level `permissions` block with `pull-requests: write`
-2. A `check-bot-commit` job to prevent infinite review loops
-3. An `automated_reviewer` job that runs after tests pass
+```yaml
+  automated_reviewer:
+    name: "Automated reviewer"
+    needs: [sanity_checks, smoke_collection]
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    uses: shakenfist/actions/.github/workflows/pr-auto-review.yml@main
+```
+
+Only two things are per-project: the `needs:` list, which names that
+project's test jobs and is therefore the "review only once CI has
+passed" gate, and the `permissions:` block, which has to be at the call
+site because a cross-repository reusable workflow cannot grant itself
+more token scope than its caller has.
+
+Do not add `secrets: inherit`. Neither the reusable workflow nor the
+`review-pr-with-claude` action reads a secret -- both authenticate with
+`github.token` -- so inheriting would hand every secret the calling
+repository has to a workflow in another repository for no benefit.
+
+Projects do not need their own `check-bot-commit` job for the reviewer;
+the reusable workflow does that check itself. A project may still keep
+one for other automation, as Shaken Fist does for its
+`automated_delinter`.
 
 See the
 [template README](https://github.com/shakenfist/development/tree/main/templates/ci-review-automation/README.md)
-for the exact YAML snippets.
+for the other snippets.
 
 ### Step 3: Ensure Runner Labels
 
@@ -129,8 +153,14 @@ Your self-hosted runners need these labels:
 
 ## Preventing Infinite Loops
 
-The `check-bot-commit` job detects if the last commit was authored
-by `bot@shakenfist.com`. If so, the automated reviewer is skipped.
+The reusable review workflow reads the PR head commit over the API and
+skips the review if it was authored by `bot@shakenfist.com` or by
+`noreply@anthropic.com` (the address a Claude Code commit made on a
+runner carries). Reading the head commit by SHA rather than taking the
+last element of the PR commits list matters, because that endpoint pages
+at thirty and an "address comments" run which makes one commit per
+review item passes thirty easily.
+
 This prevents loops where:
 
 1. Bot makes a commit (from test fixing or comment addressing)
@@ -149,7 +179,14 @@ repository:
 - **pr-bot-trigger** -- parses `@shakenfist-bot` commands, checks
   permissions, adds reactions, posts status messages
 - **review-pr-with-claude** -- runs automated code reviews with
-  structured JSON output and embedded review data
+  structured JSON output and embedded review data. Called directly by
+  `pr-re-review.yml`, which passes `force` so that a human asking for a
+  re-review is the only way to get a second review on a PR
+- **.github/workflows/pr-auto-review.yml** -- a reusable workflow
+  wrapping `review-pr-with-claude` for the CI reviewer. It owns the
+  runner, the 60 minute timeout, the pull-request-event and
+  same-repository restrictions, its own concurrency group, and the
+  bot-commit check, so those cannot drift between projects
 
 ## Projects Using This Automation
 


### PR DESCRIPTION
The automatic PR review has until now been an "automated_reviewer" job
written out in full in this repository's CI workflow, copied from a
snippet in the development repository's README. Eight projects each
carried a copy and they had drifted from one another. None of them set
timeout-minutes, so a wedged Claude Code run could hold a scarce
claude-code runner for GitHub's six hour default.

The job body now lives once, in
shakenfist/actions/.github/workflows/pr-auto-review.yml. What stays
here is the part which is genuinely per-project: the needs: list
naming this project's test jobs, which is what gates the review on CI
passing. A job skipped because a dependency failed never starts the
reusable workflow.

Adopting the shared workflow brings this project:

* A 60 minute timeout on the review. Real reviews finish in three to
  six minutes.
* The same-repository restriction. The reviewer runs Claude Code with
  --dangerously-skip-permissions while holding a token with
  pull-requests: write and issues: write, and is fed the PR diff,
  which is untrusted input, so a fork PR would put an attacker's text
  in front of a write-capable token.
* A bot-commit check which also recognises noreply@anthropic.com, the
  address a Claude Code commit made on a runner is authored as. Only
  clingwrap's copy caught that address before.

The check_bot_commit job stays, because automated_delinter also
consumes its is_bot output. It is no longer wired to the reviewer.

automated_delinter is the other unbounded Claude Code job here, so it
gains a 60 minute timeout for the same reason.

While here, bring the rest of the Claude Code workflow timeouts into line
with the templates: 60 minutes on the re-review, 10 on the address-comments
trigger and 10 on the fix-tests trigger.

Validated with each project's own `pre-commit` on the changed files, and by diffing actionlint findings before and after so pre-existing noise is not mistaken for a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
