### PR TITLE
Stop unit tests leaking tempdirs in /tmp.

### DIFF
--- a/shakenfist/tests/base.py
+++ b/shakenfist/tests/base.py
@@ -1,3 +1,5 @@
+import shutil
+import tempfile
 from unittest import mock
 
 import testtools
@@ -26,3 +28,36 @@ class ShakenFistTestCase(testtools.TestCase):
             return_value=None)
         self.mock_record_exception = self.mock_record_exception_patcher.start()
         self.addCleanup(self.mock_record_exception_patcher.stop)
+
+
+class SpoolRootMixin:
+    """Redirect a spool module's ``SPOOL_ROOT`` to a per-test tempdir.
+
+    Subclasses set ``spool_module`` (a module exposing ``SPOOL_ROOT``
+    and ``reset_for_tests()``) and ``spool_prefix`` (the tempdir name
+    prefix). Modules with additional singletons to reset between tests
+    (for example ``shakenfist.logship``) list the reset callables in
+    ``extra_resets``.
+    """
+
+    spool_module = None
+    spool_prefix = None
+    extra_resets = ()
+
+    def setUp(self):
+        super().setUp()
+        self.tmp = tempfile.mkdtemp(prefix=self.spool_prefix)
+        # Registered first so LIFO cleanup ordering runs it last, after
+        # reset_for_tests() has closed the spool's sqlite connection.
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self._original_root = self.spool_module.SPOOL_ROOT
+        self.spool_module.SPOOL_ROOT = self.tmp
+        self.spool_module.reset_for_tests()
+        self.addCleanup(self.spool_module.reset_for_tests)
+        for reset in self.extra_resets:
+            reset()
+            self.addCleanup(reset)
+        self.addCleanup(self._restore_root)
+
+    def _restore_root(self):
+        self.spool_module.SPOOL_ROOT = self._original_root

--- a/shakenfist/tests/test_eventlog.py
+++ b/shakenfist/tests/test_eventlog.py
@@ -1,6 +1,4 @@
 import json
-import shutil
-import tempfile
 import uuid
 from unittest import mock
 
@@ -14,21 +12,11 @@ from shakenfist.tests import base
 LOG, _ = logs.setup(__name__)
 
 
-class _SpoolRootMixin:
+class _SpoolRootMixin(base.SpoolRootMixin):
     """Redirect ``SPOOL_ROOT`` to a tempdir and initialise a fresh spool."""
 
-    def setUp(self):
-        super().setUp()
-        self.tmp = tempfile.mkdtemp(prefix='sf-eventlog-test-')
-        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
-        self._original_root = eventlog_spool.SPOOL_ROOT
-        eventlog_spool.SPOOL_ROOT = self.tmp
-        eventlog_spool.reset_for_tests()
-        self.addCleanup(eventlog_spool.reset_for_tests)
-        self.addCleanup(self._restore_root)
-
-    def _restore_root(self):
-        eventlog_spool.SPOOL_ROOT = self._original_root
+    spool_module = eventlog_spool
+    spool_prefix = 'sf-eventlog-test-'
 
 
 class AddEventMultiSpoolPayloadTestCase(

--- a/shakenfist/tests/test_eventlog.py
+++ b/shakenfist/tests/test_eventlog.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 import tempfile
 import uuid
 from unittest import mock
@@ -19,6 +20,7 @@ class _SpoolRootMixin:
     def setUp(self):
         super().setUp()
         self.tmp = tempfile.mkdtemp(prefix='sf-eventlog-test-')
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
         self._original_root = eventlog_spool.SPOOL_ROOT
         eventlog_spool.SPOOL_ROOT = self.tmp
         eventlog_spool.reset_for_tests()

--- a/shakenfist/tests/test_eventlog_drainer.py
+++ b/shakenfist/tests/test_eventlog_drainer.py
@@ -7,8 +7,6 @@ batch-building (translates spool payload dicts into
 (``mariadb.record_event_batch`` failure, backoff, poison-row
 drop).
 """
-import shutil
-import tempfile
 from unittest import mock
 
 from shakenfist import eventlog_drainer
@@ -17,19 +15,9 @@ from shakenfist.schema.event import EventRecord
 from shakenfist.tests import base
 
 
-class _SpoolRootMixin:
-    def setUp(self):
-        super().setUp()
-        self.tmp = tempfile.mkdtemp(prefix='sf-drainer-test-')
-        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
-        self._original_root = eventlog_spool.SPOOL_ROOT
-        eventlog_spool.SPOOL_ROOT = self.tmp
-        eventlog_spool.reset_for_tests()
-        self.addCleanup(eventlog_spool.reset_for_tests)
-        self.addCleanup(self._restore_root)
-
-    def _restore_root(self):
-        eventlog_spool.SPOOL_ROOT = self._original_root
+class _SpoolRootMixin(base.SpoolRootMixin):
+    spool_module = eventlog_spool
+    spool_prefix = 'sf-drainer-test-'
 
 
 class BuildRecordsTestCase(

--- a/shakenfist/tests/test_eventlog_drainer.py
+++ b/shakenfist/tests/test_eventlog_drainer.py
@@ -7,6 +7,7 @@ batch-building (translates spool payload dicts into
 (``mariadb.record_event_batch`` failure, backoff, poison-row
 drop).
 """
+import shutil
 import tempfile
 from unittest import mock
 
@@ -20,6 +21,7 @@ class _SpoolRootMixin:
     def setUp(self):
         super().setUp()
         self.tmp = tempfile.mkdtemp(prefix='sf-drainer-test-')
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
         self._original_root = eventlog_spool.SPOOL_ROOT
         eventlog_spool.SPOOL_ROOT = self.tmp
         eventlog_spool.reset_for_tests()

--- a/shakenfist/tests/test_eventlog_spool.py
+++ b/shakenfist/tests/test_eventlog_spool.py
@@ -7,6 +7,7 @@ are the things that have to work right -- everything else in
 """
 import fcntl
 import os
+import shutil
 import tempfile
 import threading
 import time
@@ -22,6 +23,7 @@ class _SpoolRootMixin:
     def setUp(self):
         super().setUp()
         self.tmp = tempfile.mkdtemp(prefix='sf-spool-test-')
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
         self._original_root = eventlog_spool.SPOOL_ROOT
         eventlog_spool.SPOOL_ROOT = self.tmp
         # Reset module-level singletons between tests so each test

--- a/shakenfist/tests/test_eventlog_spool.py
+++ b/shakenfist/tests/test_eventlog_spool.py
@@ -7,8 +7,6 @@ are the things that have to work right -- everything else in
 """
 import fcntl
 import os
-import shutil
-import tempfile
 import threading
 import time
 from unittest import mock
@@ -17,23 +15,11 @@ from shakenfist import eventlog_spool
 from shakenfist.tests import base
 
 
-class _SpoolRootMixin:
+class _SpoolRootMixin(base.SpoolRootMixin):
     """Redirect ``SPOOL_ROOT`` to a tempdir for every test."""
 
-    def setUp(self):
-        super().setUp()
-        self.tmp = tempfile.mkdtemp(prefix='sf-spool-test-')
-        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
-        self._original_root = eventlog_spool.SPOOL_ROOT
-        eventlog_spool.SPOOL_ROOT = self.tmp
-        # Reset module-level singletons between tests so each test
-        # starts from a clean slate.
-        eventlog_spool.reset_for_tests()
-        self.addCleanup(eventlog_spool.reset_for_tests)
-        self.addCleanup(self._restore_root)
-
-    def _restore_root(self):
-        eventlog_spool.SPOOL_ROOT = self._original_root
+    spool_module = eventlog_spool
+    spool_prefix = 'sf-spool-test-'
 
 
 class SpoolBasicsTestCase(_SpoolRootMixin, base.ShakenFistTestCase):

--- a/shakenfist/tests/test_logship.py
+++ b/shakenfist/tests/test_logship.py
@@ -10,6 +10,7 @@ under v0.9.0 it is the library's instance. We assert *type*
 """
 import json
 import logging
+import shutil
 import tempfile
 import uuid
 from logging.handlers import SysLogHandler
@@ -26,6 +27,7 @@ class _SpoolRootMixin:
     def setUp(self):
         super().setUp()
         self.tmp = tempfile.mkdtemp(prefix='sf-logship-test-')
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
         self._original_root = logship_spool.SPOOL_ROOT
         logship_spool.SPOOL_ROOT = self.tmp
         logship_spool.reset_for_tests()

--- a/shakenfist/tests/test_logship.py
+++ b/shakenfist/tests/test_logship.py
@@ -10,8 +10,6 @@ under v0.9.0 it is the library's instance. We assert *type*
 """
 import json
 import logging
-import shutil
-import tempfile
 import uuid
 from logging.handlers import SysLogHandler
 from unittest import mock
@@ -23,21 +21,10 @@ from shakenfist import logship_spool
 from shakenfist.tests import base
 
 
-class _SpoolRootMixin:
-    def setUp(self):
-        super().setUp()
-        self.tmp = tempfile.mkdtemp(prefix='sf-logship-test-')
-        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
-        self._original_root = logship_spool.SPOOL_ROOT
-        logship_spool.SPOOL_ROOT = self.tmp
-        logship_spool.reset_for_tests()
-        logship.reset_for_tests()
-        self.addCleanup(logship_spool.reset_for_tests)
-        self.addCleanup(logship.reset_for_tests)
-        self.addCleanup(self._restore_root)
-
-    def _restore_root(self):
-        logship_spool.SPOOL_ROOT = self._original_root
+class _SpoolRootMixin(base.SpoolRootMixin):
+    spool_module = logship_spool
+    spool_prefix = 'sf-logship-test-'
+    extra_resets = (logship.reset_for_tests,)
 
 
 class HandlerEmitTestCase(_SpoolRootMixin, base.ShakenFistTestCase):

--- a/shakenfist/tests/test_logship_drainer.py
+++ b/shakenfist/tests/test_logship_drainer.py
@@ -6,8 +6,6 @@ tenant/auth headers, and the failure-handling branches (push
 failure, backoff, row retention). Mirrors
 ``test_eventlog_drainer.py``.
 """
-import shutil
-import tempfile
 from unittest import mock
 
 import requests
@@ -17,19 +15,9 @@ from shakenfist import logship_spool
 from shakenfist.tests import base
 
 
-class _SpoolRootMixin:
-    def setUp(self):
-        super().setUp()
-        self.tmp = tempfile.mkdtemp(prefix='sf-logship-drainer-test-')
-        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
-        self._original_root = logship_spool.SPOOL_ROOT
-        logship_spool.SPOOL_ROOT = self.tmp
-        logship_spool.reset_for_tests()
-        self.addCleanup(logship_spool.reset_for_tests)
-        self.addCleanup(self._restore_root)
-
-    def _restore_root(self):
-        logship_spool.SPOOL_ROOT = self._original_root
+class _SpoolRootMixin(base.SpoolRootMixin):
+    spool_module = logship_spool
+    spool_prefix = 'sf-logship-drainer-test-'
 
 
 class PushBodyTestCase(_SpoolRootMixin, base.ShakenFistTestCase):

--- a/shakenfist/tests/test_logship_drainer.py
+++ b/shakenfist/tests/test_logship_drainer.py
@@ -6,6 +6,7 @@ tenant/auth headers, and the failure-handling branches (push
 failure, backoff, row retention). Mirrors
 ``test_eventlog_drainer.py``.
 """
+import shutil
 import tempfile
 from unittest import mock
 
@@ -20,6 +21,7 @@ class _SpoolRootMixin:
     def setUp(self):
         super().setUp()
         self.tmp = tempfile.mkdtemp(prefix='sf-logship-drainer-test-')
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
         self._original_root = logship_spool.SPOOL_ROOT
         logship_spool.SPOOL_ROOT = self.tmp
         logship_spool.reset_for_tests()

--- a/shakenfist/tests/test_logship_spool.py
+++ b/shakenfist/tests/test_logship_spool.py
@@ -8,6 +8,7 @@ suite mirrors ``test_eventlog_spool.py``.
 """
 import fcntl
 import os
+import shutil
 import tempfile
 from unittest import mock
 
@@ -21,6 +22,7 @@ class _SpoolRootMixin:
     def setUp(self):
         super().setUp()
         self.tmp = tempfile.mkdtemp(prefix='sf-logship-spool-test-')
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
         self._original_root = logship_spool.SPOOL_ROOT
         logship_spool.SPOOL_ROOT = self.tmp
         logship_spool.reset_for_tests()

--- a/shakenfist/tests/test_logship_spool.py
+++ b/shakenfist/tests/test_logship_spool.py
@@ -8,29 +8,17 @@ suite mirrors ``test_eventlog_spool.py``.
 """
 import fcntl
 import os
-import shutil
-import tempfile
 from unittest import mock
 
 from shakenfist import logship_spool
 from shakenfist.tests import base
 
 
-class _SpoolRootMixin:
+class _SpoolRootMixin(base.SpoolRootMixin):
     """Redirect ``SPOOL_ROOT`` to a tempdir for every test."""
 
-    def setUp(self):
-        super().setUp()
-        self.tmp = tempfile.mkdtemp(prefix='sf-logship-spool-test-')
-        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
-        self._original_root = logship_spool.SPOOL_ROOT
-        logship_spool.SPOOL_ROOT = self.tmp
-        logship_spool.reset_for_tests()
-        self.addCleanup(logship_spool.reset_for_tests)
-        self.addCleanup(self._restore_root)
-
-    def _restore_root(self):
-        logship_spool.SPOOL_ROOT = self._original_root
+    spool_module = logship_spool
+    spool_prefix = 'sf-logship-spool-test-'
 
 
 class SpoolBasicsTestCase(_SpoolRootMixin, base.ShakenFistTestCase):

--- a/shakenfist/tests/test_util_exceptions.py
+++ b/shakenfist/tests/test_util_exceptions.py
@@ -2,6 +2,7 @@ import contextlib
 import json
 import logging
 import os
+import shutil
 import sys
 import tempfile
 import threading
@@ -20,14 +21,9 @@ class RecordExceptionTestCase(base.ShakenFistTestCase):
 
         # Create a temporary directory for exception files
         self.temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.temp_dir, ignore_errors=True)
         self.exceptions_path = os.path.join(self.temp_dir, 'exceptions')
         os.makedirs(self.exceptions_path, exist_ok=True)
-
-    def tearDown(self):
-        super().tearDown()
-        # Clean up temp directory
-        import shutil
-        shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def _get_exception_info(self):
         """Helper to generate exception info for testing."""
@@ -170,13 +166,9 @@ class RecordExceptionLoggingTestCase(base.ShakenFistTestCase):
         self.mock_record_exception_patcher.stop()
 
         self.temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.temp_dir, ignore_errors=True)
         self.exceptions_path = os.path.join(self.temp_dir, 'exceptions')
         os.makedirs(self.exceptions_path, exist_ok=True)
-
-    def tearDown(self):
-        super().tearDown()
-        import shutil
-        shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def _redirect_open(self):
         """Send record_exception's writes into the temp directory."""
@@ -423,6 +415,7 @@ class IgnoreExceptionEndToEndTestCase(base.ShakenFistTestCase):
         self.mock_record_exception_patcher.stop()
 
         self.temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.temp_dir, ignore_errors=True)
         self.exceptions_path = os.path.join(self.temp_dir, 'exceptions')
         os.makedirs(self.exceptions_path, exist_ok=True)
 
@@ -437,11 +430,6 @@ class IgnoreExceptionEndToEndTestCase(base.ShakenFistTestCase):
         original_level = logger.level
         logger.setLevel(logging.DEBUG)
         self.addCleanup(logger.setLevel, original_level)
-
-    def tearDown(self):
-        super().tearDown()
-        import shutil
-        shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_exactly_one_shipped_record_carrying_the_hash(self):
         real_os_open = os.open
@@ -551,13 +539,9 @@ class IntegrationTestCase(base.ShakenFistTestCase):
         self.mock_record_exception_patcher.stop()
 
         self.temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.temp_dir, ignore_errors=True)
         self.exceptions_path = os.path.join(self.temp_dir, 'exceptions')
         os.makedirs(self.exceptions_path, exist_ok=True)
-
-    def tearDown(self):
-        super().tearDown()
-        import shutil
-        shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_record_exception_full_flow(self):
         """Test recording an exception with a real temp file."""


### PR DESCRIPTION
## Summary

The `_SpoolRootMixin` classes in the eventlog and logship unit test files create a tempdir with `tempfile.mkdtemp()` to redirect `SPOOL_ROOT`, and register cleanups to reset the spool singleton and restore `SPOOL_ROOT` — but never register one to delete the directory. Every test therefore leaked a directory into `/tmp`; over 26,000 had accumulated on the development machine across the prefixes `sf-logship-test-`, `sf-logship-spool-test-`, `sf-logship-drainer-test-`, `sf-eventlog-test-`, `sf-spool-test-` and `sf-drainer-test-`. The logship tests inherited the bug verbatim when they were modelled on the eventlog ones.

This registers `shutil.rmtree(..., ignore_errors=True)` as the first cleanup in each of the six affected mixins. Cleanups run LIFO, so registering it immediately after `mkdtemp` means it fires last, after `reset_for_tests()` has closed the sqlite spool handles.

## Testing

- Ran all six affected test modules via tox: all pass.
- Counted matching directories in `/tmp` before and after the run: unchanged, so nothing new leaks.
- `pre-commit run --all-files` passes.
- Audited the rest of the test tree for the same pattern: all other `mkdtemp` users already register cleanups, and the remainder use `tempfile.TemporaryDirectory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
