### PR TITLE
ci: send deliberately-empty rule fields.

### DIFF
--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_federation.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_federation.py
@@ -213,12 +213,18 @@ class TestFederation(base.BaseNamespacedTestCase):
 
     def _create_rule(self, name, scopes=None, bound_claims=None,
                      key_ttl=3600, token=None):
+        # Distinguish "not supplied" from "supplied but empty": the rule
+        # validation test passes empty containers on purpose, and an `or`
+        # here would silently replace them with the valid defaults.
+        if bound_claims is None:
+            bound_claims = {'repository': 'sf/ci'}
+        if scopes is None:
+            scopes = ['artifact.read']
         return requests.post(
             self._rules_url(),
             headers={'Authorization': 'Bearer %s' % (token or self.token)},
             json={'name': name, 'issuer': self.issuer_name,
-                  'bound_claims': bound_claims or {'repository': 'sf/ci'},
-                  'scopes': scopes or ['artifact.read'],
+                  'bound_claims': bound_claims, 'scopes': scopes,
                   'key_ttl': key_ttl, 'key_name_prefix': 'ci'},
             timeout=30)
 


### PR DESCRIPTION
_create_rule filled defaults with `or`, so the rule validation test's explicitly empty bound_claims and scopes were silently replaced with the valid defaults before the request was sent. The server correctly accepted the resulting well-formed rule and the test's assertion of a 400 failed, deterministically, in every merge queue run since the test landed. Distinguish "not supplied" from "supplied but empty" with explicit None checks instead.

Fixes #3652

Prompt: Michael asked why merge CI failed on PR #3598 and whether it was the PR's fault or systemic. Investigation showed a deterministic bug in the federation CI test helper from PR #3625 that wedged every merge queue run. He then asked to file issue #3652, reserve it with the automated-fix-attempted label, and implement this one-helper fix on a new worktree and branch, then commit and push.