### PR TITLE
Stringify uuids in the DELETE /artifacts response

### DIFF
--- a/shakenfist/external_api/artifact.py
+++ b/shakenfist/external_api/artifact.py
@@ -521,7 +521,10 @@ class ArtifactsEndpoint(api_base.Resource):
         for a in Artifacts(namespace=namespace):
             a.add_event(EVENT_TYPE_AUDIT, 'deletion request from REST API')
             a.delete()
-            deleted.append(a.uuid)
+            # The uuid is stringified here: this response does not pass
+            # through an external view, and flask_restful's JSON encoder
+            # cannot serialize a raw uuid.UUID (issue 3656).
+            deleted.append(str(a.uuid))
 
         return deleted
 

--- a/shakenfist/tests/external_api/test_artifact_bulk_delete.py
+++ b/shakenfist/tests/external_api/test_artifact_bulk_delete.py
@@ -1,0 +1,46 @@
+"""The bulk `DELETE /artifacts` route must return a serializable body.
+
+The handler returns a plain list of the deleted artifact uuids rather
+than an external view, so nothing between it and flask_restful's JSON
+encoder stringifies them. When `BaseObject.uuid` became a `uuid.UUID`
+the deletions kept committing but the response crashed with
+`TypeError: Object of type UUID is not JSON serializable`, failing
+namespace deletes after their artifacts were already gone (issue 3656).
+
+These tests go through the flask test client so the real flask_restful
+representation runs -- asserting on the handler's return value alone
+would not have caught this.
+"""
+
+import json
+
+from shakenfist.artifact import Artifact
+from shakenfist.tests.external_api.test_artifact_access import (
+    ArtifactAccessFixture)
+
+
+class ArtifactBulkDeleteTestCase(ArtifactAccessFixture):
+    def _bulk_delete(self, namespace, body):
+        return self.client.delete(
+            '/artifacts', data=json.dumps(body),
+            headers={'Authorization': self._token(namespace)})
+
+    def test_owner_bulk_delete_returns_deleted_uuids(self):
+        resp = self._bulk_delete('owner', {'confirm': True})
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([str(self.artifact.uuid)], resp.get_json())
+        self.assertEqual(
+            Artifact.STATE_DELETED,
+            Artifact.from_db(self.artifact.uuid).state.value)
+
+    def test_bulk_delete_requires_confirm(self):
+        resp = self._bulk_delete('owner', {})
+        self.assertEqual(400, resp.status_code)
+        self.assertNotEqual(
+            Artifact.STATE_DELETED,
+            Artifact.from_db(self.artifact.uuid).state.value)
+
+    def test_empty_namespace_returns_empty_list(self):
+        resp = self._bulk_delete('stranger', {'confirm': True})
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([], resp.get_json())


### PR DESCRIPTION
## Summary

Fixes #3656.

Since 95974afc9 ("Store UUIDs as uuid.UUID objects in BaseObject."), `ArtifactsEndpoint.delete()` has returned a list of raw `uuid.UUID` objects. This response does not pass through an external view, so nothing stringifies them and flask_restful's JSON encoder raises `TypeError: Object of type UUID is not JSON serializable`. The deletions commit before the response is built, so every bulk artifact delete that actually deletes something 500s *after* doing the work — which aborts `sf-client namespace delete` partway through cleanup (observed on the sfcbr production cluster, 2026-08-08).

## Changes

- Stringify the uuids when building the `DELETE /artifacts` response, matching the documented response schema ("A list of artifact uuids") and the serialization the external-view models apply everywhere else.
- Add `shakenfist/tests/external_api/test_artifact_bulk_delete.py`: three regression tests exercising the route through the flask test client so the real flask_restful representation runs. Asserting on the handler's return value alone would not have caught this; the main test reproduces the exact production `TypeError` against the unfixed handler.

## Testing

- New tests pass under tox; the primary test fails with the production traceback when the fix is reverted.
- `pre-commit run --all-files` clean (flake8, full unit suite, namespace-scoping and auth-default consistency checks, mypy).

A sweep of `shakenfist/external_api/` found no other response path returning raw `uuid.UUID` values — the similar appends in `auth.py`'s namespace delete handler only feed log fields and error counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
