### PR TITLE
Validate the generated OpenAPI specification

### DIFF
--- a/docs/developer_guide/writing_an_endpoint.md
+++ b/docs/developer_guide/writing_an_endpoint.md
@@ -157,7 +157,9 @@ Two known gaps:
   count the wrong way (the federated-authentication endpoints then
   added several more). The published specification is not yet
   linter-clean. Phase 2 collapses the parameters into a generated
-  `schema`;
-  [issue #3626](https://github.com/shakenfist/shakenfist/issues/3626)
-  tracks the specification-validation test that will prove the count
-  reaches zero rather than asserting it.
+  `schema`; until that lands,
+  `shakenfist/tests/external_api/test_openapi_spec.py` validates the
+  generated specification and holds this class to an exact count, so
+  a change that adds another invalid body parameter fails CI rather
+  than quietly raising the number
+  ([issue #3626](https://github.com/shakenfist/shakenfist/issues/3626)).

--- a/docs/plans/PLAN-api-input-validation-phase-02-type-vocabulary.md
+++ b/docs/plans/PLAN-api-input-validation-phase-02-type-vocabulary.md
@@ -1,0 +1,338 @@
+# Phase 2: Type vocabulary and a valid published specification
+
+Phase 2 of [PLAN-api-input-validation](PLAN-api-input-validation.md).
+Phase 1 made every individual parameter declaration correct; this
+phase makes the *rendered* specification valid, measurable in CI,
+and expressive enough to carry the bounds phase 3 will compile.
+
+## Context
+
+Phase 1 (PR #3620) corrected ~120 declarations and added the audit
+that keeps them correct, but deliberately did not change how
+`swagger_helper()` renders them. The published specification is
+therefore still invalid OpenAPI 2.0, and nothing in CI measures
+that. Measured with `openapi_spec_validator` over the flasgger
+output at the end of phase 1: **129 validation errors**, in
+exactly two classes:
+
+* **128 from body parameters.** Swagger 2.0 permits at most one
+  `in: body` parameter per operation, and it must carry a
+  `schema` rather than `type`/`format`. `swagger_helper()` emits
+  one `type`/`format` parameter per declaration, so the 32 of 132
+  operations that declare more than one body parameter render an
+  invalid operation — and even single body parameters carry
+  `type` where a `schema` is required.
+* **1 from `schemes`.** `API_ADVERTISED_HTTP_SCHEMES` is typed
+  `str` in `config.py` (its own description says "space separated
+  list") and `app.py` feeds it straight into the top-level
+  `schemes` key, which must be an array of strings. A default
+  deployment publishes `schemes: 'http'`. Pre-existing
+  (`01ef8a563`), and the *first* thing a validator trips over.
+
+A third defect found while planning this phase: the flasgger
+template in `app.py` defines no `securityDefinitions`, so the
+`security: [{'bearerAuth': []}]` requirement phase 1 attached to
+every authenticated operation references a scheme the document
+never defines. A generated client has no way to learn that
+`bearerAuth` means "Authorization header carrying a JWT".
+
+The master plan's phase table also assigns D9 here: new type
+tokens (`unsignedinteger`, `macaddr`, `base64`, `netblock`) and
+an optional constraints element (`minimum`/`maximum`/`pattern`),
+rendered into the published OpenAPI so bounds are visible to
+callers rather than invisible the way the events `limit` cap was.
+
+## Shape of the work: three PRs, not one
+
+Phase 1 shipped as a single PR and took twelve review rounds,
+four of which found defects in machinery added the round before.
+The review loop converges faster on small diffs, and each step
+below is independently landable and independently valuable. The
+ordering is forced anyway: the master plan records that the
+validation test is worth having *before* the renderer fix,
+because it turns "invalid in N places" into a number that moves.
+
+| PR | Delivers | Ratchet after |
+|----|----------|---------------|
+| 1 | Specification-validation test (#3626); `schemes` and `securityDefinitions` template fixes | 128 errors, one class |
+| 2 | Collapse body parameters into one schema-carrying parameter | 0 errors |
+| 3 | New type tokens and the constraints element, applied where the issue list demands | 0 errors, richer spec |
+
+### PR 1 — the validation ratchet and template fixes
+
+**Closes #3626** (the test is the issue; the remaining error
+class it measures is PR 2's job).
+
+1. **Add `openapi_spec_validator` to the `test` extra** in
+   `pyproject.toml` (Apache-2.0, so the license comment pattern
+   holds). It is a test-only dependency; the API daemon never
+   validates its own spec at runtime.
+
+2. **New test module**
+   `shakenfist/tests/external_api/test_openapi_spec.py`. The unit
+   test suite already builds the real Flask app with mocks
+   (`test_health_endpoints.py` is the minimal pattern: set
+   `external_api.TESTING`, pin `config.NODE_UUID`, use
+   `external_api.app.test_client()`). The test fetches
+   `/apispec_1.json` (flasgger 0.9.7.1's default specs route —
+   verify it is served unauthenticated, since flasgger registers
+   it directly on the Flask app rather than through
+   `api_base.Resource`; if it is not reachable, fall back to
+   `swagger.get_apispecs()` inside an app context) and runs
+   `openapi_spec_validator.validate()` over it.
+
+   The assertion is a **ratchet with an exact count, not a
+   ceiling**: iterate the validator's errors, classify each
+   against a small table of known classes (initially just
+   "multiple/typed body parameters"), fail on any error outside
+   the table, and assert the total equals the recorded number.
+   Exact equality means a new endpoint that adds another
+   multi-body operation fails CI instead of quietly raising the
+   count — the same honesty rule the phase 1 audit applies to
+   declarations. When PR 2 lands, the table empties and the test
+   collapses to "the specification is valid", which is its
+   permanent form.
+
+3. **Fix `schemes`.** Split in `app.py`:
+   `config.API_ADVERTISED_HTTP_SCHEMES.split()`. The config
+   field's documented contract is already "space separated
+   list", so the consumer honours it; changing the field to
+   `list[str]` would change the environment-variable format for
+   every deployment to fix a rendering bug, which is the wrong
+   trade. One-scheme deployments publish `['http']`, two-scheme
+   deployments finally publish two entries.
+
+4. **Define `securityDefinitions`** in the flasgger template:
+
+   ```python
+   'securityDefinitions': {
+       'bearerAuth': {
+           'type': 'apiKey',
+           'name': 'Authorization',
+           'in': 'header',
+           'description': 'JWT bearer token, as "Bearer <token>".'
+       }
+   }
+   ```
+
+   Swagger 2.0 has no first-class bearer scheme (that arrived in
+   OpenAPI 3); `apiKey` in the `Authorization` header is the
+   standard 2.0 idiom. This makes the per-operation `security`
+   requirement resolvable and lets generated clients attach the
+   header automatically.
+
+5. **Rider: issue #3643.** The locale-dependent `open()` calls in
+   `test_parameter_declarations.py` get `encoding='utf-8'` while
+   a PR is already touching the test tree. Trivial, and keeps the
+   issue from going stale. (`Fixes #3643` in the commit that does
+   it.)
+
+### PR 2 — one body parameter per operation
+
+A change to the renderer only: declarations keep their
+five-element shape, the audit and fixer read tuples via AST and
+never see rendered output, so neither needs to change.
+
+In `swagger_helper()`, parameters declared `body` no longer
+append individual entries. They accumulate, and after the loop
+render as a single parameter:
+
+```python
+{
+    'name': 'body',
+    'in': 'body',
+    'required': <any body declaration is required>,
+    'schema': {
+        'type': 'object',
+        'properties': {
+            <name>: {'type': ..., 'format': ...,
+                     'description': <argdescription>},
+            ...
+        },
+        'required': [<names declared required>],  # omitted if empty
+    }
+}
+```
+
+Rules and edge cases, enumerated up front (the phase 1 review
+loop existed because edges were found one round at a time):
+
+* **Zero body declarations** — no body parameter is emitted at
+  all. Eight operations have empty parameter lists; more have
+  only path/query parameters.
+* **One body declaration** — still collapses. A single body
+  parameter carrying `type` instead of `schema` is just as
+  invalid as three of them.
+* **`RAW_BODY_PARAMETER`** — a declaration named `body` with type
+  `binary` means "the raw request body", renders as
+  `schema: {'type': 'string', 'format': 'binary'}` with no
+  object wrapper, and **must be the only body declaration** on
+  its operation: raw bytes and named JSON keys cannot share a
+  request body, so mixing them raises `InvalidAPIDeclaration` at
+  import time like every other malformed declaration.
+* **A named parameter that happens to be called `body`** with a
+  non-binary type is not the raw marker; it becomes a property
+  like any other. No collision: the wrapper's `name: 'body'`
+  lives at parameter level, properties live inside the schema.
+* **`required` inside a schema is a JSON Schema array of property
+  names** — a different thing from the parameter-level boolean —
+  and an *empty* `required` array is itself invalid, so it is
+  omitted when no body property is required. The wrapper's
+  parameter-level `required` is true iff any property is.
+* **Descriptions survive** as per-property `description` keys.
+  The prose "formats" phase 1 kept (`'a JSON dictionary'` etc.)
+  ride along unchanged; `format` is an open string in schema
+  objects too. Turning `arrayofstring`/`arrayofdict` into real
+  `type: array` schemas is deliberately deferred to PR 3's
+  vocabulary work — one behaviour change per PR.
+
+Verification for this PR:
+
+* The ratchet count goes 128 → 0 and the test's known-class
+  table empties; the test now asserts plain validity.
+* Direct unit tests of `swagger_helper()` output in
+  `test_parameter_declarations.py`'s
+  `SwaggerHelperValidationTestCase`: multi-body collapse shape,
+  single-body collapse, raw-body rendering, the
+  raw-plus-named-body rejection, empty-required omission.
+* `tools/check-api-declaration-guards.sh` still passes — the
+  mutations target declarations, which have not changed shape.
+* The generated OpenAPI published at openapi.shakenfist.com
+  changes shape for every operation with a body: release note
+  required. The official Python client does not read the spec,
+  so nothing breaks operationally; anyone *generating* a client
+  finally can.
+
+### PR 3 — type tokens and the constraints element (D9)
+
+Two vocabulary changes to `swagger_helper()`, then their
+application across the tree.
+
+**New tokens** in `argtypes`:
+
+| Token | Renders as | For |
+|-------|-----------|-----|
+| `unsignedinteger` | `{'type': 'integer', 'format': 'int64', 'minimum': 0}` | artifact `max_versions` (negative is silently destructive — `delete_old_versions()` slices `[:-max]`), version indexes, blob offsets |
+| `macaddr` | `{'type': 'string', 'format': 'mac address', 'pattern': <colon-separated hex>}` | #534 |
+| `base64` | `{'type': 'string', 'format': 'byte'}` — `byte` is Swagger 2.0's standard token for base64 | user data, #3269 |
+| `netblock` | `{'type': 'string', 'format': 'CIDR netblock', 'pattern': <a.b.c.d/n>}` | network create, #323 |
+
+`arrayofstring` and `arrayofdict` also become real schemas here
+(`type: array` with `items`) now that body rendering goes through
+schema objects where `array` is legal.
+
+**The constraints element**: an optional sixth tuple element, a
+dict whose keys are drawn from `{'minimum', 'maximum',
+'pattern'}`. Validated at import time in the established style —
+every malformed declaration raises `InvalidAPIDeclaration`:
+
+* arity check becomes "5 or 6 elements";
+* a sixth element must be a dict with only known keys;
+* `minimum`/`maximum` must be numbers, `pattern` must compile
+  under `re.compile`;
+* a constraint that contradicts its token (a `minimum` on a
+  `string`, a second `minimum` on `unsignedinteger`) is rejected
+  rather than merged silently.
+
+Constraints render directly onto query/path parameters (valid
+Swagger 2.0 parameter keywords) and into body schema properties
+(valid JSON Schema keywords) — the ratchet test proves both stay
+valid.
+
+**Applications in this PR** (documentation-layer only; nothing is
+*enforced* until phases 3–4 compile and turn on rejection):
+
+* events `limit`: `{'minimum': 0, 'maximum': 1000}` — the cap
+  exists in code today and is invisible to callers, the original
+  D9 motivating case;
+* blob read `offset`/`limit` and upload truncate `offset` →
+  `unsignedinteger`;
+* artifact `max_versions` → `unsignedinteger`;
+* interface MAC on instance create → `macaddr`;
+* instance `user_data` → `base64`;
+* network `netblock` → `netblock` (the reserved-range *semantic*
+  check stays in phase 6).
+
+**Machinery updates forced by the sixth element:**
+
+* `test_parameter_declarations.py`'s AST walk and
+  `tools/fix-api-parameter-locations.py` both destructure
+  declaration tuples; both learn the optional element. The
+  fixer's byte-splice targets element `[1]` by AST node offsets,
+  so a sixth element does not move what it splices — verify with
+  a fixture rather than asserting it in review.
+* `tools/check-api-declaration-guards.sh` gains mutations: a
+  six-element tuple with an unknown constraint key, a non-dict
+  sixth element, an uncompilable `pattern`, a `minimum` on a
+  string token. Run the harness; every new guard must be caught,
+  not read.
+* `docs/developer_guide/writing_an_endpoint.md`: tuple shape
+  becomes "five elements, or six when constrained", new token
+  table, constraints reference.
+* **Rider: issue #3642.** The variadic-handler vacuous pass in
+  the accepted-parameters check is audit machinery this PR is
+  already editing; fix it here (`Fixes #3642`).
+
+## Coordination and adjacencies
+
+* **#1974 / api-query-batching-roadmap** — the bounded
+  `limit`/`offset` types PR 3 defines are exactly what pagination
+  needs. Coordinate on the tokens; the query and response-shape
+  work stays in that roadmap.
+* **#3616 (mypy for `external_api/base.py`)** — the master plan
+  lists it as enabling. Optional rider on PR 2, which rewrites
+  the renderer anyway; take it if the annotation diff stays
+  small, defer without guilt otherwise.
+* **The autofixer** may pick up filed issues; #3642 and #3643
+  have sat since 2026-08-03 untouched, but label them
+  `automated-fix-attempted` when their carrying PR branches, so
+  an automated fix does not race the in-flight work.
+* **openapi.shakenfist.com** republishes from the tree, so PR 2's
+  shape change propagates on the next docs sync; nothing manual.
+
+## What this phase does not do
+
+* No request is validated or rejected — compilation is phase 3,
+  enforcement phase 4. Everything here changes what is
+  *published* and what the compiler will later have to work with.
+* No `required` semantics change (phase 6).
+* No response validation (out of scope by D7).
+* No semantic validators (netblock overlap, MAC uniqueness) —
+  the tokens publish the format; cluster-state checks are
+  phase 6.
+
+## Verification, phase-wide
+
+* The ratchet number: 129 before PR 1, 128 after it, 0 after
+  PR 2, still 0 after PR 3. Each PR's commit message records the
+  measurement.
+* `tools/check-api-declaration-guards.sh` after every PR — a
+  guard that passes on a deliberately broken tree is not a
+  guard, and the harness grows with PR 3's constraint checks.
+* `pre-commit run --all-files` before every commit; the
+  `check-api-parameter-locations` hook must stay green through
+  the tuple-arity change.
+* Adversarial pass per the review-loop lessons: enumerate the
+  declaration input space (0/1/N body parameters, raw body,
+  raw-plus-named, five- and six-element tuples, every new token,
+  every constraint key, contradictory constraints) rather than
+  sampling what the tree happens to contain today.
+
+## Success criteria
+
+- [ ] CI fails when the generated specification acquires a new
+      validity error class (#3626 closed).
+- [ ] `openapi_spec_validator` reports zero errors on the
+      generated specification.
+- [ ] `securityDefinitions` published; `security` requirements
+      resolvable; `schemes` an array.
+- [ ] Every operation renders at most one body parameter, always
+      schema-carrying.
+- [ ] The four D9 tokens and the constraints element exist,
+      import-time validated, mutation-tested, documented.
+- [ ] The events `limit` bounds are visible in the published
+      OpenAPI.
+- [ ] #3642 and #3643 closed as riders.
+- [ ] Master plan phase table, `docs/plans/index.md`, and
+      `writing_an_endpoint.md` updated; release note for the
+      published-spec shape change.

--- a/docs/plans/PLAN-api-input-validation.md
+++ b/docs/plans/PLAN-api-input-validation.md
@@ -312,18 +312,17 @@ class, 1 from `schemes`.
   to collapse an operation's body parameters into a single `body`
   parameter with a generated `schema` object, which is a change to
   the renderer rather than to any declaration.
-* **`schemes` renders as a string, not an array.**
-  `API_ADVERTISED_HTTP_SCHEMES` is typed `str` in `config.py` while
-  its own description calls it a "space separated list", and
-  `app.py` feeds it straight into the specification's top-level
-  `schemes` key, which OpenAPI 2.0 requires to be an array of
-  strings. A default deployment therefore publishes
-  `schemes: 'http'`, and a two-scheme one publishes a single
-  nonsense string rather than two entries. Pre-existing —
-  introduced in `01ef8a563`, not by this plan — but it is the
-  *first* thing a validator trips over, ahead of the body
-  parameters above, so #3626 has to fix or explicitly waive it to
-  reach anything else.
+* **`schemes` renders as a string, not an array — fixed in
+  phase 2.** `API_ADVERTISED_HTTP_SCHEMES` is typed `str` in
+  `config.py` while its own description calls it a "space
+  separated list", and `app.py` fed it straight into the
+  specification's top-level `schemes` key, which OpenAPI 2.0
+  requires to be an array of strings. A default deployment
+  therefore published `schemes: 'http'`. Pre-existing —
+  introduced in `01ef8a563`, not by this plan. Phase 2's first PR
+  splits the documented space-separated contract at the consumer
+  in `app.py`, and added the `securityDefinitions` entry the
+  `security` requirements referenced without defining.
 * **`security` renders as an object, not an array — fixed in
   phase 1 after all.** `swagger_helper()` emitted
   `'security': {'bearerAuth': []}`, but OpenAPI 2.0 requires
@@ -335,16 +334,18 @@ class, 1 from `schemes`.
   `'security': [{'bearerAuth': []}]` eliminated the entire
   126-error class, the largest remaining. Kept in this list as a
   record of the scoping call rather than as work to do.
-* **Nothing validates the generated specification.** Phase 1's
-  path-implies-required rule exists to satisfy linters and client
-  generators, and was checked by hand. A unit test running
-  `openapi_spec_validator` over flasgger's output would catch the
-  next regression, including the body-parameter one above. The
-  only current functional coverage fetches `swagger-ui.css`.
-  Filed as [#3626](https://github.com/shakenfist/shakenfist/issues/3626)
-  so it is not gated on the renderer work — the test is worth
-  having before the fix, since it turns "invalid in N places"
-  into a number that moves.
+* **Nothing validates the generated specification — fixed in
+  phase 2.** Phase 1's path-implies-required rule exists to
+  satisfy linters and client generators, and was checked by hand.
+  Phase 2's first PR added
+  `shakenfist/tests/external_api/test_openapi_spec.py`, which
+  runs `openapi_spec_validator` over flasgger's output and holds
+  the remaining invalidity to an exact ratchet count (128, all in
+  the body-parameter class above), failing on any new error class
+  or any change in the count
+  ([#3626](https://github.com/shakenfist/shakenfist/issues/3626)).
+  The test landed before the renderer fix on purpose: it turns
+  "invalid in N places" into a number that moves.
 
 ### Carried into phase 3 from phase 1
 

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -62,6 +62,11 @@
 * A request to `/upload/...uuid.../truncate/...offset...` with a non-numeric
   offset now returns a 404 (the route no longer matches) where it previously
   returned a 500.
+* The published OpenAPI specification now declares its HTTP `schemes` as an
+  array (previously a single space separated string, which is invalid OpenAPI
+  2.0) and defines the `bearerAuth` security scheme that authenticated
+  operations reference, so generated clients can discover how to
+  authenticate. The specification is now validated in CI.
 
 ## Supported distributions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,10 @@ test = [
     "types-protobuf==7.34.1.20260518",    # apache2
     "types-PyYAML==6.0.12.20260724",      # apache2
     "types-requests==2.33.0.20260712",    # apache2
+    "openapi-spec-validator==0.9.0",      # apache2 -- test only: the API
+                                          #            daemon never
+                                          #            validates its own
+                                          #            spec at runtime
 ]
 
 # mypy configuration

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -74,7 +74,27 @@ swagger = flasgger.Swagger(app, template={
     },
     'host': config.API_ADVERTISED_HOST,
     'basePath': config.API_ADVERTISED_BASE_PATH,
-    'schemes': config.API_ADVERTISED_HTTP_SCHEMES
+    # The config field is a space separated list by its own documented
+    # contract, but OpenAPI 2.0 requires schemes to be an array of
+    # strings, so a default deployment used to publish the invalid
+    # schemes: 'http'. Split here rather than retyping the field:
+    # changing it to a list would change the environment variable
+    # format for every deployment to fix a rendering bug.
+    'schemes': config.API_ADVERTISED_HTTP_SCHEMES.split(),
+    # Swagger 2.0 has no first class bearer scheme (that arrived in
+    # OpenAPI 3); apiKey in the Authorization header is the standard
+    # 2.0 idiom for a JWT bearer token. Without this definition the
+    # security requirement swagger_helper() attaches to authenticated
+    # operations references a scheme the document never defines, so a
+    # generated client cannot learn how to authenticate.
+    'securityDefinitions': {
+        'bearerAuth': {
+            'type': 'apiKey',
+            'name': 'Authorization',
+            'in': 'header',
+            'description': 'A JWT token, presented as "Bearer <token>".'
+        }
+    }
 })
 
 # Use our handler to get SF log format (instead of gunicorn's handlers)

--- a/shakenfist/tests/external_api/test_openapi_spec.py
+++ b/shakenfist/tests/external_api/test_openapi_spec.py
@@ -1,0 +1,123 @@
+# Copyright 2019 Michael Still and contributors
+
+from openapi_spec_validator import OpenAPIV2SpecValidator
+
+from shakenfist.config import config
+from shakenfist.external_api import app as external_api
+from shakenfist.tests import base
+
+
+# The number of body parameters rendered with type/format where Swagger
+# 2.0 requires a schema. This is a ratchet with an exact count, not a
+# ceiling: an endpoint change that adds another one fails this test
+# instead of quietly raising the number, the same honesty rule the
+# declaration audit applies. Phase 2 of PLAN-api-input-validation
+# collapses each operation's body parameters into a single
+# schema-carrying parameter, at which point this reaches zero and the
+# ratchet machinery should be deleted, leaving only "the specification
+# is valid".
+KNOWN_UNSCHEMAD_BODY_PARAMETERS = 128
+
+
+class OpenAPISpecificationTestCase(base.ShakenFistTestCase):
+    """Validate the OpenAPI specification flasgger generates.
+
+    The published specification is what client generators read, and it
+    was invalid in three ways nothing measured (issue 3626): schemes
+    rendered as a string, security as a bare object, and body
+    parameters carrying type/format instead of a schema. This test is
+    the measurement.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        external_api.TESTING = True
+        external_api.app.testing = True
+
+        # The before_request hook resolves config.NODE_UUID, hitting
+        # the database if it is not already set. Serving the
+        # specification has no database dependency, so pin the UUID to
+        # keep this hermetic.
+        self.saved_node_uuid = config.NODE_UUID
+        config.NODE_UUID = 'test-node-uuid'
+        self.addCleanup(self._restore_node_uuid)
+
+        self.client = external_api.app.test_client()
+
+    def _restore_node_uuid(self):
+        config.NODE_UUID = self.saved_node_uuid
+
+    def _fetch_spec(self):
+        # flasgger registers its specs route directly on the Flask app
+        # rather than through api_base.Resource, so it is served
+        # without authentication, like the health probes.
+        resp = self.client.get('/apispec_1.json')
+        self.assertEqual(200, resp.status_code)
+        return resp.get_json()
+
+    @staticmethod
+    def _node_at(spec, path):
+        node = spec
+        for key in path:
+            node = node[key]
+        return node
+
+    def _is_unschemad_body_parameter(self, spec, error):
+        # The known error class: a parameter declared in: body which
+        # carries type/format where Swagger 2.0 requires a schema.
+        # Classified structurally -- by looking at what the error
+        # points to -- rather than by matching message text, which is
+        # jsonschema's and changes between releases.
+        node = self._node_at(spec, error.absolute_path)
+        return (isinstance(node, dict) and node.get('in') == 'body'
+                and 'schema' not in node)
+
+    def test_specification_valid_apart_from_known_classes(self):
+        spec = self._fetch_spec()
+        errors = list(OpenAPIV2SpecValidator(spec).iter_errors())
+
+        unknown = []
+        known = 0
+        for error in errors:
+            if self._is_unschemad_body_parameter(spec, error):
+                known += 1
+            else:
+                unknown.append('%s: %s' % (
+                    '/'.join(str(p) for p in error.absolute_path),
+                    error.message[:200]))
+
+        self.assertEqual(
+            [], unknown,
+            'The generated specification has validation errors outside '
+            'the known unschemad-body-parameter class:\n' +
+            '\n'.join(unknown))
+        self.assertEqual(
+            KNOWN_UNSCHEMAD_BODY_PARAMETERS, known,
+            'The count of body parameters rendered without a schema '
+            'changed. If it went down, lower the ratchet constant; if '
+            'it went up, a change added an invalid body parameter the '
+            'phase 2 renderer work would have to unwind.')
+
+    def test_security_requirements_resolve(self):
+        # openapi_spec_validator does not check that a security
+        # requirement names a defined scheme, and this was wrong in the
+        # tree: operations required 'bearerAuth' while the template
+        # defined no securityDefinitions at all, so a generated client
+        # had no way to learn how to authenticate.
+        spec = self._fetch_spec()
+        defined = set(spec.get('securityDefinitions', {}))
+        self.assertIn('bearerAuth', defined)
+
+        unresolved = []
+        for path, methods in spec['paths'].items():
+            for method, operation in methods.items():
+                if not isinstance(operation, dict):
+                    continue
+                for requirement in operation.get('security', []):
+                    for scheme in requirement:
+                        if scheme not in defined:
+                            unresolved.append(
+                                '%s %s references undefined security '
+                                'scheme %r' % (method, path, scheme))
+        self.assertEqual([], unresolved, '\n'.join(unresolved))

--- a/shakenfist/tests/external_api/test_parameter_declarations.py
+++ b/shakenfist/tests/external_api/test_parameter_declarations.py
@@ -350,7 +350,11 @@ class ParameterDeclarationTestCase(base.ShakenFistTestCase):
         falsify the comment without failing a test.
         """
         exempt = {cls for cls, _ in UNDOCUMENTED_BY_DESIGN}
-        with open(os.path.join(declarations.API_DIR, 'app.py')) as f:
+        # Explicit encoding, like every other read in this module:
+        # Python source is UTF-8 by definition (PEP 3120), while a bare
+        # open() consults the caller's locale (issue 3643).
+        with open(os.path.join(declarations.API_DIR, 'app.py'),
+                  encoding='utf-8') as f:
             tree = ast.parse(f.read())
 
         routes = set()
@@ -1020,7 +1024,8 @@ class Thing(api_base.Resource):
         return ast.parse(source).body[0]
 
     def _write(self, name, source):
-        with open(os.path.join(self.tempdir, name), 'w') as f:
+        with open(os.path.join(self.tempdir, name), 'w',
+                  encoding='utf-8') as f:
             f.write(source)
 
 
@@ -1077,7 +1082,8 @@ class FakeEndpoint(api_base.Resource):
         self.assertEqual(1, self.fixer.main(False, self.tempdir))
         self.assertEqual(0, self.fixer.main(True, self.tempdir))
 
-        with open(os.path.join(self.tempdir, 'fake.py')) as f:
+        with open(os.path.join(self.tempdir, 'fake.py'),
+                  encoding='utf-8') as f:
             rewritten = f.read()
         self.assertIn(
             "[('fake_ref', 'path', 'uuid', 'A ref.', True), "
@@ -1145,13 +1151,15 @@ class FakeEndpoint(api_base.Resource):
     def get(self, fake_ref=None):
         pass
 ''')
-        with open(os.path.join(self.tempdir, 'fake.py')) as f:
+        with open(os.path.join(self.tempdir, 'fake.py'),
+                  encoding='utf-8') as f:
             before = f.read()
 
         self.assertRaises(
             SystemExit, self.fixer.main, True, self.tempdir)
 
-        with open(os.path.join(self.tempdir, 'fake.py')) as f:
+        with open(os.path.join(self.tempdir, 'fake.py'),
+                  encoding='utf-8') as f:
             self.assertEqual(before, f.read())
 
     def test_refuses_a_multiline_location_literal(self):
@@ -1176,14 +1184,16 @@ class FakeEndpoint(api_base.Resource):
     def get(self, fake_ref=None):
         pass
 ''')
-        with open(os.path.join(self.tempdir, 'fake.py')) as f:
+        with open(os.path.join(self.tempdir, 'fake.py'),
+                  encoding='utf-8') as f:
             before = f.read()
 
         self.assertRaisesRegex(
             SystemExit, 'multi-line location literal',
             self.fixer.main, True, self.tempdir)
 
-        with open(os.path.join(self.tempdir, 'fake.py')) as f:
+        with open(os.path.join(self.tempdir, 'fake.py'),
+                  encoding='utf-8') as f:
             self.assertEqual(before, f.read())
 
     def test_refuses_an_offset_that_does_not_hold_the_literal(self):
@@ -1206,14 +1216,16 @@ class FakeEndpoint(api_base.Resource):
     def get(self, fake_ref=None):
         pass
 ''')
-        with open(os.path.join(self.tempdir, 'fake.py')) as f:
+        with open(os.path.join(self.tempdir, 'fake.py'),
+                  encoding='utf-8') as f:
             before = f.read()
 
         self.assertRaisesRegex(
             SystemExit, 'does not hold',
             self.fixer.main, True, self.tempdir)
 
-        with open(os.path.join(self.tempdir, 'fake.py')) as f:
+        with open(os.path.join(self.tempdir, 'fake.py'),
+                  encoding='utf-8') as f:
             self.assertEqual(before, f.read())
 
     def test_leaves_a_correct_tree_alone(self):
@@ -1227,12 +1239,14 @@ class FakeEndpoint(api_base.Resource):
     def post(self, name=None):
         pass
 ''')
-        with open(os.path.join(self.tempdir, 'fake.py')) as f:
+        with open(os.path.join(self.tempdir, 'fake.py'),
+                  encoding='utf-8') as f:
             before = f.read()
 
         self.assertEqual(0, self.fixer.main(True, self.tempdir))
 
-        with open(os.path.join(self.tempdir, 'fake.py')) as f:
+        with open(os.path.join(self.tempdir, 'fake.py'),
+                  encoding='utf-8') as f:
             self.assertEqual(before, f.read())
 
 


### PR DESCRIPTION
Part 1 of 3 for phase 2 of `PLAN-api-input-validation`. The phase plan document is the first commit here; parts 2 and 3 (the body-parameter collapse, then the type vocabulary and constraints) follow one at a time once this lands, per the plan's three-PR split — phase 1's single large PR took twelve review rounds, and smaller diffs converge faster.

This part makes the published specification's validity *measurable* before anything fixes the remaining invalidity:

* A new unit test, `shakenfist/tests/external_api/test_openapi_spec.py`, builds the real Flask app with the established mocks, fetches `/apispec_1.json`, and runs `openapi_spec_validator` (new test-only dependency, Apache-2.0) over it. The assertion is a ratchet with an **exact** count: every error must belong to the one known class (a body parameter rendered with `type`/`format` where Swagger 2.0 requires a `schema` — 128 today), so a change that adds another invalid body parameter fails CI, and part 2 must lower the constant to zero rather than quietly inheriting slack.
* `schemes` was fed a space-separated string, so a default deployment published the invalid `schemes: 'http'`. Now split at the consumer in `app.py`, honouring the config field's documented "space separated list" contract rather than changing the environment-variable format for every deployment.
* The flasgger template defined no `securityDefinitions`, so the `security: [{'bearerAuth': []}]` requirement phase 1 attached to authenticated operations referenced a scheme the document never defines — a generated client had no way to learn how to authenticate. `bearerAuth` is now defined via the standard Swagger 2.0 apiKey-in-Authorization idiom, and a second test checks requirement resolution, which the validator itself does not.
* Rider: every `open()` in `test_parameter_declarations.py` now passes `encoding='utf-8'` explicitly (issue 3643).

Both new guards were verified adversarially: unsplitting `schemes` fails the ratchet on an unknown error class, and renaming `securityDefinitions` fails both new tests. All 12 mutations in `tools/check-api-declaration-guards.sh` remain caught.

Fixes #3626
Fixes #3643

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nPqvWFVKNtS63aNm74kRq