### PR TITLE
Render one schema-carrying body parameter per operation

### DIFF
--- a/docs/developer_guide/writing_an_endpoint.md
+++ b/docs/developer_guide/writing_an_endpoint.md
@@ -88,7 +88,17 @@ specification invalid — client generators reject it outright.
 **4. A raw request body is declared as `api_base.RAW_BODY_PARAMETER`.**
 Upload endpoints read the body from `flask.request` rather than
 receiving it as a kwarg. Use the constant rather than inventing a name,
-so the "declared but not accepted" check knows to let it through.
+so the "declared but not accepted" check knows to let it through. An
+operation cannot declare both the raw body and named body parameters —
+raw bytes and JSON keys cannot share a request body, and
+`swagger_helper()` rejects the combination at import time.
+
+**A note on rendering:** declarations stay one tuple per parameter,
+but Swagger 2.0 permits at most one `in: body` parameter per
+operation, carrying a `schema`. `swagger_helper()` therefore collapses
+an operation's body declarations into a single generated body
+parameter whose schema has one property per declaration. You declare
+parameters individually; the collapse is the renderer's business.
 
 **A constraint on routing rather than on declarations:** a class
 mounted on more than one route must carry the same parameters on
@@ -134,6 +144,12 @@ per-endpoint request validation is phase 3 of the plan; until then a
 correct declaration does not stop a caller sending something else.
 Two known gaps:
 
+(The published specification itself *is* checked:
+`shakenfist/tests/external_api/test_openapi_spec.py` validates the
+generated OpenAPI with `openapi_spec_validator` on every CI run, so a
+change that renders an invalid specification fails rather than
+shipping — the fate of the 129 validation errors phase 2 removed.)
+
 * `header` and `formData` cannot be derived from the code, so they are
   reported rather than corrected. No endpoint uses either today, and
   using one requires an `UNDERIVABLE_BY_DESIGN` entry in
@@ -148,18 +164,3 @@ Two known gaps:
   know which parameters arrive in the query string, so an opt-out
   entry would have to restate the schema's keys by hand — exactly the
   second source of truth this machinery exists to remove.
-* Swagger 2.0 allows at most one `in: body` parameter per operation,
-  carrying a `schema` rather than a `type`. `swagger_helper()` emits
-  one parameter per declaration, so operations with several body
-  parameters render an invalid specification — **32 of 132 operations
-  today, up from 23 of 124 before the declaration audit**, because
-  correcting a parameter to `body` is individually right and moves this
-  count the wrong way (the federated-authentication endpoints then
-  added several more). The published specification is not yet
-  linter-clean. Phase 2 collapses the parameters into a generated
-  `schema`; until that lands,
-  `shakenfist/tests/external_api/test_openapi_spec.py` validates the
-  generated specification and holds this class to an exact count, so
-  a change that adds another invalid body parameter fails CI rather
-  than quietly raising the number
-  ([issue #3626](https://github.com/shakenfist/shakenfist/issues/3626)).

--- a/docs/plans/PLAN-api-input-validation.md
+++ b/docs/plans/PLAN-api-input-validation.md
@@ -299,19 +299,22 @@ and a rebase brought in the eleven federated-authentication
 handlers, so the branch now measures **129**: 128 from the body
 class, 1 from `schemes`.
 
-* **Multiple body parameters per operation.** Swagger 2.0 permits
-  at most one `in: body` parameter, and it must carry a `schema`
-  rather than `type`/`format`; `swagger_helper()` emits
-  `type`/`format` for everything. 32 of 132 operations declare
-  more than one body parameter (23 before phase 1 — correcting
-  `key` from query to body on the metadata endpoints added most
-  of the rest, and the federated-authentication endpoints arrived
-  with several more). Every individual declaration is now right
-  and the specification is still invalid, so the generated-client
-  problem this plan opens with is only partly closed. The fix is
-  to collapse an operation's body parameters into a single `body`
-  parameter with a generated `schema` object, which is a change to
-  the renderer rather than to any declaration.
+* **Multiple body parameters per operation — fixed in phase 2.**
+  Swagger 2.0 permits at most one `in: body` parameter, and it
+  must carry a `schema` rather than `type`/`format`;
+  `swagger_helper()` emitted `type`/`format` for everything, and
+  32 of 132 operations declared more than one body parameter (23
+  before phase 1 — correcting `key` from query to body on the
+  metadata endpoints added most of the rest, and the
+  federated-authentication endpoints arrived with several more).
+  Phase 2's second PR collapses an operation's body declarations
+  into a single generated `schema` at render time — declarations
+  keep their one-tuple-per-parameter shape, which is what the
+  audit reads and phase 3 compiles. The raw-body marker renders
+  as a binary schema, and declaring raw and named body parameters
+  together is rejected at import time. This took the validation
+  error count from 128 to zero, so the ratchet in
+  `test_openapi_spec.py` became a plain validity assertion.
 * **`schemes` renders as a string, not an array — fixed in
   phase 2.** `API_ADVERTISED_HTTP_SCHEMES` is typed `str` in
   `config.py` while its own description calls it a "space

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -75,6 +75,12 @@
   2.0) and defines the `bearerAuth` security scheme that authenticated
   operations reference, so generated clients can discover how to
   authenticate. The specification is now validated in CI.
+* Operations that accept several request body values now publish a single
+  `in: body` parameter carrying a generated JSON schema, as OpenAPI 2.0
+  requires, instead of one `type`/`format` parameter per value. With this
+  change the published specification validates cleanly, so standard client
+  generators can consume it. The request wire format is unchanged — this
+  only alters how the API is described.
 
 ## Supported distributions
 

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -247,6 +247,17 @@ def swagger_helper(section, description, parameters, responses,
 
     declarable = set(argtypes) - {'bearer'}
 
+    # Swagger 2.0 permits at most one in: body parameter per operation,
+    # and it must carry a schema rather than type/format. Declarations
+    # stay one tuple per parameter -- that is the shape the audit reads
+    # and phase 3 will compile -- but body-located declarations render
+    # as properties of a single generated schema instead of as
+    # parameters of their own, which used to be the largest class of
+    # specification-validity errors (128 at its peak).
+    body_properties = {}
+    body_required = []
+    raw_body = None
+
     for parameter in parameters:
         # Checked explicitly, and first, because every malformed
         # declaration has to arrive as an InvalidAPIDeclaration for
@@ -293,13 +304,66 @@ def swagger_helper(section, description, parameters, responses,
                 '%s parameter %s declares type %r, which is not one of %s'
                 % (section, name, argtype, ', '.join(sorted(declarable))))
 
+        if location != 'body':
+            out['parameters'].append({
+                'name': name,
+                'in': location,
+                'required': argrequired,
+                'description': argdescription
+            })
+            out['parameters'][-1].update(argtypes[argtype])
+            continue
+
+        # The raw request body marker: the handler reads bytes from
+        # flask.request rather than receiving named JSON keys. A
+        # parameter which merely happens to be called 'body' but has a
+        # non-binary type is not the marker; it becomes a schema
+        # property like any other named parameter, and there is no
+        # collision because the generated wrapper's name lives at
+        # parameter level while properties live inside the schema.
+        if name == RAW_BODY_PARAMETER and argtype == 'binary':
+            raw_body = (argdescription, argrequired)
+            continue
+
+        prop = dict(argtypes[argtype])
+        prop['description'] = argdescription
+        body_properties[name] = prop
+        if argrequired:
+            body_required.append(name)
+
+    if raw_body is not None and body_properties:
+        raise exceptions.InvalidAPIDeclaration(
+            '%s declares both the raw request body and named body '
+            'parameters (%s); raw bytes and JSON keys cannot share a '
+            'request body' % (section, ', '.join(sorted(body_properties))))
+
+    if raw_body is not None:
+        (argdescription, argrequired) = raw_body
         out['parameters'].append({
-            'name': name,
-            'in': location,
+            'name': RAW_BODY_PARAMETER,
+            'in': 'body',
             'required': argrequired,
-            'description': argdescription
+            'description': argdescription,
+            'schema': dict(argtypes['binary'])
         })
-        out['parameters'][-1].update(argtypes[argtype])
+    elif body_properties:
+        schema = {
+            'type': 'object',
+            'properties': body_properties
+        }
+        # In a schema object 'required' is a JSON Schema array of
+        # property names -- a different thing from the parameter-level
+        # boolean -- and an empty array is itself invalid, so it is
+        # only present when something is required.
+        if body_required:
+            schema['required'] = body_required
+        out['parameters'].append({
+            'name': RAW_BODY_PARAMETER,
+            'in': 'body',
+            'required': bool(body_required),
+            'description': 'The JSON request body.',
+            'schema': schema
+        })
 
     if requires_auth:
         responses.append((

--- a/shakenfist/tests/external_api/test_openapi_spec.py
+++ b/shakenfist/tests/external_api/test_openapi_spec.py
@@ -7,26 +7,19 @@ from shakenfist.external_api import app as external_api
 from shakenfist.tests import base
 
 
-# The number of body parameters rendered with type/format where Swagger
-# 2.0 requires a schema. This is a ratchet with an exact count, not a
-# ceiling: an endpoint change that adds another one fails this test
-# instead of quietly raising the number, the same honesty rule the
-# declaration audit applies. Phase 2 of PLAN-api-input-validation
-# collapses each operation's body parameters into a single
-# schema-carrying parameter, at which point this reaches zero and the
-# ratchet machinery should be deleted, leaving only "the specification
-# is valid".
-KNOWN_UNSCHEMAD_BODY_PARAMETERS = 128
-
-
 class OpenAPISpecificationTestCase(base.ShakenFistTestCase):
     """Validate the OpenAPI specification flasgger generates.
 
     The published specification is what client generators read, and it
     was invalid in three ways nothing measured (issue 3626): schemes
-    rendered as a string, security as a bare object, and body
-    parameters carrying type/format instead of a schema. This test is
-    the measurement.
+    rendered as a string, body parameters carrying type/format instead
+    of a schema, and security requirements referencing an undefined
+    scheme. All three are fixed; this test is what keeps them fixed.
+
+    This began life as a ratchet holding the body-parameter error
+    class to an exact count of 128 while the schemes fix landed ahead
+    of the renderer collapse. The collapse took it to zero, so the
+    classifier is gone and simple validity is the permanent assertion.
     """
 
     def setUp(self):
@@ -56,48 +49,16 @@ class OpenAPISpecificationTestCase(base.ShakenFistTestCase):
         self.assertEqual(200, resp.status_code)
         return resp.get_json()
 
-    @staticmethod
-    def _node_at(spec, path):
-        node = spec
-        for key in path:
-            node = node[key]
-        return node
-
-    def _is_unschemad_body_parameter(self, spec, error):
-        # The known error class: a parameter declared in: body which
-        # carries type/format where Swagger 2.0 requires a schema.
-        # Classified structurally -- by looking at what the error
-        # points to -- rather than by matching message text, which is
-        # jsonschema's and changes between releases.
-        node = self._node_at(spec, error.absolute_path)
-        return (isinstance(node, dict) and node.get('in') == 'body'
-                and 'schema' not in node)
-
-    def test_specification_valid_apart_from_known_classes(self):
+    def test_specification_is_valid(self):
         spec = self._fetch_spec()
-        errors = list(OpenAPIV2SpecValidator(spec).iter_errors())
-
-        unknown = []
-        known = 0
-        for error in errors:
-            if self._is_unschemad_body_parameter(spec, error):
-                known += 1
-            else:
-                unknown.append('%s: %s' % (
-                    '/'.join(str(p) for p in error.absolute_path),
-                    error.message[:200]))
-
+        errors = [
+            '%s: %s' % ('/'.join(str(p) for p in error.absolute_path),
+                        error.message[:200])
+            for error in OpenAPIV2SpecValidator(spec).iter_errors()]
         self.assertEqual(
-            [], unknown,
-            'The generated specification has validation errors outside '
-            'the known unschemad-body-parameter class:\n' +
-            '\n'.join(unknown))
-        self.assertEqual(
-            KNOWN_UNSCHEMAD_BODY_PARAMETERS, known,
-            'The count of body parameters rendered without a schema '
-            'changed. If it went down, lower the ratchet constant; if '
-            'it went up, a change added an invalid body parameter the '
-            'phase 2 renderer work would have to unwind.')
+            [], errors,
+            'The generated specification is not valid OpenAPI 2.0:\n' +
+            '\n'.join(errors))
 
     def test_security_requirements_resolve(self):
         # openapi_spec_validator does not check that a security
@@ -121,3 +82,26 @@ class OpenAPISpecificationTestCase(base.ShakenFistTestCase):
                                 '%s %s references undefined security '
                                 'scheme %r' % (method, path, scheme))
         self.assertEqual([], unresolved, '\n'.join(unresolved))
+
+    def test_at_most_one_body_parameter_per_operation(self):
+        # The validator catches an unschemad body parameter, but "at
+        # most one body parameter" is checked here directly so a
+        # regression names the operation rather than surfacing as a
+        # oneOf mismatch deep in jsonschema output.
+        spec = self._fetch_spec()
+        offenders = []
+        for path, methods in spec['paths'].items():
+            for method, operation in methods.items():
+                if not isinstance(operation, dict):
+                    continue
+                bodies = [p for p in operation.get('parameters', [])
+                          if p.get('in') == 'body']
+                if len(bodies) > 1:
+                    offenders.append('%s %s has %d body parameters'
+                                     % (method, path, len(bodies)))
+                for body in bodies:
+                    if 'schema' not in body:
+                        offenders.append(
+                            '%s %s body parameter %r has no schema'
+                            % (method, path, body.get('name')))
+        self.assertEqual([], offenders, '\n'.join(offenders))

--- a/shakenfist/tests/external_api/test_parameter_declarations.py
+++ b/shakenfist/tests/external_api/test_parameter_declarations.py
@@ -1265,12 +1265,98 @@ class SwaggerHelperValidationTestCase(base.ShakenFistTestCase):
             [(200, 'No return value', '')])
 
     def test_valid_declaration_renders(self):
-        out = self._helper([('thing', 'body', 'string', 'A thing.', False)])
+        out = self._helper([('thing', 'query', 'string', 'A thing.', False)])
 
         declared = [p for p in out['parameters'] if p['name'] == 'thing']
         self.assertEqual(1, len(declared))
-        self.assertEqual('body', declared[0]['in'])
+        self.assertEqual('query', declared[0]['in'])
         self.assertFalse(declared[0]['required'])
+
+    def _body_parameters(self, out):
+        return [p for p in out['parameters'] if p['in'] == 'body']
+
+    def test_body_parameters_collapse_to_one_schema(self):
+        # Swagger 2.0 permits at most one body parameter per operation,
+        # carrying a schema. Declarations stay one tuple per parameter;
+        # the renderer collapses them.
+        out = self._helper([
+            ('first', 'body', 'string', 'The first thing.', True),
+            ('sneaky', 'query', 'string', 'Not a body thing.', False),
+            ('second', 'body', 'integer', 'The second thing.', False)])
+
+        bodies = self._body_parameters(out)
+        self.assertEqual(1, len(bodies))
+        body = bodies[0]
+        self.assertEqual('body', body['name'])
+        self.assertTrue(body['required'])
+        self.assertEqual(
+            {'first', 'second'}, set(body['schema']['properties']))
+        self.assertEqual(
+            'The first thing.',
+            body['schema']['properties']['first']['description'])
+        self.assertEqual(
+            'integer', body['schema']['properties']['second']['type'])
+        self.assertEqual(['first'], body['schema']['required'])
+
+        # The query parameter is untouched by the collapse.
+        self.assertEqual(
+            1, len([p for p in out['parameters'] if p['name'] == 'sneaky']))
+
+    def test_single_body_parameter_still_collapses(self):
+        # One body parameter carrying type/format instead of a schema
+        # is just as invalid as three of them.
+        out = self._helper([('thing', 'body', 'string', 'A thing.', False)])
+
+        bodies = self._body_parameters(out)
+        self.assertEqual(1, len(bodies))
+        self.assertIn('thing', bodies[0]['schema']['properties'])
+        self.assertNotIn('type', bodies[0])
+
+    def test_all_optional_body_omits_required_array(self):
+        # In a schema object 'required' is an array of property names,
+        # and an *empty* required array is itself invalid JSON Schema,
+        # so it must be absent rather than empty.
+        out = self._helper([
+            ('one', 'body', 'string', 'One.', False),
+            ('two', 'body', 'string', 'Two.', False)])
+
+        body = self._body_parameters(out)[0]
+        self.assertNotIn('required', body['schema'])
+        self.assertFalse(body['required'])
+
+    def test_no_body_declarations_no_body_parameter(self):
+        out = self._helper([('thing', 'query', 'string', 'A thing.', False)])
+        self.assertEqual([], self._body_parameters(out))
+
+    def test_raw_body_renders_as_schema(self):
+        out = self._helper([
+            (api_base.RAW_BODY_PARAMETER, 'body', 'binary',
+             'Binary data.', True)])
+
+        bodies = self._body_parameters(out)
+        self.assertEqual(1, len(bodies))
+        self.assertEqual('string', bodies[0]['schema']['type'])
+        self.assertNotIn('type', bodies[0])
+        self.assertNotIn('properties', bodies[0]['schema'])
+
+    def test_raw_and_named_body_rejected(self):
+        # Raw bytes and named JSON keys cannot share a request body, so
+        # declaring both is a contradiction caught at import time.
+        self.assertRaises(
+            exceptions.InvalidAPIDeclaration, self._helper,
+            [(api_base.RAW_BODY_PARAMETER, 'body', 'binary', 'Bytes.', True),
+             ('thing', 'body', 'string', 'A thing.', False)])
+
+    def test_parameter_named_body_is_not_the_raw_marker(self):
+        # A named parameter which happens to be called 'body' with a
+        # non-binary type is an ordinary schema property. There is no
+        # collision with the generated wrapper: its name lives at
+        # parameter level, properties live inside the schema.
+        out = self._helper([('body', 'body', 'string', 'A thing.', False)])
+
+        bodies = self._body_parameters(out)
+        self.assertEqual(1, len(bodies))
+        self.assertIn('body', bodies[0]['schema']['properties'])
 
     def test_security_and_authorization_travel_together(self):
         """An unauthenticated operation publishes neither the security


### PR DESCRIPTION
Part 2 of 3 for phase 2 of `PLAN-api-input-validation`, following #3666.
The plan is
[`docs/plans/PLAN-api-input-validation-phase-02-type-vocabulary.md`](https://github.com/shakenfist/shakenfist/blob/develop/docs/plans/PLAN-api-input-validation-phase-02-type-vocabulary.md),
landed in that PR.

## What this fixes

Swagger 2.0 permits at most one `in: body` parameter per operation, and it
must carry a `schema` rather than `type`/`format`. `swagger_helper()` emitted
one type/format parameter per declaration, which is the entire remaining class
of specification-validity errors that #3666's ratchet pinned at 128: 32 of our
132 operations declare more than one body parameter, and every operation
declaring one at all was invalid.

So this PR takes the ratchet from 128 to zero, which is what #3666 committed
the next change to doing.

## How

**Declarations do not change shape.** One five-element tuple per parameter is
what the AST audit reads and what phase 3 will compile into request
validation. The collapse happens purely at render time: body-located
declarations become properties of a single generated body parameter, whose
schema carries the per-property type, format and description, plus a JSON
Schema `required` array naming the required properties — omitted entirely when
empty, because an empty `required` array is itself invalid.

**The raw body still works.** `RAW_BODY_PARAMETER` with the `binary` type (the
upload data endpoint) renders as a binary string schema with no object
wrapper. Declaring it alongside named body parameters is a contradiction —
raw bytes and JSON keys cannot share a request body — and now raises
`InvalidAPIDeclaration` at import time, like every other malformed
declaration. A parameter which merely happens to be *named* `body` with a
non-binary type is an ordinary schema property; the generated wrapper's name
lives at parameter level, so there is no collision.

**The wire format is unchanged.** This alters only how the API is described to
specification consumers. Nothing about what the server accepts moves until
phase 3.

## Tests

`test_openapi_spec.py`'s ratchet collapses to its permanent form: a plain
validity assertion, plus a direct at-most-one-schema-carrying-body-parameter
check so a future regression names the offending operation instead of
surfacing as a `oneOf` mismatch deep in jsonschema output.

Each renderer edge case carries a unit test: multi-parameter collapse,
single-parameter collapse, all-optional `required` omission, operations with no
body at all, the raw body, raw-plus-named rejection, and a property named
`body`.

## Verification

* With the renderer change stashed, the validity and one-body tests fail and
  the 128 errors return — the tests are load-bearing, not decorative.
* All 12 mutations in `tools/check-api-declaration-guards.sh` remain caught.
* Full unit suite: 2585 passed, 0 failed. `pre-commit run --all-files` clean.

Part 3 (the typed vocabulary: `unsignedinteger`, `base64`, `netblock`, real
array types, and optional per-parameter bounds) follows once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nPqvWFVKNtS63aNm74kRq
