### PR TITLE
Fall back between models in the issue fixer

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -26,6 +26,11 @@
 #   workflow has no path to merging code.
 #
 # NOTES:
+# - The fix attempt runs through tools/claude-model-fallback.sh, which
+#   tries each model in the `models` input in order and moves on when one
+#   reports its subscription credit is exhausted (an HTTP 429 that the
+#   claude CLI's own --fallback-model flag does not cover). Triage stays
+#   pinned to Haiku, which is cheap enough not to need this.
 # - GitHub does not run CI on pull requests created with the default
 #   workflow token (this prevents recursive workflow triggering), so
 #   the draft PR needs a human nudge -- push to it, or close and
@@ -64,10 +69,10 @@ on:
         required: false
         default: '400'
         type: string
-      model:
-        description: 'Model used for the fix attempt'
+      models:
+        description: 'Comma-separated models to try for the fix, in preference order'
         required: false
-        default: 'claude-fable-5'
+        default: 'claude-fable-5,claude-opus-5'
         type: string
       dry_run:
         description: 'Dry run (no label, no comments, no commits, no PR)'
@@ -274,7 +279,7 @@ jobs:
       ISSUE_NUMBER: ${{ needs.triage.outputs.issue_number }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DRY_RUN: ${{ inputs.dry_run }}
-      MODEL: ${{ inputs.model }}
+      MODELS: ${{ inputs.models }}
       MAX_TURNS: ${{ inputs.max_turns }}
       MAX_DIFF_LINES: ${{ inputs.max_diff_lines }}
 
@@ -464,9 +469,20 @@ jobs:
 
           start_time=$(date +%s)
 
-          claude -p "$(cat ${{ runner.temp }}/claude-prompt.txt)" \
+          # Run the wrapper from a copy outside the workspace: Claude is
+          # about to edit this checkout, and bash reads a script lazily as
+          # it executes, so a fix which touched tools/ would corrupt the
+          # running wrapper.
+          cp tools/claude-model-fallback.sh ${{ runner.temp }}/
+
+          # MODELS is tried in order, moving on when a model reports its
+          # subscription credit is exhausted (HTTP 429). Every model being
+          # out of credit exits 1 and produces no output, which the assess
+          # step below sees as "no changes".
+          ${{ runner.temp }}/claude-model-fallback.sh \
+            --models "${MODELS}" \
+            -- "$(cat ${{ runner.temp }}/claude-prompt.txt)" \
             --dangerously-skip-permissions \
-            --model "${MODEL}" \
             --max-turns "${MAX_TURNS}" \
             --output-format text \
             2>&1 | tee ${{ runner.temp }}/claude-output.txt \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,16 @@ Authorized users can trigger automation by commenting on PRs:
   unit test failures (`tox -ecover`). Uses `test-drift-fix.yml` with
   structured commit summaries.
 
+`issue-fix.yml` runs its fix attempt through
+`tools/claude-model-fallback.sh`, which takes a comma-separated
+preference list (`--models`, default `claude-fable-5,claude-opus-5`) and
+moves to the next model when one reports its subscription credit is
+exhausted. That case arrives as an HTTP 429 in the `--output-format json`
+payload (`api_error_status`), which the claude CLI's own
+`--fallback-model` flag does not handle -- it only covers overloaded or
+unavailable models. A refused request is free, so the wrapper attempts
+the real job rather than paying for a pre-flight probe.
+
 ## Working with This Codebase
 
 ### Code Style

--- a/tools/claude-model-fallback.sh
+++ b/tools/claude-model-fallback.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+# Run a headless `claude -p` job against a preferred model, falling back to
+# other models when the preferred one's subscription credit is exhausted.
+#
+# Claude Code signals an exhausted per-model allowance as an HTTP 429 whose
+# JSON result looks like:
+#
+#   {"is_error": true, "total_cost_usd": 0, "api_error_status": 429,
+#    "result": "You've reached your Fable 5 limit. Run /usage-credits to
+#               continue or switch models with /model.", ...}
+#
+# The built-in --fallback-model flag does NOT cover this case (it only
+# handles overloaded or unavailable models), so automated jobs need to
+# detect it themselves.
+#
+# A rejected request is free -- it burns zero tokens and reports
+# total_cost_usd of 0 -- so this wrapper attempts the real job rather than
+# running a separate pre-flight probe, which would cost real money on every
+# run in which the preferred model *is* available.
+#
+# Usage:
+#   tools/claude-model-fallback.sh [options] -- <claude args...>
+#   tools/claude-model-fallback.sh --check MODEL
+#
+# Options:
+#   --models LIST  Comma-separated models to try in order
+#                  (default: claude-fable-5,claude-opus-5)
+#   --quiet        Suppress the "falling back" notice on stderr
+#   --check MODEL  Probe MODEL only and exit; 0 = available, 1 = out of
+#                  credit. Note that a successful probe costs a small
+#                  amount of credit.
+#   --help         Show this help message
+#
+# Do not pass --model yourself; use --models. A caller supplied
+# --output-format is honoured but consumed by this wrapper, which always
+# asks claude for JSON internally (that is what carries the 429 signal) and
+# reshapes the output afterwards. Formats "text" (the default) and "json"
+# are supported, "stream-json" is not, because a fallback decision cannot be
+# unwound once streamed output has been emitted.
+#
+# Exit codes:
+#   0    a model succeeded
+#   1    every model in the list was out of credit
+#   2    usage error
+#   *    the underlying claude exit code for any non-credit failure
+
+set -uo pipefail
+
+models='claude-fable-5,claude-opus-5'
+quiet=0
+check_model=''
+output_format='text'
+claude_args=()
+
+usage() {
+    cat << 'USAGE_EOF'
+Usage:
+  tools/claude-model-fallback.sh [options] -- <claude args...>
+  tools/claude-model-fallback.sh --check MODEL
+
+Options:
+  --models LIST  Comma-separated models to try in order
+                 (default: claude-fable-5,claude-opus-5)
+  --quiet        Suppress the "falling back" notice on stderr
+  --check MODEL  Probe MODEL only and exit; 0 = available, 1 = out of credit
+  --help         Show this help message
+
+Do not pass --model yourself; use --models. Output formats "text" (the
+default) and "json" are supported, "stream-json" is not.
+
+Exit codes:
+  0    a model succeeded
+  1    every model in the list was out of credit
+  2    usage error
+  *    the underlying claude exit code for any non-credit failure
+USAGE_EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --models)
+            [ $# -ge 2 ] || { echo 'claude-model-fallback: --models needs a value' >&2; exit 2; }
+            models="$2"
+            shift 2
+            ;;
+        --models=*)
+            models="${1#*=}"
+            shift
+            ;;
+        --quiet)
+            quiet=1
+            shift
+            ;;
+        --check)
+            [ $# -ge 2 ] || { echo 'claude-model-fallback: --check needs a model' >&2; exit 2; }
+            check_model="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+command -v jq > /dev/null || { echo 'claude-model-fallback: jq is required' >&2; exit 2; }
+
+# --check: probe a single model with a throwaway prompt.
+if [ -n "${check_model}" ]; then
+    out=$(claude -p --model "${check_model}" --output-format json --tools '' \
+        --disable-slash-commands --no-session-persistence 'Reply with: ok' 2>/dev/null)
+    status=$(jq -r '.api_error_status // empty' <<< "${out}" 2>/dev/null)
+    if [ "${status}" = '429' ]; then
+        [ "${quiet}" -eq 1 ] || jq -r '.result' <<< "${out}" >&2
+        exit 1
+    fi
+    exit 0
+fi
+
+# Split the caller's claude arguments from the output format, which this
+# wrapper owns: claude is always asked for JSON (that is what carries the
+# 429 signal) and the output is reshaped afterwards. Leaving a caller's
+# --output-format in place would override the internal request and break
+# credit detection.
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --output-format)
+            [ $# -ge 2 ] || { echo 'claude-model-fallback: --output-format needs a value' >&2; exit 2; }
+            output_format="$2"
+            shift 2
+            ;;
+        --output-format=*)
+            output_format="${1#*=}"
+            shift
+            ;;
+        --model|--model=*)
+            echo 'claude-model-fallback: do not pass --model, use --models' >&2
+            exit 2
+            ;;
+        *)
+            claude_args+=("$1")
+            shift
+            ;;
+    esac
+done
+
+case "${output_format}" in
+    text|json)
+        ;;
+    *)
+        echo "claude-model-fallback: unsupported --output-format '${output_format}'" >&2
+        exit 2
+        ;;
+esac
+
+[ "${#claude_args[@]}" -gt 0 ] || {
+    echo 'claude-model-fallback: no claude arguments given' >&2
+    exit 2
+}
+
+rc=0
+IFS=',' read -ra model_list <<< "${models}"
+for model in "${model_list[@]}"; do
+    out=$(claude -p --output-format json --model "${model}" "${claude_args[@]}")
+    rc=$?
+
+    status=$(jq -r '.api_error_status // empty' <<< "${out}" 2>/dev/null)
+    if [ "${status}" = '429' ]; then
+        if [ "${quiet}" -eq 0 ]; then
+            printf 'claude-model-fallback: %s out of credit: %s\n' \
+                "${model}" "$(jq -r '.result' <<< "${out}")" >&2
+        fi
+        continue
+    fi
+
+    # Anything else -- success, or a failure unrelated to credit -- is the
+    # caller's answer. Falling back would not help and would cost money.
+    if [ "${output_format}" = 'json' ]; then
+        printf '%s\n' "${out}"
+    else
+        jq -r '.result // empty' <<< "${out}" 2>/dev/null || printf '%s\n' "${out}"
+    fi
+    exit ${rc}
+done
+
+echo "claude-model-fallback: every model in '${models}' is out of credit" >&2
+exit 1


### PR DESCRIPTION
The automated bug fix pipeline pinned itself to a single model, so once
that model's subscription credit was exhausted every fix attempt failed
immediately.

The claude CLI's own `--fallback-model` flag does not cover this case --
it handles overloaded or unavailable models, not an exhausted per-model
allowance. That arrives as an HTTP 429 carried in the `--output-format
json` payload:

```json
{"is_error": true, "total_cost_usd": 0, "api_error_status": 429,
 "result": "You've reached your Fable 5 limit. ..."}
```

## Changes

- **`tools/claude-model-fallback.sh`** (new) takes a comma-separated
  model preference list and moves to the next model when one reports it
  is out of credit. A refused request is free, so the wrapper attempts
  the real job rather than paying for a pre-flight probe on every run
  where the preferred model is available.
- **`issue-fix.yml`**: the `model` input becomes `models`, defaulting to
  `claude-fable-5,claude-opus-5`. The wrapper runs from a copy in
  `runner.temp`, because Claude is about to edit the checkout and bash
  reads a script lazily as it executes -- a fix which touched `tools/`
  would corrupt the running wrapper.
- **`AGENTS.md`**: documents the wrapper and why `--fallback-model` is
  not sufficient.

Triage stays pinned to Haiku, which is cheap enough not to need this.

## Verification

Checked against the live API rather than from the docs:

- `claude-fable-5` returns `api_error_status: 429` with
  `total_cost_usd: 0`, confirming the detection key and that a refusal
  is free.
- End to end, a run with `--models claude-fable-5,claude-opus-5` logged
  the fable refusal to stderr, fell through to Opus, printed the answer
  on stdout and exited 0.
- The exhausted-list path exits 1, and passing `--model` is rejected
  with exit 2.
- `pre-commit run --all-files` passes, including actionlint.

## Notes for review

Two things worth a second opinion:

1. **The input rename is safe for the conductor.** Checked in
   private-ci: `bugfixer.py` calls
   `github.dispatch_workflow(owner, repo, workflow, ref)` with no
   `inputs`, and `dispatch_workflow` only adds an `inputs` key when
   one is passed -- so the dispatch body is just `{"ref": "develop"}`
   and the workflow's defaults apply. No caller anywhere in that repo
   passes workflow inputs. Anyone dispatching by hand with
   `-f model=...` does need to switch to `-f models=...`, since
   GitHub rejects a `workflow_dispatch` carrying an undeclared
   input.
2. **Template drift.** This workflow's header names
   `shakenfist/development/templates/issue-fix/` as its source, so the
   same change is being made there.

The wrapper deliberately consumes the caller's `--output-format` rather
than passing it through. Appending it after the internal
`--output-format json` would have overridden the JSON request and
silently disabled credit detection, so the fallback would never have
fired.
