### PR TITLE
Compile the API parameter declarations, and warn

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,6 +117,6 @@ repos:
         description: Run mypy type checking on selected files (incremental rollout)
         entry: tox -e mypy
         language: system
-        files: ^shakenfist/(schema/|mariadb\.py|daemons/database/|operations/|resource_health\.py|node_health\.py|external_api/(declarations|base)\.py)
+        files: ^shakenfist/(schema/|mariadb\.py|daemons/database/|operations/|resource_health\.py|node_health\.py|external_api/(declarations|base|validation)\.py)
         pass_filenames: false
         types: [python]

--- a/docs/developer_guide/writing_an_endpoint.md
+++ b/docs/developer_guide/writing_an_endpoint.md
@@ -114,11 +114,14 @@ non-numeric types, contradictory bounds, patterns that do not
 compile, patterns on non-string types, unanchored patterns, and a
 constraint restating a key its type token already renders (a second
 `minimum` on `unsignedinteger`) all raise `InvalidAPIDeclaration`.
-A pattern must be `^...$` anchored because its two consumers read an
-unanchored one differently: JSON Schema `pattern` is an unanchored
-*search*, while the compiled marshmallow validator uses `re.match`,
-which anchors at the start only. Full anchoring is the one form both
-read identically, so it is required rather than documented. Note that
+A pattern must be `^...$` anchored, with no top-level alternation
+(`^a|b$` is anchored on neither branch — wrap it in a group), because
+its two consumers read anything looser differently: JSON Schema
+`pattern` is an unanchored *search*, while the compiled validator
+requires the whole value to match (`re.fullmatch`, chosen because
+Python's `$` also matches before a trailing newline and ECMA-262's
+does not). Fully anchored and group-wrapped is the one form both read
+identically, so it is required rather than documented. Note that
 declared constraints are *published documentation* until phase 3 of
 [PLAN-api-input-validation](../plans/PLAN-api-input-validation.md)
 compiles them — a constraint does not reject anything yet.

--- a/docs/developer_guide/writing_an_endpoint.md
+++ b/docs/developer_guide/writing_an_endpoint.md
@@ -269,8 +269,10 @@ questions: `unknown-parameter`, `type-mismatch`, `missing-required`
 and `body-path-collision`.
 
 Two things it deliberately does not do. `required` is recorded but
-never enforced — several parameters are declared required while
-omitting them has always worked, and what to do about that is phase 6.
+never enforced — not even in `enforce` mode, where missing-required
+findings are filtered out of the rejection decision. Several
+parameters are declared required while omitting them has always
+worked, and what to do about that is phase 6.
 And the prose `format` on a type token is documentation: `netblock`,
 `uuidorname`, `namespace`, `node`, `url` and `ipv4` compile to plain
 strings, because semantic validation of them is also phase 6. Only

--- a/docs/developer_guide/writing_an_endpoint.md
+++ b/docs/developer_guide/writing_an_endpoint.md
@@ -111,9 +111,14 @@ exactly that reason, and now reads:
 Constraints are validated at import time in the same style as
 everything else: unknown keys, non-numeric bounds, bounds on
 non-numeric types, contradictory bounds, patterns that do not
-compile, patterns on non-string types, and a constraint restating a
-key its type token already renders (a second `minimum` on
-`unsignedinteger`) all raise `InvalidAPIDeclaration`. Note that
+compile, patterns on non-string types, unanchored patterns, and a
+constraint restating a key its type token already renders (a second
+`minimum` on `unsignedinteger`) all raise `InvalidAPIDeclaration`.
+A pattern must be `^...$` anchored because its two consumers read an
+unanchored one differently: JSON Schema `pattern` is an unanchored
+*search*, while the compiled marshmallow validator uses `re.match`,
+which anchors at the start only. Full anchoring is the one form both
+read identically, so it is required rather than documented. Note that
 declared constraints are *published documentation* until phase 3 of
 [PLAN-api-input-validation](../plans/PLAN-api-input-validation.md)
 compiles them — a constraint does not reject anything yet.

--- a/docs/developer_guide/writing_an_endpoint.md
+++ b/docs/developer_guide/writing_an_endpoint.md
@@ -228,6 +228,19 @@ assertions: it breaks each property on purpose and confirms the guard
 fires. Run it if you change the derivation or add an assertion, since
 a guard that passes on a deliberately broken tree is not a guard.
 
+Those assertions compare declarations against the derivation, so they
+are only as good as the derivation itself — and the tree can only
+exercise the source shapes it happens to contain.
+`shakenfist/tests/external_api/test_derivation_generator.py` covers
+the rest: it crosses route form, `@use_kwargs` binding and
+`flask.request.args` read style, builds a synthetic endpoint for each
+of the 225 combinations, and asserts the derivation recovers what that
+case was constructed to mean. Every defect found while building the
+phase 1 audit was a shape absent from the tree, which is why this is
+generated rather than sampled. **If you add a way for a parameter to
+arrive, add an axis value here** — a shape the generator does not
+enumerate is a shape nothing checks.
+
 ## What is not checked yet
 
 The declarations are documentation today. Compiling them into

--- a/docs/developer_guide/writing_an_endpoint.md
+++ b/docs/developer_guide/writing_an_endpoint.md
@@ -241,12 +241,41 @@ generated rather than sampled. **If you add a way for a parameter to
 arrive, add an axis value here** — a shape the generator does not
 enumerate is a shape nothing checks.
 
+## What validation does with them
+
+The declarations are compiled into marshmallow schemas at startup
+(`shakenfist/external_api/validation.py`) and checked against every
+request. **Nothing is rejected**: `API_VALIDATION_MODE` defaults to
+`warn`, which logs what would have been refused and changes no
+response. Setting it to `enforce` answers `400` in the usual
+`{"error": ..., "status": ...}` shape, and is phase 4's switch to
+throw once the warn log is understood.
+
+A warn record carries the endpoint, the parameter, the reason, the
+offending value's **type** — never its value — and the status the
+request went on to return anyway. That last field is the interesting
+one: a finding on a request which returned 200 is a rejection
+enforcement would introduce, while one on a request which returned 404
+is a status code enforcement would merely change, because validation
+runs ahead of the per-method decorators which produce those.
+
+Reasons are counted separately because they answer different
+questions: `unknown-parameter`, `type-mismatch`, `missing-required`
+and `body-path-collision`.
+
+Two things it deliberately does not do. `required` is recorded but
+never enforced — several parameters are declared required while
+omitting them has always worked, and what to do about that is phase 6.
+And the prose `format` on a type token is documentation: `netblock`,
+`uuidorname`, `namespace`, `node`, `url` and `ipv4` compile to plain
+strings, because semantic validation of them is also phase 6. Only
+`type`, `pattern`, `minimum` and `maximum` constrain anything.
+
 ## What is not checked yet
 
-The declarations are documentation today. Compiling them into
-per-endpoint request validation is phase 3 of the plan; until then a
-correct declaration does not stop a caller sending something else.
-Two known gaps:
+Enforcement is off, so a correct declaration still does not stop a
+caller sending something else. Two known gaps in the derivation
+itself:
 
 (The published specification itself *is* checked:
 `shakenfist/tests/external_api/test_openapi_spec.py` validates the

--- a/docs/operator_guide/logging.md
+++ b/docs/operator_guide/logging.md
@@ -157,6 +157,30 @@ metrics endpoint:
 | `logship_push_total{result=...}` | Loki push attempts by outcome. |
 | `logship_push_seconds` | Loki push request latency. |
 
+## API request validation findings
+
+After upgrading you may see `API request validation finding` lines
+from `sf-api` in your log stream. These are **informational**: they
+record a request which did not match its endpoint's published
+parameter declarations, and while `API_VALIDATION_MODE` is `warn`
+(the default) they change no response — the request was answered
+exactly as it always was. Do not set `enforce` yet; that switch is
+phase 4 of the API input validation plan and only makes sense once
+the warn log for your own callers has been read and understood.
+
+Each line carries:
+
+| Field | Meaning |
+|---|---|
+| `validation-reason` | Which rule the request missed: `unknown-parameter` (a body key the endpoint does not declare), `type-mismatch` (a declared parameter with a value of the wrong type), `missing-required` (a declared-required parameter that was not supplied), or `body-path-collision` (a body key with the same name as a URL path parameter). |
+| `validation-parameter` | The parameter concerned, truncated to 64 characters. |
+| `validation-value-type` | The Python type of the offending value. The value itself is never logged. |
+| `validation-response-status` | The status the request went on to return anyway, which is what separates a rejection enforcement would introduce from a status code it would merely change. |
+| `validation-mode` | The active `API_VALIDATION_MODE`. |
+
+The reason codes and the measurement they feed are described in
+`docs/plans/PLAN-api-input-validation-phase-03-compile-and-warn.md`.
+
 ## Events vs logs
 
 Shaken Fist has two structured-record streams, and they are not

--- a/docs/operator_guide/logging.md
+++ b/docs/operator_guide/logging.md
@@ -166,7 +166,11 @@ parameter declarations, and while `API_VALIDATION_MODE` is `warn`
 (the default) they change no response — the request was answered
 exactly as it always was. Do not set `enforce` yet; that switch is
 phase 4 of the API input validation plan and only makes sense once
-the warn log for your own callers has been read and understood.
+the warn log for your own callers has been read and understood. If
+the lines themselves become a problem — a chatty caller sending an
+undeclared key on every request is an extra line per request —
+`API_VALIDATION_MODE` can be set to `off`, which disables the layer
+entirely.
 
 Each line carries:
 
@@ -174,7 +178,9 @@ Each line carries:
 |---|---|
 | `validation-reason` | Which rule the request missed: `unknown-parameter` (a body key the endpoint does not declare), `type-mismatch` (a declared parameter with a value of the wrong type), `missing-required` (a declared-required parameter that was not supplied), or `body-path-collision` (a body key with the same name as a URL path parameter). |
 | `validation-parameter` | The parameter concerned, truncated to 64 characters. |
+| `validation-detail` | The specific rule that was missed — for a `type-mismatch`, the validation message (for example `Not a valid integer.`). |
 | `validation-value-type` | The Python type of the offending value. The value itself is never logged. |
+| `route` | The route template (for example `/instances/<instance_ref>`), so findings aggregate by endpoint; `path` carries the concrete request path. |
 | `validation-response-status` | The status the request went on to return anyway, which is what separates a rejection enforcement would introduce from a status code it would merely change. |
 | `validation-mode` | The active `API_VALIDATION_MODE`. |
 

--- a/docs/plans/PLAN-api-input-validation-phase-03-compile-and-warn.md
+++ b/docs/plans/PLAN-api-input-validation-phase-03-compile-and-warn.md
@@ -569,6 +569,22 @@ the validator reads the body `log_request` stashed on `flask.g` rather
 than re-fetching it, so it reports on exactly what the handler
 receives and a non-JSON body is not parsed twice.
 
+**The third review round found the round-two fix had a defect of its
+own** -- the restructured enforce branch returned before stashing its
+findings, so an enforced rejection would have emitted no warn line:
+the measurement going dark at the exact moment phase 4 flips the
+switch. Findings are now stashed before the enforce decision, and the
+round's other real gap is closed too: nothing had pinned that a
+finding on a *successful* request leaves the response untouched,
+which is the phase's central promise and the population D10 sizes.
+Both ship with request-level tests. Defensive hardening from the same
+round: an unrecognised type token now drops its published bounds
+(Range on a Raw field raises TypeError through schema.validate()),
+_schema_findings() catches anything a schema raises and reports
+nothing rather than changing a response, and build_registry() refuses
+two endpoint classes sharing a bare name at mount time, since the
+registry key could not tell their requests apart.
+
 **The next step is not code.** Deploy to sfcbr, run functional CI, and
 read the warn log. Success criterion 3 is that every remaining finding
 is explained, not that there are none.

--- a/docs/plans/PLAN-api-input-validation-phase-03-compile-and-warn.md
+++ b/docs/plans/PLAN-api-input-validation-phase-03-compile-and-warn.md
@@ -397,7 +397,13 @@ Two notes for whoever reads the log, both from the review round:
 * Query-declared parameters are checked against the merged,
   body-authoritative view the `json_or_query` loader reads, so the
   shipped client's everything-in-the-body habit is measured rather
-  than a blind spot. A repeated query key (`?tag=a&tag=b`) is still
+  than a blind spot. The merge is applied to every query-declared
+  parameter, but only the `json_or_query` sites actually read the
+  body -- `blob.py`'s data endpoint binds plain `query` -- so a
+  body-supplied `offset`/`limit` there produces a finding about a
+  value the endpoint ignores. Read such findings as caller defects
+  (the value was sent somewhere it does nothing), not as rejections
+  enforcement would introduce. A repeated query key (`?tag=a&tag=b`) is still
   collapsed to its first value before checking; no query parameter
   is array-typed today (arrays are refused outside a body at import
   time), so a finding of that shape would be an artefact of the
@@ -584,6 +590,20 @@ _schema_findings() catches anything a schema raises and reports
 nothing rather than changing a response, and build_registry() refuses
 two endpoint classes sharing a bare name at mount time, since the
 registry key could not tell their requests apart.
+
+**The fourth review round had no fix items and the loop was declared
+converged** (fix trajectory 8, 1, 2, 0). Considers taken because they
+were real: the pattern validator now uses re.fullmatch (Python's $
+matches before a trailing newline, ECMA-262's does not) and the
+import-time check also refuses top-level alternation, which escapes
+the anchors; and the finding line redacts the parameter name on
+credential-carrying routes, because it was a third body-reading
+logger and the other two consult handles_credentials() and drop the
+lot. Declined, with reasons: a HEAD bypass matters only if a HEAD
+route ever takes parameters; CompiledEndpoint.names is recomputed per
+request but is a set-union over tiny sets; and the functional-CI
+self-check remains recorded in the measurement notes above rather
+than in this phase.
 
 **The next step is not code.** Deploy to sfcbr, run functional CI, and
 read the warn log. Success criterion 3 is that every remaining finding

--- a/docs/plans/PLAN-api-input-validation-phase-03-compile-and-warn.md
+++ b/docs/plans/PLAN-api-input-validation-phase-03-compile-and-warn.md
@@ -313,10 +313,17 @@ The behaviour-visible PR, and still not a behaviour change.
   per-method decorator.
 * A `@webargs_parser.error_handler` replacing webargs' default
   `abort(422)` with `sf_api.error(400, ...)`, per D4. **This fixes an
-  existing defect as a side effect:** no error handler is registered
-  today, so the three `json_or_query` sites and `blob.py`'s `query`
-  site currently emit a raw 422 in webargs' own shape rather than
-  the API's `{"error": ..., "status": ...}`. Worth a line in the
+  existing defect as a side effect** — though not the one this
+  paragraph first claimed. No error handler is registered today, but
+  no client ever saw webargs' raw 422 either:
+  `suppress_exceptions_to_client`'s bare `except Exception` swallowed
+  the abort's `HTTPException` into a 500 with a traceback and an
+  on-disk exception record per occurrence. The review round proved
+  the handler alone is inert for the same reason, so the fix is two
+  halves: this handler, and an `HTTPException` carve-out in
+  `suppress_exceptions_to_client` (and `record_exception`) restricted
+  to aborts carrying a crafted response, so a bare `abort()` cannot
+  start answering werkzeug's HTML error pages. Worth a line in the
   release notes.
 * Warn-only is the default and is controlled by one config setting,
   `API_VALIDATION_MODE`, with values `warn` and `enforce`. Phase 4
@@ -379,6 +386,22 @@ exercises the ansible collection, which is a second implementation
 of this API's contract and the one most likely to send something the
 declarations do not describe (see #3308, where the collection's
 networkspec parser makes every non-empty value truthy).
+
+Two notes for whoever reads the log, both from the review round:
+
+* Query-declared parameters are checked against the merged,
+  body-authoritative view the `json_or_query` loader reads, so the
+  shipped client's everything-in-the-body habit is measured rather
+  than a blind spot. A repeated query key (`?tag=a&tag=b`) is still
+  collapsed to its first value before checking; no query parameter
+  is array-typed today (arrays are refused outside a body at import
+  time), so a finding of that shape would be an artefact of the
+  collapse rather than a caller defect.
+* The measurement apparatus itself has no functional-CI self-check:
+  nothing in `shakenfist_ci` sends a deliberately-undeclared key and
+  asserts a finding line appears. Verify the apparatus by hand early
+  in the sfcbr window — one malformed request, one grep — before
+  reading seven days of quiet log as seven days of clean callers.
 
 ## Coordination and adjacencies
 
@@ -502,6 +525,29 @@ input this layer will start handling.
 break the derivation and three which break the compiler. 2725 unit
 tests pass. `pre-commit run --all-files` clean. The published
 specification still validates with zero errors.
+
+**The review round found three runtime defects, all fixed.** The
+automated review of the phase 3 PR proved (with a reproduction) that
+the webargs error handler was inert -- its 400 abort was swallowed
+into a 500 by `suppress_exceptions_to_client`, exactly as webargs' own
+422 always had been, so the baseline claim in this plan's first draft
+was wrong and is corrected above. It also caught `kwargs.update(j)`
+turning a non-object JSON body into a 500 (and silently merging a list
+of two-character strings), and the validator re-parsing raw upload
+bodies as JSON. The shape of the first two is worth remembering: both
+were behaviour changes hiding inside refactors of code whose old
+behaviour was itself an accident (`TypeError` from a merge loop,
+caught by a broad `except` two decorators out), and the unit tests
+passed because they tested components in isolation while the defect
+lived in the stack. The fixes ship with request-level tests through
+the real decorator stack, and each fix was mutation-tested. Hardening
+from the same round: unknown-parameter findings are capped per request
+and parameter names truncated (log-amplification), `API_VALIDATION_MODE`
+is a `Literal` so a typo fails at config load instead of silently
+meaning warn, declared patterns must be `^...$` anchored at import
+time so JSON Schema search and marshmallow match semantics provably
+coincide, and query-declared parameters are checked against the
+merged `json_or_query` view.
 
 **The next step is not code.** Deploy to sfcbr, run functional CI, and
 read the warn log. Success criterion 3 is that every remaining finding

--- a/docs/plans/PLAN-api-input-validation-phase-03-compile-and-warn.md
+++ b/docs/plans/PLAN-api-input-validation-phase-03-compile-and-warn.md
@@ -1,0 +1,449 @@
+# Phase 3: Compile the declarations, and warn
+
+Phase 3 of [`PLAN-api-input-validation.md`](PLAN-api-input-validation.md),
+following [phase 2](PLAN-api-input-validation-phase-02-type-vocabulary.md).
+
+It turns 271 parameter declarations into marshmallow schemas, runs
+them against every request, and **rejects nothing**. The output of
+the phase is not a behaviour change; it is evidence about whether
+the declarations can safely become one in phase 4.
+
+## Context
+
+Phases 1 and 2 made the declarations correct and made them render
+into a valid specification. Nothing yet reads them at request time.
+
+The baseline, measured on `057e24c1a` rather than carried over from
+phase 0:
+
+| | Phase 0 | Now |
+|---|---|---|
+| Handler methods | 129 | **135** |
+| Carrying a declaration | 124 (96%) | **132 (98%)** |
+| Declared parameters | 254 | **271** |
+| ...`path` / `body` / `query` | 3 / 113 / 118 | **136 / 128 / 7** |
+| Declarations carrying constraints | n/a | **5** |
+| `audit()` drift / underivable / problems | 116 / — / — | **0 / 0 / 0** |
+
+The location column is the phase 1 result: `query` was never right
+for 116 of those parameters, and only 7 parameters in the whole API
+genuinely arrive in a query string. That matters below, because D6's
+query-string fallback turns out to be a seven-parameter feature
+rather than a general one.
+
+Type tokens in use, which is what has to be compiled:
+
+```
+string 109   uuidorname 55   uuid 26   boolean 19   namespace 13
+node 11      unsignedinteger 9   integer 6   url 5   dict 5
+arrayofstring 3   number 2   arrayofdict 2   base64 1   netblock 1
+ipv4 1
+```
+
+## What this phase inherits rather than decides
+
+Three things landed outside the phase and are now constraints on it.
+
+**The query fallback exists.** `0de6c3b5c` registered a
+`json_or_query` webargs location loader in `base.py`: query string
+and JSON body merged, body authoritative, keys the schema does not
+name dropped. Three endpoints are bound to it. Phase 3 generalises
+that loader; it does not choose a precedence rule. It must also not
+retry the `('query', 'json')` tuple location — webargs keys
+validation failures by location, a tuple key is not
+JSON-serialisable, and the 422 becomes a 500. That was already
+tried.
+
+**`declarations.py` derives `json_or_query` as `query`,** so
+published declarations are unchanged and phase 1's audit still
+holds.
+
+**`base.py` is under mypy** (#3616), and the pre-commit hook matches
+it. The validation layer lands in a type-checked file, which is what
+that issue was for.
+
+## What phase 3 must decide that phase 0 did not
+
+Phase 0 answered nine questions. Reading the code for this plan
+turned up four more, three of which are only visible from the
+runtime side and so could not have been seen when the plan was
+written against the declarations.
+
+### D10. What happens to a body key nothing declares
+
+**This is the central decision of the phase, and today's behaviour
+is not what the master plan assumes.**
+
+Verified against the running app rather than reasoned about, on a
+declared endpoint (`POST /auth`, which is `@public` and so reachable
+without a token) with the namespace lookup mocked so the request
+reaches the handler:
+
+```
+{"namespace": .., "key": ..}                -> 401 unauthorized
+{"namespace": .., "key": .., "zzz": 1}      -> 400 {"error": "AuthEndpoint.post()
+                                                got an unexpected keyword
+                                                argument 'zzz'", "status": 400}
+{"namespace": .., "key": .., "uuid": "x"}   -> 400 {"error": "AuthEndpoint.post()
+                                                got an unexpected keyword
+                                                argument 'passed_uuid'", ...}
+```
+
+`log_request` merges every body key into `kwargs` and calls onward.
+No handler in the tree is variadic (#3642 guarantees it and the
+audit enforces it), so **an undeclared body key on a request that
+reaches its handler is already a 400 carrying interpreter text.**
+That is #3612 in its most general form, and it is a de-facto
+`unknown=RAISE` policy with the worst possible message.
+
+**But "reaches its handler" is load-bearing, and it is what makes
+this decision harder than it first looks.** The same probe without
+the mock returns `404 namespace not found`, undeclared key and all:
+`arg_is_namespace` is a *per-method* decorator, so it runs after
+index 0 but before the handler, and its early return means the
+`TypeError` never happens. Today an undeclared key is only fatal if
+nothing short-circuits ahead of it.
+
+Validation at index 0 runs before every per-method decorator, so it
+preempts all of them. That gives:
+
+* **`unknown=EXCLUDE`** (webargs' default for query) drops the key.
+  Nothing that succeeds today fails, and nothing that
+  short-circuits today changes. Requests that are 400s today would
+  start working — a compatibility improvement in the "was broken,
+  now works" direction, at the cost of silently swallowing a typo:
+  `{"nmae": "x"}` would create something unnamed rather than
+  erroring.
+* **`unknown=RAISE`** keeps rejecting, with
+  `{"error": "zzz: unknown parameter", "status": 400}` instead of
+  interpreter text. Requests that 400 today still 400. But a request
+  that today is short-circuited to a 404 or 403 by a per-method
+  decorator would now be a 400 instead.
+
+So **neither option is behaviour-preserving**, and the earlier
+framing of RAISE as "changes no outcome, only the message" was
+wrong: it changes the status code on every path where a per-method
+decorator currently answers first.
+
+**Recommendation: `RAISE`, provisionally.** A malformed request
+being reported as malformed rather than as "namespace not found" is
+the more truthful answer, and it keeps the phase's rejections a
+superset of today's rather than a different set. But this is exactly
+what warn-only exists to settle, so the phase must count the two
+populations separately:
+
+* undeclared key on a request that would have reached its handler
+  (RAISE and today agree);
+* undeclared key on a request something else would have answered
+  first (RAISE changes the status).
+
+If the second population is large or is dominated by the official
+client, EXCLUDE wins and the recommendation should flip. That
+decision belongs to phase 4, with the counts in hand.
+
+**This preemption is general, not specific to unknown keys.** Any
+validation failure at index 0 answers ahead of the per-method
+decorators, so a request that is both malformed *and* refers to a
+nonexistent object moves from 404 to 400 at enforcement. That is
+defensible — the request was malformed — but it is a contract change
+across the whole API, and phase 4 should state it in the release
+notes rather than discover it in a bug report.
+
+### D11. The `uuid` → `passed_uuid` remap is dead, and D8 rests on it
+
+Decision D8 says a body key colliding with a path parameter is
+rejected, and cites `log_request` mapping body `uuid` to
+`passed_uuid` as evidence "it is a known hazard rather than a
+feature".
+
+`passed_uuid` appears exactly once in the tree — at the assignment
+in `log_request` itself. No handler accepts it; no declaration names
+it. The remap therefore does not dodge the collision. It converts
+`{"uuid": ...}` on *every* endpoint into a guaranteed 400 with
+interpreter text, as the probe above shows.
+
+Phase 3 should delete the special case and let `uuid` fall under
+D10 with every other undeclared key. D8's underlying point survives
+— a body key overwriting a path parameter is a real hazard — but its
+supporting evidence does not, and the plan should stop citing it.
+
+### D12. Collision detection cannot live in the validator
+
+D3 places validation at index 0 of `Resource.method_decorators`.
+That is correct and unchanged: flask_restful applies the list in
+order with each wrapping the previous, so index 0 is *innermost*,
+running after authentication and still outside every per-method
+decorator.
+
+But `log_request` is at index 1, which means it runs **before**
+index 0 — and it has already merged the body into `kwargs` by the
+time the validator sees anything. A body key that overwrote a path
+parameter is, at index 0, indistinguishable from a path parameter
+that simply had that value.
+
+So D8 cannot be implemented in the validator. Either `log_request`
+records what it overwrote (a request-scoped marker on `flask.g`,
+the pattern `record_exception` already uses for
+`_RECORDED_EXCEPTION_FIELDS`), or the check lives in `log_request`
+itself. The marker is preferable: it keeps `log_request` doing one
+job and keeps the policy in one place.
+
+### D13. How the compiled schema reaches the handler
+
+`swagger_helper(section, description, parameters, responses, ...)`
+does not know which class or method it is decorating, so it cannot
+key a registry by handler. And `swag_from`'s `specs_dict` is an
+attribute on the function: `base.py` warns in two places that
+several of its decorators predate `functools.wraps` and do not
+propagate attributes, which is why `_sf_public` is documented as
+"apply it as the outermost decorator" with a structural test to
+enforce it. Reading `specs_dict` off a wrapped bound method is the
+same trap.
+
+**Build the registry at mount time in `app.py`**, from the 94
+`api.add_resource()` calls. That is the same ground truth phase 1
+used for the location audit, it yields the class, the route and
+therefore the path-parameter set together, and it involves no
+attribute propagation. The validator looks up
+`(type(self).__name__, request.method.lower())`.
+
+A test asserts every mounted handler resolves to a compiled schema,
+so a route added without one fails rather than silently skipping
+validation. That is the same "absence must not be indistinguishable
+from success" rule the audit was rewritten around.
+
+## Shape of the work: three PRs and a measurement
+
+### PR 1 — Generate the derivation's input space
+
+The precondition the master plan sets, and the reason it is a
+precondition rather than a step: while declarations are
+documentation, a misread costs a wrong line in the published API;
+once they are compiled, the same misread rejects a valid request.
+
+Phase 1 took five review rounds and four of them found a defect in
+the machinery added by the round before — the Werkzeug converter
+regex, the `flask.request.args` fallback, the webargs scope leak, an
+emptied parameter list. Every one was `declarations.py` misreading
+source, and every one was a shape absent from the tree, so neither
+testing against the tree nor mutating it could have found them.
+
+Enumerate the axes and assert the derivation recovers what the
+source was constructed to mean:
+
+| Axis | Values |
+|---|---|
+| Route | absent, `<x>`, `<path:x>`, `<int(min=1):x>`, non-literal |
+| webargs | none, `get_args` on the class, on the module, inline dict, `location='json'`, `location='json_or_query'` |
+| `request.args` | absent, `.get()`, subscript, on a non-request object |
+| Declaration | well-formed, wrong arity, non-literal name, raw-body sentinel |
+
+The `json_or_query` value is new since the master plan listed these
+axes, and is exactly the kind of shape that was absent from the tree
+until it wasn't.
+
+A few dozen cases, deterministic, well under a second. The oracle is
+free: the source is constructed knowing where each parameter comes
+from. This is what makes it different from mutating declarations in
+the tree — flipping a declared location and asserting drift tests
+the *comparison*, and every real defect was on the other side of it,
+in the derivation.
+
+No new dependency; `hypothesis` is not in the project and randomness
+buys nothing over enumerating a space this small.
+
+`tools/check-api-declaration-guards.sh` is unchanged. It proves the
+guards fire, which is a different question from whether the
+derivation is right.
+
+**Ships nothing to production.** Its whole value is that it either
+finds defects in `declarations.py` before compilation depends on it,
+or it demonstrates there are none.
+
+### PR 2 — Compile, wired but inert
+
+Turn the declarations into marshmallow schemas and mount the
+registry. Nothing validates yet; nothing changes for any caller.
+
+* An `ARGTYPES` → marshmallow field mapping. The table already
+  carries `type`, `format` and, for two tokens, `pattern`, plus the
+  optional constraints element on 5 declarations. The mapping is
+  mechanical, with three rules that are not:
+  * **`netblock` compiles to a plain string.** It is deliberately
+    format-only, with no pattern, because `NetworksEndpoint.post()`
+    validates with `ipaddress.ip_network()`, which parses IPv6 too.
+    Compiling a CIDR regex here would publish and then enforce an
+    API narrower than the one that ships. Phase 2 wrote that
+    reasoning down; phase 3 is where ignoring it would do damage.
+  * **`uuidorname`, `namespace`, `node`, `url`, `ipv4` compile to
+    plain strings.** Their prose `format` is documentation. Turning
+    them into semantic validators is phase 6 (#534, #3269, #323,
+    #936), and doing it here would smuggle enforcement into a
+    warn-only phase.
+  * **`binary` and the raw-body sentinel are excluded.** Upload
+    bodies are not JSON and must never be parsed as such.
+* The registry, built at mount time per D13, keyed by class and
+  method.
+* `required` is compiled as **metadata, not as a constraint**. The
+  master plan already found `mode` on the agent-put endpoint
+  declared required while omitting it has always been accepted.
+  Enforcing required-ness is phase 6's decision; phase 3 records
+  what it *would* have rejected so phase 6 has data.
+
+Tests: every mounted handler compiles; the compiled field set
+matches the declared parameter set for all 132 documented handlers;
+`netblock` and the five prose-format tokens compile to unconstrained
+strings; the three UNDOCUMENTED_BY_DESIGN handlers are absent by
+name rather than by accident.
+
+This PR should also reconcile with phase 2's `STRUCTURED_PARAMETERS`
+table in `test_openapi_spec.py`. That table pins what the *published
+specification* says about 16 parameters; the compiler is a second
+consumer of the same declarations. They must not be able to
+disagree — a test that walks both is cheap and closes the gap that
+produced two consecutive rounds of type-token defects in phase 2.
+
+### PR 3 — Validate, and warn
+
+The behaviour-visible PR, and still not a behaviour change.
+
+* A `validate_request` decorator inserted at index 0 of
+  `method_decorators`, so it runs after authentication (an
+  unauthenticated caller cannot probe the schema) and before every
+  per-method decorator.
+* A `@webargs_parser.error_handler` replacing webargs' default
+  `abort(422)` with `sf_api.error(400, ...)`, per D4. **This fixes an
+  existing defect as a side effect:** no error handler is registered
+  today, so the three `json_or_query` sites and `blob.py`'s `query`
+  site currently emit a raw 422 in webargs' own shape rather than
+  the API's `{"error": ..., "status": ...}`. Worth a line in the
+  release notes.
+* Warn-only is the default and is controlled by one config setting,
+  `API_VALIDATION_MODE`, with values `warn` and `enforce`. Phase 4
+  flips the default; the setting exists from the start so the flip
+  is a one-line, revertible change rather than a code change.
+* The D12 collision marker in `log_request`, and deletion of the
+  dead `passed_uuid` remap (D11).
+
+**What a warn record contains.** One structured log line per
+request that would have been rejected, at `info`, with:
+`request-id` (already threaded), endpoint class and method, route,
+parameter name, declared location and type, the reason, and the
+offending value's **type**. Never its value — D5, and several of
+these routes carry credentials, which is why `log_request` drops the
+whole body on `handles_credentials()` routes rather than naming
+fields.
+
+Rejection reasons must be counted separately, because they answer
+different questions:
+
+| Reason | What a nonzero count means |
+|---|---|
+| type mismatch | the declaration is wrong, or callers send junk |
+| unknown parameter (D10) | callers send keys we do not declare |
+| missing required (D12) | `required` is over-declared; phase 6 input |
+| body/path collision (D8) | the hazard is real in practice |
+| constraint violation | the five bounds are wrong or callers exceed them |
+
+Each record also carries **what the request returned anyway**. That
+single field is what separates D10's two populations, and it is the
+only way to measure the preemption cost: a warn whose request went
+on to return 200 is a rejection enforcement would introduce, and a
+warn whose request returned 404 is a status code enforcement would
+change rather than a new refusal. Without it the warn log says how
+often validation *would* fire but not what it would cost, which is
+the question phase 4 has to answer.
+
+That has a design consequence: the validator cannot log and move
+on, because at index 0 the outcome is not known yet. It stashes the
+pending warn on `flask.g` and something downstream emits it once the
+response exists — the same request-scoped hand-off
+`record_exception` uses for `_RECORDED_EXCEPTION_FIELDS`, and a
+reason to build the telemetry as a Flask `after_request` hook rather
+than as part of the decorator.
+
+A prometheus counter with those as labels, alongside the log line,
+so "is it quiet?" is answerable from a dashboard rather than by
+grepping Loki. The label set is bounded and small; parameter name is
+*not* a label.
+
+### Then: measure
+
+Deploy to sfcbr and read the logs. Per D5 the window is not a fixed
+duration — it ends when every remaining rejection is intended — and
+it must cover a full functional CI run plus seven days of sfcbr.
+
+CI matters as much as sfcbr here, and for a different reason: sfcbr
+has one workload driven mostly by the official client, while CI
+exercises the ansible collection, which is a second implementation
+of this API's contract and the one most likely to send something the
+declarations do not describe (see #3308, where the collection's
+networkspec parser makes every non-empty value truthy).
+
+## Coordination and adjacencies
+
+* **#3612** is the issue this phase's mechanism section describes,
+  and D10 is where it actually gets closed — but not until phase 4,
+  because warn-only still returns the interpreter text.
+* **#1974 (pagination)** needs the bounded `limit`/`offset` types
+  this compiles. Coordinate on the parameter types; the query and
+  response-shape work stays in
+  [`api-query-batching-roadmap.md`](api-query-batching-roadmap.md).
+* **Phase 6** consumes the `required` and constraint warn counts.
+  Nothing in phase 3 pre-empts its decision.
+* **The client** (`shakenfist_client`, a separate repository) is not
+  changed by this phase and must not need to be. If warn data shows
+  the shipped client sends something the declarations reject, that
+  is a declaration bug until proven otherwise — the client is the
+  reference implementation of what the API accepts today.
+
+## What this phase does not do
+
+* **It rejects nothing.** Every request that succeeds today
+  succeeds afterwards, with the same status and body.
+* **No semantic validation.** MAC format, base64-ness, netblock
+  overlap and the instance-create structures are phase 6.
+* **No `required` enforcement.**
+* **No response validation.** Out of scope by D7, not deferred.
+* **It does not narrow `except TypeError`.** That is phase 5 and it
+  is gated on phase 4: the broad catch is currently absorbing the
+  malformed input this layer will start handling, and removing it
+  before enforcement would turn 400s into 500s.
+
+## Verification, phase-wide
+
+* The derivation generator (PR 1) passes, and is demonstrated to
+  fail when `declarations.py` is mutated — a generator that cannot
+  fail proves nothing, which is the lesson the mutation harness
+  exists to encode.
+* `tools/check-api-declaration-guards.sh` still reports all
+  mutations caught, with new mutations for the compilation path:
+  a token compiled to the wrong field, a handler mounted without a
+  schema, a semantic validator smuggled onto a prose-format token.
+* The full unit suite passes; `pre-commit run --all-files` clean.
+* The published specification still validates with zero errors, so
+  phase 2's assertion holds and compilation has not perturbed
+  rendering.
+* Functional CI green, which for this phase is a *measurement* as
+  much as a gate: a warn count of zero across a full CI run is
+  evidence, and a warn count that is large is the finding.
+
+## Success criteria
+
+1. Every mounted handler resolves to a compiled schema, enforced by
+   a test rather than by inspection.
+2. Warn-only runs for a full CI run plus seven days on sfcbr.
+3. Every remaining warn is classified: declaration bug, caller bug,
+   or intended rejection. **The exit condition is that the list is
+   explained, not that it is empty** — an intended rejection is a
+   success, and phase 4 is what turns it into a 400.
+4. No production behaviour change attributable to the phase.
+5. A written recommendation for D10's `EXCLUDE`/`RAISE` choice,
+   backed by the two undeclared-key populations — reaches-handler
+   versus answered-first — rather than by taste, together with an
+   estimate of how many requests change status code at enforcement
+   because validation preempts a per-method decorator.
+
+## Outcome
+
+To be filled in as the phase lands.

--- a/docs/plans/PLAN-api-input-validation-phase-03-compile-and-warn.md
+++ b/docs/plans/PLAN-api-input-validation-phase-03-compile-and-warn.md
@@ -446,4 +446,63 @@ networkspec parser makes every non-empty value truthy).
 
 ## Outcome
 
-To be filled in as the phase lands.
+The three PRs have landed. The measurement has not: warn-only is
+deployed nowhere yet, so the phase is code-complete and evidence-empty.
+
+**Four deviations from this plan, all recorded because each was a
+better answer than the one planned.**
+
+1. **Compiled from the rendered specification, not from `ARGTYPES`.**
+   The plan called for a second token-to-marshmallow mapping. Reading
+   `swagger_helper()`'s output instead means there is exactly one
+   interpretation of a token in the process, so the compiled schema and
+   the published specification cannot drift apart — and the three
+   special cases the plan wrote out (netblock, prose formats, raw body)
+   became consequences of the rendering rather than rules this module
+   states and could get wrong.
+2. **The derivation had a defect, and PR 1 found it.**
+   `derived_location()` returned `path` before consulting the query
+   sources, so a handler whose declared parameters are all path
+   parameters could read `flask.request.args` with a key the walk
+   cannot name and the audit would report the tree clean. No handler in
+   the tree has that shape, which is exactly why the generated cross
+   product was a precondition rather than a nicety.
+3. **The decorator had to propagate markers.** Putting `validate_request`
+   at index 0 puts it between the bound method and
+   `_authenticate_unless_public`, which reads `__self__` for the
+   resource class and `_sf_public` / `_sf_scope` for the policy
+   markers. Without `functools.wraps` plus an explicit `__self__` copy,
+   **every `@public` endpoint would have started demanding a token**.
+   The plan named this file's attribute-propagation trap as a reason to
+   avoid `specs_dict`; it did not notice the decorator itself walks
+   into it.
+4. **No prometheus counter.** The plan asked for one alongside the log
+   line. sf-api has no metrics exporter — it is a gunicorn app, and the
+   database daemon's `start_http_server` has no equivalent here — so
+   the counter would have meant inventing one. The structured log is
+   what the measurement step actually reads, and it carries the same
+   labels. Adding an exporter to sf-api is worth doing, and is not this
+   phase.
+
+**D10's framing was wrong in the first draft and is corrected in the
+plan above.** `RAISE` was written up as behaviour-preserving; probing
+`POST /auth` without mocking the namespace lookup disproved it, because
+`arg_is_namespace` short-circuits to 404 before the handler is reached.
+Neither `RAISE` nor `EXCLUDE` is neutral. The recommendation stands as
+`RAISE`, provisionally, and warn-only counts the two populations.
+
+**Not done, and deliberately.** `required` is recorded and never
+enforced. Semantic validation of the prose formats is untouched.
+`except TypeError` is still broad — narrowing it is phase 5 and is
+gated on phase 4, because it is currently absorbing the malformed
+input this layer will start handling.
+
+**Verification.** All 31 mutations in
+`tools/check-api-declaration-guards.sh` caught, including three which
+break the derivation and three which break the compiler. 2725 unit
+tests pass. `pre-commit run --all-files` clean. The published
+specification still validates with zero errors.
+
+**The next step is not code.** Deploy to sfcbr, run functional CI, and
+read the warn log. Success criterion 3 is that every remaining finding
+is explained, not that there are none.

--- a/docs/plans/PLAN-api-input-validation-phase-03-compile-and-warn.md
+++ b/docs/plans/PLAN-api-input-validation-phase-03-compile-and-warn.md
@@ -334,12 +334,17 @@ The behaviour-visible PR, and still not a behaviour change.
 
 **What a warn record contains.** One structured log line per
 request that would have been rejected, at `info`, with:
-`request-id` (already threaded), endpoint class and method, route,
-parameter name, declared location and type, the reason, and the
-offending value's **type**. Never its value — D5, and several of
-these routes carry credentials, which is why `log_request` drops the
-whole body on `handles_credentials()` routes rather than naming
-fields.
+`request-id` (already threaded), method, the concrete path and the
+route template (so findings aggregate by endpoint), the parameter
+name (truncated and stripped of non-printables — it is client
+supplied), the reason, the validation detail, the active mode, the
+status the request returned anyway, and the offending value's
+**type**. Never its value — D5, and several of these routes carry
+credentials, which is why `log_request` drops the whole body on
+`handles_credentials()` routes rather than naming fields. (The first
+draft promised the declared location and type as fields; the
+declaration is recoverable from route + parameter, so they are not
+carried on every line.)
 
 Rejection reasons must be counted separately, because they answer
 different questions:
@@ -548,6 +553,21 @@ meaning warn, declared patterns must be `^...$` anchored at import
 time so JSON Schema search and marshmallow match semantics provably
 coincide, and query-declared parameters are checked against the
 merged `json_or_query` view.
+
+**The second review round found one more contradiction, fixed.**
+`enforce` rejected on *any* finding, including `missing-required` --
+while three documents said required is recorded and never enforced,
+and the unit test asserting that only checked the compiled marshmallow
+field (the missing-required path bypasses marshmallow entirely). The
+enforcement decision now filters `missing-required` findings out, with
+a request-level test that `enforce` plus an omitted required parameter
+still reaches the handler. From the same round: `API_VALIDATION_MODE`
+gained `off` as an operator safety valve against log volume; parameter
+names are stripped of non-printables as well as truncated; the warn
+line carries the route template so findings aggregate by endpoint; and
+the validator reads the body `log_request` stashed on `flask.g` rather
+than re-fetching it, so it reports on exactly what the handler
+receives and a non-JSON body is not parsed twice.
 
 **The next step is not code.** Deploy to sfcbr, run functional CI, and
 read the warn log. Success criterion 3 is that every remaining finding

--- a/docs/plans/PLAN-api-input-validation.md
+++ b/docs/plans/PLAN-api-input-validation.md
@@ -32,7 +32,7 @@ appended.
 I prefer one commit per logical change, and at minimum one
 commit per phase. Each commit should be self-contained.
 
-**Status: phases 0, 1 and 2 complete.**
+**Status: phases 0, 1, 2 and 3 planned; 0, 1 and 2 complete.**
 The open questions at the bottom are answered in the Decisions
 section; see
 [`PLAN-api-input-validation-phase-00-decisions.md`](PLAN-api-input-validation-phase-00-decisions.md)
@@ -41,7 +41,10 @@ for the measurements behind them,
 for what the audit found,
 [`PLAN-api-input-validation-phase-02-type-vocabulary.md`](PLAN-api-input-validation-phase-02-type-vocabulary.md)
 for what the vocabulary work shipped and the four deviations it
-recorded. Phases 3 onward are not yet cut into per-phase files.
+recorded, and
+[`PLAN-api-input-validation-phase-03-compile-and-warn.md`](PLAN-api-input-validation-phase-03-compile-and-warn.md)
+for the phase now ready to start. Phases 4 onward are not yet cut
+into per-phase files.
 
 ## Situation
 
@@ -269,6 +272,14 @@ declarations are good enough to compile.
    `log_request` already dodges one instance of this by mapping
    body `uuid` to `passed_uuid`, which shows it is a known
    hazard rather than a feature.
+   *Amended by phase 3:* the decision stands, the supporting
+   evidence does not. `passed_uuid` occurs once in the tree — the
+   assignment itself — so no handler accepts it and the remap
+   dodges nothing; it converts a body `uuid` into a guaranteed 400
+   on every endpoint. The check also cannot live where D3 puts the
+   validator, because `log_request` runs first and has already
+   merged the body. See D11 and D12 in
+   [phase 3](PLAN-api-input-validation-phase-03-compile-and-warn.md).
 9. **The type vocabulary gains tokens and an optional
    constraints element** (`unsignedinteger`, `macaddr`,
    `base64`, `netblock`; `minimum` / `maximum` / `pattern`).
@@ -283,7 +294,7 @@ declarations are good enough to compile.
 | 0: Research and decisions | Complete | Measured declaration accuracy; chose webargs, compilation, chain placement, error shape, warn-only criterion. See [phase 0](PLAN-api-input-validation-phase-00-decisions.md) |
 | 1: Declaration audit | Complete | Correct 116 path-parameter locations from the route table, 2 invalid location tokens, 5 wrong names (incl. `sshkey`/`userdata` in the published OpenAPI) and 20 undeclared parameters; make `swagger_helper()` reject unknown locations; add a test that keeps declarations honest. A precondition for phase 3, and a documentation-correctness fix worth landing on its own merits. See [phase 1](PLAN-api-input-validation-phase-01-declaration-audit.md) |
 | 2: Type vocabulary | Complete | The specification-validation test (#3626) plus `schemes`/`securityDefinitions` template fixes; one schema-carrying body parameter per operation, taking the validation error count from 129 to zero; `unsignedinteger`/`macaddr`/`base64`/`netblock` tokens and the optional constraints element, rendered into the published OpenAPI so bounds like the events `limit` cap are visible to callers. See [phase 2](PLAN-api-input-validation-phase-02-type-vocabulary.md) |
-| 3: Compile and warn | Not started | Declarations to schemas; validate in warn-only mode; deploy to sfcbr and read the logs. Opens with the derivation generator below, which is a precondition rather than a step |
+| 3: Compile and warn | Planned, not started | Declarations to schemas; validate in warn-only mode; deploy to sfcbr and read the logs. Opens with the derivation generator below, which is a precondition rather than a step. Four further decisions (D10-D13) are recorded there, including that an undeclared body key is *already* a 400 carrying interpreter text. See [phase 3](PLAN-api-input-validation-phase-03-compile-and-warn.md) |
 | 4: Enforce | Not started | Turn on rejection once the warn log is quiet, with one malformed-input response shape that never contains interpreter text; fold the hand-authored `get_args` schemas into the compiled path |
 | 5: Narrow the handlers | Partly overtaken | Narrow `except TypeError` to JWT errors — still owned by this plan, and still gated on phase 4. The attribution issues are being closed independently: #3615 landed 2026-08-10, #3606 is in flight as PR #3714, leaving #3523 and #3371. See the note below |
 | 6: Required and semantics | Not started | Enforce `required` — or decide not to, since it is the change most likely to break working clients; semantic validators for #534, #3269, #323, #936 |
@@ -466,7 +477,8 @@ the mechanism rather than choosing one:
 
 Phase 3 therefore generalises an existing, tested loader to
 every parameter derived `query`, rather than introducing a
-second precedence rule alongside it.
+second precedence rule alongside it. See
+[phase 3](PLAN-api-input-validation-phase-03-compile-and-warn.md).
 
 ## Open questions for phase 0
 

--- a/docs/plans/PLAN-api-input-validation.md
+++ b/docs/plans/PLAN-api-input-validation.md
@@ -32,13 +32,16 @@ appended.
 I prefer one commit per logical change, and at minimum one
 commit per phase. Each commit should be self-contained.
 
-**Status: phases 0 and 1 complete.** The open questions at the
-bottom are answered in the Decisions section; see
+**Status: phases 0, 1 and 2 complete.**
+The open questions at the bottom are answered in the Decisions
+section; see
 [`PLAN-api-input-validation-phase-00-decisions.md`](PLAN-api-input-validation-phase-00-decisions.md)
-for the measurements behind them and
+for the measurements behind them,
 [`PLAN-api-input-validation-phase-01-declaration-audit.md`](PLAN-api-input-validation-phase-01-declaration-audit.md)
-for what the audit found. Phases 2 onward are not yet cut into
-per-phase files.
+for what the audit found,
+[`PLAN-api-input-validation-phase-02-type-vocabulary.md`](PLAN-api-input-validation-phase-02-type-vocabulary.md)
+for what the vocabulary work shipped and the four deviations it
+recorded. Phases 3 onward are not yet cut into per-phase files.
 
 ## Situation
 
@@ -118,9 +121,11 @@ generator.
 Making it load-bearing is the cheap path to closing #528: no new
 per-endpoint schemas need to be authored for the 96% that already
 declare, and webargs is already a dependency doing exactly this
-job at four sites (`blob.py:187`, `network.py:796`,
-`artifact.py:871`, `instance.py:1784`) — all of them
-`location='query'`, none on request bodies.
+job at four sites (`blob.py`, `network.py`, `artifact.py`,
+`instance.py`) — none of them on request bodies. All four were
+`location='query'` when this was written; three are now
+`location='json_or_query'`, the custom loader #3629 introduced
+(see D6 below).
 
 ### The catch, stated up front
 
@@ -278,11 +283,39 @@ declarations are good enough to compile.
 | 0: Research and decisions | Complete | Measured declaration accuracy; chose webargs, compilation, chain placement, error shape, warn-only criterion. See [phase 0](PLAN-api-input-validation-phase-00-decisions.md) |
 | 1: Declaration audit | Complete | Correct 116 path-parameter locations from the route table, 2 invalid location tokens, 5 wrong names (incl. `sshkey`/`userdata` in the published OpenAPI) and 20 undeclared parameters; make `swagger_helper()` reject unknown locations; add a test that keeps declarations honest. A precondition for phase 3, and a documentation-correctness fix worth landing on its own merits. See [phase 1](PLAN-api-input-validation-phase-01-declaration-audit.md) |
 | 2: Type vocabulary | Complete | The specification-validation test (#3626) plus `schemes`/`securityDefinitions` template fixes; one schema-carrying body parameter per operation, taking the validation error count from 129 to zero; `unsignedinteger`/`macaddr`/`base64`/`netblock` tokens and the optional constraints element, rendered into the published OpenAPI so bounds like the events `limit` cap are visible to callers. See [phase 2](PLAN-api-input-validation-phase-02-type-vocabulary.md) |
-| 3: Compile and warn | Not started | Declarations to schemas; validate in warn-only mode; deploy to sfcbr and read the logs. Precondition: generate the derivation's input space rather than sampling it — see below |
-| 4: Enforce | Not started | Turn on rejection once the warn log is quiet, with one malformed-input response shape that never contains interpreter text; fold the four hand-authored `get_args` schemas into the compiled path |
-| 5: Narrow the handlers | Not started | Narrow `except TypeError` to JWT errors; fix the attribution issues (#3523, #3371, #3606, #3615) |
+| 3: Compile and warn | Not started | Declarations to schemas; validate in warn-only mode; deploy to sfcbr and read the logs. Opens with the derivation generator below, which is a precondition rather than a step |
+| 4: Enforce | Not started | Turn on rejection once the warn log is quiet, with one malformed-input response shape that never contains interpreter text; fold the hand-authored `get_args` schemas into the compiled path |
+| 5: Narrow the handlers | Partly overtaken | Narrow `except TypeError` to JWT errors — still owned by this plan, and still gated on phase 4. The attribution issues are being closed independently: #3615 landed 2026-08-10, #3606 is in flight as PR #3714, leaving #3523 and #3371. See the note below |
 | 6: Required and semantics | Not started | Enforce `required` — or decide not to, since it is the change most likely to break working clients; semantic validators for #534, #3269, #323, #936 |
 
+### Where the tracked issues stand
+
+Recorded here rather than by editing the tables above, so there
+is one place to maintain and the tables stay a record of what
+the plan was scoped against.
+
+**Closed since the plan was written:** #3609 (the trigger,
+2026-08-07), #3626 (specification validation in CI), #3616
+(`base.py` under mypy), #3642 (variadic handlers in the audit),
+#3629 (body-supplied `all`, see D6 below), #3615 (`log_request`
+discarding headers).
+
+**Still open and still owned by this plan:** #528 (parent), #3612
+(the mechanism), #936, #534, #3269, #323, #3523, #3371, #2094;
+#3606 is in flight as PR #3714.
+
+**Phase 5 is being overtaken from outside.** Two of its four
+attribution issues have been picked up by the automated issue
+fixer rather than by this plan. That is fine — they are genuinely
+independent of phases 3 and 4, which is why they were grouped
+rather than sequenced. It is recorded because it changes what
+phase 5 *is*: by the time phases 3 and 4 land, phase 5 is likely
+to be the single item that actually depends on them — narrowing
+`except TypeError` to JWT errors, which cannot happen until a
+validation layer is rejecting the malformed input that broad
+catch currently absorbs. Nobody picks that up incidentally,
+because on its own it looks like a regression risk with no
+visible benefit.
 
 ### Carried into phase 2 from phase 1
 
@@ -402,22 +435,38 @@ mutates the real tree to prove the *guards* fire, which is a
 different question from whether the *derivation* is right, and
 the two are complementary.
 
-**D6's query-string fallback has a caller waiting on it.**
+**D6's query-string fallback shipped early, at three sites.**
 [Issue #3629](https://github.com/shakenfist/shakenfist/issues/3629):
-`all` on the four outstanding-operations endpoints is bound with
+`all` on the outstanding-operations endpoints was bound with
 `@use_kwargs(get_args, location='query')`, and webargs finishes
 with `kwargs.update(parsed_args)`, so the `load_default=False`
-from an absent query string overwrites the `all=True` that
+from an absent query string overwrote the `all=True` that
 `log_request` merged in from the JSON body. The shipped client
-only ever sends a body, so the parameter has never worked
-through it.
+only ever sends a body, so the parameter never worked through
+it.
 
-Phase 1 declared these `query`, which is accurate about where
-the code parses them from. Making the declaration *true of the
-client* is what D6 is for, so #3629 closes when phase 3 lands
-the fallback — or sooner, with `location=('query', 'json')` at
-those four sites, if the two are kept in agreement about
-precedence.
+This was predicted here to close with phase 3, "or sooner". It
+closed sooner, in `0de6c3b5c` (2026-08-09), and phase 3 inherits
+the mechanism rather than choosing one:
+
+* `base.py` registers a **`json_or_query` webargs location
+  loader** which merges `req.args` and the JSON body with the
+  body authoritative, then drops keys the schema does not name
+  (mirroring webargs' `unknown=EXCLUDE` default for the query
+  location). The instance, artifact and network
+  outstanding-operations endpoints are bound to it.
+* **A `('query', 'json')` tuple location was tried and
+  rejected.** webargs keys validation failures by location, and
+  a tuple key is not JSON-serialisable, so a 422 becomes a 500.
+  Phase 3 must not re-derive this: the custom loader is the
+  supported shape.
+* `declarations.py` derives a schema bound to `json_or_query`
+  as a **`query`** location, so the published declaration is
+  unchanged and phase 1's audit still holds.
+
+Phase 3 therefore generalises an existing, tested loader to
+every parameter derived `query`, rather than introducing a
+second precedence rule alongside it.
 
 ## Open questions for phase 0
 

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -88,6 +88,23 @@
   published as base64 content. A rule's `key_ttl` also documents its real
   bounds of 1 to 86400 seconds, which the server has always enforced.
   These are documentation — requests are not yet rejected against them.
+  The API now checks every request against these declarations, but in
+  **warn-only** mode: it logs what it would have refused and changes no
+  response. The new `API_VALIDATION_MODE` setting controls this and
+  defaults to `warn`; `enforce` answers 400 instead, and is not
+  recommended until you have read your own warn logs. Two related
+  behaviour changes did ship:
+    * A webargs validation failure (a malformed query parameter on the
+      four endpoints which parse one) now returns `400` in the usual
+      `{"error": ..., "status": ...}` shape. It previously returned
+      `422` carrying webargs' own body, which was the only response in
+      the API not in that shape. What is rejected is unchanged.
+    * A JSON body key named `uuid` was previously renamed to
+      `passed_uuid` before being merged into the handler's arguments.
+      No handler accepted that name, so sending `uuid` in a body was a
+      guaranteed 400 on every endpoint in the API; it is now treated as
+      an ordinary undeclared parameter, which in warn mode means the
+      request behaves as it always did and the occurrence is logged.
   There are two exceptions, both cases where publishing a bound the
   server did not back would have been worse than publishing nothing:
     * A negative `max_versions` is now refused with a 400 on all three

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -116,8 +116,10 @@
       guaranteed 400 on every endpoint in the API; it is now treated as
       an ordinary undeclared parameter, which in warn mode means the
       request behaves as it always did and the occurrence is logged.
-  There are two exceptions, both cases where publishing a bound the
-  server did not back would have been worse than publishing nothing:
+  Separately, two of the newly published bounds are backed by the
+  server's own handlers rather than waiting for enforcement -- both
+  cases where publishing a bound the server did not back would have
+  been worse than publishing nothing:
     * A negative `max_versions` is now refused with a 400 on all three
       routes that set it — the artifact versions route, label create and
       instance snapshot. It was silently destructive rather than merely

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -96,9 +96,17 @@
   behaviour changes did ship:
     * A webargs validation failure (a malformed query parameter on the
       four endpoints which parse one) now returns `400` in the usual
-      `{"error": ..., "status": ...}` shape. It previously returned
-      `422` carrying webargs' own body, which was the only response in
-      the API not in that shape. What is rejected is unchanged.
+      `{"error": ..., "status": ...}` shape. It previously returned a
+      `500`: webargs aborted with a `422`, but the API's outermost
+      exception handler swallowed that abort into a server error,
+      complete with a traceback in the log and an exception record on
+      disk for every occurrence. What is rejected is unchanged. As part
+      of this, a deliberate abort carrying a crafted response is now
+      returned to the client rather than suppressed into a 500.
+    * A JSON body which is not a JSON object (for example a list or a
+      bare string) is still refused with a `400`, but the message is
+      now `the request body must be a JSON object` rather than
+      interpreter text about failed dictionary iteration.
     * A JSON body key named `uuid` was previously renamed to
       `passed_uuid` before being merged into the handler's arguments.
       No handler accepted that name, so sending `uuid` in a body was a

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -95,7 +95,7 @@
   parameters declared required but omitted, which are recorded and
   never enforced), and is not recommended until you have read your
   own warn logs; `off` disables the layer entirely, as a safety
-  valve against unexpected log volume. Two related
+  valve against unexpected log volume. Three related
   behaviour changes did ship:
     * A webargs validation failure (a malformed query parameter on the
       four endpoints which parse one) now returns `400` in the usual

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -91,8 +91,11 @@
   The API now checks every request against these declarations, but in
   **warn-only** mode: it logs what it would have refused and changes no
   response. The new `API_VALIDATION_MODE` setting controls this and
-  defaults to `warn`; `enforce` answers 400 instead, and is not
-  recommended until you have read your own warn logs. Two related
+  defaults to `warn`; `enforce` answers 400 instead (except for
+  parameters declared required but omitted, which are recorded and
+  never enforced), and is not recommended until you have read your
+  own warn logs; `off` disables the layer entirely, as a safety
+  valve against unexpected log volume. Two related
   behaviour changes did ship:
     * A webargs validation failure (a malformed query parameter on the
       four endpoints which parse one) now returns `400` in the usual

--- a/shakenfist/config.py
+++ b/shakenfist/config.py
@@ -171,15 +171,18 @@ class SFConfig(BaseSettings):
     # setting exists to be flipped, and 'Enforce' or 'enforced'
     # silently meaning warn is exactly the operator error that would
     # otherwise go unnoticed until an incident.
-    API_VALIDATION_MODE: Literal['warn', 'enforce'] = Field(
+    API_VALIDATION_MODE: Literal['off', 'warn', 'enforce'] = Field(
         'warn',
         description=(
             'What the request validation layer does with input which does '
             'not match an endpoint\'s published parameter declarations. '
             '"warn" logs what it would have rejected and changes nothing, '
             'which is phase 3 of PLAN-api-input-validation; "enforce" '
-            'answers 400. Leave this at "warn" until the warn log is '
-            'understood -- see docs/developer_guide/writing_an_endpoint.md.'
+            'answers 400 (except for missing-required findings, which are '
+            'recorded and never enforced); "off" disables the layer '
+            'entirely, as a safety valve against unexpected log volume. '
+            'Leave this at "warn" until the warn log is understood -- see '
+            'docs/developer_guide/writing_an_endpoint.md.'
         )
     )
     FEDERATION_MAX_TOKEN_BYTES: int = Field(

--- a/shakenfist/config.py
+++ b/shakenfist/config.py
@@ -4,6 +4,7 @@ import os
 import socket
 import sys
 from typing import Annotated
+from typing import Literal
 from typing import NoReturn
 from typing import Optional
 
@@ -166,7 +167,11 @@ class SFConfig(BaseSettings):
         15,
         description='How long in minutes an API token is valid for.'
     )
-    API_VALIDATION_MODE: str = Field(
+    # Literal rather than str so a typo fails at config load. The
+    # setting exists to be flipped, and 'Enforce' or 'enforced'
+    # silently meaning warn is exactly the operator error that would
+    # otherwise go unnoticed until an incident.
+    API_VALIDATION_MODE: Literal['warn', 'enforce'] = Field(
         'warn',
         description=(
             'What the request validation layer does with input which does '

--- a/shakenfist/config.py
+++ b/shakenfist/config.py
@@ -166,6 +166,17 @@ class SFConfig(BaseSettings):
         15,
         description='How long in minutes an API token is valid for.'
     )
+    API_VALIDATION_MODE: str = Field(
+        'warn',
+        description=(
+            'What the request validation layer does with input which does '
+            'not match an endpoint\'s published parameter declarations. '
+            '"warn" logs what it would have rejected and changes nothing, '
+            'which is phase 3 of PLAN-api-input-validation; "enforce" '
+            'answers 400. Leave this at "warn" until the warn log is '
+            'understood -- see docs/developer_guide/writing_an_endpoint.md.'
+        )
+    )
     FEDERATION_MAX_TOKEN_BYTES: int = Field(
         16384,
         description=(

--- a/shakenfist/exceptions.py
+++ b/shakenfist/exceptions.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 class HTTPError(Exception):
     ...
 
@@ -416,10 +419,6 @@ class LocklessUpdateFailed(Exception):
     ...
 
 
-class LocklessUpdateFailed(LocklessUpdateFailed):
-    ...
-
-
 # gRPC call failures
 class gRPCException(Exception):
     ...
@@ -514,16 +513,17 @@ class NetworkOperationFailed(Exception):
     reached ``STATE_ERROR``. Carries the persisted ``ErrorReport`` as
     an attribute so callers can branch on its stable ``code`` field."""
 
-    def __init__(self, error_report):
+    def __init__(self, error_report: Any) -> None:
         super().__init__()
         self.error_report = error_report
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f'{self.error_report.code}: {self.error_report.message}'
 
 
 class ProcessExecutionError(Exception):
-    def __init__(self, stdout=None, stderr=None, exit_code=None, cmd=None):
+    def __init__(self, stdout: Any = None, stderr: Any = None,
+                 exit_code: Any = None, cmd: Any = None) -> None:
         super().__init__(stdout, stderr, exit_code, cmd)
         self.exit_code = exit_code
         self.stderr = stderr

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -541,6 +541,11 @@ def log_validation_findings(response):
     if not findings:
         return response
 
+    # The route template as well as the concrete path, because the
+    # measurement groups findings by endpoint and re-templating
+    # /instances/<some uuid> back out of every path is the wrong place
+    # to do that work.
+    url_rule = flask.request.url_rule
     for finding in findings:
         fields = finding.fields()
         fields.update({
@@ -548,6 +553,7 @@ def log_validation_findings(response):
                 'FLASK_REQUEST_ID', 'none'),
             'method': flask.request.method,
             'path': flask.request.path,
+            'route': url_rule.rule if url_rule is not None else None,
             'validation-mode': config.API_VALIDATION_MODE,
             'validation-response-status': response.status_code,
         })

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -45,6 +45,7 @@ from shakenfist.external_api import node as api_node
 from shakenfist.external_api import snapshot as api_snapshot
 from shakenfist.external_api import base as api_base
 from shakenfist.external_api import upload as api_upload
+from shakenfist.external_api import validation
 from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
 
@@ -509,3 +510,47 @@ api.add_resource(api_upload.UploadDataEndpoint, '/upload/<upload_uuid>')
 # response for a different one with nothing wrong to fix.
 api.add_resource(api_upload.UploadTruncateEndpoint,
                  '/upload/<upload_uuid>/truncate/<int:offset>')
+
+
+# Compile every mounted handler's parameter declarations. Last, because
+# it reads the finished route table: a call placed above any
+# add_resource() would compile a registry missing whatever followed it,
+# and a handler missing from the registry is simply not validated.
+# test_validation_compiler.py asserts the count rather than trusting
+# placement.
+validation.install(app)
+
+
+@app.after_request
+def log_validation_findings(response):
+    """Emit what validation would have refused, once the outcome is known.
+
+    Deliberately after the fact rather than at validation time. A
+    finding on a request which went on to return 200 is a rejection
+    enforcement would introduce; one on a request which returned 404 is
+    a status code enforcement would change, because validation sits
+    ahead of the per-method decorators which produce those. Phase 4
+    needs to tell those two populations apart to choose between
+    webargs' EXCLUDE and RAISE (decision D10), and neither is knowable
+    from inside the validator.
+
+    Values are never logged, only their types: decision D5, and some of
+    these routes carry credentials.
+    """
+    findings = getattr(flask.g, validation.VALIDATION_FINDINGS, None)
+    if not findings:
+        return response
+
+    for finding in findings:
+        fields = finding.fields()
+        fields.update({
+            'request-id': flask.request.environ.get(
+                'FLASK_REQUEST_ID', 'none'),
+            'method': flask.request.method,
+            'path': flask.request.path,
+            'validation-mode': config.API_VALIDATION_MODE,
+            'validation-response-status': response.status_code,
+        })
+        LOG.with_fields(fields).info('API request validation finding')
+
+    return response

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -546,8 +546,19 @@ def log_validation_findings(response):
     # /instances/<some uuid> back out of every path is the wrong place
     # to do that work.
     url_rule = flask.request.url_rule
+
+    # On a credential-carrying route the parameter name is dropped like
+    # everything else body-derived: both other body loggers consult
+    # this same predicate and drop the lot, for the reasons on
+    # handles_credentials() -- a buggy caller can put secret-bearing
+    # material in a key position, and /auth is the one place that
+    # would matter. The reason code is what the measurement needs; the
+    # key name is not, there.
+    redact = _handles_credentials()
     for finding in findings:
         fields = finding.fields()
+        if redact:
+            fields['validation-parameter'] = '*****'
         fields.update({
             'request-id': flask.request.environ.get(
                 'FLASK_REQUEST_ID', 'none'),

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -1002,6 +1002,20 @@ def log_request(func):
     def wrapper(*args, **kwargs):
         j = sf_api.flask_get_post_body()
 
+        # Stashed for the validator, which runs two decorators later:
+        # reading it back means validation reports on exactly the body
+        # merged into the handler's kwargs below, and a body which
+        # failed to parse as JSON is not re-parsed to find that out a
+        # second time. Stashed before the type guard so the empty
+        # default is stashed too -- the fallback in validate_request
+        # distinguishes "log_request saw no object" from "log_request
+        # never ran" by None.
+        if isinstance(j, dict):
+            try:
+                setattr(flask.g, validation.PARSED_BODY, j)
+            except RuntimeError:
+                pass
+
         if j:
             # Only a JSON object can merge into kwargs. Any other JSON
             # document -- a list, a string, a number -- has always been
@@ -1381,6 +1395,12 @@ def validate_request(func):
     """
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
+        # The operator's safety valve: if the layer itself is the
+        # problem -- log volume from a chatty caller being the
+        # foreseeable case -- it can be turned off without a downgrade.
+        if config.API_VALIDATION_MODE == 'off':
+            return func(*args, **kwargs)
+
         resource = getattr(func, '__self__', None)
         if resource is None:
             return func(*args, **kwargs)
@@ -1397,9 +1417,15 @@ def validate_request(func):
         # ignore anyway, so it is never fetched: flask_get_post_body()
         # attempts two full JSON parses of a body that is not JSON
         # before returning nothing, and the upload data path is the
-        # API's bulk transfer route.
-        body = ({} if compiled.raw_body
-                else sf_api.flask_get_post_body() or {})
+        # API's bulk transfer route. Everything else reads the body
+        # log_request already parsed and merged, so validation reports
+        # on exactly what the handler receives; the fallback fetch only
+        # runs if log_request somehow did not stash one.
+        body: dict[str, Any] = {}
+        if not compiled.raw_body:
+            stashed = getattr(flask.g, validation.PARSED_BODY, None)
+            body = (stashed if stashed is not None
+                    else sf_api.flask_get_post_body() or {})
         findings = validation.check(
             compiled, body, flask.request.args.to_dict(),
             getattr(flask.g, validation.BODY_PATH_COLLISIONS, set()))
@@ -1407,9 +1433,17 @@ def validate_request(func):
             return func(*args, **kwargs)
 
         if config.API_VALIDATION_MODE == 'enforce':
-            first = findings[0]
-            return sf_api.error(
-                400, '%s: %s' % (first.parameter, first.detail))
+            # required is recorded and never enforced, even here:
+            # several parameters are declared required while omitting
+            # them has always worked (CompiledEndpoint's docstring has
+            # the example), so a missing-required finding is telemetry
+            # for phase 6's decision, not grounds for rejection.
+            enforceable = [f for f in findings
+                           if f.reason != validation.MISSING_REQUIRED]
+            if enforceable:
+                first = enforceable[0]
+                return sf_api.error(
+                    400, '%s: %s' % (first.parameter, first.detail))
 
         try:
             setattr(flask.g, validation.VALIDATION_FINDINGS, findings)

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -24,6 +24,7 @@ from jwt.exceptions import DecodeError
 from jwt.exceptions import ExpiredSignatureError
 import requests
 from webargs.flaskparser import parser as webargs_parser
+from werkzeug.exceptions import HTTPException
 from shakenfist_utilities import api as sf_api  # noreorder
 
 from shakenfist.external_api import validation
@@ -133,14 +134,19 @@ def _webargs_error(error, req, schema, *, error_status_code, error_headers):
     """Answer a webargs parse failure in this API's error shape.
 
     webargs' default handler aborts 422 carrying its own
-    {"json": {"field": ["message"]}} body. Nothing registered a handler
-    before phase 3, so the four @use_kwargs sites have always answered
-    a bad query parameter that way: the wrong status, and the only
-    responses in the API which are not {"error": ..., "status": ...}.
+    {"json": {"field": ["message"]}} body -- but no client ever saw
+    that. Nothing registered a handler before phase 3, and the abort's
+    HTTPException was swallowed by suppress_exceptions_to_client's bare
+    except Exception, so the four @use_kwargs sites answered a bad
+    query parameter with a 500, a 'Server error' log line and an
+    exception record on disk. This handler and the HTTPException
+    carve-out in suppress_exceptions_to_client are the two halves of
+    the fix: the abort below only reaches a client because that
+    carve-out returns the response it carries.
 
-    Decision D4 fixes the shape without changing what is rejected --
-    every request webargs refused before is still refused, and one it
-    accepted is still accepted. Only the response changes.
+    Decision D4 fixes the status and the shape without changing what
+    is rejected -- every request webargs refused before is still
+    refused, and one it accepted is still accepted.
     """
     # error.messages is keyed by location, then by field. The location
     # is not useful to a caller, and for the custom json_or_query
@@ -369,6 +375,20 @@ def _validated_constraints(section: str, name: str,
                 '%s parameter %s declares a pattern using the Python only '
                 'construct(s) %s; OpenAPI patterns are ECMA-262'
                 % (section, name, ', '.join(dialect)))
+        # Anchoring is where the consumers genuinely disagree: JSON
+        # Schema pattern is an unanchored search, while the compiled
+        # marshmallow validator uses re.match, which is anchored at the
+        # start only. A declared ^...$ pattern is the one form both
+        # read identically, so it is required rather than documented --
+        # an unanchored pattern would pass here and then wrongly reject
+        # (or wrongly admit) requests once phase 4 enforces.
+        if not (pattern.startswith('^') and pattern.endswith('$')):
+            raise exceptions.InvalidAPIDeclaration(
+                '%s parameter %s declares a pattern which is not '
+                'anchored with ^...$: %r. JSON Schema searches and the '
+                'compiled validator matches, and full anchoring is the '
+                'only form they read identically'
+                % (section, name, pattern))
 
     return constraints
 
@@ -983,6 +1003,17 @@ def log_request(func):
         j = sf_api.flask_get_post_body()
 
         if j:
+            # Only a JSON object can merge into kwargs. Any other JSON
+            # document -- a list, a string, a number -- has always been
+            # refused as a 400 (previously by the per-key merge raising
+            # TypeError on the lookup), and this guard keeps it that
+            # way: dict.update would raise ValueError for most of them,
+            # which nothing in the decorator chain catches, and would
+            # silently merge a list of two-character strings as key
+            # value pairs.
+            if not isinstance(j, dict):
+                raise TypeError('the request body must be a JSON object')
+
             # A body key with the same name as a URL path parameter
             # overwrites it. Recorded here rather than in the validator
             # because this decorator is applied outside it and so runs
@@ -1160,6 +1191,15 @@ def record_exception(func):
         try:
             return func(*args, **kwargs)
         except Exception as e:
+            # An HTTPException carrying a crafted response is a
+            # deliberate abort -- _webargs_error is the one source in
+            # this tree -- not a server fault. Recording it would write
+            # an exception record for every malformed query parameter.
+            # Mirrors the carve-out on the got_request_exception
+            # handler in app.py.
+            if isinstance(e, HTTPException) and e.response is not None:
+                raise
+
             # suppress_exceptions_to_client wraps this decorator -- it
             # is last in Resource.method_decorators and therefore
             # outermost -- and is guaranteed to log the full detail of
@@ -1196,6 +1236,20 @@ def suppress_exceptions_to_client(func):
         try:
             return func(*args, **kwargs)
         except Exception as e:
+            # A deliberate abort carrying a crafted response is returned
+            # as that response rather than suppressed into a 500.
+            # HTTPException is an Exception subclass, so without this
+            # the 400 _webargs_error aborts with would never reach a
+            # client -- which is exactly what happened to webargs' own
+            # 422 abort for as long as the @use_kwargs sites have
+            # existed. Restricted to response-carrying exceptions so a
+            # bare abort() somewhere cannot start answering werkzeug's
+            # HTML error pages: every response in this API is
+            # {"error": ..., "status": ...}, and an abort which wants
+            # through this gate has to build one.
+            if isinstance(e, HTTPException) and e.response is not None:
+                return e.response
+
             # Attach the exception class, traceback and request context as
             # explicit structured fields. The .exception() call also carries
             # exc_info for the formatter's exception_class / stack_trace
@@ -1339,9 +1393,15 @@ def validate_request(func):
             # not a way for a new endpoint to opt out silently.
             return func(*args, **kwargs)
 
+        # A raw body is bytes of arbitrary size which check() would
+        # ignore anyway, so it is never fetched: flask_get_post_body()
+        # attempts two full JSON parses of a body that is not JSON
+        # before returning nothing, and the upload data path is the
+        # API's bulk transfer route.
+        body = ({} if compiled.raw_body
+                else sf_api.flask_get_post_body() or {})
         findings = validation.check(
-            compiled, sf_api.flask_get_post_body() or {},
-            flask.request.args.to_dict(),
+            compiled, body, flask.request.args.to_dict(),
             getattr(flask.g, validation.BODY_PATH_COLLISIONS, set()))
         if not findings:
             return func(*args, **kwargs)

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -376,11 +376,14 @@ def _validated_constraints(section: str, name: str,
                 % (section, name, ', '.join(dialect)))
         # Anchoring is where the consumers genuinely disagree: JSON
         # Schema pattern is an unanchored search, while the compiled
-        # marshmallow validator uses re.match, which is anchored at the
-        # start only. A declared ^...$ pattern is the one form both
-        # read identically, so it is required rather than documented --
-        # an unanchored pattern would pass here and then wrongly reject
-        # (or wrongly admit) requests once phase 4 enforces.
+        # validator requires the pattern to consume the whole value
+        # (re.fullmatch -- see validation._field(), which uses it
+        # precisely because Python's $ also matches before a trailing
+        # newline and ECMA-262's does not). A declared ^...$ pattern is
+        # the one form both read identically, so it is required rather
+        # than documented -- an unanchored pattern would pass here and
+        # then wrongly reject (or wrongly admit) requests once phase 4
+        # enforces.
         if not (pattern.startswith('^') and pattern.endswith('$')):
             raise exceptions.InvalidAPIDeclaration(
                 '%s parameter %s declares a pattern which is not '
@@ -388,6 +391,27 @@ def _validated_constraints(section: str, name: str,
                 'compiled validator matches, and full anchoring is the '
                 'only form they read identically'
                 % (section, name, pattern))
+        # A top-level alternation defeats the anchors the check above
+        # just required: '^a|b$' means (^a)|(b$) and is anchored on
+        # neither branch, so the string test alone would bless a
+        # pattern the two consumers still read differently. Wrap the
+        # alternation in a group instead.
+        depth, escaped = 0, False
+        for character in pattern:
+            if escaped:
+                escaped = False
+            elif character == '\\':
+                escaped = True
+            elif character == '(':
+                depth += 1
+            elif character == ')':
+                depth -= 1
+            elif character == '|' and depth == 0:
+                raise exceptions.InvalidAPIDeclaration(
+                    '%s parameter %s declares a pattern with a top '
+                    'level alternation, which escapes the ^...$ '
+                    'anchors: %r. Wrap the alternation in a group'
+                    % (section, name, pattern))
 
     return constraints
 

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 import json
 import re
 import sys
@@ -24,6 +25,8 @@ from jwt.exceptions import ExpiredSignatureError
 import requests
 from webargs.flaskparser import parser as webargs_parser
 from shakenfist_utilities import api as sf_api  # noreorder
+
+from shakenfist.external_api import validation
 from shakenfist_utilities import logs  # noreorder
 
 from shakenfist import exceptions
@@ -123,6 +126,34 @@ def _load_json_or_query(req, schema):
     if isinstance(json_body, dict):
         data.update(json_body)
     return {key: value for key, value in data.items() if key in schema.fields}
+
+
+@webargs_parser.error_handler
+def _webargs_error(error, req, schema, *, error_status_code, error_headers):
+    """Answer a webargs parse failure in this API's error shape.
+
+    webargs' default handler aborts 422 carrying its own
+    {"json": {"field": ["message"]}} body. Nothing registered a handler
+    before phase 3, so the four @use_kwargs sites have always answered
+    a bad query parameter that way: the wrong status, and the only
+    responses in the API which are not {"error": ..., "status": ...}.
+
+    Decision D4 fixes the shape without changing what is rejected --
+    every request webargs refused before is still refused, and one it
+    accepted is still accepted. Only the response changes.
+    """
+    # error.messages is keyed by location, then by field. The location
+    # is not useful to a caller, and for the custom json_or_query
+    # loader it would name a location no caller can address.
+    parameters = []
+    for by_field in error.messages.values():
+        if isinstance(by_field, dict):
+            for field, messages in by_field.items():
+                detail = ('; '.join(messages)
+                          if isinstance(messages, list) else str(messages))
+                parameters.append('%s: %s' % (field, detail))
+    flask.abort(sf_api.error(
+        400, parameters[0] if parameters else 'invalid request parameter'))
 
 
 def caller_is_admin(func):
@@ -952,12 +983,30 @@ def log_request(func):
         j = sf_api.flask_get_post_body()
 
         if j:
-            for key in j:
-                if key == 'uuid':
-                    destkey = 'passed_uuid'
-                else:
-                    destkey = key
-                kwargs[destkey] = j[key]
+            # A body key with the same name as a URL path parameter
+            # overwrites it. Recorded here rather than in the validator
+            # because this decorator is applied outside it and so runs
+            # first: by the time the validator sees kwargs the overwrite
+            # has happened and is indistinguishable from a path
+            # parameter which simply had that value (decision D12).
+            #
+            # The 'uuid' -> 'passed_uuid' remap which used to live here
+            # was not the dodge decision D8 cites it as. 'passed_uuid'
+            # occurred nowhere else in the tree, so no handler accepted
+            # it and a body 'uuid' was a guaranteed 400 carrying
+            # interpreter text on every endpoint in the API. Dropped, so
+            # a body 'uuid' is now an undeclared parameter like any
+            # other and is reported as one (decision D11).
+            collisions = set(j) & set(kwargs)
+            if collisions:
+                try:
+                    setattr(flask.g, validation.BODY_PATH_COLLISIONS,
+                            collisions)
+                except RuntimeError:
+                    # No application context. Losing the record is
+                    # survivable; replacing the request is not.
+                    pass
+            kwargs.update(j)
 
         formatted_headers = []
         for header in flask.request.headers:
@@ -1252,6 +1301,77 @@ def _enforce_scope(func, resource_class, override):
     return wrapper
 
 
+def validate_request(func):
+    """Check a request against its published parameter declarations.
+
+    Phase 3 of PLAN-api-input-validation. While API_VALIDATION_MODE is
+    'warn' -- the default, and what phase 3 ships -- this changes
+    nothing about any request: it records what it would have refused
+    and calls through. app.py emits those records once the response
+    status is known, because whether a finding represents a rejection
+    enforcement would *introduce* or a status code it would merely
+    *change* depends on what the request returned anyway.
+
+    First in Resource.method_decorators and so innermost, which puts it
+    after authentication (an unauthenticated caller cannot probe the
+    schema) and before every per-method decorator. That ordering is
+    also why enforcement is a contract change beyond the obvious: a
+    request which is both malformed and refers to a missing object is
+    answered here rather than by the 404 an arg_is_* decorator would
+    have returned.
+
+    Being innermost is also what makes func a bound method, so the
+    endpoint class is readable from it without depending on attribute
+    propagation through the decorators in this file which predate
+    functools.wraps.
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        resource = getattr(func, '__self__', None)
+        if resource is None:
+            return func(*args, **kwargs)
+
+        compiled = validation.REGISTRY.get(
+            (type(resource).__name__, flask.request.method.lower()))
+        if compiled is None:
+            # Undocumented by design: Root, Livez and Readyz. The list is
+            # held closed by test_parameter_declarations.py, so this is
+            # not a way for a new endpoint to opt out silently.
+            return func(*args, **kwargs)
+
+        findings = validation.check(
+            compiled, sf_api.flask_get_post_body() or {},
+            flask.request.args.to_dict(),
+            getattr(flask.g, validation.BODY_PATH_COLLISIONS, set()))
+        if not findings:
+            return func(*args, **kwargs)
+
+        if config.API_VALIDATION_MODE == 'enforce':
+            first = findings[0]
+            return sf_api.error(
+                400, '%s: %s' % (first.parameter, first.detail))
+
+        try:
+            setattr(flask.g, validation.VALIDATION_FINDINGS, findings)
+        except RuntimeError:
+            pass
+        return func(*args, **kwargs)
+
+    # Being first in method_decorators means every entry after this one
+    # sees this wrapper rather than the bound method.
+    # _authenticate_unless_public reads __self__ for the resource class
+    # and _sf_public / _sf_scope for the policy markers, and this file
+    # already documents that several of its decorators predate
+    # functools.wraps and swallow attributes. functools.wraps above
+    # carries the function __dict__, which is where _sf_public,
+    # _sf_scope and flasgger's specs_dict live; __self__ is a bound
+    # method attribute rather than a dict entry, so it is copied here.
+    # Without both, every @public endpoint would start demanding a token
+    # and every scope check would lose the class it is scoped to.
+    wrapper.__self__ = getattr(func, '__self__', None)  # type: ignore[attr-defined]  # noqa: E501
+    return wrapper
+
+
 def _authenticate_unless_public(func):
     # The method_decorators entry which makes authentication the
     # default. flask_restful applies these to the bound method at
@@ -1289,6 +1409,7 @@ class Resource(flask_restful.Resource):
     # ahead of every per-method decorator, so an unauthenticated
     # request never reaches an ownership check.
     method_decorators = [
+        validate_request,
         _authenticate_unless_public,
         log_request,
         handle_authorization_exceptions,

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -26,8 +26,6 @@ import requests
 from webargs.flaskparser import parser as webargs_parser
 from werkzeug.exceptions import HTTPException
 from shakenfist_utilities import api as sf_api  # noreorder
-
-from shakenfist.external_api import validation
 from shakenfist_utilities import logs  # noreorder
 
 from shakenfist import exceptions
@@ -38,6 +36,7 @@ from shakenfist.config import config
 from shakenfist.constants import EVENT_TYPE_AUDIT
 from shakenfist.daemons import daemon
 from shakenfist.external_api import scopes as api_scopes
+from shakenfist.external_api import validation
 from shakenfist.instance import Instance
 from shakenfist.namespace import get_api_token
 from shakenfist.node import Node
@@ -1006,15 +1005,16 @@ def log_request(func):
         # reading it back means validation reports on exactly the body
         # merged into the handler's kwargs below, and a body which
         # failed to parse as JSON is not re-parsed to find that out a
-        # second time. Stashed before the type guard so the empty
-        # default is stashed too -- the fallback in validate_request
-        # distinguishes "log_request saw no object" from "log_request
-        # never ran" by None.
-        if isinstance(j, dict):
-            try:
-                setattr(flask.g, validation.PARSED_BODY, j)
-            except RuntimeError:
-                pass
+        # second time. Stashed unconditionally -- check() already
+        # normalises a non-dict body -- so the fallback fetch in
+        # validate_request only runs when log_request never ran. The
+        # one body it cannot distinguish is a JSON null, which stashes
+        # the same None as "unset"; the fallback re-fetch is answered
+        # from flask's parse cache in that case.
+        try:
+            setattr(flask.g, validation.PARSED_BODY, j)
+        except RuntimeError:
+            pass
 
         if j:
             # Only a JSON object can merge into kwargs. Any other JSON
@@ -1432,6 +1432,17 @@ def validate_request(func):
         if not findings:
             return func(*args, **kwargs)
 
+        # Stashed before the enforce decision, so a rejected request
+        # still emits its finding lines from the after_request hook --
+        # carrying mode=enforce and the 400. Rejecting silently would
+        # turn the measurement apparatus off at the exact moment phase
+        # 4 flips the switch, which is when an operator most needs to
+        # see which parameter a refused request was refused for.
+        try:
+            setattr(flask.g, validation.VALIDATION_FINDINGS, findings)
+        except RuntimeError:
+            pass
+
         if config.API_VALIDATION_MODE == 'enforce':
             # required is recorded and never enforced, even here:
             # several parameters are declared required while omitting
@@ -1445,10 +1456,6 @@ def validate_request(func):
                 return sf_api.error(
                     400, '%s: %s' % (first.parameter, first.detail))
 
-        try:
-            setattr(flask.g, validation.VALIDATION_FINDINGS, findings)
-        except RuntimeError:
-            pass
         return func(*args, **kwargs)
 
     # Being first in method_decorators means every entry after this one

--- a/shakenfist/external_api/declarations.py
+++ b/shakenfist/external_api/declarations.py
@@ -527,13 +527,23 @@ def derived_location(name: str, fn: ast.FunctionDef, tree: ast.Module,
                      cls: ast.ClassDef, routes: dict[str, set[str]],
                      problems: Optional[list[str]] = None) -> str:
     """Where a parameter of this name actually arrives."""
-    if name in routes.get(cls.name, set()):
-        return 'path'
-    # Both sources are always consulted, rather than short-circuiting on
-    # the first hit, so that a problem in the second is collected even
-    # for a name the first already resolved.
+    # Every source is consulted before answering, rather than
+    # short-circuiting on the first hit, so that a problem in a later
+    # source is collected even for a name an earlier one resolved.
+    #
+    # The route check used to return ahead of these two, which made the
+    # rule true of the query pair and false of the path case: a handler
+    # whose declared parameters are all path parameters could read
+    # flask.request.args with a key this cannot name and the audit would
+    # report the tree clean, because the only call which would have
+    # noticed returned before making it. That is the confident wrong
+    # answer request_args_parameters() exists to refuse, reintroduced one
+    # level up. Found by the generated cross product rather than by the
+    # tree, which contains no handler of that shape.
     in_query = name in query_parameters(fn, [cls, tree], problems)
     in_args = name in request_args_parameters(fn, problems)
+    if name in routes.get(cls.name, set()):
+        return 'path'
     if in_query or in_args:
         return 'query'
     return 'body'

--- a/shakenfist/external_api/validation.py
+++ b/shakenfist/external_api/validation.py
@@ -230,10 +230,15 @@ def build_registry(app: Any) -> dict[tuple[str, str], CompiledEndpoint]:
 # rejection enforcement would introduce from a status code it would
 # merely change -- and at validation time that is not yet known.
 
-# The request-scoped hand-off, named like base.py's
-# _RECORDED_EXCEPTION_FIELDS because it is the same pattern.
+# The request-scoped hand-offs, named like base.py's
+# _RECORDED_EXCEPTION_FIELDS because they are the same pattern.
+# PARSED_BODY carries the body log_request parsed and merged, so the
+# validator reports on exactly what the handler will receive rather
+# than on a re-read of the request -- and so a body which is not JSON
+# is not paid for twice.
 VALIDATION_FINDINGS = 'sf_validation_findings'
 BODY_PATH_COLLISIONS = 'sf_body_path_collisions'
+PARSED_BODY = 'sf_parsed_body'
 
 # Reason codes. Counted separately because they answer different
 # questions: see the table in the phase 3 plan.
@@ -272,7 +277,13 @@ class Finding:
     def __init__(self, reason: str, parameter: str, detail: str,
                  value: Any = None):
         self.reason = reason
-        self.parameter = parameter[:MAX_PARAMETER_NAME]
+        # Truncated *and* stripped of non-printables: the length bound
+        # alone would still let a newline in a key forge extra fields
+        # in a log line or, in enforce mode, in the response. The JSON
+        # formatter escapes these anyway, so this is defence in depth
+        # rather than the only wall.
+        self.parameter = ''.join(
+            c for c in parameter if c.isprintable())[:MAX_PARAMETER_NAME]
         self.detail = detail
         self.value_type = type(value).__name__ if value is not None else None
 

--- a/shakenfist/external_api/validation.py
+++ b/shakenfist/external_api/validation.py
@@ -129,10 +129,15 @@ def _field(spec: dict[str, Any]) -> fields.Field[Any]:
         # A type this does not know is documented rather than enforced.
         # Raw accepts anything, which keeps an unrecognised token from
         # silently becoming a rejection -- the failure mode phase 2's
-        # netblock reasoning is about.
+        # netblock reasoning is about. Its bounds are dropped too: Raw
+        # deserialises without coercing, so a Range or Regexp validator
+        # would raise TypeError from inside schema.validate() the
+        # moment it met a value of the wrong Python type, and an
+        # unrecognised type cannot meaningfully carry a bound anyway.
         LOG.with_fields({'type': declared}).warning(
             'Unrecognised parameter type in the published specification; '
             'compiled as unvalidated')
+        kwargs.pop('validate', None)
         return fields.Raw(**kwargs)
     return field_class(**kwargs)
 
@@ -199,10 +204,26 @@ def build_registry(app: Any) -> dict[tuple[str, str], CompiledEndpoint]:
     that question entirely.
     """
     out: dict[tuple[str, str], CompiledEndpoint] = {}
+    compiled_classes: dict[str, type] = {}
     for view in app.view_functions.values():
         cls = getattr(view, 'view_class', None)
         if cls is None:
             continue
+        # The key is the bare class name, because that is all the
+        # validating decorator can reconstruct at dispatch. Two
+        # endpoint classes sharing a name in different modules would
+        # therefore silently validate one endpoint's requests against
+        # the other's schema, and the completeness test collapses the
+        # duplicate on both sides of its comparison -- so the collision
+        # is refused here, loudly, at mount time.
+        seen = compiled_classes.get(cls.__name__)
+        if seen is not None and seen is not cls:
+            raise ValueError(
+                'two endpoint classes named %s are mounted (%s and %s); '
+                'the validation registry is keyed by class name and '
+                'cannot tell their requests apart'
+                % (cls.__name__, seen.__module__, cls.__module__))
+        compiled_classes[cls.__name__] = cls
         for method in ('get', 'post', 'put', 'delete', 'patch'):
             handler = getattr(cls, method, None)
             if handler is None:
@@ -303,7 +324,20 @@ def _schema_findings(schema: Optional[marshmallow.Schema],
     known = {name: value for name, value in supplied.items()
              if name in schema.fields}
     findings = []
-    for parameter, messages in schema.validate(known).items():
+    try:
+        mismatches = schema.validate(known)
+    except Exception:
+        # A warn-only layer must never raise from inside itself, and
+        # marshmallow does not catch everything a validator can throw
+        # (a Range validator meeting a value of an uncoercible Python
+        # type raises TypeError straight through validate()). No
+        # findings is the honest answer when the check itself failed;
+        # the log line is what stops a compiler defect hiding forever.
+        LOG.with_fields({
+            'parameters': sorted(known)}).exception(
+            'Request validation raised internally; no findings reported')
+        return []
+    for parameter, messages in mismatches.items():
         findings.append(Finding(
             TYPE_MISMATCH, str(parameter),
             '; '.join(messages) if isinstance(messages, list)

--- a/shakenfist/external_api/validation.py
+++ b/shakenfist/external_api/validation.py
@@ -39,6 +39,7 @@ cases:
 ``minimum`` and ``maximum`` constrain anything.
 """
 
+import re
 from typing import Any
 from typing import Optional
 
@@ -46,6 +47,8 @@ import marshmallow
 from marshmallow import fields
 from marshmallow import validate
 from shakenfist_utilities import logs
+
+from shakenfist import exceptions
 
 LOG, _ = logs.setup(__name__)
 
@@ -112,7 +115,23 @@ def _field(spec: dict[str, Any]) -> fields.Field[Any]:
         validators.append(validate.Range(min=minimum, max=maximum))
     pattern = spec.get('pattern')
     if pattern is not None:
-        validators.append(validate.Regexp(pattern))
+        # fullmatch rather than validate.Regexp's re.match: Python's $
+        # also matches before a trailing newline, ECMA-262's does not,
+        # so re.match('^...$', 'value\n') accepts what the published
+        # JSON Schema pattern refuses. fullmatch requires the pattern
+        # to consume the whole string, which is the strict reading both
+        # dialects share for a ^...$-anchored pattern -- and anchoring
+        # is required at import time.
+        compiled_pattern = re.compile(pattern)
+
+        def _fullmatch(value: Any,
+                       _re: 're.Pattern[str]' = compiled_pattern) -> Any:
+            if not isinstance(value, str) or _re.fullmatch(value) is None:
+                raise marshmallow.ValidationError(
+                    'String does not match expected pattern.')
+            return value
+
+        validators.append(_fullmatch)
     if validators:
         kwargs['validate'] = validators
 
@@ -218,7 +237,7 @@ def build_registry(app: Any) -> dict[tuple[str, str], CompiledEndpoint]:
         # is refused here, loudly, at mount time.
         seen = compiled_classes.get(cls.__name__)
         if seen is not None and seen is not cls:
-            raise ValueError(
+            raise exceptions.InvalidAPIDeclaration(
                 'two endpoint classes named %s are mounted (%s and %s); '
                 'the validation registry is keyed by class name and '
                 'cannot tell their requests apart'

--- a/shakenfist/external_api/validation.py
+++ b/shakenfist/external_api/validation.py
@@ -1,0 +1,220 @@
+# Copyright 2019 Michael Still and contributors
+
+"""Compile the published parameter declarations into request schemas.
+
+Phase 3 of ``docs/plans/PLAN-api-input-validation.md``. Nothing here
+rejects anything: this module turns declarations into marshmallow
+schemas and mounts them in a registry. The decorator which consults
+them, and the warn-only telemetry which reports what they would have
+refused, are separate.
+
+**Compiled from the rendered specification, not from the declaration
+tuples.** ``swagger_helper()`` already resolves the tuples into the
+OpenAPI an endpoint publishes -- collapsing an operation's body
+declarations into one schema, and expanding each type token into
+``type``/``format`` and any constraints. Reading that output rather
+than re-interpreting the tokens means the compiled schema and the
+published specification cannot disagree, because there is only one
+interpretation of a token in the process. Two consecutive review
+rounds in phase 2 found a type token that contradicted its handler,
+and a second independent mapping here would be a third way for that
+class of defect to arrive.
+
+It also gets three rules from the plan for free rather than as special
+cases:
+
+* ``netblock`` is deliberately format-only, with no pattern, because
+  ``NetworksEndpoint.post()`` parses with ``ipaddress.ip_network()``,
+  which accepts IPv6 too. It renders as a plain string and so compiles
+  to one.
+* ``uuidorname``, ``namespace``, ``node``, ``url`` and ``ipv4`` carry
+  prose formats which are documentation. They render as plain strings
+  and compile to plain strings; turning them into semantic validators
+  is phase 6, not something this can do by accident.
+* The raw request body renders as a body schema whose type is not
+  ``object``, which is exactly the discriminator needed to leave
+  upload bodies alone.
+
+``format`` is documentation in every case. Only ``type``, ``pattern``,
+``minimum`` and ``maximum`` constrain anything.
+"""
+
+from typing import Any
+from typing import Optional
+
+import marshmallow
+from marshmallow import fields
+from marshmallow import validate
+from shakenfist_utilities import logs
+
+LOG, _ = logs.setup(__name__)
+
+
+# Parameter locations which are not request input this can validate.
+# 'header' carries the JWT, which the authentication decorators own.
+_IGNORED_LOCATIONS = frozenset(['header', 'formData'])
+
+_SCALARS: dict[str, type[fields.Field[Any]]] = {
+    'string': fields.String,
+    'integer': fields.Integer,
+    'number': fields.Float,
+    'boolean': fields.Boolean,
+    'object': fields.Dict,
+}
+
+
+class CompiledEndpoint:
+    """The schemas one handler's declarations compile to.
+
+    ``required_names`` is recorded rather than enforced. The plan found
+    ``mode`` on the agent-put endpoint declared required while omitting
+    it has always been accepted, so enforcing required-ness would break
+    working clients; phase 6 decides that, and warn-only exists to give
+    it the numbers.
+    """
+
+    def __init__(self, body: Optional[marshmallow.Schema],
+                 query: Optional[marshmallow.Schema],
+                 path_names: set[str], required_names: set[str],
+                 raw_body: bool):
+        self.body = body
+        self.query = query
+        self.path_names = path_names
+        self.required_names = required_names
+        self.raw_body = raw_body
+
+    @property
+    def names(self) -> set[str]:
+        """Every parameter name this endpoint declares, any location."""
+        out = set(self.path_names)
+        for schema in (self.body, self.query):
+            if schema is not None:
+                out |= set(schema.fields)
+        return out
+
+
+def _field(spec: dict[str, Any]) -> fields.Field[Any]:
+    """One rendered parameter or property as a marshmallow field.
+
+    Every field is optional and nullable. Optional because required-ness
+    is metadata here (see CompiledEndpoint). Nullable because a JSON
+    null reaches the handler as None today and several handlers treat
+    that as "not supplied" -- rejecting it would be a behaviour change
+    invented by the compiler rather than described by a declaration,
+    and in warn-only it would fill the log with findings that are
+    artefacts of this module.
+    """
+    kwargs: dict[str, Any] = {'required': False, 'allow_none': True}
+
+    validators: list[Any] = []
+    minimum, maximum = spec.get('minimum'), spec.get('maximum')
+    if minimum is not None or maximum is not None:
+        validators.append(validate.Range(min=minimum, max=maximum))
+    pattern = spec.get('pattern')
+    if pattern is not None:
+        validators.append(validate.Regexp(pattern))
+    if validators:
+        kwargs['validate'] = validators
+
+    declared = spec.get('type')
+    if not isinstance(declared, str):
+        declared = ''
+    if declared == 'array':
+        # items is always present: swagger_helper() renders the array
+        # tokens with it, and OpenAPI 2.0 requires it.
+        return fields.List(_field(spec.get('items', {})), **kwargs)
+
+    field_class = _SCALARS.get(declared)
+    if field_class is None:
+        # A type this does not know is documented rather than enforced.
+        # Raw accepts anything, which keeps an unrecognised token from
+        # silently becoming a rejection -- the failure mode phase 2's
+        # netblock reasoning is about.
+        LOG.with_fields({'type': declared}).warning(
+            'Unrecognised parameter type in the published specification; '
+            'compiled as unvalidated')
+        return fields.Raw(**kwargs)
+    return field_class(**kwargs)
+
+
+def _schema(properties: dict[str, dict[str, Any]]) -> marshmallow.Schema:
+    return marshmallow.Schema.from_dict(
+        {name: _field(spec) for name, spec in properties.items()})()
+
+
+def compile_parameters(parameters: list[dict[str, Any]]) -> CompiledEndpoint:
+    """Compile one handler's rendered OpenAPI parameters."""
+    body_properties: dict[str, dict[str, Any]] = {}
+    query_properties: dict[str, dict[str, Any]] = {}
+    path_names: set[str] = set()
+    required: set[str] = set()
+    raw_body = False
+
+    for parameter in parameters:
+        location = parameter.get('in')
+        name = parameter.get('name')
+        if location in _IGNORED_LOCATIONS or name is None:
+            continue
+
+        if location == 'body':
+            schema = parameter.get('schema', {})
+            if schema.get('type') != 'object':
+                # The raw body marker. Not JSON, so there is nothing to
+                # parse and nothing to validate.
+                raw_body = True
+                continue
+            body_properties.update(schema.get('properties', {}))
+            required |= set(schema.get('required', []))
+            continue
+
+        if parameter.get('required'):
+            required.add(name)
+        if location == 'path':
+            # Werkzeug has already matched these, and their values
+            # arrive as URL segments rather than as JSON.
+            path_names.add(name)
+        elif location == 'query':
+            query_properties[name] = parameter
+
+    return CompiledEndpoint(
+        body=_schema(body_properties) if body_properties else None,
+        query=_schema(query_properties) if query_properties else None,
+        path_names=path_names, required_names=required, raw_body=raw_body)
+
+
+def build_registry(app: Any) -> dict[tuple[str, str], CompiledEndpoint]:
+    """Compile every handler mounted on ``app``.
+
+    Keyed by (endpoint class name, lowercased HTTP method), which is
+    what the validating decorator can reconstruct at dispatch from
+    ``type(self)`` and ``flask.request.method``.
+
+    Built from the mounted routes rather than from a registration
+    inside ``swagger_helper()``, which does not know which class or
+    method it is decorating, and rather than from an attribute the
+    decorator chain would have to propagate: ``base.py`` documents in
+    two places that several of its decorators predate
+    ``functools.wraps`` and drop attributes, which is why ``_sf_public``
+    must be applied outermost. Reading the class off the mount avoids
+    that question entirely.
+    """
+    out: dict[tuple[str, str], CompiledEndpoint] = {}
+    for view in app.view_functions.values():
+        cls = getattr(view, 'view_class', None)
+        if cls is None:
+            continue
+        for method in ('get', 'post', 'put', 'delete', 'patch'):
+            handler = getattr(cls, method, None)
+            if handler is None:
+                continue
+            specs = getattr(handler, 'specs_dict', None)
+            if specs is None:
+                # Not documented, so nothing to compile. The three
+                # handlers in this state are Root, Livez and Readyz, and
+                # test_parameter_declarations.py holds that list closed;
+                # a new undocumented endpoint fails there rather than
+                # quietly arriving here.
+                continue
+            out[(cls.__name__, method)] = compile_parameters(
+                specs.get('parameters', []))
+    return out

--- a/shakenfist/external_api/validation.py
+++ b/shakenfist/external_api/validation.py
@@ -243,19 +243,36 @@ MISSING_REQUIRED = 'missing-required'
 BODY_PATH_COLLISION = 'body-path-collision'
 
 
+# The longest parameter name a finding will carry. Names are client
+# supplied, so without a bound one request could put megabytes -- or
+# control characters -- into a log line and, in enforce mode, into the
+# response. 64 comfortably covers every declared name in the API.
+MAX_PARAMETER_NAME = 64
+
+# The most unknown-parameter findings one request can produce. The
+# other reasons are bounded by the declaration (declared fields, path
+# names), but unknown body keys are bounded only by what a caller
+# sends, and each finding is a log line shipped to centralised
+# logging. The overflow is summarised in one finding carrying the
+# count, so the measurement still learns the request happened.
+MAX_UNKNOWN_PARAMETER_FINDINGS = 20
+
+
 class Finding:
     """One thing validation would have refused.
 
     Carries the offending value's *type* and never its value: decision
     D5, and several of these routes carry credentials, which is why
     log_request drops the whole body on a credential-handling route
-    rather than naming fields.
+    rather than naming fields. The parameter *name* is also client
+    supplied on the unknown-parameter path, so it is truncated rather
+    than trusted.
     """
 
     def __init__(self, reason: str, parameter: str, detail: str,
                  value: Any = None):
         self.reason = reason
-        self.parameter = parameter
+        self.parameter = parameter[:MAX_PARAMETER_NAME]
         self.detail = detail
         self.value_type = type(value).__name__ if value is not None else None
 
@@ -284,14 +301,23 @@ def _schema_findings(schema: Optional[marshmallow.Schema],
     return findings
 
 
-def check(compiled: CompiledEndpoint, body: dict[str, Any],
+def check(compiled: CompiledEndpoint, body: Any,
           query: dict[str, Any], collisions: set[str]) -> list[Finding]:
     """Everything this request would have been refused for.
 
     Pure, so it is testable without a request context, and so the
     decorator is only responsible for deciding what to do with the
     answer.
+
+    ``body`` is whatever the request body parsed to. A non-dict body
+    is refused by log_request before validation runs, so a dict is
+    what arrives in practice -- but a warn-only layer must never raise
+    from inside itself, so anything else is treated as no body at all
+    rather than iterated on trust.
     """
+    if not isinstance(body, dict):
+        body = {}
+
     findings: list[Finding] = []
 
     # An undeclared body key is already fatal when the request reaches
@@ -301,11 +327,16 @@ def check(compiled: CompiledEndpoint, body: dict[str, Any],
     # carrying interpreter text. Counting these is how phase 4 chooses
     # between webargs' EXCLUDE and RAISE (decision D10).
     if not compiled.raw_body:
-        for name in body:
-            if name not in compiled.names:
-                findings.append(Finding(
-                    UNKNOWN_PARAMETER, name,
-                    'not declared by this endpoint', body[name]))
+        unknown = [name for name in body if name not in compiled.names]
+        for name in unknown[:MAX_UNKNOWN_PARAMETER_FINDINGS]:
+            findings.append(Finding(
+                UNKNOWN_PARAMETER, name,
+                'not declared by this endpoint', body[name]))
+        if len(unknown) > MAX_UNKNOWN_PARAMETER_FINDINGS:
+            findings.append(Finding(
+                UNKNOWN_PARAMETER, '(overflow)',
+                '%d further undeclared keys not reported individually'
+                % (len(unknown) - MAX_UNKNOWN_PARAMETER_FINDINGS)))
 
     supplied = dict(body)
     supplied.update(query)
@@ -316,7 +347,22 @@ def check(compiled: CompiledEndpoint, body: dict[str, Any],
 
     if not compiled.raw_body:
         findings.extend(_schema_findings(compiled.body, body))
-    findings.extend(_schema_findings(compiled.query, query))
+
+    # Query-declared parameters are checked against the merged view the
+    # json_or_query loader reads, body authoritative, mirroring
+    # _load_json_or_query's precedence. The shipped client serialises
+    # every request to a JSON body and never builds a query string, so
+    # checking the query string alone would systematically miss type
+    # mismatches from the API's dominant caller -- and a body-supplied
+    # value for a query-declared name is not an unknown parameter
+    # (names is location-agnostic), so nothing else reports it either.
+    if compiled.query is not None:
+        query_supplied = dict(query)
+        if not compiled.raw_body:
+            for name in compiled.query.fields:
+                if name in body:
+                    query_supplied[name] = body[name]
+        findings.extend(_schema_findings(compiled.query, query_supplied))
 
     for name in sorted(collisions):
         findings.append(Finding(

--- a/shakenfist/external_api/validation.py
+++ b/shakenfist/external_api/validation.py
@@ -218,3 +218,124 @@ def build_registry(app: Any) -> dict[tuple[str, str], CompiledEndpoint]:
             out[(cls.__name__, method)] = compile_parameters(
                 specs.get('parameters', []))
     return out
+
+
+# ---------------------------------------------------------------------
+# Warn-only checking.
+#
+# Nothing below rejects anything while API_VALIDATION_MODE is 'warn',
+# which is the default and is what phase 3 ships. The findings are
+# recorded on flask.g and emitted once the response status is known,
+# because "what did this request return anyway" is what separates a
+# rejection enforcement would introduce from a status code it would
+# merely change -- and at validation time that is not yet known.
+
+# The request-scoped hand-off, named like base.py's
+# _RECORDED_EXCEPTION_FIELDS because it is the same pattern.
+VALIDATION_FINDINGS = 'sf_validation_findings'
+BODY_PATH_COLLISIONS = 'sf_body_path_collisions'
+
+# Reason codes. Counted separately because they answer different
+# questions: see the table in the phase 3 plan.
+UNKNOWN_PARAMETER = 'unknown-parameter'
+TYPE_MISMATCH = 'type-mismatch'
+MISSING_REQUIRED = 'missing-required'
+BODY_PATH_COLLISION = 'body-path-collision'
+
+
+class Finding:
+    """One thing validation would have refused.
+
+    Carries the offending value's *type* and never its value: decision
+    D5, and several of these routes carry credentials, which is why
+    log_request drops the whole body on a credential-handling route
+    rather than naming fields.
+    """
+
+    def __init__(self, reason: str, parameter: str, detail: str,
+                 value: Any = None):
+        self.reason = reason
+        self.parameter = parameter
+        self.detail = detail
+        self.value_type = type(value).__name__ if value is not None else None
+
+    def fields(self) -> dict[str, Any]:
+        return {
+            'validation-reason': self.reason,
+            'validation-parameter': self.parameter,
+            'validation-detail': self.detail,
+            'validation-value-type': self.value_type,
+        }
+
+
+def _schema_findings(schema: Optional[marshmallow.Schema],
+                     supplied: dict[str, Any]) -> list[Finding]:
+    if schema is None:
+        return []
+    known = {name: value for name, value in supplied.items()
+             if name in schema.fields}
+    findings = []
+    for parameter, messages in schema.validate(known).items():
+        findings.append(Finding(
+            TYPE_MISMATCH, str(parameter),
+            '; '.join(messages) if isinstance(messages, list)
+            else str(messages),
+            known.get(parameter)))
+    return findings
+
+
+def check(compiled: CompiledEndpoint, body: dict[str, Any],
+          query: dict[str, Any], collisions: set[str]) -> list[Finding]:
+    """Everything this request would have been refused for.
+
+    Pure, so it is testable without a request context, and so the
+    decorator is only responsible for deciding what to do with the
+    answer.
+    """
+    findings: list[Finding] = []
+
+    # An undeclared body key is already fatal when the request reaches
+    # its handler -- log_request merges every key into kwargs and no
+    # handler is variadic, so Python raises TypeError and the broad
+    # except in handle_authorization_exceptions returns it as a 400
+    # carrying interpreter text. Counting these is how phase 4 chooses
+    # between webargs' EXCLUDE and RAISE (decision D10).
+    if not compiled.raw_body:
+        for name in body:
+            if name not in compiled.names:
+                findings.append(Finding(
+                    UNKNOWN_PARAMETER, name,
+                    'not declared by this endpoint', body[name]))
+
+    supplied = dict(body)
+    supplied.update(query)
+    for name in sorted(compiled.required_names):
+        if name not in supplied and name not in compiled.path_names:
+            findings.append(Finding(
+                MISSING_REQUIRED, name, 'declared required but not supplied'))
+
+    if not compiled.raw_body:
+        findings.extend(_schema_findings(compiled.body, body))
+    findings.extend(_schema_findings(compiled.query, query))
+
+    for name in sorted(collisions):
+        findings.append(Finding(
+            BODY_PATH_COLLISION, name,
+            'a body key of this name overwrote the URL path parameter'))
+
+    return findings
+
+
+# Populated by install(), which app.py calls once every route is
+# mounted. A module global rather than something base.py builds,
+# because base.py is imported to define the endpoints and so cannot see
+# the finished app.
+REGISTRY: dict[tuple[str, str], CompiledEndpoint] = {}
+
+
+def install(app: Any) -> None:
+    """Compile every mounted handler. Call once, after the last route."""
+    REGISTRY.clear()
+    REGISTRY.update(build_registry(app))
+    LOG.with_fields({'handlers': len(REGISTRY)}).info(
+        'Compiled API parameter declarations')

--- a/shakenfist/tests/external_api/test_auth_universal.py
+++ b/shakenfist/tests/external_api/test_auth_universal.py
@@ -152,14 +152,44 @@ class DecoratorOrderingTestCase(base.ShakenFistTestCase):
         # authentication. In method_decorators the last entry is
         # outermost and therefore runs first, so authentication being
         # at index 0 puts it innermost of the class-level set.
+        #
+        # Asserted as an ordering rather than as authentication sitting
+        # at index 0, which is what this said while authentication was
+        # the innermost entry. Phase 3's request validation is now
+        # inside it -- deliberately, so an unauthenticated caller cannot
+        # probe an endpoint's schema -- and pinning the index would have
+        # made that read as a regression rather than as the property it
+        # is.
         decorators = api_base.Resource.method_decorators
-        self.assertEqual(
-            api_base._authenticate_unless_public, decorators[0],
-            'authentication must be first in the list, which makes it '
-            'the last class-level decorator to run and therefore the '
-            'closest to the endpoint body')
+        self.assertLess(
+            decorators.index(api_base._authenticate_unless_public),
+            decorators.index(api_base.log_request),
+            'authentication must sit inside log_request, so an attempt '
+            'is logged even when the caller turns out to be '
+            'unauthenticated')
         self.assertLess(
             decorators.index(api_base._authenticate_unless_public),
             decorators.index(api_base.handle_authorization_exceptions),
             'authentication must sit inside handle_authorization_'
             'exceptions so the errors it raises become responses')
+
+    def test_validation_runs_after_authentication(self):
+        """An unauthenticated caller must not be able to probe a schema.
+
+        Decision D3. Validation is innermost of the class-level set, so
+        it runs after authentication and before every per-method
+        decorator -- which is also why enforcing it in phase 4 will
+        answer ahead of the 404s those decorators produce.
+        """
+        decorators = api_base.Resource.method_decorators
+
+        self.assertEqual(
+            api_base.validate_request, decorators[0],
+            'request validation must be first in the list, which makes '
+            'it the last class-level decorator to run')
+        self.assertLess(
+            decorators.index(api_base.validate_request),
+            decorators.index(api_base._authenticate_unless_public),
+            'validation must run after authentication, so an '
+            'unauthenticated caller cannot learn what an endpoint '
+            'accepts by watching which errors it returns')

--- a/shakenfist/tests/external_api/test_derivation_generator.py
+++ b/shakenfist/tests/external_api/test_derivation_generator.py
@@ -1,0 +1,273 @@
+# Copyright 2019 Michael Still and contributors
+
+"""Generate the derivation's input space rather than sampling it.
+
+Phase 1 of PLAN-api-input-validation took five review rounds, and four
+of them found a defect in the machinery added by the round before: the
+Werkzeug converter regex, the ``flask.request.args`` fallback, the
+webargs scope leak, and an emptied parameter list. Every one was
+``declarations.py`` misreading source, and every one was a shape which
+did not occur anywhere in the tree -- so no amount of testing against
+the tree could have found them, and neither could mutating it, which
+only permutes shapes already present.
+
+While the declarations are documentation a misread costs a wrong line
+in the published API. Once phase 3 compiles them, the same misread
+rejects a valid request: a ``path`` parameter derived as ``body``
+produces a schema hunting the JSON body for a URL segment, and D6's
+query-string fallback is granted only to parameters derived as
+``query``. That is why this is a precondition for compiling rather
+than a step in it.
+
+The oracle is free because each case is *constructed* knowing where
+its parameter comes from, which is what makes this different from
+mutating declarations in the tree: ``audit()`` derives the truth and
+compares, so flipping a declared location and asserting drift tests the
+comparison. Every real defect was on the other side of that comparison,
+in the derivation.
+
+Three axes are crossed rather than sampled, because the defects were in
+how the sources interact -- one axis reporting a problem must not stop
+another from deriving, and one axis deriving must not stop another from
+reporting. The fourth axis in the plan, declaration well-formedness, is
+about reading the declaration rather than deriving the location and is
+covered case-by-case in test_parameter_declarations.py.
+"""
+
+import itertools
+import os
+import shutil
+import tempfile
+
+from shakenfist.external_api import declarations
+from shakenfist.tests import base
+
+
+# Each axis value is (label, fragments, derives, problem).
+#
+# ``derives`` is what this value alone contributes to the derivation:
+# 'path', 'query' or None. ``problem`` is a substring of the report
+# ``audit()`` must produce for it, or None when the value is readable.
+# The expected outcome of a case is composed from the three, which is
+# the whole point -- an axis is not allowed to mask another.
+
+ROUTES = [
+    ('no path parameter',
+     "api.add_resource(FakeEndpoint, '/fakes')",
+     None, None),
+    ('bare name',
+     "api.add_resource(FakeEndpoint, '/fakes/<alpha>')",
+     'path', None),
+    # The converter forms are here because a bare <([a-z_]+)> regex
+    # missed them, silently skipping three LabelEndpoint declarations.
+    ('path converter',
+     "api.add_resource(FakeEndpoint, '/fakes/<path:alpha>')",
+     'path', None),
+    ('int converter with arguments',
+     "api.add_resource(FakeEndpoint, '/fakes/<int(min=1):alpha>')",
+     'path', None),
+    # An unreadable route must not merely be skipped: skipping empties
+    # the class's route set, which derives every one of its parameters
+    # to 'body' and sends the fixer to rewrite a correct 'path'.
+    ('non-literal route',
+     "ROUTE = '/fakes/<alpha>'\napi.add_resource(FakeEndpoint, ROUTE)",
+     None, 'mounted on a route this cannot read'),
+]
+
+WEBARGS = [
+    ('no use_kwargs', '', '', None, None),
+    ('schema on the class',
+     "    get_args = {'alpha': None}\n",
+     "    @use_kwargs(get_args, location='query')\n",
+     'query', None),
+    ('schema on the module',
+     '', "    @use_kwargs(get_args, location='query')\n",
+     'query', None),
+    # An inline dict is readable as a dict but is not a name any scope
+    # defines, so the keys cannot be attributed to a scope; reported
+    # rather than resolved to nothing.
+    ('inline dict schema',
+     '', "    @use_kwargs({'alpha': None}, location='query')\n",
+     None, 'schema this cannot resolve'),
+    # Bound at json rather than query: not a query parameter, and the
+    # earlier class-wide scan derived it as one anyway.
+    ('schema bound at json',
+     "    get_args = {'alpha': None}\n",
+     "    @use_kwargs(get_args, location='json')\n",
+     None, None),
+    # D6's fallback location. A query schema too -- reading it as "not
+    # query" would send the fixer to rewrite the very declarations
+    # issue 3629's fix made true.
+    ('schema bound at json_or_query',
+     "    get_args = {'alpha': None}\n",
+     "    @use_kwargs(get_args, location='json_or_query')\n",
+     'query', None),
+    # The next three are the scope-resolution shapes. The module always
+    # defines get_args = {'alpha': None}, so each of these asks whether
+    # the class-level definition really wins. Under the original
+    # cross-scope leak -- and under a first-definition-to-yield-a-key
+    # rule, which is the same leak with an extra step -- alpha would be
+    # derived 'query' from the module in all three.
+    ('empty schema on the class',
+     '    get_args = {}\n',
+     "    @use_kwargs(get_args, location='query')\n",
+     None, None),
+    ('class schema shadowing the module',
+     "    get_args = {'beta': None}\n",
+     "    @use_kwargs(get_args, location='query')\n",
+     None, None),
+    # Defined but not as a dict literal: reported by name rather than
+    # falling through to the module, because 'not found' and 'cannot
+    # read this' must not share an answer.
+    ('unreadable schema on the class',
+     '    get_args = OTHER\n',
+     "    @use_kwargs(get_args, location='query')\n",
+     None, 'is assigned something this cannot read'),
+]
+
+REQUEST_ARGS = [
+    ('no request.args read', '        pass\n', None, None),
+    ('.get() with a literal',
+     "        flask.request.args.get('alpha')\n", 'query', None),
+    ('literal subscript',
+     "        flask.request.args['alpha']\n", 'query', None),
+    # .args on something which is not the request. Contributes nothing
+    # and is not a problem: the walk must not claim every attribute
+    # named args.
+    ('args on a non-request object',
+     "        helper.args.get('alpha')\n", None, None),
+    # A key the walk cannot name. Reported, because deriving 'body'
+    # from it is the confident wrong answer this module refuses.
+    ('.get() with a non-literal key',
+     '        flask.request.args.get(KEY)\n',
+     None, 'key which is not a literal'),
+]
+
+MODULE = '''import flask
+from flasgger import swag_from
+from webargs.flaskparser import use_kwargs
+
+from shakenfist.external_api import base as api_base
+
+KEY = 'alpha'
+OTHER = {'alpha': None}
+get_args = {'alpha': None}
+
+
+class FakeEndpoint(api_base.Resource):
+%(class_level)s
+    @swag_from(api_base.swagger_helper(
+        'fakes', 'A fake.',
+        [('alpha', '%(location)s', 'string', 'A parameter.', %(required)s)],
+        []))
+%(decorator)sdef get(self, alpha=None):
+%(body)s'''
+
+
+class DerivationGeneratorTestCase(base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+        self.tempdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tempdir)
+
+    def _write(self, name, source):
+        with open(os.path.join(self.tempdir, name), 'w',
+                  encoding='utf-8') as f:
+            f.write(source)
+
+    def _build(self, route, webargs, request_args, location):
+        _, mount, _, _ = route
+        _, class_level, decorator, _, _ = webargs
+        _, body, _, _ = request_args
+
+        self._write('app.py', mount + '\n')
+        self._write('fake.py', MODULE % {
+            'class_level': class_level,
+            'decorator': decorator + '    ' if decorator else '    ',
+            'location': location,
+            # Phase 1's rule: a path parameter is always required.
+            'required': location == 'path',
+            'body': body,
+        })
+
+    @staticmethod
+    def _expected(route, webargs, request_args):
+        derives = [axis[-2] for axis in (route, webargs, request_args)]
+        if 'path' in derives:
+            location = 'path'
+        elif 'query' in derives:
+            location = 'query'
+        else:
+            location = 'body'
+        problems = {axis[-1] for axis in (route, webargs, request_args)}
+        return location, problems - {None}
+
+    def test_every_combination_derives_what_it_was_built_to_mean(self):
+        """The cross product, with the declaration written to match.
+
+        Each case declares its parameter at the location the case was
+        constructed to produce, so an empty ``drifted`` means the
+        derivation agreed with the construction. The problems assertion
+        is exact in both directions: a missing report is a source read
+        with false confidence, and an extra one is a source the audit
+        would refuse to derive from for no reason -- which, because the
+        fixer and the pre-commit hook both stop on any problem, would
+        block a clean tree.
+        """
+        cases = list(itertools.product(ROUTES, WEBARGS, REQUEST_ARGS))
+        # Pinned so that dropping an axis value is a failure rather than
+        # a quietly smaller cross product.
+        self.assertEqual(
+            len(ROUTES) * len(WEBARGS) * len(REQUEST_ARGS), len(cases))
+        self.assertEqual(225, len(cases))
+
+        for route, webargs, request_args in cases:
+            label = '%s + %s + %s' % (route[0], webargs[0], request_args[0])
+            with self.subTest(label):
+                location, want_problems = self._expected(
+                    route, webargs, request_args)
+                self._build(route, webargs, request_args, location)
+
+                drifted, underivable, problems = declarations.audit(
+                    self.tempdir)
+
+                self.assertEqual(
+                    [], [(d.name, d.location, want) for d, want in drifted],
+                    '%s: declared %s, which is what this case was built to '
+                    'mean, but the derivation disagreed' % (label, location))
+                self.assertEqual([], underivable, label)
+
+                for fragment in want_problems:
+                    self.assertTrue(
+                        any(fragment in p for p in problems),
+                        '%s: expected a problem containing %r, got %s'
+                        % (label, fragment, problems))
+                self.assertEqual(
+                    len(want_problems), len(problems),
+                    '%s: expected %d problem(s), got %s'
+                    % (label, len(want_problems), problems))
+
+    def test_a_wrong_declaration_drifts_in_every_combination(self):
+        """The comparison, which is the other side of the assertion above.
+
+        Written as its own pass rather than folded into the one above:
+        that one holds ``drifted`` empty, so on its own it cannot
+        distinguish a derivation which is right from one which returns
+        the declared value. Declaring the one location the case cannot
+        mean must always drift.
+        """
+        for route, webargs, request_args in itertools.product(
+                ROUTES, WEBARGS, REQUEST_ARGS):
+            label = '%s + %s + %s' % (route[0], webargs[0], request_args[0])
+            with self.subTest(label):
+                location, _ = self._expected(route, webargs, request_args)
+                wrong = 'query' if location != 'query' else 'body'
+                self._build(route, webargs, request_args, wrong)
+
+                drifted, _, _ = declarations.audit(self.tempdir)
+
+                self.assertEqual(
+                    [(wrong, location)],
+                    [(d.location, want) for d, want in drifted],
+                    '%s: declared %s where the case means %s, and the audit '
+                    'did not report drift' % (label, wrong, location))

--- a/shakenfist/tests/external_api/test_parameter_declarations.py
+++ b/shakenfist/tests/external_api/test_parameter_declarations.py
@@ -1555,7 +1555,7 @@ class SwaggerHelperValidationTestCase(base.ShakenFistTestCase):
                   {'pattern': '('})],
                 # Patterns which are not ^...$ anchored. JSON Schema
                 # pattern is an unanchored search while the compiled
-                # marshmallow validator uses re.match, and full
+                # validator requires the whole value to match, and full
                 # anchoring is the only form the two read identically.
                 [('thing', 'body', 'string', 'A thing.', False,
                   {'pattern': 'a+'})],
@@ -1563,6 +1563,11 @@ class SwaggerHelperValidationTestCase(base.ShakenFistTestCase):
                   {'pattern': '^a+'})],
                 [('thing', 'body', 'string', 'A thing.', False,
                   {'pattern': 'a+$'})],
+                # A top-level alternation escapes the anchors: ^a|b$ is
+                # (^a)|(b$), anchored on neither branch. A grouped
+                # alternation like ^(a|b)$ is fine.
+                [('thing', 'body', 'string', 'A thing.', False,
+                  {'pattern': '^a|b$'})],
                 # A sixth element which is not a dictionary, in the
                 # shape that used to be a wrong-arity case.
                 [('thing', 'body', 'string', 'A thing.', False, 1)],

--- a/shakenfist/tests/external_api/test_parameter_declarations.py
+++ b/shakenfist/tests/external_api/test_parameter_declarations.py
@@ -1553,6 +1553,16 @@ class SwaggerHelperValidationTestCase(base.ShakenFistTestCase):
                 # A pattern which does not compile.
                 [('thing', 'body', 'string', 'A thing.', False,
                   {'pattern': '('})],
+                # Patterns which are not ^...$ anchored. JSON Schema
+                # pattern is an unanchored search while the compiled
+                # marshmallow validator uses re.match, and full
+                # anchoring is the only form the two read identically.
+                [('thing', 'body', 'string', 'A thing.', False,
+                  {'pattern': 'a+'})],
+                [('thing', 'body', 'string', 'A thing.', False,
+                  {'pattern': '^a+'})],
+                [('thing', 'body', 'string', 'A thing.', False,
+                  {'pattern': 'a+$'})],
                 # A sixth element which is not a dictionary, in the
                 # shape that used to be a wrong-arity case.
                 [('thing', 'body', 'string', 'A thing.', False, 1)],

--- a/shakenfist/tests/external_api/test_request_validation.py
+++ b/shakenfist/tests/external_api/test_request_validation.py
@@ -1,0 +1,204 @@
+# Copyright 2019 Michael Still and contributors
+
+"""Warn-only request validation.
+
+Phase 3 PR 3. The property that matters most here is a negative one:
+with API_VALIDATION_MODE at its default of 'warn', no request behaves
+differently than it did before this layer existed. The findings are
+recorded and logged; nothing acts on them until phase 4.
+"""
+
+from unittest import mock
+
+from shakenfist.config import config
+from shakenfist.external_api import app as external_api
+from shakenfist.external_api import base as api_base
+from shakenfist.external_api import validation
+from shakenfist.tests import base
+
+
+class RequestValidationTestCase(base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+        external_api.TESTING = True
+        external_api.app.testing = True
+
+        self.saved_node_uuid = config.NODE_UUID
+        self.saved_mode = config.API_VALIDATION_MODE
+        config.NODE_UUID = 'test-node-uuid'
+        self.addCleanup(self._restore)
+
+        self.client = external_api.app.test_client()
+        self.namespace = mock.MagicMock()
+        self.namespace.uuid = 'ns-uuid'
+
+    def _restore(self):
+        config.NODE_UUID = self.saved_node_uuid
+        config.API_VALIDATION_MODE = self.saved_mode
+
+    def _post_auth(self, body):
+        """POST /auth, which is @public and declares two body parameters.
+
+        Public so no token is needed, and the namespace lookup is
+        mocked so the request reaches its handler rather than being
+        short-circuited into a 404 -- which is itself one of the things
+        this phase measures.
+        """
+        findings = []
+        real = validation.check
+
+        def spy(*args, **kwargs):
+            out = real(*args, **kwargs)
+            findings.extend(out)
+            return out
+
+        with mock.patch.object(validation, 'check', spy), \
+                mock.patch('shakenfist.namespace.Namespace.from_db',
+                           return_value=self.namespace):
+            response = self.client.post('/auth', json=body)
+        return response, findings
+
+    def test_warn_mode_changes_no_response(self):
+        """The whole point of the phase.
+
+        A body carrying an undeclared key produces a finding, and the
+        response is byte for byte what it was before validation
+        existed: the 400 log_request's merge has always produced, with
+        the interpreter's own text. Phase 4 replaces that message; phase
+        3 must not.
+        """
+        response, findings = self._post_auth(
+            {'namespace': 'sys', 'key': 'k', 'zzz': 1})
+
+        self.assertEqual(
+            [validation.UNKNOWN_PARAMETER], [f.reason for f in findings])
+        self.assertEqual(400, response.status_code)
+        self.assertIn(
+            'unexpected keyword argument', response.get_json()['error'])
+
+    def test_a_clean_request_produces_no_findings(self):
+        """Otherwise every request is a finding and the log says nothing."""
+        response, findings = self._post_auth({'namespace': 'sys', 'key': 'k'})
+
+        self.assertEqual([], findings)
+        # 401 because the mocked namespace has no matching key. What
+        # matters is that validation did not intervene.
+        self.assertEqual(401, response.status_code)
+
+    def test_a_body_uuid_is_an_ordinary_undeclared_parameter(self):
+        """Decision D11: the passed_uuid remap is gone.
+
+        It renamed a body `uuid` to a kwarg no handler in the tree
+        accepts and no declaration names, so `{"uuid": ...}` was a
+        guaranteed 400 carrying interpreter text on every endpoint --
+        not the collision dodge decision D8 cites it as. Reported as
+        what it is instead.
+        """
+        _, findings = self._post_auth(
+            {'namespace': 'sys', 'key': 'k', 'uuid': 'x'})
+
+        self.assertEqual(
+            [(validation.UNKNOWN_PARAMETER, 'uuid')],
+            [(f.reason, f.parameter) for f in findings])
+
+    def test_a_wrong_type_is_reported(self):
+        response, findings = self._post_auth(
+            {'namespace': 'sys', 'key': 5})
+
+        self.assertEqual(
+            [(validation.TYPE_MISMATCH, 'key')],
+            [(f.reason, f.parameter) for f in findings])
+        # Unchanged: the handler's own guard answered, not validation.
+        self.assertEqual(400, response.status_code)
+
+    def test_a_finding_records_the_type_and_never_the_value(self):
+        """Decision D5. Several of these routes carry credentials, which
+        is why log_request drops the whole body on one rather than
+        naming fields."""
+        _, findings = self._post_auth({'namespace': 'sys', 'key': 5})
+
+        fields = findings[0].fields()
+        self.assertEqual('int', fields['validation-value-type'])
+        self.assertNotIn(
+            '5', str(fields), 'a finding must not carry the value')
+
+    def test_enforce_mode_answers_in_the_api_error_shape(self):
+        """Phase 4's switch, present from the start so the flip is
+        configuration rather than a code change. webargs' own 422 shape
+        is not what this API returns."""
+        config.API_VALIDATION_MODE = 'enforce'
+
+        response, _ = self._post_auth(
+            {'namespace': 'sys', 'key': 'k', 'zzz': 1})
+
+        self.assertEqual(400, response.status_code)
+        body = response.get_json()
+        self.assertEqual(400, body['status'])
+        self.assertTrue(body['error'].startswith('zzz: '), body['error'])
+        self.assertNotIn('unexpected keyword argument', body['error'])
+
+    def test_check_is_pure(self):
+        """The decision is separable from the request context, which is
+        what lets the interesting cases be tested without one."""
+        compiled = validation.CompiledEndpoint(
+            body=None, query=None, path_names={'thing_ref'},
+            required_names={'thing_ref'}, raw_body=False)
+
+        self.assertEqual([], validation.check(compiled, {}, {}, set()))
+
+        findings = validation.check(compiled, {}, {}, {'thing_ref'})
+        self.assertEqual(
+            [(validation.BODY_PATH_COLLISION, 'thing_ref')],
+            [(f.reason, f.parameter) for f in findings])
+
+    def test_a_raw_body_is_never_reported(self):
+        """Upload bodies are bytes. Every key of a JSON body would
+        otherwise be undeclared, so an upload would be one long finding
+        in warn mode and rejected outright in enforce."""
+        compiled = validation.REGISTRY[('UploadDataEndpoint', 'post')]
+
+        self.assertTrue(compiled.raw_body)
+        self.assertEqual(
+            [], validation.check(compiled, {'anything': 1}, {}, set()))
+
+    def test_undocumented_endpoints_are_not_validated(self):
+        """Root, Livez and Readyz compile to nothing, and a request to
+        one must pass through rather than fail a lookup."""
+        self.assertNotIn(('Root', 'get'), validation.REGISTRY)
+
+        self.assertEqual(200, self.client.get('/').status_code)
+
+    def test_validation_is_innermost(self):
+        """Restated here as well as in test_auth_universal, because this
+        is the file which explains why: being innermost is what makes
+        func a bound method, so the endpoint class is readable without
+        depending on attribute propagation through decorators in
+        base.py which predate functools.wraps."""
+        self.assertEqual(
+            api_base.validate_request,
+            api_base.Resource.method_decorators[0])
+
+    def test_webargs_failures_use_the_api_error_shape(self):
+        """Decision D4, and a defect fixed on the way past.
+
+        No webargs error handler was registered before phase 3, so the
+        four @use_kwargs sites answered a bad query parameter with
+        webargs' default: 422, carrying {"json": {"field": [...]}} --
+        the wrong status, and the only responses in the API which are
+        not {"error": ..., "status": ...}. Nothing about *what* is
+        rejected changes.
+        """
+        import werkzeug
+        from marshmallow import ValidationError
+
+        with external_api.app.test_request_context('/'):
+            with self.assertRaises(werkzeug.exceptions.HTTPException) as caught:
+                api_base._webargs_error(
+                    ValidationError({'query': {'limit': ['Not a valid integer.']}}),
+                    None, None, error_status_code=422, error_headers=None)
+
+        response = caught.exception.get_response()
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            {'error': 'limit: Not a valid integer.', 'status': 400},
+            response.get_json())

--- a/shakenfist/tests/external_api/test_request_validation.py
+++ b/shakenfist/tests/external_api/test_request_validation.py
@@ -8,13 +8,17 @@ differently than it did before this layer existed. The findings are
 recorded and logged; nothing acts on them until phase 4.
 """
 
+import json
 from unittest import mock
+
+import shakenfist_utilities.api as sf_utils_api
 
 from shakenfist.config import config
 from shakenfist.external_api import app as external_api
 from shakenfist.external_api import base as api_base
 from shakenfist.external_api import validation
 from shakenfist.tests import base
+from shakenfist.tests.mock_mariadb import MockMariaDB
 
 
 class RequestValidationTestCase(base.ShakenFistTestCase):
@@ -151,6 +155,73 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
             [(validation.BODY_PATH_COLLISION, 'thing_ref')],
             [(f.reason, f.parameter) for f in findings])
 
+    def test_check_tolerates_a_non_dict_body(self):
+        """A warn-only layer must never raise from inside itself.
+
+        log_request refuses a non-object body before validation runs,
+        so a dict is what arrives in practice -- but check() is pure
+        and independently callable, and iterating a list body on trust
+        raised from inside the validator.
+        """
+        compiled = validation.CompiledEndpoint(
+            body=None, query=None, path_names=set(),
+            required_names=set(), raw_body=False)
+
+        for body in (['ab', 'cd'], 'abc', 5, None):
+            with self.subTest(body=body):
+                self.assertEqual(
+                    [], validation.check(compiled, body, {}, set()))
+
+    def test_unknown_parameter_findings_are_capped(self):
+        """Unknown body keys are bounded only by what a caller sends,
+        and each finding is a log line shipped to centralised logging.
+        The overflow is one summarising finding carrying the count, so
+        the measurement still learns the request happened."""
+        compiled = validation.CompiledEndpoint(
+            body=None, query=None, path_names=set(),
+            required_names=set(), raw_body=False)
+        body = {'key%03d' % i: i for i in range(50)}
+
+        findings = validation.check(compiled, body, {}, set())
+
+        self.assertEqual(
+            validation.MAX_UNKNOWN_PARAMETER_FINDINGS + 1, len(findings))
+        overflow = findings[-1]
+        self.assertEqual(validation.UNKNOWN_PARAMETER, overflow.reason)
+        self.assertEqual('(overflow)', overflow.parameter)
+        self.assertIn(
+            '%d further undeclared keys'
+            % (50 - validation.MAX_UNKNOWN_PARAMETER_FINDINGS),
+            overflow.detail)
+
+    def test_a_parameter_name_is_truncated(self):
+        """The name is as client-supplied as the value on the
+        unknown-parameter path: without a bound one request could put
+        megabytes into a log line and, in enforce mode, into the
+        response."""
+        finding = validation.Finding(
+            validation.UNKNOWN_PARAMETER, 'x' * 500, 'detail')
+
+        self.assertEqual(
+            validation.MAX_PARAMETER_NAME, len(finding.parameter))
+
+    def test_a_body_supplied_query_parameter_is_type_checked(self):
+        """The shipped client serialises every request to a JSON body
+        and never builds a query string, so a query-declared parameter
+        checked against the query string alone is never checked for
+        the API's dominant caller. check() mirrors the json_or_query
+        loader's merged, body-authoritative view instead."""
+        compiled = validation.REGISTRY[
+            ('InstanceOutstandingOperationsEndpoint', 'get')]
+        self.assertIn('all', compiled.query.fields)
+
+        findings = validation.check(
+            compiled, {'all': 'banana'}, {}, set())
+
+        self.assertEqual(
+            [(validation.TYPE_MISMATCH, 'all')],
+            [(f.reason, f.parameter) for f in findings])
+
     def test_a_raw_body_is_never_reported(self):
         """Upload bodies are bytes. Every key of a JSON body would
         otherwise be undeclared, so an upload would be one long finding
@@ -181,12 +252,18 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
     def test_webargs_failures_use_the_api_error_shape(self):
         """Decision D4, and a defect fixed on the way past.
 
-        No webargs error handler was registered before phase 3, so the
-        four @use_kwargs sites answered a bad query parameter with
-        webargs' default: 422, carrying {"json": {"field": [...]}} --
-        the wrong status, and the only responses in the API which are
-        not {"error": ..., "status": ...}. Nothing about *what* is
-        rejected changes.
+        No webargs error handler was registered before phase 3, and
+        webargs' default 422 abort was swallowed into a 500 by
+        suppress_exceptions_to_client's bare except -- so the four
+        @use_kwargs sites answered a bad query parameter with a server
+        error, a traceback in the log and an exception record on disk.
+        Nothing about *what* is rejected changes.
+
+        This exercises the handler in isolation, which asserts the
+        response it builds and nothing about what a client sees; the
+        first review round proved those are different questions. The
+        request-level assertion lives in
+        AuthenticatedValidationTestCase.
         """
         import werkzeug
         from marshmallow import ValidationError
@@ -202,3 +279,152 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
         self.assertEqual(
             {'error': 'limit: Not a valid integer.', 'status': 400},
             response.get_json())
+
+    def test_a_non_object_body_is_still_a_400(self):
+        """A JSON body which is not an object has always been a 400.
+
+        The per-key merge this phase replaced raised TypeError for one,
+        which handle_authorization_exceptions answers as 400.
+        dict.update would instead raise ValueError for most of these
+        (a 500, since nothing catches ValueError) -- and would silently
+        merge a list of two-character strings as key/value pairs, which
+        is an unintended input path into the kwargs merge. The explicit
+        guard keeps all of them a 400.
+        """
+        for payload in (['a', 'b'], 'abc', ['ab', 'cd'], 5):
+            with self.subTest(payload=payload):
+                response = self.client.post(
+                    '/auth', data=json.dumps(payload),
+                    content_type='application/json')
+
+                self.assertEqual(400, response.status_code)
+                self.assertEqual(
+                    'the request body must be a JSON object',
+                    response.get_json()['error'])
+
+    def test_findings_are_emitted_with_the_response_status(self):
+        """The after_request hook is the deliverable: a finding line
+        carrying what the request returned anyway is what separates a
+        rejection enforcement would introduce from a status code it
+        would merely change."""
+        with mock.patch.object(external_api, 'LOG') as log:
+            response, findings = self._post_auth(
+                {'namespace': 'sys', 'key': 'k', 'zzz': 1})
+
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(1, len(findings))
+
+        emitted = [c.args[0] for c in log.with_fields.call_args_list
+                   if 'validation-reason' in c.args[0]]
+        self.assertEqual(1, len(emitted))
+        self.assertEqual(
+            validation.UNKNOWN_PARAMETER, emitted[0]['validation-reason'])
+        self.assertEqual(400, emitted[0]['validation-response-status'])
+        self.assertEqual('warn', emitted[0]['validation-mode'])
+
+    def test_findings_do_not_leak_between_requests(self):
+        """flask.g is request scoped by contract; this pins that a
+        clean request after a finding-producing one emits nothing."""
+        _, findings = self._post_auth(
+            {'namespace': 'sys', 'key': 'k', 'zzz': 1})
+        self.assertEqual(1, len(findings))
+
+        with mock.patch.object(external_api, 'LOG') as log:
+            _, findings = self._post_auth({'namespace': 'sys', 'key': 'k'})
+
+        self.assertEqual([], findings)
+        emitted = [c.args[0] for c in log.with_fields.call_args_list
+                   if 'validation-reason' in c.args[0]]
+        self.assertEqual([], emitted)
+
+
+class AuthenticatedValidationTestCase(base.ShakenFistTestCase):
+    """Request-level properties which need the full decorator stack.
+
+    The first review round found the deployed behaviour and the
+    behaviour of a handler tested in isolation were different answers:
+    _webargs_error built a perfect 400 which
+    suppress_exceptions_to_client then swallowed into a 500. Everything
+    here therefore drives a real authenticated request end to end and
+    asserts only what a client sees or what actually reached a spy.
+    """
+
+    def setUp(self):
+        super().setUp()
+        external_api.TESTING = True
+        external_api.app.testing = True
+
+        self.mock_mariadb = MockMariaDB(self, node_count=1)
+        self.mock_mariadb.setup()
+        self.mock_mariadb.create_namespace('system', 'key1', 'bar')
+
+        self.client = external_api.app.test_client()
+        resp = self.client.post(
+            '/auth',
+            data=json.dumps({'namespace': 'system', 'key': 'bar'}))
+        self.assertEqual(200, resp.status_code)
+        self.token = 'Bearer %s' % resp.get_json()['access_token']
+
+    def test_a_webargs_failure_answers_400_through_the_real_stack(self):
+        """The whole journey: use_kwargs raises, _webargs_error aborts
+        with a crafted response, record_exception declines to record
+        it, and suppress_exceptions_to_client returns it instead of
+        swallowing it into a 500."""
+        with mock.patch.object(
+                api_base.util_exceptions, 'record_exception') as recorded:
+            response = self.client.get(
+                '/blobs/00000000-0000-0000-0000-000000000000/data'
+                '?limit=notanint',
+                headers={'Authorization': self.token})
+
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            {'error': 'limit: Not a valid integer.', 'status': 400},
+            response.get_json())
+        # A malformed query parameter is a client error, not something
+        # to write under /srv/shakenfist/exceptions/ on every request.
+        recorded.assert_not_called()
+
+    def test_a_raw_body_is_not_parsed_as_json(self):
+        """An upload body is arbitrary binary of arbitrary size, and
+        flask_get_post_body() attempts two full JSON parses of a body
+        which is not JSON. log_request pays that once today; the
+        validator must not pay it again for a result check() would
+        discard anyway."""
+        real = sf_utils_api.flask_get_post_body
+        with mock.patch.object(
+                sf_utils_api, 'flask_get_post_body',
+                mock.Mock(wraps=real)) as spy:
+            self.client.post(
+                '/upload/00000000-0000-0000-0000-000000000000',
+                data=b'\x00\x01\x02 not json',
+                headers={'Authorization': self.token})
+
+        self.assertEqual(1, spy.call_count)
+
+    def test_a_body_path_collision_is_recorded_through_the_stack(self):
+        """The log_request -> flask.g -> validate_request hand-off,
+        driven by a real request rather than a hand-constructed
+        CompiledEndpoint: a body key shadowing a path parameter is
+        recorded where the overwrite happens and reported by the
+        validator which runs after it."""
+        findings = []
+        real = validation.check
+
+        def spy(*args, **kwargs):
+            out = real(*args, **kwargs)
+            findings.extend(out)
+            return out
+
+        with mock.patch.object(validation, 'check', spy):
+            response = self.client.delete(
+                '/instances/nosuchinstance',
+                data=json.dumps({'instance_ref': 'adifferentinstance'}),
+                content_type='application/json',
+                headers={'Authorization': self.token})
+
+        self.assertIn(
+            (validation.BODY_PATH_COLLISION, 'instance_ref'),
+            [(f.reason, f.parameter) for f in findings])
+        # And warn mode changed nothing: the handler's own 404 answered.
+        self.assertEqual(404, response.status_code)

--- a/shakenfist/tests/external_api/test_request_validation.py
+++ b/shakenfist/tests/external_api/test_request_validation.py
@@ -11,8 +11,11 @@ recorded and logged; nothing acts on them until phase 4.
 import json
 from unittest import mock
 
+from marshmallow import ValidationError
 import shakenfist_utilities.api as sf_utils_api
+import werkzeug
 
+from shakenfist import exceptions
 from shakenfist.config import config
 from shakenfist.external_api import app as external_api
 from shakenfist.external_api import base as api_base
@@ -318,7 +321,25 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
             view_functions = {'a': view_a, 'b': view_b}
 
         self.assertRaises(
-            ValueError, validation.build_registry, FakeApp())
+            exceptions.InvalidAPIDeclaration,
+            validation.build_registry, FakeApp())
+
+    def test_a_pattern_requires_the_whole_value_to_match(self):
+        """Python's $ also matches before a trailing newline; ECMA-262's
+        does not. The compiled validator uses fullmatch so 'value\\n'
+        fails it exactly as it fails the published JSON Schema
+        pattern."""
+        compiled = validation.compile_parameters([
+            {'in': 'body', 'name': 'payload', 'schema': {
+                'type': 'object', 'properties': {
+                    'thing': {'type': 'string', 'pattern': '^a+$'}}}}])
+
+        self.assertEqual(
+            [], validation.check(compiled, {'thing': 'aaa'}, {}, set()))
+        findings = validation.check(compiled, {'thing': 'aaa\n'}, {}, set())
+        self.assertEqual(
+            [(validation.TYPE_MISMATCH, 'thing')],
+            [(f.reason, f.parameter) for f in findings])
 
     def test_a_body_supplied_query_parameter_is_type_checked(self):
         """The shipped client serialises every request to a JSON body
@@ -380,9 +401,6 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
         request-level assertion lives in
         AuthenticatedValidationTestCase.
         """
-        import werkzeug
-        from marshmallow import ValidationError
-
         with external_api.app.test_request_context('/'):
             with self.assertRaises(werkzeug.exceptions.HTTPException) as caught:
                 api_base._webargs_error(
@@ -461,6 +479,26 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
         self.assertEqual(1, len(emitted))
         self.assertEqual('enforce', emitted[0]['validation-mode'])
         self.assertEqual(400, emitted[0]['validation-response-status'])
+
+    def test_credential_routes_redact_the_parameter_name(self):
+        """/auth drops everything body-derived from its logs, and the
+        finding line is a third body-reading logger: a buggy caller
+        can put secret-bearing material in a key position, so the
+        parameter name is redacted where the other two loggers drop
+        the whole body. The reason code -- what the measurement needs
+        -- still rides out."""
+        with mock.patch.object(external_api, 'LOG') as log:
+            response, _ = self._post_auth(
+                {'namespace': 'sys', 'key': 'k', 'zzz': 1})
+
+        self.assertEqual(400, response.status_code)
+        emitted = [c.args[0] for c in log.with_fields.call_args_list
+                   if 'validation-reason' in c.args[0]]
+        self.assertEqual(1, len(emitted))
+        self.assertEqual(
+            validation.UNKNOWN_PARAMETER, emitted[0]['validation-reason'])
+        self.assertEqual('*****', emitted[0]['validation-parameter'])
+        self.assertNotIn('zzz', str(emitted[0]))
 
     def test_findings_do_not_leak_between_requests(self):
         """flask.g is request scoped by contract; this pins that a

--- a/shakenfist/tests/external_api/test_request_validation.py
+++ b/shakenfist/tests/external_api/test_request_validation.py
@@ -141,6 +141,58 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
         self.assertTrue(body['error'].startswith('zzz: '), body['error'])
         self.assertNotIn('unexpected keyword argument', body['error'])
 
+    def test_enforce_mode_never_rejects_missing_required(self):
+        """required is recorded and never enforced -- even in enforce
+        mode. Several parameters are declared required while omitting
+        them has always worked, so a missing-required finding is
+        telemetry for phase 6's decision, not grounds for rejection.
+        The second review round proved the first cut of the enforce
+        branch rejected on any finding, contradicting this three times
+        over in the documentation.
+        """
+        config.API_VALIDATION_MODE = 'enforce'
+
+        response, findings = self._post_auth({'namespace': 'sys'})
+
+        self.assertIn(
+            validation.MISSING_REQUIRED, [f.reason for f in findings])
+        # The handler's own guard answered, in its own words --
+        # validation did not preempt it.
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            'missing key in request', response.get_json()['error'])
+
+    def test_off_mode_disables_the_layer(self):
+        """The operator's safety valve: if the layer itself becomes the
+        problem -- log volume being the foreseeable case -- it can be
+        turned off without a downgrade. Off means check() never runs,
+        not merely that findings are discarded."""
+        config.API_VALIDATION_MODE = 'off'
+
+        response, findings = self._post_auth(
+            {'namespace': 'sys', 'key': 'k', 'zzz': 1})
+
+        self.assertEqual([], findings)
+        # And the request itself behaved exactly as it always did.
+        self.assertEqual(400, response.status_code)
+        self.assertIn(
+            'unexpected keyword argument', response.get_json()['error'])
+
+    def test_the_validator_does_not_refetch_the_body(self):
+        """The validator reads the body log_request stashed, so it
+        reports on exactly what the handler receives and a body which
+        is not JSON is not paid for twice."""
+        real = sf_utils_api.flask_get_post_body
+        with mock.patch.object(
+                sf_utils_api, 'flask_get_post_body',
+                mock.Mock(wraps=real)) as spy, \
+                mock.patch('shakenfist.namespace.Namespace.from_db',
+                           return_value=self.namespace):
+            self.client.post(
+                '/auth', json={'namespace': 'sys', 'key': 'k'})
+
+        self.assertEqual(1, spy.call_count)
+
     def test_check_is_pure(self):
         """The decision is separable from the request context, which is
         what lets the interesting cases be tested without one."""
@@ -204,6 +256,15 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
 
         self.assertEqual(
             validation.MAX_PARAMETER_NAME, len(finding.parameter))
+
+    def test_control_characters_are_stripped_from_names(self):
+        """The length bound alone would still let a newline in a key
+        forge extra fields in a log line or, in enforce mode, in the
+        response."""
+        finding = validation.Finding(
+            validation.UNKNOWN_PARAMETER, 'a\nfake-field=x\tb', 'detail')
+
+        self.assertEqual('afake-field=xb', finding.parameter)
 
     def test_a_body_supplied_query_parameter_is_type_checked(self):
         """The shipped client serialises every request to a JSON body

--- a/shakenfist/tests/external_api/test_request_validation.py
+++ b/shakenfist/tests/external_api/test_request_validation.py
@@ -266,6 +266,60 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
 
         self.assertEqual('afake-field=xb', finding.parameter)
 
+    def test_an_unrecognised_type_drops_its_bounds(self):
+        """A Range validator on a Raw field raises TypeError from
+        inside schema.validate() the moment it meets a value of an
+        uncoercible Python type -- out through check() and out of the
+        warn-only layer. An unrecognised type cannot meaningfully
+        carry a bound, so the bound is dropped with the type."""
+        compiled = validation.compile_parameters([
+            {'in': 'body', 'name': 'payload', 'schema': {
+                'type': 'object', 'properties': {
+                    'thing': {'type': 'wibble', 'minimum': 1,
+                              'maximum': 10}}}}])
+
+        self.assertEqual([], list(
+            compiled.body.fields['thing'].validators))
+        # And the whole path is exercised: a value no Range could
+        # compare against produces no findings and no exception.
+        self.assertEqual(
+            [], validation.check(
+                compiled, {'thing': 'abc'}, {}, set()))
+
+    def test_check_never_raises_even_if_a_schema_does(self):
+        """The class-closing guarantee behind the instance above: if
+        schema.validate() itself raises, the layer logs and reports
+        nothing rather than changing the response."""
+        compiled = validation.REGISTRY[('AuthEndpoint', 'post')]
+
+        with mock.patch.object(
+                type(compiled.body), 'validate',
+                side_effect=TypeError('validator exploded')):
+            self.assertEqual(
+                [], validation.check(
+                    compiled, {'namespace': 'sys', 'key': 'k'}, {}, set()))
+
+    def test_two_endpoint_classes_with_one_name_are_refused(self):
+        """The registry is keyed by bare class name, so a collision
+        would silently validate one endpoint's requests against the
+        other's schema -- and the completeness test collapses the
+        duplicate on both sides of its comparison. Refused loudly at
+        mount time instead."""
+        first = type('CollidingEndpoint', (), {})
+        second = type('CollidingEndpoint', (), {})
+
+        class FakeView:
+            pass
+
+        view_a, view_b = FakeView(), FakeView()
+        view_a.view_class, view_b.view_class = first, second
+
+        class FakeApp:
+            view_functions = {'a': view_a, 'b': view_b}
+
+        self.assertRaises(
+            ValueError, validation.build_registry, FakeApp())
+
     def test_a_body_supplied_query_parameter_is_type_checked(self):
         """The shipped client serialises every request to a JSON body
         and never builds a query string, so a query-declared parameter
@@ -383,6 +437,31 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
         self.assertEqual(400, emitted[0]['validation-response-status'])
         self.assertEqual('warn', emitted[0]['validation-mode'])
 
+    def test_enforced_rejections_still_emit_their_findings(self):
+        """An enforced rejection must not be silent in the log.
+
+        The third review round caught the enforce branch returning
+        before the findings were stashed, which would have turned the
+        measurement apparatus off at the exact moment phase 4 flips
+        the switch -- when an operator most needs to see which
+        parameter a refused request was refused for.
+        """
+        config.API_VALIDATION_MODE = 'enforce'
+
+        with mock.patch.object(external_api, 'LOG') as log:
+            response, _ = self._post_auth(
+                {'namespace': 'sys', 'key': 'k', 'zzz': 1})
+
+        self.assertEqual(400, response.status_code)
+        self.assertTrue(
+            response.get_json()['error'].startswith('zzz: '))
+
+        emitted = [c.args[0] for c in log.with_fields.call_args_list
+                   if 'validation-reason' in c.args[0]]
+        self.assertEqual(1, len(emitted))
+        self.assertEqual('enforce', emitted[0]['validation-mode'])
+        self.assertEqual(400, emitted[0]['validation-response-status'])
+
     def test_findings_do_not_leak_between_requests(self):
         """flask.g is request scoped by contract; this pins that a
         clean request after a finding-producing one emits nothing."""
@@ -462,6 +541,42 @@ class AuthenticatedValidationTestCase(base.ShakenFistTestCase):
                 headers={'Authorization': self.token})
 
         self.assertEqual(1, spy.call_count)
+
+    def test_a_finding_on_a_successful_request_changes_nothing(self):
+        """The phase's central promise, pinned on a 2xx.
+
+        Every other warn-mode test lands on a request that was already
+        failing, so none of them could catch the warn layer breaking
+        traffic that works today -- and a finding on a 200 is exactly
+        the population decision D10 is trying to size. A body key
+        shadowing its own path parameter with the same value is a
+        finding by construction and a no-op by construction, so the
+        response must be byte for byte the response of the same
+        request without the body.
+        """
+        findings = []
+        real = validation.check
+
+        def spy(*args, **kwargs):
+            out = real(*args, **kwargs)
+            findings.extend(out)
+            return out
+
+        headers = {'Authorization': self.token}
+        clean = self.client.get('/auth/namespaces/system', headers=headers)
+        self.assertEqual(200, clean.status_code)
+
+        with mock.patch.object(validation, 'check', spy):
+            response = self.client.get(
+                '/auth/namespaces/system',
+                data=json.dumps({'namespace': 'system'}),
+                content_type='application/json', headers=headers)
+
+        self.assertEqual(
+            [(validation.BODY_PATH_COLLISION, 'namespace')],
+            [(f.reason, f.parameter) for f in findings])
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(clean.get_data(), response.get_data())
 
     def test_a_body_path_collision_is_recorded_through_the_stack(self):
         """The log_request -> flask.g -> validate_request hand-off,

--- a/shakenfist/tests/external_api/test_validation_compiler.py
+++ b/shakenfist/tests/external_api/test_validation_compiler.py
@@ -1,0 +1,243 @@
+# Copyright 2019 Michael Still and contributors
+
+"""The compilation of declarations into request schemas.
+
+Phase 3 PR 2. Nothing validates yet, so these assertions are about
+whether the compiled schemas *describe* what the declarations say --
+which is the property phase 4 turns into rejections, and so the last
+point at which a mistake is cheap.
+"""
+
+import marshmallow
+from marshmallow import fields
+
+from shakenfist.config import config
+from shakenfist.external_api import app as external_api
+from shakenfist.external_api import base as api_base
+from shakenfist.external_api import declarations
+from shakenfist.external_api import validation
+from shakenfist.tests import base
+from shakenfist.tests.external_api.test_parameter_declarations import (
+    UNDOCUMENTED_BY_DESIGN)
+
+
+class ValidationCompilerTestCase(base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+        self.saved_node_uuid = config.NODE_UUID
+        config.NODE_UUID = 'test-node-uuid'
+        self.addCleanup(self._restore_node_uuid)
+        self.registry = validation.build_registry(external_api.app)
+
+    def _restore_node_uuid(self):
+        config.NODE_UUID = self.saved_node_uuid
+
+    def test_every_documented_handler_compiles(self):
+        """A mounted handler resolves to a schema, or is exempt by name.
+
+        The absence of a schema and the presence of an empty one are
+        different things, and only one of them is allowed to be silent.
+        Without this, a route mounted without a declaration would simply
+        not be validated -- absence indistinguishable from success,
+        which is the rule the audit was rewritten around.
+        """
+        mounted = set()
+        for view in external_api.app.view_functions.values():
+            cls = getattr(view, 'view_class', None)
+            if cls is None or not issubclass(cls, api_base.Resource):
+                continue
+            for method in ('get', 'post', 'put', 'delete', 'patch'):
+                if getattr(cls, method, None) is not None:
+                    mounted.add((cls.__name__, method))
+
+        uncompiled = mounted - set(self.registry)
+        self.assertEqual(
+            UNDOCUMENTED_BY_DESIGN, uncompiled,
+            'every mounted handler must compile to a schema or be listed '
+            'in UNDOCUMENTED_BY_DESIGN. Uncompiled and unlisted: %s'
+            % sorted(uncompiled - UNDOCUMENTED_BY_DESIGN))
+
+    def test_compiled_names_match_the_declared_names(self):
+        """The runtime compilation agrees with the static audit.
+
+        Two independent readings of the same declarations: this one
+        through swagger_helper() and flasgger at import time, the other
+        by parsing the source. They are the inputs to phase 4's
+        enforcement and to the fixer respectively, so a disagreement
+        between them is a parameter which is validated but not audited,
+        or audited but not validated.
+        """
+        for path, tree, cls, fn in declarations.handlers():
+            key = (cls.name, fn.name)
+            if key not in self.registry:
+                continue
+            declared = {d.name for d in declarations.declarations(fn)}
+            # The raw body marker names the whole body rather than a
+            # parameter within it, and compiles to a flag.
+            declared.discard(api_base.RAW_BODY_PARAMETER)
+
+            self.assertEqual(
+                declared, self.registry[key].names,
+                '%s.%s: the compiled parameter names differ from the '
+                'declared ones' % key)
+
+    def test_the_raw_body_is_not_compiled_as_json(self):
+        """An upload body is bytes. Parsing it as JSON would reject
+        every upload the moment phase 4 enforces."""
+        compiled = self.registry[('UploadDataEndpoint', 'post')]
+
+        self.assertTrue(compiled.raw_body)
+        self.assertIsNone(compiled.body)
+
+    def test_documented_formats_do_not_become_validators(self):
+        """Prose formats are documentation, and netblock is deliberately
+        pattern-free.
+
+        ``netblock`` has no pattern because NetworksEndpoint.post()
+        parses with ipaddress.ip_network(), which takes IPv6 as well;
+        publishing an IPv4 CIDR regex would describe the API as
+        narrower than it is and phase 4 would compile that into a 400
+        for input which works today. The prose formats on uuidorname,
+        namespace, node, url and ipv4 are the same kind of claim.
+        Semantic validation of any of them is phase 6.
+        """
+        netblock = self.registry[('NetworksEndpoint', 'post')].body
+        self.assertIsInstance(netblock.fields['netblock'], fields.String)
+        self.assertEqual([], list(netblock.fields['netblock'].validators))
+
+        # And the general rule the netblock case is one instance of,
+        # derived from the published specification rather than from a
+        # list of examples, which would go stale as tokens are retyped:
+        # a validator exists only where a bound is published. `format`
+        # never produces one.
+        constrained = 0
+        for view in external_api.app.view_functions.values():
+            cls = getattr(view, 'view_class', None)
+            if cls is None or not issubclass(cls, api_base.Resource):
+                continue
+            for method in ('get', 'post', 'put', 'delete', 'patch'):
+                handler = getattr(cls, method, None)
+                specs = getattr(handler, 'specs_dict', None)
+                if specs is None:
+                    continue
+                compiled = self.registry[(cls.__name__, method)]
+                for parameter in specs['parameters']:
+                    if parameter.get('in') == 'body':
+                        published = parameter.get(
+                            'schema', {}).get('properties', {})
+                        schema = compiled.body
+                    elif parameter.get('in') == 'query':
+                        published = {parameter['name']: parameter}
+                        schema = compiled.query
+                    else:
+                        continue
+                    for name, spec in published.items():
+                        bounded = any(k in spec for k in
+                                      ('minimum', 'maximum', 'pattern'))
+                        constrained += bool(bounded)
+                        self.assertEqual(
+                            bounded, bool(schema.fields[name].validators),
+                            '%s.%s %s: published bound %s, compiled '
+                            'validators %s' % (cls.__name__, method, name,
+                                               bounded,
+                                               schema.fields[name].validators))
+
+        # The rule above is vacuous if nothing is bounded, so the count
+        # is pinned. Fourteen, from two sources which both have to work:
+        # seven carrying an explicit constraints element (the five
+        # events `limit` caps and the two `key_ttl` ranges), and seven
+        # whose bound comes from the type token alone -- `minimum: 0`
+        # rendered by `unsignedinteger` on max_versions, offset, blob
+        # limit, cpus and memory. A change in either is meant to fail
+        # here and be re-counted deliberately.
+        self.assertEqual(14, constrained)
+
+    def test_published_bounds_compile_into_validators(self):
+        """The other direction: a bound which *is* declared must arrive.
+
+        Phase 2 published these into the specification so callers could
+        see them. If they did not compile, phase 4 would enforce a
+        contract looser than the one it publishes.
+        """
+        limit = self.registry[('BlobEventsEndpoint', 'get')].body.fields['limit']
+        ranges = [v for v in limit.validators
+                  if isinstance(v, marshmallow.validate.Range)]
+
+        self.assertEqual(1, len(ranges))
+        self.assertEqual(1, ranges[0].min)
+        self.assertEqual(1000, ranges[0].max)
+
+    def test_required_is_recorded_but_not_enforced(self):
+        """`required` is metadata in this phase.
+
+        `mode` on the agent-put endpoint is declared required while
+        omitting it has always been accepted, so compiling required-ness
+        into a constraint would break working clients the moment phase 4
+        enforced. Phase 6 decides what to do about it; warn-only exists
+        to give that decision numbers.
+        """
+        compiled = self.registry[('InstanceAgentPutEndpoint', 'post')]
+
+        self.assertIn('mode', compiled.required_names)
+        self.assertFalse(compiled.body.fields['mode'].required)
+
+        for key, endpoint in self.registry.items():
+            for schema in (endpoint.body, endpoint.query):
+                if schema is None:
+                    continue
+                required = [n for n, f in schema.fields.items() if f.required]
+                self.assertEqual(
+                    [], required,
+                    '%s.%s compiled a required field, which would reject a '
+                    'request phase 3 must not reject' % key)
+
+    def test_every_field_accepts_null(self):
+        """A JSON null reaches the handler as None today.
+
+        Several handlers treat that as "not supplied". Rejecting it
+        would be a rule this module invented rather than one any
+        declaration states, and in warn-only it would fill the log with
+        findings that are artefacts of the compiler.
+        """
+        for key, endpoint in self.registry.items():
+            for schema in (endpoint.body, endpoint.query):
+                if schema is None:
+                    continue
+                rejects = [n for n, f in schema.fields.items()
+                           if not f.allow_none]
+                self.assertEqual([], rejects, '%s.%s' % key)
+
+    def test_structured_parameters_compile_to_structures(self):
+        """The compiler and the specification pin cannot disagree.
+
+        test_openapi_spec.STRUCTURED_PARAMETERS pins what the published
+        specification says about the parameters carrying a structure or
+        a bound. This compiles from that same rendered specification, so
+        the two agreeing is close to tautological -- which is the point.
+        It is asserted anyway because the alternative design, mapping
+        the type tokens a second time here, would have made them
+        independent and therefore able to drift, and that is exactly the
+        defect class phase 2 hit twice.
+        """
+        instance_create = self.registry[('InstancesEndpoint', 'post')].body
+
+        self.assertIsInstance(instance_create.fields['metadata'], fields.Dict)
+        self.assertIsInstance(instance_create.fields['disk'], fields.List)
+        self.assertIsInstance(
+            instance_create.fields['disk'].inner, fields.Dict)
+        self.assertIsInstance(instance_create.fields['cpus'], fields.Integer)
+
+    def test_console_length_keeps_its_sentinel(self):
+        """-1 means "the whole log", and the functional suite sends it.
+
+        The regression this guards was shipped once already: phase 2
+        retyped this to unsignedinteger, publishing minimum 0 over a
+        value get_console_data() special-cases. Here it would compile
+        into a rejection rather than merely a wrong line of
+        documentation.
+        """
+        length = self.registry[
+            ('InstanceConsoleDataEndpoint', 'get')].body.fields['length']
+
+        self.assertEqual([], list(length.validators))
+        self.assertEqual([], length.deserialize(-1) and [])

--- a/shakenfist/tests/external_api/test_validation_compiler.py
+++ b/shakenfist/tests/external_api/test_validation_compiler.py
@@ -73,8 +73,13 @@ class ValidationCompilerTestCase(base.ShakenFistTestCase):
                 continue
             declared = {d.name for d in declarations.declarations(fn)}
             # The raw body marker names the whole body rather than a
-            # parameter within it, and compiles to a flag.
-            declared.discard(api_base.RAW_BODY_PARAMETER)
+            # parameter within it, and compiles to a flag. Discarded
+            # only where the compiler actually treated it as one:
+            # RAW_BODY_PARAMETER is the literal string 'body', so an
+            # unconditional discard would also hide an ordinary
+            # parameter of that name failing to compile.
+            if self.registry[key].raw_body:
+                declared.discard(api_base.RAW_BODY_PARAMETER)
 
             self.assertEqual(
                 declared, self.registry[key].names,
@@ -240,4 +245,4 @@ class ValidationCompilerTestCase(base.ShakenFistTestCase):
             ('InstanceConsoleDataEndpoint', 'get')].body.fields['length']
 
         self.assertEqual([], list(length.validators))
-        self.assertEqual([], length.deserialize(-1) and [])
+        self.assertEqual(-1, length.deserialize(-1))

--- a/shakenfist/tests/test_config.py
+++ b/shakenfist/tests/test_config.py
@@ -34,3 +34,18 @@ class ConfigTestCase(base.ShakenFistTestCase):
                      {'SHAKENFIST_NODE_RAM_RESERVATION_GB': 'banana'})
     def test_bogus_override(self):
         self.assertRaises(ValueError, SFConfig)
+
+    @mock.patch.dict('os.environ',
+                     {'SHAKENFIST_API_VALIDATION_MODE': 'enforced'})
+    def test_bogus_validation_mode_fails_at_load(self):
+        # The setting exists to be flipped to 'enforce' in phase 4 of
+        # PLAN-api-input-validation. A typo silently meaning warn is no
+        # validation and no signal anything is wrong, so anything other
+        # than the two literals must refuse to load.
+        self.assertRaises(ValueError, SFConfig)
+
+    @mock.patch.dict('os.environ',
+                     {'SHAKENFIST_API_VALIDATION_MODE': 'enforce'})
+    def test_valid_validation_mode_loads(self):
+        conf = SFConfig()
+        self.assertEqual('enforce', conf.API_VALIDATION_MODE)

--- a/tools/check-api-declaration-guards.sh
+++ b/tools/check-api-declaration-guards.sh
@@ -85,15 +85,19 @@ trap 'rsync -a --delete "${BACKUP}"/ shakenfist/external_api/; rm -rf "${BACKUP}
 total=0
 failures=0
 
-# Both modules, because the guard surface spans both: the import-time
-# checks are asserted by test_parameter_declarations, but whether a
-# declaration describes the shape the handler actually accepts can only
-# be seen in the generated specification, which is
-# test_openapi_spec's subject. A mutation caught by neither is a gap in
-# the guards, not in the mutation.
+# All three modules, because the guard surface spans them: the
+# import-time checks are asserted by test_parameter_declarations;
+# whether a declaration describes the shape the handler actually
+# accepts can only be seen in the generated specification, which is
+# test_openapi_spec's subject; and whether the *derivation* those two
+# compare against is itself right belongs to test_derivation_generator,
+# which is the only one building sources the tree does not contain. A
+# mutation caught by none of them is a gap in the guards, not in the
+# mutation.
 run() {
     "${PYTHON}" -m stestr run \
-        '(test_parameter_declarations|test_openapi_spec)' 2>&1
+        '(test_parameter_declarations|test_openapi_spec|test_derivation_generator)' \
+        2>&1
 }
 
 restore() { rsync -a --delete "${BACKUP}"/ shakenfist/external_api/; }
@@ -380,6 +384,50 @@ check 'spurious maximum on a registered parameter'
 sed -i "s/def get(self, instance_ref=None, instance_from_db=None):/def get(self, instance_ref=None, instance_from_db=None, **kwargs):/" \
     shakenfist/external_api/snapshot.py
 check 'variadic handler signature'
+
+# 26-28 mutate the derivation itself rather than a declaration. Every
+# mutation above asks "does a guard notice a wrong declaration?", which
+# takes the derivation those guards compare against on trust. These ask
+# whether that trust is earned. They are caught only by
+# test_derivation_generator, because each breaks a source shape the
+# tree does not contain -- which is exactly why the tree could not have
+# found them and why the generator exists.
+
+# 26. The route check answering before the query sources are consulted.
+# This was the state of the code until the generator found it: a
+# handler whose declared parameters are all path parameters could read
+# flask.request.args with a key the walk cannot name, and the audit
+# reported the tree clean because the call which would have noticed
+# returned first.
+python3 - <<'PY'
+p = 'shakenfist/external_api/declarations.py'
+s = open(p).read()
+s = s.replace("""    in_query = name in query_parameters(fn, [cls, tree], problems)
+    in_args = name in request_args_parameters(fn, problems)
+    if name in routes.get(cls.name, set()):
+        return 'path'""", """    if name in routes.get(cls.name, set()):
+        return 'path'
+    in_query = name in query_parameters(fn, [cls, tree], problems)
+    in_args = name in request_args_parameters(fn, problems)""")
+open(p, 'w').write(s)
+PY
+check 'path derived before the query sources are consulted'
+
+# 27. A defining scope whose dict is empty falling through to the next
+# scope. The cross-scope leak with an extra step: a class-level
+# `get_args = {}` would pick up a same-named module-level dict, and the
+# fixer would rewrite a correct body declaration to query.
+sed -i "s/^        if defined:/        if defined and out:/" \
+    shakenfist/external_api/declarations.py
+check 'empty defining scope falls through'
+
+# 28. Werkzeug converters dropped from route parameter names, so
+# <path:x> yields 'path' rather than 'x'. This one is a regression of a
+# defect the tree *did* have -- three LabelEndpoint declarations -- and
+# is here because the generator covers it more cheaply than the tree.
+sed -i "s/names = {segment.split(':')\[-1\]/names = {segment.split(':')[0]/" \
+    shakenfist/external_api/declarations.py
+check 'route converter prefix taken as the name'
 
 echo
 if [ "${failures}" -ne 0 ]; then

--- a/tools/check-api-declaration-guards.sh
+++ b/tools/check-api-declaration-guards.sh
@@ -85,18 +85,19 @@ trap 'rsync -a --delete "${BACKUP}"/ shakenfist/external_api/; rm -rf "${BACKUP}
 total=0
 failures=0
 
-# All three modules, because the guard surface spans them: the
+# All four modules, because the guard surface spans them: the
 # import-time checks are asserted by test_parameter_declarations;
 # whether a declaration describes the shape the handler actually
 # accepts can only be seen in the generated specification, which is
-# test_openapi_spec's subject; and whether the *derivation* those two
+# test_openapi_spec's subject; whether the *derivation* those two
 # compare against is itself right belongs to test_derivation_generator,
-# which is the only one building sources the tree does not contain. A
-# mutation caught by none of them is a gap in the guards, not in the
-# mutation.
+# the only one building sources the tree does not contain; and whether
+# the declarations compile into the schemas phase 4 will enforce is
+# test_validation_compiler's. A mutation caught by none of them is a
+# gap in the guards, not in the mutation.
 run() {
     "${PYTHON}" -m stestr run \
-        '(test_parameter_declarations|test_openapi_spec|test_derivation_generator)' \
+        '(test_parameter_declarations|test_openapi_spec|test_derivation_generator|test_validation_compiler)' \
         2>&1
 }
 
@@ -428,6 +429,32 @@ check 'empty defining scope falls through'
 sed -i "s/names = {segment.split(':')\[-1\]/names = {segment.split(':')[0]/" \
     shakenfist/external_api/declarations.py
 check 'route converter prefix taken as the name'
+
+# 29-31 mutate the compiler. Phase 3 compiles the declarations into
+# marshmallow schemas, so from here a misreading is not a wrong line of
+# documentation but a rejected request the moment phase 4 enforces.
+
+# 29. required compiled as a constraint rather than recorded as
+# metadata. `mode` on the agent-put endpoint is declared required while
+# omitting it has always been accepted, so this would reject working
+# requests.
+sed -i "s/kwargs: dict\[str, Any\] = {'required': False, 'allow_none': True}/kwargs: dict[str, Any] = {'required': True, 'allow_none': True}/" \
+    shakenfist/external_api/validation.py
+check 'required compiled as a constraint'
+
+# 30. The raw upload body parsed as JSON. Upload bodies are bytes, so
+# every upload would fail validation.
+sed -i "s/if schema.get('type') != 'object':/if False:/" \
+    shakenfist/external_api/validation.py
+check 'raw body compiled as JSON'
+
+# 31. A handler with no declaration compiled as an empty schema instead
+# of being left out of the registry. Absence and success would then be
+# indistinguishable: a route mounted without a declaration would simply
+# not be validated, and nothing would say so.
+sed -i "s/            if specs is None:/            if False:/" \
+    shakenfist/external_api/validation.py
+check 'undocumented handler compiled as empty'
 
 echo
 if [ "${failures}" -ne 0 ]; then

--- a/tools/check-api-declaration-guards.sh
+++ b/tools/check-api-declaration-guards.sh
@@ -452,8 +452,20 @@ check 'raw body compiled as JSON'
 # of being left out of the registry. Absence and success would then be
 # indistinguishable: a route mounted without a declaration would simply
 # not be validated, and nothing would say so.
-sed -i "s/            if specs is None:/            if False:/" \
-    shakenfist/external_api/validation.py
+#
+# Compiled as empty rather than "stop skipping it", which was the first
+# attempt: the registry is built at import time, so letting None reach
+# specs.get() raised AttributeError before any test ran and the harness
+# correctly reported HARNESS BROKEN rather than a catch. A mutation
+# which prevents the run says nothing about the guards.
+python3 - <<'PY'
+p = 'shakenfist/external_api/validation.py'
+s = open(p).read()
+s = s.replace("""                # quietly arriving here.
+                continue""", """                # quietly arriving here.
+                specs = {}""")
+open(p, 'w').write(s)
+PY
 check 'undocumented handler compiled as empty'
 
 echo

--- a/tox.ini
+++ b/tox.ini
@@ -73,6 +73,7 @@ envdir = {toxworkdir}/shared
 commands =
   mypy --strict --ignore-missing-imports shakenfist/resource_health.py
   mypy --strict --ignore-missing-imports shakenfist/external_api/declarations.py
+  mypy --strict --ignore-missing-imports shakenfist/external_api/validation.py
   mypy --ignore-missing-imports --follow-imports=silent --disable-error-code=no-untyped-def --disable-error-code=no-untyped-call --disable-error-code=misc --disable-error-code=no-any-return shakenfist/external_api/base.py
   mypy --ignore-missing-imports --follow-imports=silent --disallow-untyped-defs --disable-error-code=no-untyped-call shakenfist/node_health.py
   mypy --strict --ignore-missing-imports shakenfist/schema/sqlalchemy.py


### PR DESCRIPTION
Phase 3 of `PLAN-api-input-validation`, following #3666, #3682 and #3685.

Every request is now checked against its endpoint's published parameter
declarations, and **nothing is rejected**. `API_VALIDATION_MODE` defaults to
`warn`, which logs what would have been refused and changes no response.
Phase 4 flips it once those logs are understood.

Five commits, split so this can be staged as three PRs if you would rather
review it that way:

| Commit | |
|---|---|
| `d20ab74` | Master plan drift |
| `68b25d5` | The phase 3 plan |
| `c30476a` | **PR 1** — generate the derivation's input space |
| `e239251` | **PR 2** — compile the declarations into schemas |
| `6e1e65c` | **PR 3** — validate, and reject nothing |

## PR 1 — the generator, and the defect it found

The precondition the master plan sets rather than a step in it. Every
assertion in `test_parameter_declarations` compares a declaration against the
derivation, which takes the derivation on trust — and the derivation can only
be exercised by source shapes the tree happens to contain. All four defects
found while building the phase 1 audit were shapes it did not contain, and
mutating the tree cannot reach them either, since it only permutes shapes
already present.

So the axes are crossed instead: route form × `@use_kwargs` binding ×
`flask.request.args` read style, 225 synthetic endpoints, each asserting
`audit()` recovers what the case was *constructed* to mean and reports exactly
the problems its unreadable pieces earn. A second pass declares the one
location each case cannot mean and requires drift — without it the first pass
holds `drifted` empty and so cannot tell a right derivation from one that
returns whatever was declared.

**It found one on its first run.** `derived_location()` returned `path` before
consulting the query sources, so a handler whose declared parameters are all
path parameters could read `flask.request.args` with a key the walk cannot
name and the audit would report the tree clean — the confident wrong answer
`request_args_parameters()` exists to refuse, reintroduced one level up by its
caller. The comment directly beneath that early return asserts the opposite
rule for the other two sources. No handler in the tree has that shape, which
is why nothing had noticed. The tree still audits clean after the fix.

## PR 2 — compilation

132 handlers compile to marshmallow schemas, mounted in a registry built by
walking the mounted routes. Nothing consults it yet.

**Compiled from the rendered specification rather than from the declaration
tuples**, which is a deviation from the plan and a better answer than the one
it proposed. `swagger_helper()` already resolves a token into type, format and
constraints. Reading its output means there is exactly one interpretation of a
token in the process, so the compiled schema and the published specification
cannot disagree — where a second `ARGTYPES` mapping here would have been a
third independent reading, and a type token contradicting its handler is the
defect phase 2 shipped twice.

It also turns three rules the plan wrote as special cases into consequences:
`netblock` is format-only by deliberate choice so it compiles to a plain
string; the prose formats on `uuidorname`/`namespace`/`node`/`url`/`ipv4` do
the same; and the raw upload body renders as a schema whose type is not
`object`, which is the discriminator needed to leave it unparsed. None can be
got wrong by editing the compiler, because none is stated in it.

Two properties are chosen rather than derived, both to stop the compiler
inventing rejections no declaration describes: fields are never `required`
(`mode` on agent-put is declared required while omitting it has always
worked), and always accept `null` (a JSON null reaches handlers as `None`
today).

The strongest assertion cross-checks the runtime compilation against the
static audit — the same declarations read once through flasgger and once by
parsing source must yield the same names.

## PR 3 — warn-only validation

A warn record carries endpoint, parameter, reason, the offending value's
**type** and never its value, and **the status the request returned anyway**.
That last field is why the telemetry is an `after_request` hook rather than
part of the decorator: at validation time the outcome is unknown, and it is
what separates a rejection enforcement would *introduce* from a status code it
would merely *change*.

Three things found or fixed on the way:

* **The decorator had to propagate markers.** Sitting first in
  `method_decorators` puts it between the bound method and
  `_authenticate_unless_public`, which reads `__self__` for the resource class
  and `_sf_public`/`_sf_scope` for the policy markers. Without
  `functools.wraps` plus an explicit `__self__` copy, **every `@public`
  endpoint would have started demanding a token.** `base.py` already warns
  that its older decorators swallow attributes; the plan cited that as a
  reason to avoid `specs_dict` and did not notice the decorator walks into the
  same trap from the other side.
* **The `uuid` → `passed_uuid` remap is gone.** `passed_uuid` occurred once in
  the tree — the assignment itself — so no handler accepted it and sending
  `uuid` in a JSON body was a guaranteed 400 carrying interpreter text on
  *every* endpoint. It was not the collision dodge decision D8 cites it as.
  The collision it was meant to describe is now recorded properly, in
  `log_request`, because by the time the validator runs the overwrite has
  already happened.
* **A webargs error handler is registered for the first time**, so a malformed
  query parameter on the four `@use_kwargs` sites answers 400 in this API's
  `{"error", "status"}` shape rather than 422 in webargs' own. What is
  rejected is unchanged.

## D10 was framed wrongly, and the plan is corrected

I first wrote up `unknown=RAISE` as behaviour-preserving. Probing `POST /auth`
*without* mocking the namespace lookup disproved it: `arg_is_namespace`
short-circuits to 404 before the handler, so the `TypeError` never fires.

Validation at index 0 preempts every per-method decorator, so **neither option
is neutral** — RAISE changes the status wherever such a decorator answers
first, EXCLUDE wherever the request reaches the handler. The recommendation
stands as RAISE but only provisionally, and warn-only counts the two
populations separately so phase 4 decides with numbers. The preemption is
general: a request both malformed *and* referring to a missing object moves
404 → 400 at enforcement, which is a contract change phase 4 must put in the
release notes rather than discover in a bug report.

## Deliberately not done

`required` is recorded and never enforced. Semantic validation of the prose
formats is untouched (phase 6). `except TypeError` stays broad — narrowing it
is phase 5 and is gated on phase 4, since it currently absorbs the malformed
input this layer will start handling.

## Verification

* `tools/check-api-declaration-guards.sh` grows 25 → 31. Three new mutations
  break the *derivation* and three break the *compiler*, which no existing
  mutation did — they ask whether the trust the other 25 place in those is
  earned. Its `run()` gains both new modules, without which none could be
  caught.
* Mutation 31 caught a flaw in itself: written as "stop skipping undocumented
  handlers" it raised `AttributeError` at import and the harness reported
  `HARNESS BROKEN` rather than a catch — exactly the verdict that vocabulary
  exists for. Rewritten to express the defect without preventing the run.
* **All 31 mutations caught.** 2725 unit tests pass. `pre-commit run
  --all-files` clean. The published specification still validates with zero
  errors.
* `shakenfist/external_api/validation.py` is added to the mypy target list and
  passes `--strict`.

## What this does not include

**The measurement.** Warn-only is deployed nowhere, so the phase is
code-complete and evidence-empty. The next step is sfcbr plus a full
functional CI run, and the exit criterion is that every remaining finding is
*explained*, not that there are none. CI matters as much as sfcbr: the ansible
collection is a second implementation of this contract and the likeliest
source of undeclared keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nPqvWFVKNtS63aNm74kRq
