### PR TITLE
Adopt the shared plan template blocks.

### DIFF
--- a/PLAN-TEMPLATE.md
+++ b/PLAN-TEMPLATE.md
@@ -15,8 +15,6 @@ instead. Where a question touches on external concepts
 research as needed to give a confident answer. Flag any
 uncertainty explicitly rather than guessing.
 
-All planning documents should go into `docs/plans/`.
-
 Consult `ARCHITECTURE.md` for the system architecture
 overview, object types, and daemon structure. Consult
 `CLAUDE.md` for build commands, project conventions, and
@@ -27,27 +25,28 @@ machine), `shakenfist/mariadb.py` (three-layer database
 access pattern), `shakenfist/schema/` (Pydantic models), and
 `shakenfist/daemons/database/main.py` (gRPC database daemon).
 
-When we get to detailed planning, I prefer a separate plan
-file per detailed phase. These separate files should be named
-for the master plan, in the same directory as the master
-plan, and simply have `-phase-NN-descriptive` appended before
-the `.md` file extension. Tracking of these sub-phases should
-be done via a table like this in this master plan under the
-Execution section:
+<!-- shared-block: plan-file-conventions v1 -->
+Plan file conventions (shared block; do not edit -- the canonical
+copy lives in shakenfist/development at
+`templates/shared-blocks/plan-file-conventions.md`):
 
-```
-| Phase | Plan | Status |
-|-------|------|--------|
-| 1. Schema migration | PLAN-thing-phase-01-schema.md | Not started |
-| 2. gRPC endpoints | PLAN-thing-phase-02-grpc.md | Not started |
-| ...   | ...  | ...    |
-```
+- All planning documents live in `docs/plans/`.
+- Detailed planning gets one plan file per phase. Phase files are
+  named for their master plan, sit in the same directory as it,
+  and append `-phase-NN-descriptive` before the `.md` extension.
+- The master plan tracks its phases in a table under its Execution
+  section:
 
-I prefer one commit per logical change, and at minimum one
-commit per phase. Do not batch unrelated changes into a
-single commit. Each commit should be self-contained: it
-should build, pass tests, and have a clear commit message
-explaining what changed and why.
+  | Phase | Plan | Status |
+  |-------|------|--------|
+  | 1. Schema migration | PLAN-thing-phase-01-schema.md | Not started |
+  | 2. Public API | PLAN-thing-phase-02-api.md | Not started |
+
+- One commit per logical change, and at minimum one commit per
+  phase. Unrelated changes are not batched into a single commit.
+  Each commit is self-contained: it builds, passes tests, and has
+  a message explaining what changed and why.
+<!-- shared-block-end -->
 
 ## Situation
 
@@ -69,157 +68,214 @@ explaining what changed and why.
 
 ### Execution model
 
+<!-- shared-block: subagent-execution-model v1 -->
+Sub-agent execution model (shared block; do not edit -- the
+canonical copy lives in shakenfist/development at
+`templates/shared-blocks/subagent-execution-model.md`):
+
 All implementation work is done by sub-agents, never in the
-management session. The management session (this
-conversation) is reserved for planning, review, and
-decision-making. This keeps the management context lean and
-avoids drowning it in implementation diffs.
+management session. The management session is reserved for
+planning, review, and decision-making. This keeps the management
+context lean and avoids drowning it in implementation diffs.
 
 The workflow is:
 
 1. **Plan** at high effort in the management session.
-2. **Spawn a sub-agent** for each implementation step with
-   the brief from the plan, at the recommended effort level
-   and model.
-3. **Review** the sub-agent's output in the management
-   session. Check the actual files — the sub-agent's summary
-   describes what it intended, not necessarily what it did.
-4. **Fix or retry** if the output is wrong. Diagnose whether
-   the brief was insufficient (improve it) or the model was
-   too light (upgrade it), then re-run.
-5. **Commit** once the management session is satisfied with
-   the result.
+2. **Spawn a sub-agent** for each implementation step with the
+   brief from the plan, at the recommended effort level and model.
+3. **Review** the sub-agent's output in the management session.
+   Check the actual files -- the sub-agent's summary describes
+   what it intended, not necessarily what it did.
+4. **Fix or retry** if the output is wrong. Diagnose whether the
+   brief was insufficient (improve it) or the model was too light
+   (upgrade it), then re-run.
+5. **Commit** once the management session is satisfied.
 
 This applies to all steps, including high-effort ones. If a
-sub-agent can't succeed even with a detailed brief and the
-right model, that's a signal the brief needs improving, not
-that the management session should do the implementation
-itself.
+sub-agent cannot succeed even with a detailed brief and the right
+model, that is a signal the brief needs improving, not that the
+management session should do the implementation itself.
 
 Use `isolation: "worktree"` for sub-agents when the change is
-risky or experimental. The worktree is discarded if the
-output is unsatisfactory. For safe, well-understood changes,
-sub-agents can work directly in the main tree.
+risky or experimental; the worktree is discarded if the output is
+unsatisfactory. For safe, well-understood changes, sub-agents can
+work directly in the main tree.
+<!-- shared-block-end -->
 
 ### Planning effort
 
-The master plan itself should always be created at **high
-effort** — it requires broad codebase understanding,
-cross-referencing multiple source files, and making judgment
-calls about scope and sequencing.
+<!-- shared-block: plan-planning-effort v1 -->
+Planning effort (shared block; do not edit -- the canonical copy
+lives in shakenfist/development at
+`templates/shared-blocks/plan-planning-effort.md`):
 
-Each phase plan should specify the recommended effort level
-for planning that phase. Phases involving schema design,
-cross-daemon coordination, protocol changes, or subtle
-correctness questions (locking, consistency, migration
-safety) should be planned at high effort. Phases that are
-mechanical or follow well-established patterns (adding a new
-MariaDB accessor that mirrors an existing one, for example)
-can be planned at medium effort.
+The master plan itself is always created at **high effort** -- it
+requires broad codebase understanding, cross-referencing several
+source files, and judgment calls about scope and sequencing.
+
+Each phase plan states the recommended effort level for planning
+that phase. Phases that turn on design decisions, cross-component
+coordination, protocol changes, or subtle correctness questions
+should be planned at high effort. Phases that are mechanical, or
+that follow a pattern already established elsewhere in the
+codebase, can be planned at medium effort.
+<!-- shared-block-end -->
+
+!!! note "In this project"
+
+    Phases involving schema design, cross-daemon coordination,
+    protocol changes, or subtle correctness questions (locking,
+    consistency, migration safety) should be planned at high
+    effort. Phases that mirror an already-established pattern --
+    adding a new MariaDB accessor alongside an existing one, for
+    example -- can be planned at medium effort.
 
 ### Step-level guidance
 
-Each phase plan should include a table like this:
+<!-- shared-block: subagent-step-guidance v1 -->
+Sub-agent step guidance (shared block; do not edit -- the
+canonical copy lives in shakenfist/development at
+`templates/shared-blocks/subagent-step-guidance.md`):
 
-```
+Each phase plan includes a table like this:
+
 | Step | Effort | Model | Isolation | Brief for sub-agent |
 |------|--------|-------|-----------|---------------------|
-| 1a   | medium | sonnet | none     | One-sentence summary of what to do and which files to touch |
-| 1b   | high   | opus   | worktree | Why this needs high effort: requires understanding X to do Y |
-```
+| 1a | medium | sonnet | none | One-sentence summary of what to do and which files to touch |
+| 1b | high | opus | worktree | Why this needs high effort: requires understanding X to do Y |
 
-**Effort levels:**
-- **high** — Requires reading multiple files, making judgment
-  calls, understanding non-obvious invariants, or researching
-  external references. The sub-agent needs to think carefully
-  about edge cases. Typical examples: new object type
-  lifecycle, cross-daemon protocol changes, migration logic.
-- **medium** — The plan provides enough context that the
-  sub-agent can follow a clear brief. May need to read a few
-  files but the approach is well-defined. Typical examples:
-  adding a new gRPC endpoint parallel to an existing one,
-  adding a new MariaDB accessor.
-- **low** — Purely mechanical changes (rename, reformat, add
-  a log line, regenerate proto stubs). The brief is a
-  complete instruction.
+**Effort levels**, from cheapest to most thorough:
 
-**Model choice:** The planner should recommend which model is
-best suited for each step. This is a judgment call, not a
-rigid rule — the right model depends on what the step
-requires, not on whether it's "planning" or "implementation".
+- **low** -- Purely mechanical changes: rename, reformat, add a
+  log line, regenerate generated code. The brief is a complete
+  instruction.
+- **medium** -- The plan provides enough context to follow a clear
+  brief. The sub-agent may read a few files, but the approach is
+  already decided.
+- **high** -- Requires reading several files, making judgment
+  calls, or understanding non-obvious invariants. The sub-agent
+  needs to think about edge cases.
+- **xhigh** -- The setting for hard coding and agentic steps:
+  long-horizon changes, or steps where the sub-agent must both
+  research and implement.
+- **max** -- Correctness matters more than cost. Expect
+  diminishing returns and occasional overthinking; reserve it for
+  steps where a wrong answer would be expensive to detect.
 
-- **opus** — Best for steps that require deep reasoning,
-  cross-daemon architectural understanding, subtle
-  correctness judgment (locking, state machines, migration),
-  or complex protocol research. Also appropriate for
-  intricate implementation where getting it wrong would be
-  costly to debug.
-- **sonnet** — Good default for well-briefed implementation
-  work. Faster and cheaper than opus. Works well when the
-  plan front-loads the research and the brief is detailed
-  enough that the agent doesn't need to make broad judgment
-  calls.
-- **haiku** — Suitable for purely mechanical tasks:
-  search-and-replace, regenerating proto stubs, adding log
+**Brief for sub-agent:** this is the key field. Write it as if
+briefing a colleague who has never seen the codebase. Include what
+to change, which files to touch, what patterns to follow, and any
+non-obvious constraints.
+
+A good brief front-loads the research the planner already did, so
+the implementing agent does not repeat it. Instead of "add storage
+functions for the new object", name the functions to add, the file
+they belong in, the existing equivalent to mirror (with line
+numbers), and any registration the change also needs.
+
+The better the brief, the lower the effort level needed and the
+lighter the model that can succeed.
+<!-- shared-block-end -->
+
+!!! note "In this project"
+
+    High effort typically means a new object type lifecycle, a
+    cross-daemon protocol change, or migration logic; medium
+    effort typically means a new gRPC endpoint parallel to an
+    existing one, or a new MariaDB accessor; low effort typically
+    means a rename, a log line, or regenerating proto stubs.
+
+    A worked brief for this codebase: instead of "add MariaDB
+    functions for the new object", write "add direct, gRPC, and
+    public wrappers for `get_widget` in `shakenfist/mariadb.py`,
+    mirroring the `get_artifact` trio at lines
+    11129/11797/11811. The direct path uses
+    `_get_widgets_table()`; the gRPC wrapper goes through
+    `GetWidget` on the database daemon; register the counter in
+    the Monitor operations list in
+    `shakenfist/daemons/database/main.py`."
+
+### Model choice
+
+<!-- shared-block: subagent-model-roster v1 -->
+Sub-agent model roster (shared block; do not edit -- the canonical
+copy lives in shakenfist/development at
+`templates/shared-blocks/subagent-model-roster.md`):
+
+The planner recommends which model is best suited to each step.
+This is a judgment call, not a rigid rule -- the right model
+depends on what the step requires, not on whether it is "planning"
+or "implementation". The models available to sub-agents are:
+
+- **fable** -- The most capable model available, for the hardest
+  reasoning and the longest-horizon work: multi-step changes a
+  single sub-agent must carry end to end, or steps whose
+  correctness depends on holding a whole subsystem in mind at
+  once. It costs materially more than opus, so reserve it for
+  steps that have already defeated opus or are expected to.
+- **opus** -- The default for steps needing deep reasoning,
+  architectural understanding, subtle correctness judgment
+  (locking, state machines, migrations), or intricate
+  implementation that would be costly to debug if it were wrong.
+- **sonnet** -- A good default for well-briefed implementation
+  work. Faster and cheaper than opus, and effective when the plan
+  front-loads the research and the brief leaves no broad judgment
+  calls to make.
+- **haiku** -- Suitable for purely mechanical tasks:
+  search-and-replace, regenerating generated code, adding log
   lines, running commands. The brief must be a near-complete
   instruction.
 
-The model choice interacts with effort level and brief
-quality. A detailed brief compensates for a lighter model —
-sonnet at medium effort with a thorough brief often matches
-opus at medium effort with a vague brief. The planner's job
-is to write briefs good enough that the recommended model
-can succeed.
+Model choice interacts with effort level and brief quality. A
+detailed brief compensates for a lighter model -- sonnet at medium
+effort with a thorough brief often matches opus at medium effort
+with a vague brief. The planner's job is to write briefs good
+enough that the recommended model can succeed.
 
-Note: the model also determines the context window (opus has
-1M tokens, sonnet and haiku have 200K). Steps that require
-holding many files in context simultaneously — especially
-sweeping changes through `mariadb.py` or multi-daemon
-coordination — may need opus for that reason alone, even if
-the reasoning itself is straightforward.
+The model also determines the context window: fable, opus and
+sonnet have 1M tokens, haiku has 200K. A step that must hold many
+files in context at once may need one of the larger-context models
+for that reason alone, even when the reasoning itself is
+straightforward.
 
-**When in doubt, skew to the more capable model.** Saving
-money only matters if the outcome is still acceptable. A
-failed or low-quality implementation wastes more time (and
-therefore more money) than using a heavier model would have
-cost. Only recommend a lighter model when you are confident
-the brief is detailed enough for it to succeed.
-
-**Brief for sub-agent:** This is the key field. Write it as
-if briefing a colleague who has never seen the codebase.
-Include: what to change, which files to touch, what patterns
-to follow, and any non-obvious constraints. The better the
-brief, the lower the effort level needed and the lighter the
-model that can succeed.
-
-A good brief front-loads the research the planner already
-did, so the implementing agent doesn't repeat it. For
-example, instead of "add MariaDB functions for the new
-object", write "add direct, gRPC, and public wrappers for
-`get_widget` in `shakenfist/mariadb.py`, mirroring the
-`get_artifact` trio at lines 11129/11797/11811. The direct
-path uses `_get_widgets_table()`; the gRPC wrapper goes
-through `GetWidget` on the database daemon; register the
-counter in the Monitor operations list in
-`shakenfist/daemons/database/main.py`."
+**When in doubt, skew to the more capable model.** Saving money
+only matters if the outcome is still acceptable. A failed or
+low-quality implementation wastes more time -- and therefore more
+money -- than the heavier model would have cost. Recommend a
+lighter model only when you are confident the brief is detailed
+enough for it to succeed.
+<!-- shared-block-end -->
 
 ### Management session review checklist
 
-After a sub-agent completes, the management session should
-verify:
+<!-- shared-block: plan-review-checklist v1 -->
+Management session review checklist (shared block; do not edit --
+the canonical copy lives in shakenfist/development at
+`templates/shared-blocks/plan-review-checklist.md`):
 
-- [ ] The files that were supposed to change actually changed
-      (read them, don't trust the summary).
+After a sub-agent completes, the management session verifies:
+
+- [ ] The files that were supposed to change actually changed --
+      read them, do not trust the summary.
 - [ ] No unrelated files were modified.
-- [ ] The code passes `pre-commit run --all-files` (flake8,
-      stestr unit tests, mypy).
-- [ ] If proto files changed, stubs were regenerated with
-      `tox -e genprotos` and committed.
-- [ ] The changes match the intent of the brief — not just
-      syntactically correct but semantically right.
-- [ ] Commit message follows project conventions (including
-      the Co-Authored-By line with model, context window,
-      effort level, and other settings).
+- [ ] The changes match the intent of the brief: not merely
+      syntactically correct, but semantically right.
+- [ ] The project's own pre-merge checks pass, including any
+      generated code that has to be regenerated and committed
+      (see the project-specific checks below).
+- [ ] The commit message follows project conventions, including
+      the `Co-Authored-By` line recording model, context window,
+      and effort level.
+<!-- shared-block-end -->
+
+!!! note "In this project"
+
+    The project-specific checks referred to above are:
+
+    - [ ] The code passes `pre-commit run --all-files` (flake8,
+          stestr unit tests, mypy).
+    - [ ] If proto files changed, stubs were regenerated with
+          `tox -e genprotos` and committed.
 
 ## Administration and logistics
 
@@ -252,23 +308,6 @@ because the following statements will be true:
   updated if the change adds or modifies modules, daemons,
   or object types.
 
-### Future work
-
-We should list obvious extensions, known issues, unrelated
-bugs we encountered, and anything else we should one day do
-but have chosen to defer to here so that we don't forget
-them.
-
-...
-
-### Bugs fixed during this work
-
-This section should list any bugs we encounter during
-development that we fixed. You should also scan the relevant
-github bug tracker to see if there are any directly related
-bugs that we should either resolve as part of this master
-plan, or at least be aware of when planning.
-
 ### Documentation index maintenance
 
 When creating a new master plan from this template, update
@@ -291,8 +330,32 @@ The site navigation in `mkdocs.yml` is produced from
 When all phases of a plan are complete, update the status
 column in `docs/plans/index.md`.
 
+<!-- shared-block: plan-closeout-sections v1 -->
+Plan close-out sections (shared block; do not edit -- the
+canonical copy lives in shakenfist/development at
+`templates/shared-blocks/plan-closeout-sections.md`):
+
+### Future work
+
+We should list obvious extensions, known issues, unrelated bugs we
+encountered, and anything else we should one day do but have
+chosen to defer to here, so that we do not forget them.
+
+...
+
+### Bugs fixed during this work
+
+This section should list any bugs we encounter during development
+that we fixed. You should also scan the project's issue tracker,
+where one exists, for directly related issues that we should
+either resolve as part of this master plan or at least be aware of
+while planning it.
+
+...
+
 ### Back brief
 
-Before executing any step of this plan, please back brief
-the operator as to your understanding of the plan and how
-the work you intend to do aligns with that plan.
+Before executing any step of this plan, please back brief the
+operator as to your understanding of the plan and how the work you
+intend to do aligns with that plan.
+<!-- shared-block-end -->


### PR DESCRIPTION
`PLAN-TEMPLATE.md` was largely generic advice copied between
repositories by hand, and it had drifted. This copy did not list
`fable` as a model sub-agents could be given, claimed sonnet had a
200K context window when it has 1M, and stopped the effort ladder at
`high` rather than continuing through `xhigh` and `max`.

`shakenfist/development` now holds the canonical wording as seven
shared blocks and audits that every repository carrying a plan
template embeds the current version of each, so the next correction
arrives as a version bump rather than as eight hand edits. This PR
embeds them.

## What changed

* The generic half of the template is now seven shared blocks:
  `plan-file-conventions`, `subagent-execution-model`,
  `plan-planning-effort`, `subagent-step-guidance`,
  `subagent-model-roster`, `plan-review-checklist` and
  `plan-closeout-sections`.
* Project-specific examples that used to be interleaved through the
  generic prose now follow the block they qualify, in an
  `!!! note "In this project"` admonition. That renders as a callout
  in the published plans under `docs/plans/`, which is where this
  material actually gets read.
* The model roster gets its own `### Model choice` heading. It is the
  part that churns whenever a model ships or retires, so it is kept
  separate — a model launch bumps one small block, and the issue
  filed against a lagging repository names the roster rather than the
  surrounding prose.
* The close-out sections are now contiguous;
  `### Documentation index maintenance` moved up beside
  `### Success criteria`.

Nothing project-specific was dropped.

## Verification

* `plan-template` reports `pass` against this branch.
* `pre-commit run --all-files` passes.

*(Generated with Claude Code)*