### PR TITLE
Cancel superseded merge queue runs.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -306,8 +306,29 @@ jobs:
           needs.check_bot_commit.outputs.is_bot != 'true' &&
           (github.event_name != 'pull_request' ||
            github.event.pull_request.head.repo.full_name == github.repository) }}
+    # github.ref is the right key on every event except merge_group,
+    # where it is the per-attempt queue branch
+    # gh-readonly-queue/develop/pr-<N>-<SHA> and GitHub mints a fresh
+    # SHA every time it rebuilds the group -- which it does on every
+    # push to develop. Keyed on that, every rebuild landed in a group
+    # of its own, cancel-in-progress never matched, and superseded
+    # merge groups ran to completion on the shared under-cloud. See
+    # shakenfist/kerbside#284, which recorded this repository's
+    # superseded merge groups starving a neighbour's, and
+    # shakenfist/development audits/merge-group-cancellation.md.
+    #
+    # Cancelling is safe because this queue is serial
+    # (max_entries_to_build: 1), so any other in-flight merge_group run
+    # is by definition superseded and its queue branch already
+    # abandoned. The merge_group- prefix keeps a queue run from sharing
+    # a group with a workflow_dispatch run on develop, whose github.ref
+    # is the same string.
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-delinter
+      group: >-
+        ${{ github.workflow }}-delinter-${{
+        github.event_name == 'merge_group'
+        && format('merge_group-{0}', github.event.merge_group.base_ref)
+        || github.ref }}
       cancel-in-progress: true
 
     steps:
@@ -503,7 +524,11 @@ jobs:
     # is still far short of GitHub's six hour default.
     timeout-minutes: 180
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-nodelifecycle-collection
+      group: >-
+        ${{ github.workflow }}-nodelifecycle-collection-${{
+        github.event_name == 'merge_group'
+        && format('merge_group-{0}', github.event.merge_group.base_ref)
+        || github.ref }}
       cancel-in-progress: true
 
     steps:
@@ -681,7 +706,11 @@ jobs:
     runs-on: [self-hosted, vm, debian-12]
     timeout-minutes: 30
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-schema-enum-widening
+      group: >-
+        ${{ github.workflow }}-schema-enum-widening-${{
+        github.event_name == 'merge_group'
+        && format('merge_group-{0}', github.event.merge_group.base_ref)
+        || github.ref }}
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/test-drift-fix.yml
+++ b/.github/workflows/test-drift-fix.yml
@@ -33,6 +33,10 @@
 
 name: Fix test failures with Claude Code
 
+# audit-ok: merge-group-cancellation -- this workflow is reusable, but
+# its only caller is pr-fix-tests.yml on issue_comment, so it can never
+# run under a merge_group event and has no queue entry to supersede.
+
 on:
   workflow_dispatch:
     inputs:

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -63,6 +63,37 @@ The CI uses a two-stage merge queue pattern (see [this blog post](https://boinko
 in branch protection. `Can merge` is evaluated by the merge queue itself, not as
 a required check.
 
+### Superseded merge groups are cancelled
+
+Every job that can run in the queue and holds a scarce runner carries a
+`concurrency:` block whose key is merge-group aware — the four
+`functional_matrix_merge_collection` entries and `ansible_modules_collection`
+through the shared `smoke-cluster.yml`, and `node_lifecycle_collection`,
+`schema_enum_widening` and `automated_delinter` in this repository.
+
+`github.ref` is the obvious key and is right on every other event. On
+`merge_group` it is the per-attempt queue branch
+`gh-readonly-queue/develop/pr-<N>-<SHA>`, and GitHub mints a fresh SHA every
+time it rebuilds the group — which it does on every push to `develop`. Keyed
+on that, every rebuild lands in a concurrency group of its own,
+`cancel-in-progress` never matches, and superseded merge groups run to
+completion. Each one deploys several nested clusters onto the sfcbr
+under-cloud that every Shaken Fist repository shares, so the cost lands on
+the neighbours as well as here: `shakenfist/kerbside#284` records a kerbside
+merge group failing to place a 12 vCPU instance while two superseded
+shakenfist merge groups held the capacity. So the key branches on the event
+and uses `github.event.merge_group.base_ref` in the queue, with a
+`merge_group-` prefix so a queue run does not share a group with a
+`workflow_dispatch` run on `develop`.
+
+Cancelling is only safe because the queue is serial: the develop ruleset sets
+`max_entries_to_build: 1`, so any other in-flight `merge_group` run is by
+definition superseded and its queue branch already abandoned by GitHub.
+Raising that setting while keeping this key would cancel a live queue entry,
+which reports a failed required check and ejects the pull request — the two
+have to move together. This is audited fleet-wide; see
+[merge-group-cancellation](https://github.com/shakenfist/development/blob/main/audits/merge-group-cancellation.md).
+
 ## Exported Repository Configuration
 
 Repository settings (rulesets, branch protection, merge queue config) are


### PR DESCRIPTION
`github.ref` is the right concurrency key on every event except `merge_group`,
where it is the per-attempt queue branch
`gh-readonly-queue/develop/pr-<N>-<SHA>` and GitHub mints a fresh SHA every
time it rebuilds the group — on every push to `develop`. Keyed on that, every
rebuild landed in a group of its own, `cancel-in-progress` never matched, and
superseded merge groups ran to completion.

Each of those deploys several nested clusters onto the sfcbr under-cloud the
whole fleet shares, so the cost is not confined to this repository.
shakenfist/kerbside#284 records a kerbside merge group timing out waiting to
place a 12 vCPU instance while two superseded merge groups **from here** held
the capacity. kerbside had already fixed its own copy of this defect, which is
exactly why the remaining cause was visible.

## What changes

Fixed here: `node_lifecycle_collection`, `schema_enum_widening`,
`automated_delinter`.

Fixed by shakenfist/actions#30: the four `functional_matrix_merge_collection`
entries and `ansible_modules_collection` carry no group of their own — they go
through `smoke-cluster.yml`. **That PR should land first.**

Deliberately unchanged: `sanity_checks`, on the always-on `static` pool where a
superseded run costs seconds and no cloud capacity. That is the same line the
new `merge-group-cancellation` consistency audit draws.

## Safety

Cancelling is safe because this queue is serial: the develop ruleset sets
`max_entries_to_build: 1`, so any other in-flight `merge_group` run is by
definition superseded and GitHub has already abandoned its queue branch.
Raising that setting while keeping this key would cancel a live entry and eject
the pull request — the two have to move together, and
`docs/developer_guide/ci.md` now says so.

The `test-drift-fix.yml` marker is bookkeeping for the new audit: that workflow
is reusable, but its only caller is `pr-fix-tests.yml` on `issue_comment`, so it
can never see a merge group.

Part of a fleet-wide sweep; the audit lives in shakenfist/development#46.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXko24m6vN6o9P1q44gDyx