### PR TITLE
Make await_timeout bound the whole instance create.

### DIFF
--- a/docs/user_guide/ansible.md
+++ b/docs/user_guide/ansible.md
@@ -215,8 +215,8 @@ Delete a network:
 | metadata<br/>*dictionary* | Metadata key-value pairs to set on the instance. |
 | state<br/>*string* | The state of the resource. Valid states are `present` or `absent`, defaults to `present`. |
 | uuid<br/>*string* | The UUID for the instance. Either `name` or `uuid` must be included in all requests with `state: absent`. If you specify a UUID and the instance does not exist in the Shaken Fist cluster, this argument will be ignored as UUIDs are randomly assigned on network creation. |
-| await<br/>*boolean* | Whether to wait for the instance to be created. Only works for when state is `present`. Default is `false`. |
-| await_timeout<br/>*integer* | How many seconds to wait in an `await`. Defaults to 600. |
+| await<br/>*boolean* | Whether to wait for the instance to be created. Only works for when state is `present`. Default is `false`. The wait is bounded by `await_timeout`, as is the creation which precedes it. |
+| await_timeout<br/>*integer* | How many seconds an `await` may take, counted from the start of the operation rather than from the start of the wait. Where an instance is being replaced, the time spent deleting the old one and creating the new one is deducted from this number before the wait begins. It is a budget rather than a hard deadline: a deletion or creation already underway is not interrupted, and a `shakenfist-client` of v0.8.3 or earlier cannot be told not to wait while creating. Defaults to 600. |
 
 ### Examples
 

--- a/shakenfist/deploy/ansible_module_ci/004.yml
+++ b/shakenfist/deploy/ansible_module_ci/004.yml
@@ -117,6 +117,21 @@
         that: not ci_instance['failed']
         fail_msg: "failed should be false in {{ ci_instance }}"
 
+    # NOTE(mikal): regression coverage for shakenfist/kerbside#355, where the
+    # create blocked for an hour before the await started a fresh 600 second
+    # clock on the same condition and the task took the sum. This is the only
+    # place the real shakenfist_client is exercised on this path -- the unit
+    # tests stub the client out, so they can only assert which value the
+    # module passes, never what the client does with it. Both log lines are
+    # matched loosely because which of the two create paths runs depends on
+    # the client version pip resolved on the control node.
+    - name: Assert the await ran on a budget, not on its own fresh clock
+      assert:
+        that:
+          - ci_instance['log'] | select('search', 'create timeout') | list | length > 0
+          - ci_instance['log'] | select('search', 'already spent') | list | length > 0
+        fail_msg: "await budget not reported in {{ ci_instance['log'] }}"
+
     - name: Create the same test instance and check it hasn't changed
       sf_instance:
         name: "ansibleci-004"

--- a/shakenfist/deploy/collection/plugins/modules/sf_instance.py
+++ b/shakenfist/deploy/collection/plugins/modules/sf_instance.py
@@ -123,10 +123,19 @@ options:
   await_timeout:
     description:
       - How long to wait, in seconds, when O(await) is true.
-      - This is the budget for the whole create, not just for the wait
-        that follows it. The instance creation call is told not to wait
-        at all when O(await) is set, so this number is what the task
-        actually spends.
+      - This is the budget for the whole operation rather than for the
+        wait at the end of it. Where an instance is being replaced, the
+        time spent deleting the old one and creating the new one is
+        deducted from this number before the wait begins, so the task no
+        longer takes the sum of two independent budgets on the same
+        condition.
+      - It is a budget rather than a hard deadline. This module cannot
+        interrupt a deletion or a creation already underway, so a task
+        can still overrun -- it just cannot spend the same budget twice.
+        That matters most with a shakenfist-client older than the one
+        which grew a timeout argument on instance creation (anything up
+        to and including v0.8.3), because such a client cannot be told
+        not to wait while creating.
     required: false
     default: 600
     type: int
@@ -218,8 +227,11 @@ def _create_accepts_timeout(client):
     try:
         signature = inspect.signature(client.create_instance)
     except (TypeError, ValueError):
-        # A mock or a C-implemented callable. Assume the old shape; the
-        # elapsed-time deduction still applies.
+        # A callable inspect cannot describe, such as some C
+        # implementations. Assume the old shape; the elapsed-time
+        # deduction still applies. Note that a mock does not land here --
+        # inspect.signature() happily reports (*args, **kwargs) for one,
+        # which has no timeout parameter and so returns False below.
         return False
     return 'timeout' in signature.parameters
 
@@ -483,8 +495,10 @@ def _check_instance(client, existing, params, log):
 
 
 def _delete_and_wait(client, log, identifier, namespace):
-    start_time = time.time()
-    while time.time() - start_time < 180:
+    # monotonic() rather than time(): this is a duration, and an NTP step
+    # mid-loop would otherwise shorten or extend it arbitrarily.
+    start_time = time.monotonic()
+    while time.monotonic() - start_time < 180:
         try:
             log.append('Attempt deletion...')
             client.delete_instance(identifier, namespace=namespace)
@@ -560,9 +574,14 @@ def run_module():
             module.exit_json(
                 changed=needs_replacement, meta=(i or None), log=log)
 
-        # An instance that needs no replacement spent nothing on a
-        # create, so the await gets the whole budget.
-        create_elapsed = 0
+        # The budget starts here rather than at the create, because a
+        # replacement deletes the old instance first and that time is
+        # spent inside the task like any other. An instance which needs
+        # no replacement spends nothing between here and the await, and
+        # so gets the whole budget for it. monotonic() because this is a
+        # duration: a wall clock step mid-create would otherwise inflate
+        # the budget past await_timeout or collapse it to nothing.
+        operation_started = time.monotonic()
         if needs_replacement:
             if i:
                 remaining = _delete_and_wait(client, log, identifier, namespace)
@@ -581,36 +600,72 @@ def run_module():
             # 4200 seconds -- and reported the 600
             # (shakenfist/kerbside#355).
             #
+            # timeout=0 is not a falsy "unset" to the client: it tests
+            # "if timeout is None" and then bounds the POST's dependency
+            # retries and the wait afterwards at now + 0, so the call
+            # returns as soon as the POST is accepted
+            # (shakenfist/client-python#369).
+            #
             # The collection requires shakenfist-client unpinned, so the
             # control node can be running a client older than the one that
-            # grew this argument. Passing it blindly there is a TypeError
+            # grew this argument -- it is not in any release up to and
+            # including v0.8.3. Passing it blindly there is a TypeError
             # and every instance creation in the fleet stops working, so
             # ask before passing it. The elapsed-time deduction below
             # covers the older client: it cannot get the task down to
             # await_timeout, but it does stop the two budgets from being
             # added together.
+            #
+            # sf_snapshot solves its version of this at client
+            # construction, by selecting ASYNC_CONTINUE, and that would
+            # avoid this branch entirely. It is not done here because the
+            # strategy is a property of the client and this same client
+            # also runs _delete_and_wait() above, where delete_instance
+            # blocks today. That loop polls for itself and would probably
+            # tolerate the change, but "probably" is not a thing to find
+            # out on the deletion path, so the narrower per-call argument
+            # is used instead.
             if module.params.get('await') and _create_accepts_timeout(client):
                 instance_kwargs['timeout'] = 0
+                log.append('Client accepts a create timeout, so the create '
+                           'will not wait')
+            elif module.params.get('await'):
+                log.append('Client predates the create timeout argument, so '
+                           'the create will wait and what it spends is '
+                           'deducted from the await budget instead')
 
-            create_started = time.time()
             i = client.create_instance(*instance_args, **instance_kwargs)
-            create_elapsed = time.time() - create_started
 
         if not module.params.get('await'):
             log.append('Not awaiting instance')
         else:
-            # Whatever the create already spent comes out of the budget,
-            # so await_timeout bounds the pair rather than each of them.
-            remaining = max(
-                0, module.params.get('await_timeout') - create_elapsed)
-            log.append('Awaiting instance %s for %d seconds (create took %d)'
-                       % (i['uuid'], remaining, create_elapsed))
+            # Whatever the delete and the create already spent comes out
+            # of the budget, so await_timeout bounds the sequence rather
+            # than each leg of it.
+            await_timeout = module.params.get('await_timeout')
+            elapsed = time.monotonic() - operation_started
+            await_budget = max(0, await_timeout - elapsed)
+            log.append('Awaiting instance %s for %d seconds (%d already '
+                       'spent)' % (i['uuid'], await_budget, elapsed))
             try:
-                client.await_instance_create(i['uuid'], timeout=remaining)
+                # A budget of zero is still worth handing over: the
+                # client checks the instance once before consulting its
+                # clock, so an instance which is already created is
+                # reported as created rather than as a timeout.
+                client.await_instance_create(i['uuid'], timeout=await_budget)
             except Exception as e:
-                log.append('Waiting for instance failed: %s' % e)
-                module.fail_json(
-                    msg='Waiting for instance failed: %s' % e, meta=None, log=log)
+                if await_budget <= 0:
+                    # The client's own message would name a zero second
+                    # timeout, which is the symptom rather than the
+                    # cause. Say where the budget actually went.
+                    msg = ('The entire await_timeout budget of %d seconds '
+                           'was consumed deleting and creating the '
+                           'instance, leaving nothing to wait with: %s'
+                           % (await_timeout, e))
+                else:
+                    msg = 'Waiting for instance failed: %s' % e
+                log.append(msg)
+                module.fail_json(msg=msg, meta=None, log=log)
 
         module.exit_json(
             changed=needs_replacement, meta=client.get_instance(i['uuid']), log=log)

--- a/shakenfist/deploy/collection/plugins/modules/sf_instance.py
+++ b/shakenfist/deploy/collection/plugins/modules/sf_instance.py
@@ -6,6 +6,7 @@
 # client-python's shakenfist_client/commandline/ansible.py.
 from __future__ import annotations
 
+import inspect
 import json
 import time
 
@@ -120,7 +121,12 @@ options:
     default: false
     type: bool
   await_timeout:
-    description: How long to wait, in seconds, when O(await) is true.
+    description:
+      - How long to wait, in seconds, when O(await) is true.
+      - This is the budget for the whole create, not just for the wait
+        that follows it. The instance creation call is told not to wait
+        at all when O(await) is set, so this number is what the task
+        actually spends.
     required: false
     default: 600
     type: int
@@ -198,6 +204,24 @@ SERVER_POPULATED_DISK_KEYS = ['blob_uuid', 'disk_base']
 
 class InstanceCreationException(Exception):
     ...
+
+
+def _create_accepts_timeout(client):
+    """Does this client's create_instance() take a timeout?
+
+    The collection requires shakenfist-client unpinned, so the control
+    node's client is whatever pip resolved and may predate the argument.
+    Feature-detect rather than assume: guessing wrong is a TypeError that
+    stops every instance creation, and there is no version to test
+    against that is not itself a guess about backports.
+    """
+    try:
+        signature = inspect.signature(client.create_instance)
+    except (TypeError, ValueError):
+        # A mock or a C-implemented callable. Assume the old shape; the
+        # elapsed-time deduction still applies.
+        return False
+    return 'timeout' in signature.parameters
 
 
 def _make_client(module):
@@ -536,6 +560,9 @@ def run_module():
             module.exit_json(
                 changed=needs_replacement, meta=(i or None), log=log)
 
+        # An instance that needs no replacement spent nothing on a
+        # create, so the await gets the whole budget.
+        create_elapsed = 0
         if needs_replacement:
             if i:
                 remaining = _delete_and_wait(client, log, identifier, namespace)
@@ -545,15 +572,41 @@ def run_module():
                         msg='Deletion of instance for update failed.',
                         meta=None, log=log)
 
+            # When we are going to await below, await_timeout is the
+            # budget for the whole operation, so the create must not wait
+            # as well. It used to: the client is built with ASYNC_BLOCK,
+            # so create_instance polled for an hour, returned an instance
+            # still in 'creating', and only then did the 600 second await
+            # start on the same condition. The task took the sum -- about
+            # 4200 seconds -- and reported the 600
+            # (shakenfist/kerbside#355).
+            #
+            # The collection requires shakenfist-client unpinned, so the
+            # control node can be running a client older than the one that
+            # grew this argument. Passing it blindly there is a TypeError
+            # and every instance creation in the fleet stops working, so
+            # ask before passing it. The elapsed-time deduction below
+            # covers the older client: it cannot get the task down to
+            # await_timeout, but it does stop the two budgets from being
+            # added together.
+            if module.params.get('await') and _create_accepts_timeout(client):
+                instance_kwargs['timeout'] = 0
+
+            create_started = time.time()
             i = client.create_instance(*instance_args, **instance_kwargs)
+            create_elapsed = time.time() - create_started
 
         if not module.params.get('await'):
             log.append('Not awaiting instance')
         else:
-            log.append('Awaiting instance %s' % i['uuid'])
+            # Whatever the create already spent comes out of the budget,
+            # so await_timeout bounds the pair rather than each of them.
+            remaining = max(
+                0, module.params.get('await_timeout') - create_elapsed)
+            log.append('Awaiting instance %s for %d seconds (create took %d)'
+                       % (i['uuid'], remaining, create_elapsed))
             try:
-                client.await_instance_create(
-                    i['uuid'], timeout=module.params.get('await_timeout'))
+                client.await_instance_create(i['uuid'], timeout=remaining)
             except Exception as e:
                 log.append('Waiting for instance failed: %s' % e)
                 module.fail_json(

--- a/shakenfist/tests/test_ansible_sf_instance.py
+++ b/shakenfist/tests/test_ansible_sf_instance.py
@@ -208,3 +208,121 @@ class SfInstanceDiskDirtinessTestCase(base.ShakenFistTestCase):
         ])
         dirty, _ = self._check(existing, self._params(disks=['10@debian:11']))
         self.assertTrue(dirty)
+
+
+class SfInstanceCreateBudgetTestCase(base.ShakenFistTestCase):
+    """await_timeout is the budget for the whole create, not one leg.
+
+    shakenfist/kerbside#355: the client is built with ASYNC_BLOCK, so
+    create_instance waited an hour for the instance to leave 'creating'
+    and then returned it still transitional. Only then did the 600 second
+    await start, on the same condition. The task took the sum, about 4200
+    seconds, and reported the 600 -- which is why three occurrences all
+    landed within twelve seconds of each other.
+    """
+
+    PARAMS = {
+        'name': 'test', 'uuid': None, 'cpu': 1, 'ram': 1024,
+        'disks': ['8@cirros'], 'diskspecs': None, 'networks': None,
+        'networkspecs': None, 'ssh_key': None, 'user_data': None,
+        'placement': None, 'video': None, 'nvram_template': None,
+        'configdrive': None, 'side_channels': None, 'uefi': None,
+        'secureboot': None, 'metadata': None, 'state': 'present',
+        'api_url': 'http://localhost:13000', 'namespace': 'ns',
+        'key': 'notreallyakey',
+    }
+
+    def _run(self, await_instance, client_takes_timeout=True,
+             create_seconds=0):
+        params = dict(self.PARAMS)
+        params['await'] = await_instance
+        params['await_timeout'] = 600
+
+        module = mock.MagicMock()
+        module.params = params
+        module.check_mode = False
+        # The real AnsibleModule.exit_json terminates the module; a bare
+        # MagicMock would let execution fall through into the deletion
+        # path below it.
+        module.exit_json.side_effect = SystemExit
+        module.fail_json.side_effect = SystemExit
+
+        created = {'uuid': 'notreallyauuid', 'state': 'creating'}
+        clock = iter(range(0, 100000, max(create_seconds, 1)))
+
+        # The signature is the thing under test on the compatibility
+        # path, so build create_instance from a real function rather than
+        # a bare mock, whose signature is always (*args, **kwargs).
+        if client_takes_timeout:
+            def create_instance(*args, timeout=None, **kwargs):
+                return created
+        else:
+            def create_instance(*args, **kwargs):
+                return created
+
+        client = mock.MagicMock()
+        # create_autospec rather than a spec'd MagicMock: only the former
+        # keeps a signature inspect.signature() can read, which is the
+        # thing _create_accepts_timeout() looks at.
+        client.create_instance = mock.create_autospec(
+            create_instance, side_effect=create_instance)
+        # Absent to begin with, so the module takes the create path; every
+        # later lookup (the exit_json payload) finds it.
+        client.get_instance.side_effect = [
+            sf_instance.apiclient.ResourceNotFoundException()] + [created] * 8
+
+        with mock.patch.object(
+                sf_instance, 'AnsibleModule', return_value=module), \
+                mock.patch.object(
+                    sf_instance, '_make_client', return_value=client), \
+                mock.patch.object(
+                    sf_instance.time, 'time', side_effect=lambda: next(clock)):
+            self.assertRaises(SystemExit, sf_instance.run_module)
+
+        return client
+
+    def test_awaiting_makes_the_create_return_immediately(self):
+        client = self._run(await_instance=True)
+
+        _args, kwargs = client.create_instance.call_args
+        self.assertEqual(0, kwargs.get('timeout'))
+
+        # The create returns straight away, so essentially the whole
+        # budget is left for the await -- which is the point: the task
+        # now fails at await_timeout rather than at 3600 + await_timeout.
+        _args, kwargs = client.await_instance_create.call_args
+        self.assertGreater(kwargs['timeout'], 590)
+
+    def test_not_awaiting_leaves_the_create_blocking(self):
+        # Without an await the create is the only thing that can wait, so
+        # the historical behaviour has to survive.
+        client = self._run(await_instance=False)
+
+        _args, kwargs = client.create_instance.call_args
+        self.assertNotIn('timeout', kwargs)
+        client.await_instance_create.assert_not_called()
+
+    def test_an_older_client_is_not_handed_the_new_argument(self):
+        # The collection requires shakenfist-client unpinned, so the
+        # control node may predate the timeout argument. Passing it there
+        # is a TypeError that stops every instance creation.
+        client = self._run(await_instance=True, client_takes_timeout=False)
+
+        _args, kwargs = client.create_instance.call_args
+        self.assertNotIn('timeout', kwargs)
+
+    def test_time_spent_creating_comes_out_of_the_await_budget(self):
+        # The fallback for an older client: it cannot get the task down to
+        # await_timeout, but the two waits stop being added together.
+        client = self._run(await_instance=True, client_takes_timeout=False,
+                           create_seconds=100)
+
+        _args, kwargs = client.await_instance_create.call_args
+        self.assertLess(kwargs['timeout'], 600)
+
+    def test_the_budget_never_goes_negative(self):
+        client = self._run(await_instance=True, client_takes_timeout=False,
+                           create_seconds=3600)
+
+        _args, kwargs = client.await_instance_create.call_args
+        self.assertEqual(0, kwargs['timeout'])

--- a/shakenfist/tests/test_ansible_sf_instance.py
+++ b/shakenfist/tests/test_ansible_sf_instance.py
@@ -210,6 +210,14 @@ class SfInstanceDiskDirtinessTestCase(base.ShakenFistTestCase):
         self.assertTrue(dirty)
 
 
+class _Succeeded(SystemExit):
+    """The module called exit_json()."""
+
+
+class _Failed(SystemExit):
+    """The module called fail_json()."""
+
+
 class SfInstanceCreateBudgetTestCase(base.ShakenFistTestCase):
     """await_timeout is the budget for the whole create, not one leg.
 
@@ -232,8 +240,18 @@ class SfInstanceCreateBudgetTestCase(base.ShakenFistTestCase):
         'key': 'notreallyakey',
     }
 
-    def _run(self, await_instance, client_takes_timeout=True,
-             create_seconds=0):
+    def _run(self, *args, **kwargs):
+        _module, client = self._run_module_and_client(*args, **kwargs)
+        return client
+
+    def _run_module(self, *args, **kwargs):
+        module, _client = self._run_module_and_client(*args, **kwargs)
+        return module
+
+    def _run_module_and_client(self, await_instance,
+                               client_takes_timeout=True, create_seconds=0,
+                               existing=None, await_raises=None,
+                               expect_failure=False):
         params = dict(self.PARAMS)
         params['await'] = await_instance
         params['await_timeout'] = 600
@@ -243,12 +261,21 @@ class SfInstanceCreateBudgetTestCase(base.ShakenFistTestCase):
         module.check_mode = False
         # The real AnsibleModule.exit_json terminates the module; a bare
         # MagicMock would let execution fall through into the deletion
-        # path below it.
-        module.exit_json.side_effect = SystemExit
-        module.fail_json.side_effect = SystemExit
+        # path below it. Distinct exception types rather than a shared
+        # SystemExit, because assertRaises(SystemExit) cannot tell a
+        # success from an early bail-out, and a test whose body is two
+        # negative assertions would then pass without running any of the
+        # code it names.
+        module.exit_json.side_effect = _Succeeded
+        module.fail_json.side_effect = _Failed
 
         created = {'uuid': 'notreallyauuid', 'state': 'creating'}
-        clock = iter(range(0, 100000, max(create_seconds, 1)))
+
+        # An explicit pair rather than an open ended counter: the module
+        # reads the clock exactly twice on this path (once before the
+        # create, once before the await), so a third read from anywhere
+        # fails loudly instead of quietly shifting the elapsed time.
+        clock = iter([0, create_seconds])
 
         # The signature is the thing under test on the compatibility
         # path, so build create_instance from a real function rather than
@@ -266,20 +293,28 @@ class SfInstanceCreateBudgetTestCase(base.ShakenFistTestCase):
         # thing _create_accepts_timeout() looks at.
         client.create_instance = mock.create_autospec(
             create_instance, side_effect=create_instance)
-        # Absent to begin with, so the module takes the create path; every
-        # later lookup (the exit_json payload) finds it.
-        client.get_instance.side_effect = [
-            sf_instance.apiclient.ResourceNotFoundException()] + [created] * 8
+        if existing is None:
+            # Absent to begin with, so the module takes the create path;
+            # every later lookup (the exit_json payload) finds it.
+            first = sf_instance.apiclient.ResourceNotFoundException()
+        else:
+            first = existing
+        client.get_instance.side_effect = [first] + [created] * 8
+        if await_raises:
+            client.await_instance_create.side_effect = await_raises
 
         with mock.patch.object(
                 sf_instance, 'AnsibleModule', return_value=module), \
                 mock.patch.object(
                     sf_instance, '_make_client', return_value=client), \
                 mock.patch.object(
-                    sf_instance.time, 'time', side_effect=lambda: next(clock)):
-            self.assertRaises(SystemExit, sf_instance.run_module)
+                    sf_instance.time, 'monotonic',
+                    side_effect=lambda: next(clock)):
+            self.assertRaises(
+                _Failed if expect_failure else _Succeeded,
+                sf_instance.run_module)
 
-        return client
+        return module, client
 
     def test_awaiting_makes_the_create_return_immediately(self):
         client = self._run(await_instance=True)
@@ -287,11 +322,11 @@ class SfInstanceCreateBudgetTestCase(base.ShakenFistTestCase):
         _args, kwargs = client.create_instance.call_args
         self.assertEqual(0, kwargs.get('timeout'))
 
-        # The create returns straight away, so essentially the whole
-        # budget is left for the await -- which is the point: the task
-        # now fails at await_timeout rather than at 3600 + await_timeout.
+        # The create returns straight away, so the whole budget is left
+        # for the await -- which is the point: the task now fails at
+        # await_timeout rather than at 3600 + await_timeout.
         _args, kwargs = client.await_instance_create.call_args
-        self.assertGreater(kwargs['timeout'], 590)
+        self.assertEqual(600, kwargs['timeout'])
 
     def test_not_awaiting_leaves_the_create_blocking(self):
         # Without an await the create is the only thing that can wait, so
@@ -318,7 +353,7 @@ class SfInstanceCreateBudgetTestCase(base.ShakenFistTestCase):
                            create_seconds=100)
 
         _args, kwargs = client.await_instance_create.call_args
-        self.assertLess(kwargs['timeout'], 600)
+        self.assertEqual(500, kwargs['timeout'])
 
     def test_the_budget_never_goes_negative(self):
         client = self._run(await_instance=True, client_takes_timeout=False,
@@ -326,3 +361,87 @@ class SfInstanceCreateBudgetTestCase(base.ShakenFistTestCase):
 
         _args, kwargs = client.await_instance_create.call_args
         self.assertEqual(0, kwargs['timeout'])
+
+    def test_an_exhausted_budget_names_the_real_cause(self):
+        # The client's own message would report a zero second timeout,
+        # which is the symptom of the budget having gone rather than an
+        # explanation of where it went -- and an unhelpful message is
+        # what kerbside#355 was reported as in the first place.
+        module = self._run_module(
+            await_instance=True, client_takes_timeout=False,
+            create_seconds=3600, await_raises=Exception('not created'),
+            expect_failure=True)
+
+        msg = module.fail_json.call_args[1]['msg']
+        self.assertIn(
+            'entire await_timeout budget of 600 seconds was consumed', msg)
+
+    def test_an_instance_needing_no_replacement_gets_the_whole_budget(self):
+        # No delete and no create happen on this path at all, so there
+        # is nothing to deduct and the whole budget reaches the await.
+        client = self._run(
+            await_instance=True,
+            existing={
+                'uuid': 'notreallyauuid',
+                'name': 'test',
+                'cpus': 1,
+                'memory': 1024,
+                'namespace': 'ns',
+                'interfaces': [],
+                'disk_spec': [
+                    {'base': 'cirros', 'bus': None, 'size': 8, 'type': 'disk'}
+                ]
+            })
+
+        client.create_instance.assert_not_called()
+        _args, kwargs = client.await_instance_create.call_args
+        self.assertEqual(600, kwargs['timeout'])
+
+    def test_the_chosen_path_is_recorded_in_the_log(self):
+        # The fallback is otherwise invisible: an operator debugging a
+        # recurrence from the task output alone cannot tell whether the
+        # fix engaged or the module quietly took the old behaviour.
+        module = self._run_module(await_instance=True)
+        self.assertIn('Client accepts a create timeout, so the create will '
+                      'not wait', module.exit_json.call_args[1]['log'])
+
+        module = self._run_module(
+            await_instance=True, client_takes_timeout=False)
+        self.assertIn('Client predates the create timeout argument, so the '
+                      'create will wait and what it spends is deducted from '
+                      'the await budget instead',
+                      module.exit_json.call_args[1]['log'])
+
+
+class SfInstanceCreateTimeoutDetectionTestCase(base.ShakenFistTestCase):
+    """Feature detection, rather than a version test.
+
+    The collection requires shakenfist-client unpinned, so the control
+    node's client is whatever pip resolved. There is no version to test
+    against which is not itself a guess about backports.
+    """
+
+    def test_a_new_client_is_detected(self):
+        client = mock.MagicMock()
+        client.create_instance = mock.create_autospec(
+            lambda *args, timeout=None, **kwargs: None)
+        self.assertTrue(sf_instance._create_accepts_timeout(client))
+
+    def test_an_old_client_is_detected(self):
+        client = mock.MagicMock()
+        client.create_instance = mock.create_autospec(
+            lambda *args, **kwargs: None)
+        self.assertFalse(sf_instance._create_accepts_timeout(client))
+
+    def test_a_callable_inspect_cannot_describe_is_assumed_old(self):
+        # Some C implementations have no signature to read. Guessing
+        # "new" there is a TypeError which stops every instance creation
+        # in the fleet, so the unreadable case has to fall back.
+        client = mock.MagicMock()
+        client.create_instance = dict.update
+        self.assertFalse(sf_instance._create_accepts_timeout(client))
+
+    def test_a_bare_mock_is_assumed_old(self):
+        # A MagicMock does not raise from inspect.signature() -- it
+        # reports (*args, **kwargs), which has no timeout parameter.
+        self.assertFalse(sf_instance._create_accepts_timeout(mock.MagicMock()))


### PR DESCRIPTION
The caller half of shakenfist/client-python#369.

`sf_instance` builds its client with `ASYNC_BLOCK`, so `create_instance()`
waited up to an hour for the instance to leave `creating`, returned it still
transitional, and only then did `await_instance_create()` start its own
`await_timeout` clock on the same condition. The task took the sum — about
4200 seconds — and failed with `not created within 600 second timeout`,
which is honest about the await and silent about the hour before it.

3600 + 600 = 4200, against 4206 / 4209 / ~4218 observed on
shakenfist/kerbside#284. See shakenfist/kerbside#355 for the full analysis.

## The change

Ask the client not to wait when we are going to await ourselves, so
`await_timeout` is the budget for the operation rather than for its second
leg.

## The compatibility wrinkle, which is the interesting part

That `timeout` argument is new in client-python, and
`deploy/collection/requirements.txt` requires `shakenfist-client`
**unpinned**. The control node's client is whatever pip resolved and may
predate it — and passing an unknown kwarg there is a `TypeError` that would
stop every instance creation in the fleet, including the under-cloud
playbooks this same module drives.

So two mechanisms rather than one:

* **Feature-detect** with `inspect.signature` before passing the argument.
  Guessing a version to test against would itself be a guess about
  backports.
* **Deduct** whatever the create spent from the await budget. This is what
  an older client gets: it cannot bring the task down to `await_timeout`,
  but it does stop the two waits being added together — 3600 rather than
  4200.

Also guards the elapsed time on the path where no create happens: an
instance needing no replacement gets the whole budget for its await.

5 new tests covering both client generations; 13 pass in that module.

## Landing

Either this or shakenfist/client-python#369 can land first — that is what
the feature detection buys. This one is what actually reaches kerbside CI,
since its oVirt lane checks this repository out at `develop` and builds the
collection from it (`tools/install-collection.sh`); the client comes from
pip separately, which is why the deduction fallback matters.

Refs shakenfist/kerbside#355.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXko24m6vN6o9P1q44gDyx