### PR TITLE
Queue performance step 7: measure the queue, and decline fairness

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         description: Run flake8 style checks on changes since HEAD~
         entry: tox -e flake8
         language: system
-        files: ^shakenfist/
+        files: ^(shakenfist|tools)/
         pass_filenames: false
         types: [python]
 
@@ -52,7 +52,7 @@ repos:
         description: Run Python 3 unit tests with stestr
         entry: tox -e py3
         language: system
-        files: ^shakenfist/
+        files: ^(shakenfist|tools)/
         pass_filenames: false
         types: [python]
 

--- a/docs/operator_guide/networking/overview.md
+++ b/docs/operator_guide/networking/overview.md
@@ -514,9 +514,18 @@ itself):
       terminal state write).
     * `wait_seconds` — time between when the op was first inserted
       into `cluster_operations` and when the dispatcher claimed it.
-      Large values (>10 s) mean the queue was backed up; very
-      large values point at either worker saturation or a stuck
-      op blocking the worker.
+      This is not queueing alone: it also counts deliberate
+      deferral while an op waits on a dependency, and the seconds a
+      `*_high_io` background op spends gated off while the local
+      disk is busy. Both are designed behaviour, and each is large
+      enough to be the whole of a tail on its own -- the worst
+      operation type measured for the queue-performance plan had a
+      15.78 s median wait which fell to 0.77 s once deferred ops
+      were excluded. So read a large value against `defer_count`
+      and against the node's disk busy metric before calling it a
+      backup; only once those are excluded does it point at worker
+      saturation or a stuck op blocking the worker. See "Reading
+      these events back" below.
     * `defer_count` — how many times this op was re-enqueued via
       `defer()` / `defer_with_backoff()` before finally running. A
       first-time pickup is `0`; non-zero values indicate dependency
@@ -574,11 +583,17 @@ are orphaned rows which the daily prune sweep then deletes. The
 never come into it -- they bound how long an event may live, not how
 long the object it describes does. This is issue #3864.
 
-What does persist is the log stream. Every event is echoed as an
-`Added event` log line carrying the whole `extra` dict, unless
-`LOG_EVENTS_TO_LOKI` has been turned off, so wherever the cluster's
-logs are shipped is where an operation's history can still be read
-after the fact.
+What does persist is the log stream. Every event is echoed as a log
+line carrying the whole `extra` dict, unless `LOG_EVENTS_TO_LOKI` has
+been turned off, so wherever the cluster's logs are shipped is where
+an operation's history can still be read after the fact.
+
+Do not grep that stream for `Added event`. That is the message the
+echo is written with, but the logger merges the caller's fields over
+the record last and one of those fields is the event's own `message`,
+so the string never reaches the shipped JSON. Filter on the event's
+message instead -- `execution duration` for the events above -- which
+is what the record's `message` field actually holds.
 
 `tools/queue-wait-report.py` in the source repository summarises the
 `execution duration` events from such a stream: give it Shaken Fist

--- a/docs/operator_guide/networking/overview.md
+++ b/docs/operator_guide/networking/overview.md
@@ -560,6 +560,33 @@ itself):
   one, so a moderate gap between sibling-arriving and
   `coalesced sibling ops` firing is expected.
 
-The `execution duration` event is retained for
-`MAX_USAGE_EVENT_AGE` (default 30 days); the `coalesced sibling
-ops` event for `MAX_STATUS_EVENT_AGE` (default 7 days).
+### Reading these events back
+
+Neither event survives its operation for long, so plan to read them
+from the log stream rather than from the database.
+
+A cluster operation is hard deleted 30 seconds after it reaches a
+final state, and hard deleting an object removes the rows which join
+its events to it. Roughly half a minute after an operation completes
+there is nothing left to query: the operation is gone, and its events
+are orphaned rows which the daily prune sweep then deletes. The
+`MAX_USAGE_EVENT_AGE` and `MAX_STATUS_EVENT_AGE` retention settings
+never come into it -- they bound how long an event may live, not how
+long the object it describes does. This is issue #3864.
+
+What does persist is the log stream. Every event is echoed as an
+`Added event` log line carrying the whole `extra` dict, unless
+`LOG_EVENTS_TO_LOKI` has been turned off, so wherever the cluster's
+logs are shipped is where an operation's history can still be read
+after the fact.
+
+`tools/queue-wait-report.py` in the source repository summarises the
+`execution duration` events from such a stream: give it Shaken Fist
+JSON log lines on standard input -- from Loki, from
+`journalctl -u 'sf-*.service' -o cat`, or from a CI log bundle -- and
+it reports the queue-wait distribution by queue class, priority lane
+and operation type. It prints the two caveats needed to read those
+numbers: that a p90 at or below two seconds is the dispatcher's idle
+poll interval rather than queueing, and that `wait_seconds` includes
+deliberate deferral, which is why every percentile is also reported
+over just the operations which never deferred.

--- a/docs/plans/PLAN-queue-performance-phase-07-measure-and-decide.md
+++ b/docs/plans/PLAN-queue-performance-phase-07-measure-and-decide.md
@@ -2,9 +2,11 @@
 
 Master plan: [PLAN-queue-performance.md](PLAN-queue-performance.md)
 
-**Status: Not started.** This is step 7 of the master plan; the master
+**Status: Complete.** This is step 7 of the master plan; the master
 plan numbers its work in steps and this file is that step's detailed
-plan, so "step 7" and "phase 7" are the same thing throughout.
+plan, so "step 7" and "phase 7" are the same thing throughout. What
+the measurement found is in "Findings" at the end of this document,
+which corrects one thing this plan's own survey got wrong.
 
 **Planning effort: high.** The mechanical part (extract a distribution
 from a log stream) is easy. The judgement is in deciding what the
@@ -308,6 +310,88 @@ the tree accurately.
   Execution table carry the same status, and
   `python3 tools/check-plan-status.py` passes.
 * `pre-commit run --all-files` passes.
+
+## Findings
+
+Executed 2026-08-23. All six steps done.
+
+### The verdict
+
+The 26 hour `sfcbr` window and the 33 minute CI window agree with each
+other and with the planning survey: **the queue-wait tail this plan set
+out to remove is gone, and explicit fairness is not needed.** The
+numbers, and the three exclusions the verdict rests on, are written up
+in the master plan under "What step 7 measured" and are not repeated
+here.
+
+The hypothesis this plan told step 7b to falsify rather than confirm
+survived falsification. Two of the three tails were tested directly
+against the alternative explanation rather than argued away:
+
+* `node_inst_netdesc_op`'s 15.78 s median falls to 0.77 s once
+  deferred operations are excluded, on 1,013 samples. That is the
+  `defer_count == 0` split from decision 3 doing exactly the job it
+  was added for.
+* `node_blob_op`'s 403 s p90 was tested by measuring how much work its
+  own queue completed during each of the eight worst waits: between
+  1,281 and 1,334 seconds, which exceeds the wait itself because
+  several workers run concurrently. A starved queue does no work
+  during its wait; this one was saturated throughout. That test turned
+  out to be stronger than the disk-busy correlation decision 5 called
+  for, and was used instead of it.
+* `networknode`/`background`'s 4.45 s median resolved the same way:
+  during its largest burst the background lane ran 34.5 s of its own
+  work in 29 s while the user-facing lane on the same queue ran 2.9 s
+  in total.
+
+### What the survey got wrong
+
+One thing. This plan's survey listed three sources of delay inside
+`wait_seconds` plus "actual queue wait". It missed a fourth queue
+*class*: `artifact_fetch_op` enqueues against a target of literally
+`any` when no node is specified
+(`shakenfist/schema/operations/artifact_fetch_op.py:64`), which is
+neither `networknode` nor a uuid. The first version of
+`tools/queue-wait-report.py` classified those 27 CI samples as
+`unknown`. Fixed in the tool as an `any-node` class, with a test. No
+`any` queue appeared in the `sfcbr` window, so only the CI numbers
+were ever affected, and only by being filed under the wrong row.
+
+Everything else the survey asserted held, including the parts it was
+least sure of: the events really are unreachable 30 seconds after an
+operation completes, and the `~1.8 s` p90 floor really is the idle
+poll cap and appears on every quiet queue in both windows.
+
+### Deviations from the plan
+
+* **Decision 5's disk-busy correlation was not used.** The
+  same-queue-occupancy test above answers the same question from the
+  log stream alone, without needing the node metrics, and is a
+  stronger negative: it shows the queue was busy, not merely that the
+  gate was open. Decision 5's requirement -- that a
+  `background_high_io` tail is not starvation until the alternative is
+  excluded -- was met, by a different exclusion.
+* **The Loki capture had to be paged.** A single `query_range` request
+  is capped at 5,000 entries, which is about nine hours of this
+  cluster's traffic, and `--since` alone always returns the newest
+  entries in its window, so it cannot walk backwards. The 26 hour
+  capture was assembled from thirteen two-hour windows. Anyone
+  repeating this should expect to page rather than raise `--limit`.
+* **Only two of the three candidate issues were filed.** #3863 (the
+  flat 15 second dependency defer) and #3864 (operation events
+  unreachable 30 seconds after completion). The third,
+  `background_high_io`, was conditional on 7b confirming it was not
+  self-inflicted, and 7b found that it was, so there is nothing to
+  file: a queue saturated with its own work is the system working.
+
+### Follow-ups still not landed
+
+The master plan's two deferred follow-ups are unchanged by this
+measurement, and neither is now urgent.
+`NodeNetOp.network_apply_create_hypervisor` coalescing would reduce
+enqueue volume at node startup, but `node_net_op` measures a p90 wait
+of 1.86 s -- the poll floor -- so there is no latency to win, only
+work. Explicit fairness is answered above.
 
 ## Back brief
 

--- a/docs/plans/PLAN-queue-performance-phase-07-measure-and-decide.md
+++ b/docs/plans/PLAN-queue-performance-phase-07-measure-and-decide.md
@@ -170,10 +170,22 @@ live inside it.
    that cap. It is not queueing and it is not unfairness; a verdict
    that treats a p90 of 1.8 s as a latency problem has measured the
    poll interval.
-2. **Dependency deferral (15 s per defer, flat).** `defer()` takes
-   `delay=15` by default (`shakenfist/operations/baseoperation.py:393`)
-   and the dependency-wait path in both dispatchers calls it with no
-   argument. `node_inst_netdesc_op` runs on the `user_waiting` queue
+2. **Dependency deferral (15 s per defer on the queues that matter
+   here).** `defer()` takes `delay=15` by default
+   (`shakenfist/operations/baseoperation.py:393`) and `sf-queues`'
+   dependency-wait path calls it with no argument
+   (`shakenfist/daemons/queues/workitem.py:152`), so a defer there is a
+   flat fifteen seconds. `sf-net` is *not* the same: it passes an
+   explicit delay which starts at `INITIAL_DEFER_DELAY` (0.1 s) and
+   doubles to a `MAX_DEFER_DELAY` cap of 15 s
+   (`shakenfist/daemons/network/workitem.py:95-101`), so three defers
+   there cost about 0.7 s rather than 45 s. Which schedule applies
+   follows the dispatcher, and the dispatcher follows the queue:
+   `sf-net` drains the `<uuid>-network-*` queues and, on the elected
+   network node, the cluster-wide `networknode-clusteroperation-*` ones
+   (`shakenfist/daemons/network/workitem.py:174-176`); everything else
+   is `sf-queues` via `Daemon.dequeue_job`.
+   `node_inst_netdesc_op` runs on the `user_waiting` queue
    with a median `defer_count` of 1 and a median wait of 15.74 s
    against a median execution time of 1.71 s — one dependency wait is a
    flat 15 second tax on the most latency-sensitive queue there is. Its
@@ -230,9 +242,9 @@ the tree accurately.
    `defer_count == 0` only. Without that split, `node_inst_netdesc_op`'s
    15 second dependency tax reads as a queueing problem, and the
    fairness question gets answered wrongly. The report also groups by
-   queue *class* (`networknode`, per-node, per-network) and priority
-   lane, not by raw queue name, since raw names embed uuids and never
-   aggregate.
+   queue *class* (`networknode`, `any-node`, and the two per-node
+   classes) and priority lane, not by raw queue name, since raw names
+   embed uuids and never aggregate.
 
 4. **A p90 at or below `IDLE_POLL_MAX_SECONDS` is "no wait".** The
    verdict must state the floor it is measuring against, and the tool
@@ -272,7 +284,7 @@ the tree accurately.
 
 | Step | Effort | Model | Isolation | Brief for sub-agent |
 |------|--------|-------|-----------|---------------------|
-| 7a | medium | sonnet | none | Write `tools/queue-wait-report.py`: reads newline-delimited JSON on stdin, ignores non-JSON lines, and keeps objects whose `message` is `execution duration` and whose `extra` contains `wait_seconds`. For each, derive: `wait_seconds`, `extra.seconds`, `extra.defer_count`, `extra.queue_name`, `program`, and the operation type, which is the object key ending in `_op` (e.g. `node_inst_op`) — that key's value is the op uuid. Classify `queue_name` by splitting on `-clusteroperation-` (and on `-network-`, which the per-network queues use): a target of literally `networknode` is class `networknode`, a 36-character uuid target is class `per-node` or `per-network` depending on the separator, and the suffix is the priority lane. Print three tables — by (queue class, lane), by operation type, and by lane alone — each with n, p50, p90, p99, max for `wait_seconds`, the same percentiles restricted to `defer_count == 0`, the median and p90 of `extra.seconds`, and the count with `defer_count > 0`. Print the sample window (min and max `ts`) and print the line `Idle poll floor: p90 at or below 2.0s is the dispatcher poll cap (IDLE_POLL_MAX_SECONDS), not queue wait.` Follow the repo style: copyright header, single quotes, 120 columns, `argparse`, no third-party dependencies beyond the standard library. Add `shakenfist/tests/test_queue_wait_report.py` with a handful of synthetic lines covering: a `networknode` queue, a per-node queue, a per-network queue, a deferred op, a malformed line, and a line that is not an `execution duration` event. |
+| 7a | medium | sonnet | none | Write `tools/queue-wait-report.py`: reads newline-delimited JSON on stdin, ignores non-JSON lines, and keeps objects whose `message` is `execution duration` and whose `extra` contains `wait_seconds`. For each, derive: `wait_seconds`, `extra.seconds`, `extra.defer_count`, `extra.queue_name`, `program`, and the operation type, which is the object key ending in `_op` (e.g. `node_inst_op`) — that key's value is the op uuid. Classify `queue_name` by splitting on `-clusteroperation-` and on `-network-`: a target of literally `networknode` is class `networknode`, and a uuid target is a per-node class named for the separator, since both families are keyed by node uuid (there is no per-network queue) and the separator is what says which dispatcher drains it. The suffix is the priority lane. Print three tables — by (queue class, lane), by operation type, and by lane alone — each with n, p50, p90, p99, max for `wait_seconds`, the same percentiles restricted to `defer_count == 0`, the median and p90 of `extra.seconds`, and the count with `defer_count > 0`. Print the sample window (min and max `ts`) and print the line `Idle poll floor: p90 at or below 2.0s is the dispatcher poll cap (IDLE_POLL_MAX_SECONDS), not queue wait.` Follow the repo style: copyright header, single quotes, 120 columns, `argparse`, no third-party dependencies beyond the standard library. Add `shakenfist/tests/test_queue_wait_report.py` with a handful of synthetic lines covering: a `networknode` queue, a per-node cluster operation queue, a per-node network queue, a deferred op, a malformed line, and a line that is not an `execution duration` event. |
 | 7b | high | opus | none | Capture at least 24 hours of `execution duration` events from `sfcbr` and produce the verdict. The operator's `loki-query` helper reaches them: `loki-query '{job="shakenfist"} \|= "execution duration"' --tenant sfcbr --since 24h --limit 20000`. Note that the limit truncates from the *oldest* end, so check the printed window actually spans 24 hours and re-run with a larger limit if it does not. Feed the capture to `tools/queue-wait-report.py`. Then answer, in writing, with numbers: (a) is the `net_op` tail gone; (b) is any lower-priority lane starved — for each candidate, exclude the two non-fairness explanations first, using `defer_count == 0` percentiles for deferral and, for any `*_high_io` background tail, the node's `DISK_BUSY_PER_SECOND_METRIC` over the same window (available from the Grafana `shakenfist` dashboard on maui, or from `mariadb.get_node_metrics`); (c) what the largest remaining user-visible latency actually is. The expected shape of the answer from the planning survey is "the tail is gone, fairness is not needed, the remaining cost is a flat 15 s dependency defer" — treat that as a hypothesis to falsify, not a conclusion to confirm, and say so if the 24 hour window disagrees with the 9 hour one. |
 | 7c | medium | sonnet | none | Run the same report against a cluster CI run and compare. Take the most recent successful `functional-tests.yml` cluster-CI run (see the `ci-status` helper), download its `bundle.zip` artifact, and find the Shaken Fist daemon logs inside it — note that the Loki dumps in these bundles have repeatedly been empty, so fall back to the per-node journals, which carry the same JSON lines. Feed them to `tools/queue-wait-report.py` and report the same three tables. State the sample size honestly: a CI cluster runs for well under an hour and the numbers are a burst, not a steady state. The comparison that matters is `net_op` at the site where the >60 s waits were originally observed. |
 | 7d | medium | sonnet | none | Write the outcome up. In `docs/plans/PLAN-queue-performance.md`: replace step 7 with what was measured and decided, including the tables from 7b and 7c, set the Status section to Complete, and set the step 7 row of the Execution table. In `docs/plans/index.md`: set the plan's status and phase arithmetic. In `docs/operator_guide/networking/overview.md`, fix the retention paragraph at line 563 — the `execution duration` event is unreachable from its operation roughly 30 seconds after the operation completes, because cluster operations are hard-deleted then and `hard_delete()` takes their `event_objects` rows with them; the orphaned `events` row is removed by the daily prune. Say where an operator should look instead (the log stream), and mention `tools/queue-wait-report.py`. Do not restate the numbers in more than one place. |
@@ -357,10 +369,46 @@ neither `networknode` nor a uuid. The first version of
 `any` queue appeared in the `sfcbr` window, so only the CI numbers
 were ever affected, and only by being filed under the wrong row.
 
+Review found a second thing, after the measurement: this plan's
+survey said the dependency-wait path in *both* dispatchers takes
+`defer()`'s flat 15 second default. Only `sf-queues` does. `sf-net`
+has backed off from 0.1 s to a 15 s cap since commit c961fe98a, so a
+`net_op` or `node_net_op` with a `defer_count` of 3 waited under a
+second on purpose, not 45. The verdict is untouched --
+`node_inst_netdesc_op`, the tail this turns on, runs on a `sf-queues`
+queue where the flat 15 s is real -- but the corrected survey text is
+above, and `tools/queue-wait-report.py` now prints the schedule for
+each queue class rather than asserting fifteen seconds for all of
+them. The capture corroborates the correction from the other side:
+all 980 deferred samples in 26 hours are on queues `sf-queues`
+drains, and every `sf-net` lane records a defer count of zero, so no
+measured number in this phase was ever attributed to the wrong
+schedule.
+
+The tool also labelled the `<uuid>-network-*` queues `per-network`.
+They are per-*node*: `get_node_network_queues()` takes a node uuid,
+and the split between the two per-node classes is which dispatcher
+drains them, not what the work is about. Renamed to
+`per-node (cluster op)` and `per-node (network)`. No measured number
+changes -- the grouping was always by the same key -- but the earlier
+label asserted a queue family the cluster does not have.
+
 Everything else the survey asserted held, including the parts it was
 least sure of: the events really are unreachable 30 seconds after an
 operation completes, and the `~1.8 s` p90 floor really is the idle
 poll cap and appears on every quiet queue in both windows.
+
+One further finding, from the same review pass:
+`get_node_background_node_queues()` lists `f'{node_uuid}-background'`
+alongside its two `-clusteroperation-` siblings
+(`shakenfist/operations/baseoperation.py:70`). Nothing can enqueue to
+it -- every enqueue builds `f'{target}-{family}-{priority}'`
+(`shakenfist/schema/operations/util.py:53`), which always has three
+segments -- so it is carried in every background dequeue's `IN` list
+and `ORDER BY FIELD()` on every node, matching nothing. Zero of the
+19,184 measured samples had a queue name which failed to parse, which
+is the corroboration. Filed as #3867 rather than fixed here; it is a
+production change and this is a measurement phase.
 
 ### Deviations from the plan
 

--- a/docs/plans/PLAN-queue-performance-phase-07-measure-and-decide.md
+++ b/docs/plans/PLAN-queue-performance-phase-07-measure-and-decide.md
@@ -1,0 +1,320 @@
+# Phase 7 — re-measure the queue, and decide about fairness
+
+Master plan: [PLAN-queue-performance.md](PLAN-queue-performance.md)
+
+**Status: Not started.** This is step 7 of the master plan; the master
+plan numbers its work in steps and this file is that step's detailed
+plan, so "step 7" and "phase 7" are the same thing throughout.
+
+**Planning effort: high.** The mechanical part (extract a distribution
+from a log stream) is easy. The judgement is in deciding what the
+numbers mean: the pipeline has at least three distinct sources of
+delay which all land in the same `wait_seconds` field, and calling any
+of them "starvation" without separating them first is how this phase
+gets the wrong answer.
+
+## Why this phase exists
+
+Steps 1-6 attacked a specific failure: `network_apply_update_dnsmasq`
+ops waiting more than 60 seconds behind a serialised single-threaded
+`sf-net` worker. They landed batched dequeue, worker-side and
+enqueue-side coalescing, and a per-op latency event so the result could
+be seen.
+
+Step 7 is the measurement those changes were instrumented for, and the
+decision that follows it: is the wait tail gone, or does the dispatcher
+still need explicit fairness (bounded staleness, or reserved slots) so
+that sustained higher-priority load cannot starve a lower-priority
+queue?
+
+## Scope
+
+**In scope:**
+
+* A committed, repeatable tool that turns a stream of Shaken Fist JSON
+  log lines into a queue-wait distribution.
+* A measured verdict from `sfcbr` over a window of at least 24 hours,
+  and a second one from a cluster CI run.
+* The fairness decision, written into the master plan with the numbers
+  that justify it.
+* Correcting the two documentation claims the survey found to be
+  false (below), and closing out the master plan.
+* Filing issues for latency sources this phase measures but does not
+  fix.
+
+**Out of scope:**
+
+* Implementing fairness. If the verdict is "yes, we need it", that
+  becomes step 8 with its own plan. A measurement phase that also
+  changes the thing it measures cannot report a clean before and after.
+* Fixing the two non-fairness latency sources the survey already
+  found (fixed-delay dependency deferral; `background_high_io` waits
+  behind the disk-busy gate). Both are real and both are someone
+  else's plan — this phase files them.
+* The two follow-ups the master plan already defers:
+  `NodeNetOp.network_apply_create_hypervisor` coalescing, which needs
+  multi-column target support in the find/claim primitives. Step 7's
+  numbers inform whether it is worth doing; it is not done here.
+* Changing event retention. The survey found the retention
+  documentation is wrong; the *behaviour* may or may not be wrong, and
+  deciding that is not this phase's job.
+
+## What the survey found (2026-08-23)
+
+### Steps 1-6 are genuinely on `develop`
+
+The master plan's Status section said steps 1-6 were "implemented, on
+the `network-facade` branch". They merged as PR #3194 on 2026-05-26 and
+every artefact is present on `develop`:
+
+| Step | Evidence |
+|------|----------|
+| 1. Visibility | `shakenfist/daemons/queues/workitem.py:159-171`, `shakenfist/daemons/network/workitem.py:384-401` |
+| 2. Batched dequeue | `mariadb.dequeue_work_items()` (`shakenfist/mariadb.py:23290`); no singular `dequeue_work_item` remains |
+| 3. Coalescible metadata | `BaseClusterOperation.coalescible_tasks` / `coalescible_target_column` (`shakenfist/operations/baseoperation.py:130`), `COALESCIBLE_TASKS` (`shakenfist/schema/operations/net_op.py:63`) |
+| 4. Worker-side dedup | `BaseClusterOperation.execute` (`shakenfist/operations/baseoperation.py:294-380`) |
+| 5. Enqueue-side dedup | `net_op.create_and_enqueue` (`shakenfist/schema/operations/net_op.py:105-153`) |
+| 6. Caller-site audit | `reconciled_network_uuids` (`shakenfist/operations/node_inst_netdesc_op.py:315`) |
+
+The master plan's Status wording has been corrected in this commit, and
+step 1's description with it: the implementation did **not** emit a
+separate `'started executing'` event at the pickup boundary. It folded
+the wait fields into the existing end-of-op `'execution duration'`
+event, on the grounds that a second event doubles the eventlog cost on
+the dispatcher's critical path. `docs/operator_guide/networking/overview.md:507`
+already documents the combined form correctly; only the master plan was
+stale.
+
+### The measurement is possible, but not the way the plan assumed
+
+The plan says the `'started executing'` event distribution tells us
+what we need. Reading those events back out of the database is not
+possible after the fact:
+
+* Cluster operations are hard-deleted **30 seconds** after reaching a
+  final state (`_deleted_object_delay()` returns 30 for any object type
+  ending in `_op`, `shakenfist/daemons/cluster/scheduled_tasks.py:735`;
+  `FINAL_OBJECT_STATES` includes `complete`,
+  `shakenfist/constants.py:191`).
+* `hard_delete()` calls `delete_object_events()`
+  (`shakenfist/baseobject.py:689`), which drops the `event_objects`
+  rows for that op (`shakenfist/mariadb.py:5835`). The `events` row
+  survives, but orphaned — nothing joins it to an op, a queue, or a
+  target — until the daily orphan sweep deletes it
+  (`_direct_prune_orphan_events`, `shakenfist/mariadb.py:5639`;
+  scheduled at `shakenfist/daemons/cluster/main.py:619`).
+* There is no REST endpoint for cluster operation events, and
+  `get_object_events()` is per-object only.
+
+So `docs/operator_guide/networking/overview.md:563` — "The `execution
+duration` event is retained for `MAX_USAGE_EVENT_AGE` (default 30
+days)" — is false twice over: the event is unreachable from its object
+after ~30 seconds, and its row is gone within a day. Step 7d corrects
+the documentation. Whether a 30 second window is the *right* retention
+for an operation's audit trail is a separate question and is filed, not
+answered here.
+
+What does work is the log stream. `eventlog.add_event_multi` echoes
+every event as an `Added event` log line whenever `LOG_EVENTS_TO_LOKI`
+is set, which it is by default (`shakenfist/eventlog.py:96`,
+`shakenfist/config.py:702`). The echo carries the full `extra` dict.
+A live sample from `sfcbr` confirms it:
+
+```json
+{"logger_name": "shakenfist.eventlog", "message": "execution duration",
+ "event_type": "usage",
+ "extra": {"seconds": 0.1026, "wait_seconds": 2.0639, "defer_count": 0,
+           "queue_name": "7ce66641-...-clusteroperation-user_facing"},
+ "node_inst_op": "1ed3668d-351c-4f86-b1aa-f86547ce1926",
+ "program": "sf-queues"}
+```
+
+The op's uuid appears as a key named for its object type, which is how
+the analysis attributes a wait to an operation class without a join.
+
+### The original tail is gone
+
+A 9h35m sample from `sfcbr` (2026-08-23 08:14Z to 17:49Z, the most
+recent 5,000 `execution duration` events, so the window is complete for
+those events), grouped by operation type:
+
+| Op type | n | p50 | p90 | p99 | max |
+|---------|---|-----|-----|-----|-----|
+| `net_op` | 1612 | 0.79 | 1.83 | 11.30 | 23.75 |
+| `node_inst_op` | 1574 | 0.78 | 1.75 | 2.10 | 3.76 |
+| `node_net_op` | 657 | 0.99 | 1.85 | 2.21 | 4.02 |
+| `node_inst_netdesc_op` | 288 | **15.74** | 16.93 | 18.18 | **215.69** |
+| `artifact_fetch_op` | 271 | 0.96 | 1.88 | 2.07 | 2.11 |
+| `net_macaddr_ip_op` | 186 | 0.92 | 2.05 | 6.74 | 6.82 |
+| `node_blob_op` | 139 | 2.00 | **568.27** | 583.48 | **583.57** |
+| `net_iface_op` | 131 | 0.96 | 1.90 | 2.35 | 2.39 |
+| `net_iface_ip_op` | 131 | 0.93 | 1.97 | 5.74 | 6.98 |
+
+`net_op` — the family that contains `network_apply_update_dnsmasq`, and
+the whole reason this plan exists — now runs at a p90 of 1.83 seconds
+against a >60 second starting point. That is the headline result and
+the phase should say so plainly.
+
+### Three floors and two tails, which must not be confused
+
+This is the judgement the phase turns on. `wait_seconds` is
+`start_time - op.created_at`: insert to execution. Four different things
+live inside it.
+
+1. **The idle poll floor (~0.2-2.0 s).** The dispatcher polls with
+   adaptive backoff capped at `IDLE_POLL_MAX_SECONDS = 2.0`
+   (`shakenfist/daemons/daemon.py:78-80`, issue #3499). Almost every
+   queue in the sample sits at p50 ~0.8 s and p90 ~1.8 s, which *is*
+   that cap. It is not queueing and it is not unfairness; a verdict
+   that treats a p90 of 1.8 s as a latency problem has measured the
+   poll interval.
+2. **Dependency deferral (15 s per defer, flat).** `defer()` takes
+   `delay=15` by default (`shakenfist/operations/baseoperation.py:393`)
+   and the dependency-wait path in both dispatchers calls it with no
+   argument. `node_inst_netdesc_op` runs on the `user_waiting` queue
+   with a median `defer_count` of 1 and a median wait of 15.74 s
+   against a median execution time of 1.71 s — one dependency wait is a
+   flat 15 second tax on the most latency-sensitive queue there is. Its
+   215.69 s maximum is 14 defers, exactly. This is the largest
+   user-visible latency in the sample and it has nothing to do with
+   fairness.
+3. **Designed backpressure.** `Daemon.dequeue_job` omits background
+   queues entirely unless there are two free worker slots past the
+   user-facing reservation, and omits `*_high_io` background queues
+   whenever `DISK_BUSY_PER_SECOND_METRIC` exceeds 800
+   (`shakenfist/daemons/daemon.py:665-690`). `node_blob_op` on
+   `background_high_io` shows a p90 wait of 568 s with a **zero** defer
+   count and a p50 execution time of 6.1 s — consistent with a
+   deliberately gated queue on a busy disk, not with `FIELD()`
+   starvation. Distinguishing these two requires correlating the wait
+   against the node's disk-busy metric over the same window, which is
+   step 7b's real work.
+4. **Actual queue wait**, which is what the fairness question is about,
+   and which is whatever is left after the first three are accounted
+   for.
+
+The `FIELD()` starvation risk is real and documented at
+`shakenfist/mariadb.py:22050-22055`. The sample's only candidate for it
+is `networknode-background` (p50 4.29 s, p90 21.21 s against
+`networknode-user_facing`'s 0.72/1.92), on 39 samples — too few to
+decide on, which is why this phase wants 24 hours rather than an
+afternoon.
+
+### Nothing else in the master plan's step 7 was wrong
+
+The audit findings table and the follow-ups section both still describe
+the tree accurately.
+
+## Decisions
+
+1. **Measure from the log stream, not the events table.** The events
+   are unreachable in the database within 30 seconds of an op
+   completing (above), and the log echo carries every field the
+   analysis needs. This also makes CI measurable, since CI already
+   bundles the daemon logs.
+
+2. **The tool reads newline-delimited JSON on stdin.** Not a Loki
+   client. Shaken Fist's log lines reach three different places
+   depending on where you are standing — Loki on `sfcbr` (via
+   `loki-query`, an operator's personal helper that is not in this
+   repository), the CI artifact bundle, and `journalctl -o cat` on a
+   node — and all three yield the same JSON objects. A tool that reads
+   stdin works in all three; a tool with a Loki client built in works
+   in one and hardcodes home-lab specifics into the repository. It
+   lives at `tools/queue-wait-report.py`.
+
+3. **The report separates deferred from non-deferred waits.** Every
+   percentile is reported twice: over all samples, and over
+   `defer_count == 0` only. Without that split, `node_inst_netdesc_op`'s
+   15 second dependency tax reads as a queueing problem, and the
+   fairness question gets answered wrongly. The report also groups by
+   queue *class* (`networknode`, per-node, per-network) and priority
+   lane, not by raw queue name, since raw names embed uuids and never
+   aggregate.
+
+4. **A p90 at or below `IDLE_POLL_MAX_SECONDS` is "no wait".** The
+   verdict must state the floor it is measuring against, and the tool
+   must print it, so nobody later reads 1.8 s as a regression.
+
+5. **A `background_high_io` wait is not starvation until the disk-busy
+   gate is excluded.** Step 7b correlates the tail against
+   `DISK_BUSY_PER_SECOND_METRIC` for the same node and window before
+   attributing anything to queue ordering.
+
+6. **This phase decides, it does not implement.** If the numbers say
+   fairness is needed, step 7 records the decision, the shape it should
+   take, and the evidence, and step 8 gets its own plan. This is the
+   decision most likely to be argued with: it would be cheaper to add
+   bounded-staleness ordering while the context is hot. It is refused
+   because a measurement phase that changes the system it measures
+   cannot produce a clean before-and-after, and because the survey
+   already suggests fairness is *not* where the remaining latency is —
+   spending step 8 on `FIELD()` ordering when the real cost is a flat
+   15 second defer would be optimising the wrong thing.
+
+7. **`sfcbr` is the primary measurement; CI is secondary.** CI is where
+   the problem was first seen, but a CI cluster lives for under an hour
+   and its load is a burst, so its tail is dominated by cold-start
+   effects. `sfcbr` runs the same code under a real steady state and
+   over 24 hours it can answer the starvation question. CI is measured
+   too, because the original >60 s observation came from there and the
+   phase should show the same measurement at the same site.
+
+8. **Correct the retention documentation; file the behaviour.** The
+   30-day retention claim is wrong and is fixed in step 7d. Whether an
+   operation's events *should* vanish 30 seconds after it completes is
+   a design question with an obvious cost either way, and it gets an
+   issue rather than a decision here.
+
+## Step plan
+
+| Step | Effort | Model | Isolation | Brief for sub-agent |
+|------|--------|-------|-----------|---------------------|
+| 7a | medium | sonnet | none | Write `tools/queue-wait-report.py`: reads newline-delimited JSON on stdin, ignores non-JSON lines, and keeps objects whose `message` is `execution duration` and whose `extra` contains `wait_seconds`. For each, derive: `wait_seconds`, `extra.seconds`, `extra.defer_count`, `extra.queue_name`, `program`, and the operation type, which is the object key ending in `_op` (e.g. `node_inst_op`) — that key's value is the op uuid. Classify `queue_name` by splitting on `-clusteroperation-` (and on `-network-`, which the per-network queues use): a target of literally `networknode` is class `networknode`, a 36-character uuid target is class `per-node` or `per-network` depending on the separator, and the suffix is the priority lane. Print three tables — by (queue class, lane), by operation type, and by lane alone — each with n, p50, p90, p99, max for `wait_seconds`, the same percentiles restricted to `defer_count == 0`, the median and p90 of `extra.seconds`, and the count with `defer_count > 0`. Print the sample window (min and max `ts`) and print the line `Idle poll floor: p90 at or below 2.0s is the dispatcher poll cap (IDLE_POLL_MAX_SECONDS), not queue wait.` Follow the repo style: copyright header, single quotes, 120 columns, `argparse`, no third-party dependencies beyond the standard library. Add `shakenfist/tests/test_queue_wait_report.py` with a handful of synthetic lines covering: a `networknode` queue, a per-node queue, a per-network queue, a deferred op, a malformed line, and a line that is not an `execution duration` event. |
+| 7b | high | opus | none | Capture at least 24 hours of `execution duration` events from `sfcbr` and produce the verdict. The operator's `loki-query` helper reaches them: `loki-query '{job="shakenfist"} \|= "execution duration"' --tenant sfcbr --since 24h --limit 20000`. Note that the limit truncates from the *oldest* end, so check the printed window actually spans 24 hours and re-run with a larger limit if it does not. Feed the capture to `tools/queue-wait-report.py`. Then answer, in writing, with numbers: (a) is the `net_op` tail gone; (b) is any lower-priority lane starved — for each candidate, exclude the two non-fairness explanations first, using `defer_count == 0` percentiles for deferral and, for any `*_high_io` background tail, the node's `DISK_BUSY_PER_SECOND_METRIC` over the same window (available from the Grafana `shakenfist` dashboard on maui, or from `mariadb.get_node_metrics`); (c) what the largest remaining user-visible latency actually is. The expected shape of the answer from the planning survey is "the tail is gone, fairness is not needed, the remaining cost is a flat 15 s dependency defer" — treat that as a hypothesis to falsify, not a conclusion to confirm, and say so if the 24 hour window disagrees with the 9 hour one. |
+| 7c | medium | sonnet | none | Run the same report against a cluster CI run and compare. Take the most recent successful `functional-tests.yml` cluster-CI run (see the `ci-status` helper), download its `bundle.zip` artifact, and find the Shaken Fist daemon logs inside it — note that the Loki dumps in these bundles have repeatedly been empty, so fall back to the per-node journals, which carry the same JSON lines. Feed them to `tools/queue-wait-report.py` and report the same three tables. State the sample size honestly: a CI cluster runs for well under an hour and the numbers are a burst, not a steady state. The comparison that matters is `net_op` at the site where the >60 s waits were originally observed. |
+| 7d | medium | sonnet | none | Write the outcome up. In `docs/plans/PLAN-queue-performance.md`: replace step 7 with what was measured and decided, including the tables from 7b and 7c, set the Status section to Complete, and set the step 7 row of the Execution table. In `docs/plans/index.md`: set the plan's status and phase arithmetic. In `docs/operator_guide/networking/overview.md`, fix the retention paragraph at line 563 — the `execution duration` event is unreachable from its operation roughly 30 seconds after the operation completes, because cluster operations are hard-deleted then and `hard_delete()` takes their `event_objects` rows with them; the orphaned `events` row is removed by the daily prune. Say where an operator should look instead (the log stream), and mention `tools/queue-wait-report.py`. Do not restate the numbers in more than one place. |
+| 7e | medium | sonnet | none | File the issues this phase deliberately does not fix, one each, each with the measured numbers from 7b: (1) a dependency defer costs a flat 15 seconds on the `user_waiting` queue, which dominates instance-start latency — `defer()`'s `delay=15` default at `shakenfist/operations/baseoperation.py:393` is a fixed poll where an event or a shorter first delay would do; (2) `execution duration` and every other operation event become unreachable 30 seconds after the operation completes, so an operator cannot review a completed operation's own audit trail; (3) only if 7b confirms it is not the disk-busy gate, the `background_high_io` wait tail. Search for existing issues before filing each — #3516 and #3773 touch agent-operation deferral and may already cover part of (1). |
+| 7f | high | opus | none | Code review of everything this phase produced, per `CLAUDE.md`'s "perform a code review at the end of a plan". Read `tools/queue-wait-report.py` against its tests: the percentile function's behaviour on small samples, the queue-name classifier against a real capture rather than only the synthetic fixtures, and whether the `defer_count == 0` split is applied consistently in all three tables. Check that no number appears in two documents with two values. Raise concerns rather than fixing silently. |
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| The 24 hour window is quiet and contains no contention, so the starvation question goes unanswered | 7b states the sample's contention explicitly (worker occupancy, queue depths). If the window is idle, the honest verdict is "no evidence of starvation under this load", and the phase says which load it did not test rather than claiming a clean bill of health. Reviewer checks the verdict does not overclaim. |
+| A tail gets attributed to unfairness when it is the disk-busy gate or a dependency defer | Decisions 3 and 5 make the exclusions mandatory, 7a's report makes them mechanical (the `defer_count == 0` split), and 7f re-checks that they were applied. |
+| `loki-query` retention is shorter than 24 hours for the `sfcbr` tenant | 7b checks the printed window before analysing. If retention is short, capture forward instead: run the query on a schedule for a day, or capture from the nodes' journals directly. |
+| The CI bundle turns out to contain no usable log lines | Known and expected for the Loki dumps in the bundle (this has bitten before); 7c goes to the journals. If neither has them, 7c reports that fact — it is itself a CI observability defect worth filing — and the verdict rests on `sfcbr` alone, which decision 7 already treats as primary. |
+| The report tool becomes a one-off that rots | It ships with unit tests and is run by two separate steps in this phase against two different inputs. |
+
+## Definition of done
+
+* `tools/queue-wait-report.py` exists, and
+  `python3 tools/queue-wait-report.py < /dev/null` exits zero with a
+  "no samples" message rather than a traceback.
+* `shakenfist/tests/test_queue_wait_report.py` passes under `tox`, and
+  covers a malformed line, a non-matching event, and a deferred op.
+* A capture of at least 24 hours from `sfcbr` has been run through the
+  tool, and the printed window in the report spans at least 24 hours.
+* The master plan's step 7 states, with numbers, whether the `net_op`
+  wait tail is gone and whether fairness is needed, and if fairness is
+  needed it names the mechanism and the evidence.
+* Every latency source this phase identified but did not fix has either
+  an issue number or a sentence saying why it needs none.
+* `docs/operator_guide/networking/overview.md` no longer claims the
+  `execution duration` event is retained for 30 days, and no page
+  states a retention for it that another page contradicts.
+* `docs/plans/index.md`'s row for this plan and the master plan's
+  Execution table carry the same status, and
+  `python3 tools/check-plan-status.py` passes.
+* `pre-commit run --all-files` passes.
+
+## Back brief
+
+Before executing any step of this plan, back brief the operator on your
+understanding of it and how the work you intend to do aligns with it.
+
+One gate: **after step 7b, stop and report the verdict before writing
+anything into the master plan.** The fairness decision is the whole
+point of the phase, and it is much cheaper to argue about it from the
+numbers than from a finished write-up.

--- a/docs/plans/PLAN-queue-performance.md
+++ b/docs/plans/PLAN-queue-performance.md
@@ -2,11 +2,13 @@
 
 ## Status
 
-In progress.
+Complete.
 
 Steps 1-6 merged to `develop` as PR #3194 on 2026-05-26. Step 7
-(measure, decide on fairness) is planned in
-[PLAN-queue-performance-phase-07-measure-and-decide.md](PLAN-queue-performance-phase-07-measure-and-decide.md).
+measured the result and decided against explicit fairness; the
+measurement, the exclusions it rests on and the decision are in
+[PLAN-queue-performance-phase-07-measure-and-decide.md](PLAN-queue-performance-phase-07-measure-and-decide.md)
+and summarised under "What step 7 measured" below.
 
 ## Execution
 
@@ -18,7 +20,7 @@ Steps 1-6 merged to `develop` as PR #3194 on 2026-05-26. Step 7
 | 4. Worker-side dedup | (in PR #3194) | Complete |
 | 5. Enqueue-side dedup | (in PR #3194) | Complete |
 | 6. Caller-site audit | (in PR #3194) | Complete |
-| 7. Re-measure and decide on fairness | [PLAN-queue-performance-phase-07-measure-and-decide.md](PLAN-queue-performance-phase-07-measure-and-decide.md) | In progress |
+| 7. Re-measure and decide on fairness | [PLAN-queue-performance-phase-07-measure-and-decide.md](PLAN-queue-performance-phase-07-measure-and-decide.md) | Complete |
 
 ## Problem
 
@@ -96,10 +98,77 @@ Six discrete changes plus one measurement step:
 7. **Re-measure**: once steps 1-6 are deployed, the per-op
    wait distribution tells us whether the tail is gone or whether
    explicit fairness (bounded staleness, reserved-slot lottery) is
-   still needed for lower-priority queues. Planned in
-   [PLAN-queue-performance-phase-07-measure-and-decide.md](PLAN-queue-performance-phase-07-measure-and-decide.md),
-   which also records why the events have to be read from the log
-   stream rather than from the events table.
+   still needed for lower-priority queues. Done -- see "What step 7
+   measured" below,
+   [PLAN-queue-performance-phase-07-measure-and-decide.md](PLAN-queue-performance-phase-07-measure-and-decide.md)
+   for the method, and `tools/queue-wait-report.py` for the tool
+   which produced the numbers.
+
+## What step 7 measured
+
+Two windows, both through `tools/queue-wait-report.py`:
+
+* **`sfcbr`**, 25h58m, 17,936 operations
+  (2026-08-22T16:33Z to 2026-08-23T18:30Z). Production steady state.
+* **Cluster CI**, 33 minutes, 1,248 operations (merge-queue run
+  32597511463, all five cluster nodes' journals). The site where the
+  original >60 s waits were seen.
+
+### The tail this plan set out to remove is gone
+
+`net_op` -- the family containing `network_apply_update_dnsmasq` --
+against a starting point of over 60 seconds:
+
+| Window | n | p50 | p90 | p99 | max |
+|--------|---|-----|-----|-----|-----|
+| `sfcbr`, 26h | 6310 | 0.78 | 1.81 | 7.77 | 27.60 |
+| CI, 33m | 313 | 0.56 | 1.72 | 2.19 | 23.96 |
+
+A p90 of 1.8 s is the dispatcher's idle poll cap
+(`IDLE_POLL_MAX_SECONDS = 2.0`), so on both clusters the median
+operation now waits roughly one poll interval and nothing else.
+
+### Explicit fairness is not needed
+
+Three tails in the `sfcbr` window sit above that floor. None of them
+is a lower-priority queue being starved by a higher-priority one, and
+each was excluded on evidence rather than on argument:
+
+* **`user_waiting`, p50 15.78 s** (`node_inst_netdesc_op`). Entirely
+  deferral: restricted to operations which never deferred, the same
+  p50 is 0.77 s, and 962 of 1013 samples had deferred at least once.
+  A dependency wait re-enqueues an operation a flat 15 seconds into
+  the future. This is the largest user-visible latency in the whole
+  sample and it has nothing to do with queue order. Filed as #3863.
+* **`background_high_io`, p90 403 s** (`node_blob_op`), with a defer
+  count of zero, which is the shape starvation would have. It is not:
+  during each of the eight worst waits, the *same queue* executed
+  between 1,281 and 1,334 seconds of its own work, which is more than
+  the wait itself (several workers run concurrently). The queue was
+  saturated with its own blob transfers throughout, not held off by
+  user-facing work, and not gated off by the disk-busy check.
+* **`networknode`/`background`, p50 4.45 s**. All 103 samples are
+  bursts of 20-40 operations arriving within seconds of each other.
+  In the largest, the background lane ran 34.5 s of its own work in a
+  29 s span while `networknode`/`user_facing` ran 2.9 s in total. The
+  rising wait across a burst is position in that burst, not
+  higher-priority work crowding in ahead of it.
+
+So the `FIELD()` ordering's theoretical starvation risk
+(`shakenfist/mariadb.py`) did not materialise in 26 hours of
+production traffic which included exactly the bursty contention it
+would show up in. Bounded-staleness ordering and reserved slots are
+**not** being added. If the question is reopened, reopen it with a
+measurement: the tool is committed and the exclusions above are what
+any future claim of starvation has to survive.
+
+### What the measurement cost us to build
+
+The events could not be read back out of the database at all: an
+operation is hard deleted 30 seconds after it completes and takes its
+events' object references with it, so the numbers had to come from the
+log echo instead. That gap is filed as #3864 and the operator
+documentation, which claimed 30 day retention, is corrected.
 
 ## Audit findings (step 6)
 

--- a/docs/plans/PLAN-queue-performance.md
+++ b/docs/plans/PLAN-queue-performance.md
@@ -137,9 +137,12 @@ each was excluded on evidence rather than on argument:
 * **`user_waiting`, p50 15.78 s** (`node_inst_netdesc_op`). Entirely
   deferral: restricted to operations which never deferred, the same
   p50 is 0.77 s, and 962 of 1013 samples had deferred at least once.
-  A dependency wait re-enqueues an operation a flat 15 seconds into
-  the future. This is the largest user-visible latency in the whole
-  sample and it has nothing to do with queue order. Filed as #3863.
+  On the queues `sf-queues` drains, a dependency wait re-enqueues an
+  operation a flat 15 seconds into the future (`sf-net` instead backs
+  off from 0.1 s to a 15 s cap, so this cost is specific to the
+  dispatcher rather than general). This is the largest user-visible
+  latency in the whole sample and it has nothing to do with queue
+  order. Filed as #3863.
 * **`background_high_io`, p90 403 s** (`node_blob_op`), with a defer
   count of zero, which is the shape starvation would have. It is not:
   during each of the eight worst waits, the *same queue* executed

--- a/docs/plans/PLAN-queue-performance.md
+++ b/docs/plans/PLAN-queue-performance.md
@@ -4,9 +4,21 @@
 
 In progress.
 
-Steps 1-6 are implemented, on the `network-facade` branch. Step 7
-(measure, decide on fairness) is left until the per-op
-`'started executing'` event from step 1 produces real CI data.
+Steps 1-6 merged to `develop` as PR #3194 on 2026-05-26. Step 7
+(measure, decide on fairness) is planned in
+[PLAN-queue-performance-phase-07-measure-and-decide.md](PLAN-queue-performance-phase-07-measure-and-decide.md).
+
+## Execution
+
+| Phase | Plan | Status |
+|-------|------|--------|
+| 1. Visibility | (in PR #3194) | Complete |
+| 2. Unified batched dequeue | (in PR #3194) | Complete |
+| 3. Coalescible-task metadata | (in PR #3194) | Complete |
+| 4. Worker-side dedup | (in PR #3194) | Complete |
+| 5. Enqueue-side dedup | (in PR #3194) | Complete |
+| 6. Caller-site audit | (in PR #3194) | Complete |
+| 7. Re-measure and decide on fairness | [PLAN-queue-performance-phase-07-measure-and-decide.md](PLAN-queue-performance-phase-07-measure-and-decide.md) | In progress |
 
 ## Problem
 
@@ -30,12 +42,18 @@ the queue+state-machine overhead, and the work backed up.
 
 Six discrete changes plus one measurement step:
 
-1. **Visibility**: emit a `'started executing'` event at the
-   dispatcher-pickup boundary carrying `wait_seconds`,
-   `defer_count` and `queue_name`. This is the only place in the
-   pipeline that observes both `op.created_at` (insert time) and
-   `start_time` (when the worker is about to call `op.execute()`),
-   so the per-op queue-wait latency lands directly in eventlog.
+1. **Visibility**: carry `wait_seconds`, `defer_count` and
+   `queue_name` on the per-op event the dispatcher emits. The
+   dispatcher is the only place in the pipeline that observes both
+   `op.created_at` (insert time) and `start_time` (when the worker
+   is about to call `op.execute()`), so the per-op queue-wait
+   latency lands directly in eventlog. As implemented, these fields
+   ride on the existing end-of-op `'execution duration'` event
+   rather than a separate `'started executing'` event at the pickup
+   boundary: a second event doubles the eventlog cost on the
+   dispatcher's critical path, which profiling identified as the
+   largest per-op overhead this plan added. See
+   `docs/operator_guide/networking/overview.md`.
 
 2. **Unified batched dequeue**: replace `dequeue_work_item(qn)`
    and its direct/gRPC pair with `dequeue_work_items(queue_names,
@@ -75,11 +93,13 @@ Six discrete changes plus one measurement step:
    collapse before they hit `create_and_enqueue`. See the
    findings section below.
 
-7. **Re-measure**: once steps 1-6 are deployed in CI, the
-   `'started executing'` event distribution tells us whether the
-   wait tail is gone or whether explicit fairness (bounded
-   staleness, reserved-slot lottery) is still needed for
-   lower-priority queues.
+7. **Re-measure**: once steps 1-6 are deployed, the per-op
+   wait distribution tells us whether the tail is gone or whether
+   explicit fairness (bounded staleness, reserved-slot lottery) is
+   still needed for lower-priority queues. Planned in
+   [PLAN-queue-performance-phase-07-measure-and-decide.md](PLAN-queue-performance-phase-07-measure-and-decide.md),
+   which also records why the events have to be read from the log
+   stream rather than from the events table.
 
 ## Audit findings (step 6)
 

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -65,7 +65,7 @@ batching](api-query-batching-roadmap.md) and [attribute field
 masks](PLAN-attribute-field-masks.md) carry their phases as headings.
 Two more publish no arithmetic because their tables are placeholders: [owning more of the
 QEMU stack](PLAN-qemu-futures.md) names three phases and then an ellipsis, and [artifact UX
-rework](PLAN-artifact-ux-rework.md) a decisions pass and "(later phases)". These six are the
+rework](PLAN-artifact-ux-rework.md) a decisions pass and "(later phases)". These five are the
 checker's blind spot, and the only numbers here it cannot recompute.
 
 | Date | Plan | Intent | Status | Phases |

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -59,11 +59,10 @@ plan link for what each phase covers, and for why a plan is where it is. It coun
 read `Complete` without the two numbers meeting, and `—` means the plan has no enumerated
 phases yet, or has a table which is still a placeholder rather than a phase list.
 
-Four plans are counted by hand because they do not keep a phase table:
+Three plans are counted by hand because they do not keep a phase table:
 [blob storage](blob-storage-roadmap.md), [API query
 batching](api-query-batching-roadmap.md) and [attribute field
-masks](PLAN-attribute-field-masks.md) carry their phases as headings, and [queue
-performance](PLAN-queue-performance.md) is numbered in steps rather than phases.
+masks](PLAN-attribute-field-masks.md) carry their phases as headings.
 Two more publish no arithmetic because their tables are placeholders: [owning more of the
 QEMU stack](PLAN-qemu-futures.md) names three phases and then an ellipsis, and [artifact UX
 rework](PLAN-artifact-ux-rework.md) a decisions pass and "(later phases)". These six are the
@@ -89,7 +88,7 @@ checker's blind spot, and the only numbers here it cannot recompute.
 | 2026-05-22 | [Network carrier model](PLAN-network-carrier-model.md) | A lease-based per-network carrier with VIP advertisement, retiring the network-node singleton | Not started | 0 of 12 |
 | 2026-05-22 | [Network service ports](PLAN-network-service-ports.md) | Per-network DNAT'd ports for managed services | Not started | 0 of 7 |
 | 2026-05-22 | [Atomic scheduling via reservations](PLAN-scheduler-reservations.md) | Guarded-UPDATE capacity counters and namespace claims in place of read-then-place scheduling | In progress | 4 of 11 |
-| 2026-05-24 | [Queue performance and coalescing](PLAN-queue-performance.md) | Batched dequeue, and worker- and enqueue-side dedup of redundant cluster operations | In progress | 6 of 7 |
+| 2026-05-24 | [Queue performance and coalescing](PLAN-queue-performance.md) | Batched dequeue and cluster-operation coalescing, now measuring whether the queue-wait tail is gone | In progress | 6 of 7 |
 | 2026-06-01 | [OIDC authentication](PLAN-oidc-authentication.md) | Federated login against an external OIDC provider | Not started | 0 of 10 |
 | 2026-06-02 | [Owning more of the QEMU stack](PLAN-qemu-futures.md) | Direct QMP control, and perhaps one day libvirt's job as well | Not started | — |
 | 2026-06-03 | [BYO MariaDB and `sf-database` as a tier](PLAN-byo-mariadb.md) | A deployer-chosen database tier reached by client-side gRPC load balancing | Complete | 8 of 8 |

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -88,7 +88,7 @@ checker's blind spot, and the only numbers here it cannot recompute.
 | 2026-05-22 | [Network carrier model](PLAN-network-carrier-model.md) | A lease-based per-network carrier with VIP advertisement, retiring the network-node singleton | Not started | 0 of 12 |
 | 2026-05-22 | [Network service ports](PLAN-network-service-ports.md) | Per-network DNAT'd ports for managed services | Not started | 0 of 7 |
 | 2026-05-22 | [Atomic scheduling via reservations](PLAN-scheduler-reservations.md) | Guarded-UPDATE capacity counters and namespace claims in place of read-then-place scheduling | In progress | 4 of 11 |
-| 2026-05-24 | [Queue performance and coalescing](PLAN-queue-performance.md) | Batched dequeue and cluster-operation coalescing, now measuring whether the queue-wait tail is gone | In progress | 6 of 7 |
+| 2026-05-24 | [Queue performance and coalescing](PLAN-queue-performance.md) | Batched dequeue and cluster-operation coalescing, measured: the wait tail is gone and explicit fairness was not needed | Complete | 7 of 7 |
 | 2026-06-01 | [OIDC authentication](PLAN-oidc-authentication.md) | Federated login against an external OIDC provider | Not started | 0 of 10 |
 | 2026-06-02 | [Owning more of the QEMU stack](PLAN-qemu-futures.md) | Direct QMP control, and perhaps one day libvirt's job as well | Not started | — |
 | 2026-06-03 | [BYO MariaDB and `sf-database` as a tier](PLAN-byo-mariadb.md) | A deployer-chosen database tier reached by client-side gRPC load balancing | Complete | 8 of 8 |

--- a/shakenfist/tests/test_queue_wait_report.py
+++ b/shakenfist/tests/test_queue_wait_report.py
@@ -1,0 +1,203 @@
+# Copyright 2026 Michael Still and contributors
+
+"""Tests for tools/queue-wait-report.py.
+
+The report exists to answer one question -- is a queue's wait tail queueing,
+or is it something the system did on purpose -- and the way it gets that
+question wrong is by conflating the three delays which all land in
+``wait_seconds``. So the coverage that matters here is not the arithmetic,
+it is the classification: that a deferred operation is excluded from the
+undeferred columns, that a per-node queue is not counted as a per-network
+one, and that the parser tolerates every kind of line the three capture
+paths (Loki, a journal, a CI bundle) put in front of it. A parser that
+raises on a plain text log line produces no report at all from a real
+capture, and a classifier that reads uuids as distinct queues produces a
+table with three hundred rows of one sample each.
+"""
+
+import importlib.util
+import io
+import os
+
+from shakenfist.tests import base
+
+
+def _load_report():
+    # The report is a standalone script rather than an importable module,
+    # so that it can be run against a bundle of logs on a machine which has
+    # no Shaken Fist installed.
+    here = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.dirname(os.path.dirname(here))
+    path = os.path.join(root, 'tools', 'queue-wait-report.py')
+    spec = importlib.util.spec_from_file_location('queue_wait_report', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+report = _load_report()
+
+
+NETWORKNODE = (
+    '{"logger_name": "shakenfist.eventlog", "ts": "2026-08-23T17:49:41.957Z", '
+    '"message": "execution duration", "event_type": "usage", '
+    '"extra": {"seconds": 0.1, "wait_seconds": 2.5, "defer_count": 0, '
+    '"queue_name": "networknode-clusteroperation-user_facing"}, '
+    '"net_op": "1ed3668d-351c-4f86-b1aa-f86547ce1926", "program": "sf-net"}')
+
+PER_NODE = (
+    '{"message": "execution duration", "event_type": "usage", '
+    '"extra": {"seconds": 0.2, "wait_seconds": 1.0, "defer_count": 0, '
+    '"queue_name": "7ce66641-caa2-44ee-bb9b-6a02a21c66d5-clusteroperation-'
+    'user_facing"}, '
+    '"node_inst_op": "f3613565-9644-4724-9442-45d6cee49cf5", '
+    '"program": "sf-queues"}')
+
+PER_NETWORK = (
+    '{"message": "execution duration", "event_type": "usage", '
+    '"extra": {"seconds": 0.3, "wait_seconds": 1.5, "defer_count": 0, '
+    '"queue_name": "963d4df9-2a67-4abc-ae8e-96f5c29ab5b2-network-background"}, '
+    '"net_op": "e09596e9-314e-4b3f-9e7e-c4c9fe66be0e", "program": "sf-net"}')
+
+DEFERRED = (
+    '{"message": "execution duration", "event_type": "usage", '
+    '"extra": {"seconds": 1.7, "wait_seconds": 15.7, "defer_count": 1, '
+    '"queue_name": "7ce66641-caa2-44ee-bb9b-6a02a21c66d5-clusteroperation-'
+    'user_waiting"}, '
+    '"node_inst_netdesc_op": "71730e60-3a09-48d9-ac18-4463513e8bf2", '
+    '"program": "sf-queues"}')
+
+# A journal line: the JSON is preceded by a syslog style prefix.
+JOURNAL_PREFIXED = (
+    'Aug 23 17:49:41 sf-3 sf-queues[1903915]: ' + PER_NODE)
+
+MALFORMED = '{"message": "execution duration", "extra": {"wait'
+
+NOT_AN_EVENT = (
+    '{"logger_name": "shakenfist.util.concurrency", '
+    '"message": "Executing command", "command": "whoami", '
+    '"program": "sf-queues"}')
+
+# An event which is not a dispatcher pickup: emitted from a REST endpoint or
+# a unit test, where the operation was never dequeued so has no created_at.
+NO_WAIT_FIELDS = (
+    '{"message": "execution duration", "event_type": "usage", '
+    '"extra": {"seconds": 0.4}, '
+    '"net_op": "de364ce9-2a2c-43b7-a0c2-2aef231bbd62", "program": "sf-net"}')
+
+PLAIN_TEXT = 'starting sf-queues'
+
+
+class QueueWaitParseTestCase(base.ShakenFistTestCase):
+    def test_parses_a_dispatcher_event(self):
+        sample = report.parse_line(NETWORKNODE)
+        self.assertIsNotNone(sample)
+        self.assertEqual(2.5, sample.wait)
+        self.assertEqual(0.1, sample.execution)
+        self.assertEqual(0, sample.defer_count)
+        self.assertEqual('networknode', sample.queue_class)
+        self.assertEqual('user_facing', sample.lane)
+        self.assertEqual('net_op', sample.operation_type)
+        self.assertEqual('sf-net', sample.program)
+
+    def test_tolerates_a_journal_prefix(self):
+        sample = report.parse_line(JOURNAL_PREFIXED)
+        self.assertIsNotNone(sample)
+        self.assertEqual('per-node', sample.queue_class)
+        self.assertEqual('node_inst_op', sample.operation_type)
+
+    def test_ignores_lines_which_are_not_samples(self):
+        for line in (MALFORMED, NOT_AN_EVENT, NO_WAIT_FIELDS, PLAIN_TEXT, ''):
+            self.assertIsNone(report.parse_line(line), line)
+
+    def test_a_boolean_is_not_a_wait(self):
+        # json.loads turns true into a bool, which is an int in Python and
+        # would otherwise be accepted as a wait of 1.0 second.
+        line = (
+            '{"message": "execution duration", '
+            '"extra": {"wait_seconds": true, "queue_name": "a-network-b"}}')
+        self.assertIsNone(report.parse_line(line))
+
+
+class QueueClassifyTestCase(base.ShakenFistTestCase):
+    def test_classifies_each_queue_family(self):
+        self.assertEqual(
+            ('networknode', 'user_facing'),
+            report.classify_queue('networknode-clusteroperation-user_facing'))
+        self.assertEqual(
+            ('per-node', 'background_high_io'),
+            report.classify_queue(
+                '7ce66641-caa2-44ee-bb9b-6a02a21c66d5-clusteroperation-'
+                'background_high_io'))
+        self.assertEqual(
+            ('per-network', 'background'),
+            report.classify_queue(
+                '963d4df9-2a67-4abc-ae8e-96f5c29ab5b2-network-background'))
+
+    def test_classifies_the_any_node_queue(self):
+        # An artifact fetch which any node may claim is targeted at the
+        # literal 'any' rather than a uuid. Reading it as 'unknown' hides a
+        # whole class of work in a row nobody trusts.
+        self.assertEqual(
+            ('any-node', 'user_facing'),
+            report.classify_queue('any-clusteroperation-user_facing'))
+
+    def test_unparseable_queue_names_are_not_fatal(self):
+        self.assertEqual(('unknown', 'unknown'), report.classify_queue(''))
+        self.assertEqual(('unknown', 'unknown'), report.classify_queue(None))
+        self.assertEqual(
+            ('unknown', 'unknown'), report.classify_queue('rubbish'))
+
+
+class QueueWaitPercentileTestCase(base.ShakenFistTestCase):
+    def test_empty_is_none(self):
+        self.assertIsNone(report.percentile([], 0.5))
+
+    def test_single_sample_is_itself_at_every_percentile(self):
+        for fraction in (0.5, 0.9, 0.99):
+            self.assertEqual(7.0, report.percentile([7.0], fraction))
+
+    def test_percentiles_are_observed_values(self):
+        values = list(range(1, 101))
+        # Nearest rank, so every answer is a value which was measured.
+        self.assertEqual(51, report.percentile(values, 0.5))
+        self.assertEqual(90, report.percentile(values, 0.9))
+        self.assertEqual(99, report.percentile(values, 0.99))
+        self.assertIn(report.percentile(values, 0.5), values)
+
+
+class QueueWaitGroupTestCase(base.ShakenFistTestCase):
+    def _samples(self):
+        return report.read_samples(io.StringIO('\n'.join([
+            NETWORKNODE, PER_NODE, PER_NETWORK, DEFERRED,
+            MALFORMED, NOT_AN_EVENT, PLAIN_TEXT])))
+
+    def test_reads_only_the_samples(self):
+        self.assertEqual(4, len(self._samples()))
+
+    def test_deferred_operations_are_excluded_from_the_undeferred_columns(
+            self):
+        # The whole point of the split: a dependency wait is fifteen
+        # seconds of deliberate deferral, and reading it as queue wait is
+        # how this report would answer the fairness question wrongly.
+        groups = report.grouped(
+            self._samples(), lambda s: s.operation_type)
+        by_label = {g.label: g for g in groups}
+
+        deferred = by_label['node_inst_netdesc_op']
+        self.assertEqual(1, len(deferred.samples))
+        self.assertEqual(0, len(deferred.undeferred))
+        self.assertEqual(1, deferred.deferred_count)
+
+        row = deferred.row()
+        self.assertEqual('15.70', row[2])   # p50 over all samples
+        self.assertEqual('0', row[6])       # n with defer_count == 0
+        self.assertEqual('-', row[7])       # p50 over those, of which none
+
+    def test_groups_are_ordered_by_sample_count(self):
+        lines = '\n'.join([PER_NODE, PER_NODE, PER_NETWORK])
+        groups = report.grouped(
+            report.read_samples(io.StringIO(lines)),
+            lambda s: s.queue_class)
+        self.assertEqual(['per-node', 'per-network'],
+                         [g.label for g in groups])

--- a/shakenfist/tests/test_queue_wait_report.py
+++ b/shakenfist/tests/test_queue_wait_report.py
@@ -7,17 +7,19 @@ or is it something the system did on purpose -- and the way it gets that
 question wrong is by conflating the three delays which all land in
 ``wait_seconds``. So the coverage that matters here is not the arithmetic,
 it is the classification: that a deferred operation is excluded from the
-undeferred columns, that a per-node queue is not counted as a per-network
-one, and that the parser tolerates every kind of line the three capture
-paths (Loki, a journal, a CI bundle) put in front of it. A parser that
-raises on a plain text log line produces no report at all from a real
-capture, and a classifier that reads uuids as distinct queues produces a
-table with three hundred rows of one sample each.
+undeferred columns, that the two per-node queue families are told apart
+(they carry different defer schedules, so mislabelling one is how a reader
+mis-attributes its wait), and that the parser tolerates every kind of line
+the three capture paths (Loki, a journal, a CI bundle) put in front of it.
+A parser that raises on a plain text log line produces no report at all
+from a real capture, and a classifier that reads uuids as distinct queues
+produces a table with three hundred rows of one sample each.
 """
 
 import importlib.util
 import io
 import os
+import sys
 
 from shakenfist.tests import base
 
@@ -53,7 +55,7 @@ PER_NODE = (
     '"node_inst_op": "f3613565-9644-4724-9442-45d6cee49cf5", '
     '"program": "sf-queues"}')
 
-PER_NETWORK = (
+PER_NODE_NETWORK = (
     '{"message": "execution duration", "event_type": "usage", '
     '"extra": {"seconds": 0.3, "wait_seconds": 1.5, "defer_count": 0, '
     '"queue_name": "963d4df9-2a67-4abc-ae8e-96f5c29ab5b2-network-background"}, '
@@ -70,6 +72,18 @@ DEFERRED = (
 # A journal line: the JSON is preceded by a syslog style prefix.
 JOURNAL_PREFIXED = (
     'Aug 23 17:49:41 sf-3 sf-queues[1903915]: ' + PER_NODE)
+
+# A logcli line: the stream's label set is printed ahead of the record, so
+# the first '{' in the line opens the labels rather than the JSON.
+LOGCLI_PREFIXED = (
+    '2026-08-23T17:49:41Z {job="shakenfist", host="sf-3"} ' + PER_NODE)
+
+# A dispatcher event with no operation object attached, which the report
+# attributes to 'unknown' rather than dropping.
+NO_OPERATION_KEY = (
+    '{"message": "execution duration", "event_type": "usage", '
+    '"extra": {"seconds": 0.5, "wait_seconds": 0.75, "defer_count": 0, '
+    '"queue_name": "any-clusteroperation-background"}, "program": "sf-net"}')
 
 MALFORMED = '{"message": "execution duration", "extra": {"wait'
 
@@ -103,7 +117,16 @@ class QueueWaitParseTestCase(base.ShakenFistTestCase):
     def test_tolerates_a_journal_prefix(self):
         sample = report.parse_line(JOURNAL_PREFIXED)
         self.assertIsNotNone(sample)
-        self.assertEqual('per-node', sample.queue_class)
+        self.assertEqual('per-node (cluster op)', sample.queue_class)
+        self.assertEqual('node_inst_op', sample.operation_type)
+
+    def test_tolerates_a_loki_label_set_before_the_json(self):
+        # Grafana's logcli prints the stream's label set ahead of the line,
+        # so the first '{' opens something which is not the record. Giving
+        # up there loses every line of such a capture rather than one.
+        sample = report.parse_line(LOGCLI_PREFIXED)
+        self.assertIsNotNone(sample)
+        self.assertEqual('per-node (cluster op)', sample.queue_class)
         self.assertEqual('node_inst_op', sample.operation_type)
 
     def test_ignores_lines_which_are_not_samples(self):
@@ -121,18 +144,36 @@ class QueueWaitParseTestCase(base.ShakenFistTestCase):
 
 class QueueClassifyTestCase(base.ShakenFistTestCase):
     def test_classifies_each_queue_family(self):
+        # Both families are keyed by *node* uuid; there is no per-network
+        # queue. See get_node_network_queues() in
+        # shakenfist/operations/baseoperation.py, whose only argument is a
+        # node uuid, and which sf-net drains for its own node.
         self.assertEqual(
             ('networknode', 'user_facing'),
             report.classify_queue('networknode-clusteroperation-user_facing'))
         self.assertEqual(
-            ('per-node', 'background_high_io'),
+            ('per-node (cluster op)', 'background_high_io'),
             report.classify_queue(
                 '7ce66641-caa2-44ee-bb9b-6a02a21c66d5-clusteroperation-'
                 'background_high_io'))
         self.assertEqual(
-            ('per-network', 'background'),
+            ('per-node (network)', 'background'),
             report.classify_queue(
                 '963d4df9-2a67-4abc-ae8e-96f5c29ab5b2-network-background'))
+
+    def test_every_queue_class_has_a_defer_schedule(self):
+        # A row whose class is missing from DEFER_SCHEDULES prints without
+        # the one number needed to read its defers column, so adding a
+        # class without a schedule should fail here rather than in a report.
+        classes = {
+            report.classify_queue(name)[0]
+            for name in (
+                'networknode-clusteroperation-user_facing',
+                'any-clusteroperation-user_facing',
+                '7ce66641-caa2-44ee-bb9b-6a02a21c66d5-clusteroperation-'
+                'background',
+                '963d4df9-2a67-4abc-ae8e-96f5c29ab5b2-network-background')}
+        self.assertEqual(classes, set(report.DEFER_SCHEDULES))
 
     def test_classifies_the_any_node_queue(self):
         # An artifact fetch which any node may claim is targeted at the
@@ -159,7 +200,9 @@ class QueueWaitPercentileTestCase(base.ShakenFistTestCase):
 
     def test_percentiles_are_observed_values(self):
         values = list(range(1, 101))
-        # Nearest rank, so every answer is a value which was measured.
+        # Never interpolated, so every answer is a value which was
+        # measured. The index is the nearest to fraction * (n - 1), which
+        # is within one rank of the textbook nearest-rank definition.
         self.assertEqual(51, report.percentile(values, 0.5))
         self.assertEqual(90, report.percentile(values, 0.9))
         self.assertEqual(99, report.percentile(values, 0.99))
@@ -169,7 +212,7 @@ class QueueWaitPercentileTestCase(base.ShakenFistTestCase):
 class QueueWaitGroupTestCase(base.ShakenFistTestCase):
     def _samples(self):
         return report.read_samples(io.StringIO('\n'.join([
-            NETWORKNODE, PER_NODE, PER_NETWORK, DEFERRED,
+            NETWORKNODE, PER_NODE, PER_NODE_NETWORK, DEFERRED,
             MALFORMED, NOT_AN_EVENT, PLAIN_TEXT])))
 
     def test_reads_only_the_samples(self):
@@ -195,9 +238,112 @@ class QueueWaitGroupTestCase(base.ShakenFistTestCase):
         self.assertEqual('-', row[7])       # p50 over those, of which none
 
     def test_groups_are_ordered_by_sample_count(self):
-        lines = '\n'.join([PER_NODE, PER_NODE, PER_NETWORK])
+        lines = '\n'.join([PER_NODE, PER_NODE, PER_NODE_NETWORK])
         groups = report.grouped(
             report.read_samples(io.StringIO(lines)),
             lambda s: s.queue_class)
-        self.assertEqual(['per-node', 'per-network'],
+        self.assertEqual(['per-node (cluster op)', 'per-node (network)'],
                          [g.label for g in groups])
+
+    def test_a_group_reports_both_populations(self):
+        # A group holding both deferred and undeferred samples is the only
+        # one where the two halves of a row can disagree, and disagreeing
+        # is the whole reason the second half is printed.
+        lines = '\n'.join([PER_NODE, DEFERRED])
+        groups = report.grouped(
+            report.read_samples(io.StringIO(lines)), lambda s: s.lane)
+        merged = report.Group('merged')
+        for group in groups:
+            for sample in group.samples:
+                merged.add(sample)
+
+        row = merged.row()
+        self.assertEqual('2', row[1])       # n over all samples
+        self.assertEqual('15.70', row[5])   # max over all samples
+        self.assertEqual('1', row[6])       # n with defer_count == 0
+        self.assertEqual('1.00', row[10])   # max over those
+        self.assertEqual('1', row[13])      # how many deferred
+
+
+class QueueWaitOperationTypeTestCase(base.ShakenFistTestCase):
+    def test_an_event_with_no_operation_is_attributed_to_unknown(self):
+        # Dropping these would silently shrink the sample count rather than
+        # showing an operator that something is emitting the event without
+        # naming its operation.
+        sample = report.parse_line(NO_OPERATION_KEY)
+        self.assertIsNotNone(sample)
+        self.assertEqual('unknown', sample.operation_type)
+        self.assertEqual('any-node', sample.queue_class)
+
+
+class QueueWaitReportTestCase(base.ShakenFistTestCase):
+    """End to end runs of the program, which is what an operator invokes."""
+
+    def _run(self, lines, argv=None):
+        stream = io.StringIO('\n'.join(lines))
+        captured = io.StringIO()
+        stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            code = report.main(argv=argv or [], stream=stream)
+        finally:
+            sys.stdout = stdout
+        return code, captured.getvalue()
+
+    def test_empty_input_is_not_a_traceback(self):
+        # A capture which matched nothing is the most likely first run, and
+        # it has to say so rather than failing.
+        code, out = self._run([])
+        self.assertEqual(0, code)
+        self.assertIn('No queue-wait samples found on stdin.', out)
+
+    def test_renders_all_three_tables(self):
+        code, out = self._run(
+            [NETWORKNODE, PER_NODE, PER_NODE_NETWORK, DEFERRED, PLAIN_TEXT])
+        self.assertEqual(0, code)
+        self.assertIn('Samples: 4', out)
+        self.assertIn('By queue class and priority lane', out)
+        self.assertIn('By operation type', out)
+        self.assertIn('By priority lane', out)
+        self.assertIn('networknode / user_facing', out)
+        self.assertIn('per-node (network) / background', out)
+        # The defer schedules are what make a defers column readable, so
+        # they are printed with the report rather than left to the docs.
+        self.assertIn('drained by sf-net', out)
+        self.assertIn('drained by sf-queues', out)
+
+    def test_columns_line_up_under_their_banners(self):
+        # A banner label wider than the columns it spans used to push every
+        # banner to its right off its own columns, which silently mislabels
+        # the undeferred half of every row.
+        _, out = self._run([NETWORKNODE, PER_NODE])
+        lines = out.splitlines()
+        index = lines.index('By operation type')
+        banner, header = lines[index + 2], lines[index + 3]
+        for label, _span in report.BANNERS:
+            if not label:
+                continue
+            self.assertIn(label, banner)
+        self.assertGreaterEqual(len(header), len(banner))
+        self.assertEqual(banner, banner.rstrip())
+        self.assertEqual(header.count('defers'), 1)
+        self.assertEqual(
+            banner.index('exec (all)') + len('exec (all)') <= len(header),
+            True)
+
+    def test_min_samples_says_what_it_dropped(self):
+        # Silently dropping rows would hide exactly the rare, starved queue
+        # a reader raising this flag did not mean to hide.
+        _, out = self._run(
+            [NETWORKNODE, PER_NODE, PER_NODE, PER_NODE_NETWORK],
+            argv=['--min-samples', '2'])
+        self.assertIn('per-node (cluster op) / user_facing', out)
+        self.assertNotIn('networknode / user_facing', out)
+        self.assertIn(
+            '(2 rows with fewer than 2 samples omitted, 2 in total)', out)
+
+    def test_min_samples_can_empty_a_table_without_hiding_that_it_did(self):
+        _, out = self._run([NETWORKNODE], argv=['--min-samples', '5'])
+        self.assertIn('(no samples)', out)
+        self.assertIn(
+            '(1 row with fewer than 5 samples omitted, 1 in total)', out)

--- a/tools/check-plan-status.py
+++ b/tools/check-plan-status.py
@@ -61,12 +61,12 @@ in the canonical block (which lives in shakenfist/development, at
 `templates/shared-blocks/plan-status-vocabulary.md`) cannot leave this
 checker rejecting a status the template tells authors to write.
 
-Four plans predate the Execution-table convention and are counted by hand,
+Three plans predate the Execution-table convention and are counted by hand,
 and two more keep a table which is a placeholder rather than a phase list.
 They are named in `HAND_COUNTED` and `PROVISIONAL` rather than detected, so
 that a plan cannot join them by quietly omitting or stubbing its table:
 adding a name is a deliberate edit, and the index preamble names the same
-six for readers.
+five for readers.
 
 `order.yml` is registration, not navigation. Nothing in this repository
 renders it -- `mkdocs.yml.tmpl` lists the Plans nav by hand -- but the format
@@ -101,12 +101,11 @@ VOCABULARY_BLOCK_RE = re.compile(
 VOCABULARY_TERM_RE = re.compile(r'^- `([^`]+)`', re.MULTILINE)
 
 # Plans whose phases are not in an Execution table, so their index arithmetic
-# cannot be recomputed. See the index preamble, which names the same four.
+# cannot be recomputed. See the index preamble, which names the same three.
 HAND_COUNTED = {
     'blob-storage-roadmap.md',          # phases as headings
     'api-query-batching-roadmap.md',    # phases as headings
     'PLAN-attribute-field-masks.md',    # phases as headings
-    'PLAN-queue-performance.md',        # numbered in steps, not phases
 }
 
 # Plans whose Execution table is explicitly a placeholder, so its row count

--- a/tools/queue-wait-report.py
+++ b/tools/queue-wait-report.py
@@ -18,8 +18,13 @@ operation is hard deleted thirty seconds after it reaches a final state, and
 ``hard_delete()`` drops the ``event_objects`` rows that join its events to it,
 so within a minute of an operation completing there is nothing left to query.
 What survives is the log stream: ``eventlog.add_event_multi`` echoes every
-event as an ``Added event`` log line carrying the whole ``extra`` dict, gated
-only by ``LOG_EVENTS_TO_LOKI``, which is on by default.
+event as a log line carrying the whole ``extra`` dict, gated only by
+``LOG_EVENTS_TO_LOKI``, which is on by default. Note that the echo's own
+message, ``Added event``, does not survive into the emitted JSON -- pylogrus
+merges the caller's fields over the record last, and one of those fields is
+``message``, so the shipped record's ``message`` is the event's message. That
+is why this tool matches on ``execution duration`` and why grepping a log
+stream for ``Added event`` finds nothing.
 
 This reads that stream as newline delimited JSON on stdin. The same lines
 reach three different places and all three work here:
@@ -39,9 +44,10 @@ Read the numbers with two things in mind, both of which the report prints.
 The dispatcher polls with adaptive backoff capped at IDLE_POLL_MAX_SECONDS
 (2.0s, ``shakenfist/daemons/daemon.py``), so a p90 at or below that is the
 poll interval rather than queueing. And ``wait_seconds`` counts deliberate
-deferral too -- a dependency wait re-enqueues the operation fifteen seconds
-into the future -- so every percentile is reported twice, once over all
-samples and once over the operations which never deferred.
+deferral too, on a schedule which depends on which dispatcher drained the
+queue rather than on the operation (see DEFER_SCHEDULES below), so every
+percentile is reported twice, once over all samples and once over the
+operations which never deferred.
 """
 
 import argparse
@@ -62,17 +68,47 @@ IDLE_POLL_MAX_SECONDS = 2.0
 # The message which identifies a queue-wait event.
 EVENT_MESSAGE = 'execution duration'
 
-# Queue names are '<target>-<family>-<priority>', where family is
-# 'clusteroperation' for the per-node and cluster-wide queues and 'network'
-# for the per-network ones. The target is the literal 'networknode', the
-# literal 'any' (an artifact fetch which any node may take, see
-# shakenfist/schema/operations/artifact_fetch_op.py), or a uuid -- and it is
-# the uuids which make raw queue names useless for aggregation.
+# Queue names are '<target>-<family>-<priority>'. Both families are drained
+# per node, by different dispatchers: 'clusteroperation' by sf-queues (via
+# Daemon.dequeue_job) and 'network' by sf-net. The target is a node uuid,
+# the literal 'networknode' (the cluster-wide queue which only the elected
+# network node's sf-net drains), or the literal 'any' (an artifact fetch
+# which any node may take, see
+# shakenfist/schema/operations/artifact_fetch_op.py) -- and it is the uuids
+# which make raw queue names useless for aggregation. There is no
+# per-network queue family; see get_node_network_queues() in
+# shakenfist/operations/baseoperation.py, which keys the 'network' family by
+# node uuid.
 QUEUE_NAME_RE = re.compile(
     r'^(?P<target>.+)-(?P<family>clusteroperation|network)-(?P<lane>[^-]+)$')
 
 UUID_RE = re.compile(
     r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
+
+CLASS_NETWORKNODE = 'networknode'
+CLASS_ANY_NODE = 'any-node'
+CLASS_PER_NODE_CLUSTER_OP = 'per-node (cluster op)'
+CLASS_PER_NODE_NETWORK = 'per-node (network)'
+CLASS_UNKNOWN = 'unknown'
+
+# What one deferral costs, by queue class. A dependency wait re-enqueues the
+# operation into the future, and the delay is the dispatcher's choice rather
+# than the operation's: sf-queues calls op.defer() with no argument and takes
+# its flat fifteen second default (shakenfist/daemons/queues/workitem.py),
+# while sf-net backs off from INITIAL_DEFER_DELAY doubling to MAX_DEFER_DELAY
+# (0.1s to a 15s cap, shakenfist/daemons/network/workitem.py). So a
+# defer_count of 3 is 45s of deliberate wait on one and under a second on the
+# other, which is worth knowing before reading a row's defers column as
+# fifteen seconds a piece.
+SF_QUEUES_DEFER = 'drained by sf-queues, a flat 15s per defer'
+SF_NET_DEFER = 'drained by sf-net, 0.1s per defer doubling to a 15s cap'
+
+DEFER_SCHEDULES = collections.OrderedDict([
+    (CLASS_NETWORKNODE, SF_NET_DEFER),
+    (CLASS_PER_NODE_NETWORK, SF_NET_DEFER),
+    (CLASS_PER_NODE_CLUSTER_OP, SF_QUEUES_DEFER),
+    (CLASS_ANY_NODE, SF_QUEUES_DEFER),
+])
 
 
 class Sample:
@@ -93,32 +129,36 @@ class Sample:
 def classify_queue(queue_name):
     """Return (queue_class, lane) for a queue name.
 
-    The class is one of 'networknode' (the single cluster-wide network node
-    queue), 'any-node' (work any node may claim), 'per-node' (a hypervisor's
-    own cluster operation queue), 'per-network' (a single network's queue),
-    or 'unknown' for anything which does not parse. The lane is the priority
-    suffix.
+    The class is one of 'networknode' (the cluster-wide queue which only the
+    elected network node drains), 'any-node' (work any node may claim),
+    'per-node (cluster op)' (a node's own cluster operation queue),
+    'per-node (network)' (a node's own network queue), or 'unknown' for
+    anything which does not parse. The lane is the priority suffix.
+
+    Both per-node classes are keyed by *node* uuid -- the split between them
+    is which dispatcher drains the queue, not what the work is about. There
+    is no per-network queue.
     """
     if not queue_name:
-        return 'unknown', 'unknown'
+        return CLASS_UNKNOWN, CLASS_UNKNOWN
 
     match = QUEUE_NAME_RE.match(queue_name)
     if not match:
-        return 'unknown', 'unknown'
+        return CLASS_UNKNOWN, CLASS_UNKNOWN
 
     target = match.group('target')
     family = match.group('family')
     lane = match.group('lane')
 
     if family == 'network':
-        return 'per-network', lane
+        return CLASS_PER_NODE_NETWORK, lane
     if target == 'networknode':
-        return 'networknode', lane
+        return CLASS_NETWORKNODE, lane
     if target == 'any':
-        return 'any-node', lane
+        return CLASS_ANY_NODE, lane
     if UUID_RE.match(target):
-        return 'per-node', lane
-    return 'unknown', lane
+        return CLASS_PER_NODE_CLUSTER_OP, lane
+    return CLASS_UNKNOWN, lane
 
 
 def operation_type_of(record):
@@ -135,23 +175,36 @@ def operation_type_of(record):
     return None
 
 
+def load_json_object(line):
+    """Return the first decodable JSON object in a line, or None.
+
+    Retries at each subsequent '{' rather than giving up on the first,
+    because some log viewers print a label set ahead of the line itself --
+    Grafana's logcli emits '<ts> {job="shakenfist", host="..."} <line>', so
+    the first brace opens something which is not the record at all.
+    """
+    start = line.find('{')
+    while start >= 0:
+        try:
+            record = json.loads(line[start:])
+        except (ValueError, TypeError):
+            start = line.find('{', start + 1)
+            continue
+        return record if isinstance(record, dict) else None
+    return None
+
+
 def parse_line(line):
     """Turn one log line into a Sample, or None if it is not one.
 
-    Tolerates anything: journal prefixes ahead of the JSON, blank lines,
-    plain text log lines, and JSON which is not an event.
+    Tolerates anything: journal prefixes ahead of the JSON, Loki label sets
+    ahead of the JSON, blank lines, plain text log lines, and JSON which is
+    not an event.
     """
-    start = line.find('{')
-    if start < 0:
+    record = load_json_object(line)
+    if record is None:
         return None
 
-    try:
-        record = json.loads(line[start:])
-    except (ValueError, TypeError):
-        return None
-
-    if not isinstance(record, dict):
-        return None
     if record.get('message') != EVENT_MESSAGE:
         return None
 
@@ -194,12 +247,13 @@ def read_samples(stream):
 
 
 def percentile(values, fraction):
-    """Nearest-rank percentile over an unsorted list.
+    """Percentile over an unsorted list, without interpolating.
 
-    Returns None for an empty list. Uses the nearest rank rather than
-    interpolating, so every value printed is a value which was actually
-    observed -- which matters when reading a tail made of a handful of
-    samples, where an interpolated p99 is a number nothing measured.
+    Returns None for an empty list, and otherwise the value at the nearest
+    index to ``fraction * (n - 1)``. Every value printed is therefore a
+    value which was actually observed -- which matters when reading a tail
+    made of a handful of samples, where an interpolated p99 is a number
+    nothing measured.
     """
     if not values:
         return None
@@ -261,30 +315,55 @@ HEADINGS = [
     'p50', 'p90', 'defers'
 ]
 
-# Which heading each column group belongs under, for the banner row.
+# Which heading each column group belongs under, for the banner row. The
+# spans must sum to len(HEADINGS). The execution columns are over every
+# sample in the row while the wait columns are reported both ways, so the
+# banner says so: deferral inflates queue wait, not execution time.
 BANNERS = [
     ('', 1),
     ('wait_seconds (all)', 5),
     ('wait_seconds (defer_count == 0)', 5),
-    ('exec', 2),
+    ('exec (all)', 2),
     ('', 1),
 ]
 
 
-def print_table(title, groups):
-    print()
-    print(title)
-    print('-' * len(title))
+def column_widths(rows):
+    """Column widths wide enough for both the cells and the banner labels.
 
-    if not groups:
-        print('  (no samples)')
-        return
-
-    rows = [g.row() for g in groups]
+    A banner label longer than the columns it spans would otherwise push
+    everything to its right out of alignment with its own heading, so any
+    deficit is shared out across the columns of that span.
+    """
     widths = [len(h) for h in HEADINGS]
     for row in rows:
         for i, cell in enumerate(row):
             widths[i] = max(widths[i], len(cell))
+
+    column = 0
+    for label, span in BANNERS:
+        span_width = sum(widths[column:column + span]) + (span - 1)
+        deficit = len(label) - span_width
+        for i in range(deficit):
+            widths[column + (i % span)] += 1
+        column += span
+
+    return widths
+
+
+def print_table(title, groups, footnote=None):
+    print()
+    print(title)
+    print('-' * len(title))
+
+    rows = [g.row() for g in groups]
+    if not rows:
+        print('  (no samples)')
+        if footnote:
+            print('  ' + footnote)
+        return
+
+    widths = column_widths(rows)
 
     banner = []
     column = 0
@@ -292,7 +371,7 @@ def print_table(title, groups):
         width = sum(widths[column:column + span]) + (span - 1)
         banner.append(label.center(width) if label else ' ' * width)
         column += span
-    print('  ' + ' '.join(banner))
+    print(('  ' + ' '.join(banner)).rstrip())
 
     header = [HEADINGS[0].ljust(widths[0])]
     header.extend(h.rjust(widths[i]) for i, h in enumerate(HEADINGS)
@@ -305,6 +384,9 @@ def print_table(title, groups):
                     if i > 0)
         print('  ' + ' '.join(line))
 
+    if footnote:
+        print('  ' + footnote)
+
 
 def grouped(samples, key):
     groups = collections.OrderedDict()
@@ -314,6 +396,24 @@ def grouped(samples, key):
             groups[label] = Group(label)
         groups[label].add(sample)
     return sorted(groups.values(), key=lambda g: -len(g.samples))
+
+
+def apply_min_samples(groups, min_samples):
+    """Split groups into those to print and a note about what was dropped.
+
+    Nothing is dropped silently: a rare queue starved by a busy one is
+    exactly the low-n row a reader raising --min-samples would hide without
+    meaning to, so each table says what it left out.
+    """
+    kept = [g for g in groups if len(g.samples) >= min_samples]
+    dropped = [g for g in groups if len(g.samples) < min_samples]
+    if not dropped:
+        return kept, None
+
+    samples = sum(len(g.samples) for g in dropped)
+    rows = 'row' if len(dropped) == 1 else 'rows'
+    return kept, (f'({len(dropped)} {rows} with fewer than {min_samples} '
+                  f'samples omitted, {samples} in total)')
 
 
 def print_window(samples):
@@ -332,15 +432,19 @@ def print_notes():
     print()
     print(f'Idle poll floor: p90 at or below {IDLE_POLL_MAX_SECONDS:.1f}s is '
           'the dispatcher poll cap (IDLE_POLL_MAX_SECONDS), not queue wait.')
-    print('Deferral: a dependency wait re-enqueues an operation 15s into the '
+    print('Deferral: a dependency wait re-enqueues an operation into the '
           'future, so read the defer_count == 0 columns before calling a')
-    print('tail a queueing problem. Background *_high_io queues are also '
-          'gated off entirely while the local disk is busy, which is')
-    print('designed backpressure rather than starvation -- check the node\'s '
-          'disk busy metric before attributing that tail to queue order.')
+    print('tail a queueing problem. What one defer costs is the dispatcher\'s '
+          'choice, so it follows the queue class rather than the op:')
+    for queue_class, schedule in DEFER_SCHEDULES.items():
+        print(f'  {queue_class}: {schedule}')
+    print('Backpressure: background *_high_io queues are gated off entirely '
+          'while the local disk is busy, which is designed backpressure')
+    print('rather than starvation -- check the node\'s disk busy metric '
+          'before attributing that tail to queue order.')
 
 
-def main():
+def main(argv=None, stream=None):
     parser = argparse.ArgumentParser(
         description=(
             'Summarise cluster operation queue-wait latency from a stream '
@@ -349,10 +453,10 @@ def main():
         '--min-samples', type=int, default=1,
         help=('Omit table rows with fewer than this many samples. Rows made '
               'of a handful of observations have unreadable percentiles; '
-              'they are counted in the totals regardless.'))
-    args = parser.parse_args()
+              'each table reports how many rows and samples it omitted.'))
+    args = parser.parse_args(argv)
 
-    samples = read_samples(sys.stdin)
+    samples = read_samples(sys.stdin if stream is None else stream)
     if not samples:
         print('No queue-wait samples found on stdin.')
         print()
@@ -363,18 +467,14 @@ def main():
 
     print_window(samples)
 
-    def keep(groups):
-        return [g for g in groups if len(g.samples) >= args.min_samples]
-
-    print_table(
-        'By queue class and priority lane',
-        keep(grouped(samples, lambda s: f'{s.queue_class} / {s.lane}')))
-    print_table(
-        'By operation type',
-        keep(grouped(samples, lambda s: s.operation_type)))
-    print_table(
-        'By priority lane',
-        keep(grouped(samples, lambda s: s.lane)))
+    for title, key in (
+            ('By queue class and priority lane',
+             lambda s: f'{s.queue_class} / {s.lane}'),
+            ('By operation type', lambda s: s.operation_type),
+            ('By priority lane', lambda s: s.lane)):
+        kept, footnote = apply_min_samples(
+            grouped(samples, key), args.min_samples)
+        print_table(title, kept, footnote)
 
     print_notes()
     return 0

--- a/tools/queue-wait-report.py
+++ b/tools/queue-wait-report.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Michael Still and contributors
+
+"""Summarise cluster operation queue-wait latency from a Shaken Fist log stream.
+
+The queue dispatcher emits one ``execution duration`` event per operation it
+runs, carrying the queue-wait latency (``wait_seconds``: the time between the
+operation being inserted into ``cluster_operations`` and the dispatcher
+claiming it), the execution time (``seconds``), how many times the operation
+was deferred before it ran (``defer_count``), and the queue it came from. See
+``shakenfist/daemons/queues/workitem.py`` and
+``shakenfist/daemons/network/workitem.py``, which emit it, and
+``docs/operator_guide/networking/overview.md``, which documents it.
+
+Those events cannot be read back out of the database after the fact. A cluster
+operation is hard deleted thirty seconds after it reaches a final state, and
+``hard_delete()`` drops the ``event_objects`` rows that join its events to it,
+so within a minute of an operation completing there is nothing left to query.
+What survives is the log stream: ``eventlog.add_event_multi`` echoes every
+event as an ``Added event`` log line carrying the whole ``extra`` dict, gated
+only by ``LOG_EVENTS_TO_LOKI``, which is on by default.
+
+This reads that stream as newline delimited JSON on stdin. The same lines
+reach three different places and all three work here:
+
+    loki-query '{job="shakenfist"} |= "execution duration"' \\
+        --tenant sfcbr --since 24h --limit 20000 | tools/queue-wait-report.py
+
+    journalctl -u 'sf-*.service' -o cat | tools/queue-wait-report.py
+
+    unzip -p bundle.zip 'journal-*.txt' | tools/queue-wait-report.py
+
+Lines which are not JSON, and JSON objects which are not queue-wait events,
+are ignored rather than being an error: every one of those sources carries
+other traffic.
+
+Read the numbers with two things in mind, both of which the report prints.
+The dispatcher polls with adaptive backoff capped at IDLE_POLL_MAX_SECONDS
+(2.0s, ``shakenfist/daemons/daemon.py``), so a p90 at or below that is the
+poll interval rather than queueing. And ``wait_seconds`` counts deliberate
+deferral too -- a dependency wait re-enqueues the operation fifteen seconds
+into the future -- so every percentile is reported twice, once over all
+samples and once over the operations which never deferred.
+"""
+
+import argparse
+import collections
+import json
+import re
+import sys
+
+
+# The wait floor. The dispatcher's idle poll backs off to this cap between
+# empty polls, so an operation enqueued against an idle worker waits up to
+# this long before anybody looks. Kept in step with IDLE_POLL_MAX_SECONDS in
+# shakenfist/daemons/daemon.py by hand: this tool deliberately imports
+# nothing from shakenfist, so that it runs against a bundle of logs on a
+# machine which has no Shaken Fist installed.
+IDLE_POLL_MAX_SECONDS = 2.0
+
+# The message which identifies a queue-wait event.
+EVENT_MESSAGE = 'execution duration'
+
+# Queue names are '<target>-<family>-<priority>', where family is
+# 'clusteroperation' for the per-node and cluster-wide queues and 'network'
+# for the per-network ones. The target is the literal 'networknode', the
+# literal 'any' (an artifact fetch which any node may take, see
+# shakenfist/schema/operations/artifact_fetch_op.py), or a uuid -- and it is
+# the uuids which make raw queue names useless for aggregation.
+QUEUE_NAME_RE = re.compile(
+    r'^(?P<target>.+)-(?P<family>clusteroperation|network)-(?P<lane>[^-]+)$')
+
+UUID_RE = re.compile(
+    r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
+
+
+class Sample:
+    """One queue-wait observation."""
+
+    def __init__(self, wait, execution, defer_count, queue_class, lane,
+                 operation_type, program, timestamp):
+        self.wait = wait
+        self.execution = execution
+        self.defer_count = defer_count
+        self.queue_class = queue_class
+        self.lane = lane
+        self.operation_type = operation_type
+        self.program = program
+        self.timestamp = timestamp
+
+
+def classify_queue(queue_name):
+    """Return (queue_class, lane) for a queue name.
+
+    The class is one of 'networknode' (the single cluster-wide network node
+    queue), 'any-node' (work any node may claim), 'per-node' (a hypervisor's
+    own cluster operation queue), 'per-network' (a single network's queue),
+    or 'unknown' for anything which does not parse. The lane is the priority
+    suffix.
+    """
+    if not queue_name:
+        return 'unknown', 'unknown'
+
+    match = QUEUE_NAME_RE.match(queue_name)
+    if not match:
+        return 'unknown', 'unknown'
+
+    target = match.group('target')
+    family = match.group('family')
+    lane = match.group('lane')
+
+    if family == 'network':
+        return 'per-network', lane
+    if target == 'networknode':
+        return 'networknode', lane
+    if target == 'any':
+        return 'any-node', lane
+    if UUID_RE.match(target):
+        return 'per-node', lane
+    return 'unknown', lane
+
+
+def operation_type_of(record):
+    """Return the operation type for an event record, or None.
+
+    An event names the objects it is about as top level keys, so a cluster
+    operation event carries exactly one key ending in '_op' whose value is
+    the operation's uuid. There is no join to do and no other field which
+    records the operation's class.
+    """
+    for key, value in record.items():
+        if key.endswith('_op') and isinstance(value, str):
+            return key
+    return None
+
+
+def parse_line(line):
+    """Turn one log line into a Sample, or None if it is not one.
+
+    Tolerates anything: journal prefixes ahead of the JSON, blank lines,
+    plain text log lines, and JSON which is not an event.
+    """
+    start = line.find('{')
+    if start < 0:
+        return None
+
+    try:
+        record = json.loads(line[start:])
+    except (ValueError, TypeError):
+        return None
+
+    if not isinstance(record, dict):
+        return None
+    if record.get('message') != EVENT_MESSAGE:
+        return None
+
+    extra = record.get('extra')
+    if not isinstance(extra, dict):
+        return None
+
+    wait = extra.get('wait_seconds')
+    if not isinstance(wait, (int, float)) or isinstance(wait, bool):
+        return None
+
+    execution = extra.get('seconds')
+    if not isinstance(execution, (int, float)) or isinstance(execution, bool):
+        execution = None
+
+    defer_count = extra.get('defer_count')
+    if not isinstance(defer_count, int) or isinstance(defer_count, bool):
+        defer_count = 0
+
+    queue_class, lane = classify_queue(extra.get('queue_name'))
+
+    return Sample(
+        wait=float(wait),
+        execution=None if execution is None else float(execution),
+        defer_count=defer_count,
+        queue_class=queue_class,
+        lane=lane,
+        operation_type=operation_type_of(record) or 'unknown',
+        program=record.get('program') or 'unknown',
+        timestamp=record.get('ts'))
+
+
+def read_samples(stream):
+    samples = []
+    for line in stream:
+        sample = parse_line(line)
+        if sample is not None:
+            samples.append(sample)
+    return samples
+
+
+def percentile(values, fraction):
+    """Nearest-rank percentile over an unsorted list.
+
+    Returns None for an empty list. Uses the nearest rank rather than
+    interpolating, so every value printed is a value which was actually
+    observed -- which matters when reading a tail made of a handful of
+    samples, where an interpolated p99 is a number nothing measured.
+    """
+    if not values:
+        return None
+    ordered = sorted(values)
+    rank = int(round(fraction * (len(ordered) - 1)))
+    return ordered[rank]
+
+
+def format_seconds(value):
+    if value is None:
+        return '-'
+    return f'{value:.2f}'
+
+
+class Group:
+    """The samples in one row of one table."""
+
+    def __init__(self, label):
+        self.label = label
+        self.samples = []
+
+    def add(self, sample):
+        self.samples.append(sample)
+
+    @property
+    def undeferred(self):
+        return [s for s in self.samples if s.defer_count == 0]
+
+    @property
+    def deferred_count(self):
+        return len([s for s in self.samples if s.defer_count > 0])
+
+    def row(self):
+        waits = [s.wait for s in self.samples]
+        undeferred_waits = [s.wait for s in self.undeferred]
+        executions = [s.execution for s in self.samples
+                      if s.execution is not None]
+        return [
+            self.label,
+            str(len(self.samples)),
+            format_seconds(percentile(waits, 0.5)),
+            format_seconds(percentile(waits, 0.9)),
+            format_seconds(percentile(waits, 0.99)),
+            format_seconds(max(waits) if waits else None),
+            str(len(undeferred_waits)),
+            format_seconds(percentile(undeferred_waits, 0.5)),
+            format_seconds(percentile(undeferred_waits, 0.9)),
+            format_seconds(percentile(undeferred_waits, 0.99)),
+            format_seconds(max(undeferred_waits) if undeferred_waits else None),
+            format_seconds(percentile(executions, 0.5)),
+            format_seconds(percentile(executions, 0.9)),
+            str(self.deferred_count),
+        ]
+
+
+HEADINGS = [
+    '', 'n', 'p50', 'p90', 'p99', 'max',
+    'n', 'p50', 'p90', 'p99', 'max',
+    'p50', 'p90', 'defers'
+]
+
+# Which heading each column group belongs under, for the banner row.
+BANNERS = [
+    ('', 1),
+    ('wait_seconds (all)', 5),
+    ('wait_seconds (defer_count == 0)', 5),
+    ('exec', 2),
+    ('', 1),
+]
+
+
+def print_table(title, groups):
+    print()
+    print(title)
+    print('-' * len(title))
+
+    if not groups:
+        print('  (no samples)')
+        return
+
+    rows = [g.row() for g in groups]
+    widths = [len(h) for h in HEADINGS]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    banner = []
+    column = 0
+    for label, span in BANNERS:
+        width = sum(widths[column:column + span]) + (span - 1)
+        banner.append(label.center(width) if label else ' ' * width)
+        column += span
+    print('  ' + ' '.join(banner))
+
+    header = [HEADINGS[0].ljust(widths[0])]
+    header.extend(h.rjust(widths[i]) for i, h in enumerate(HEADINGS)
+                  if i > 0)
+    print('  ' + ' '.join(header))
+
+    for row in rows:
+        line = [row[0].ljust(widths[0])]
+        line.extend(cell.rjust(widths[i]) for i, cell in enumerate(row)
+                    if i > 0)
+        print('  ' + ' '.join(line))
+
+
+def grouped(samples, key):
+    groups = collections.OrderedDict()
+    for sample in samples:
+        label = key(sample)
+        if label not in groups:
+            groups[label] = Group(label)
+        groups[label].add(sample)
+    return sorted(groups.values(), key=lambda g: -len(g.samples))
+
+
+def print_window(samples):
+    stamps = sorted(s.timestamp for s in samples if s.timestamp)
+    print(f'Samples: {len(samples)}')
+    if stamps:
+        print(f'Window:  {stamps[0]} to {stamps[-1]}')
+    else:
+        print('Window:  unknown (no timestamps in the sampled lines)')
+    programs = collections.Counter(s.program for s in samples)
+    print('Emitters: ' + ', '.join(
+        f'{name} ({count})' for name, count in programs.most_common()))
+
+
+def print_notes():
+    print()
+    print(f'Idle poll floor: p90 at or below {IDLE_POLL_MAX_SECONDS:.1f}s is '
+          'the dispatcher poll cap (IDLE_POLL_MAX_SECONDS), not queue wait.')
+    print('Deferral: a dependency wait re-enqueues an operation 15s into the '
+          'future, so read the defer_count == 0 columns before calling a')
+    print('tail a queueing problem. Background *_high_io queues are also '
+          'gated off entirely while the local disk is busy, which is')
+    print('designed backpressure rather than starvation -- check the node\'s '
+          'disk busy metric before attributing that tail to queue order.')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            'Summarise cluster operation queue-wait latency from a stream '
+            'of Shaken Fist JSON log lines on stdin.'))
+    parser.add_argument(
+        '--min-samples', type=int, default=1,
+        help=('Omit table rows with fewer than this many samples. Rows made '
+              'of a handful of observations have unreadable percentiles; '
+              'they are counted in the totals regardless.'))
+    args = parser.parse_args()
+
+    samples = read_samples(sys.stdin)
+    if not samples:
+        print('No queue-wait samples found on stdin.')
+        print()
+        print(f'Looking for JSON log lines whose message is '
+              f'"{EVENT_MESSAGE}" and whose "extra" carries "wait_seconds". '
+              'See this file\'s docstring for how to capture them.')
+        return 0
+
+    print_window(samples)
+
+    def keep(groups):
+        return [g for g in groups if len(g.samples) >= args.min_samples]
+
+    print_table(
+        'By queue class and priority lane',
+        keep(grouped(samples, lambda s: f'{s.queue_class} / {s.lane}')))
+    print_table(
+        'By operation type',
+        keep(grouped(samples, lambda s: s.operation_type)))
+    print_table(
+        'By priority lane',
+        keep(grouped(samples, lambda s: s.lane)))
+
+    print_notes()
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Closes out `docs/plans/PLAN-queue-performance.md` by doing its step 7 --
re-measuring cluster operation queue latency now that the coalescing work has
been in production for three months, and deciding the fairness question it left
open.

## The verdict

**The tail this plan set out to remove is gone, and explicit fairness is not
needed.**

`net_op`, the family containing `network_apply_update_dnsmasq`, against a
starting point of over 60 seconds:

| Window | n | p50 | p90 | p99 | max |
|--------|---|-----|-----|-----|-----|
| `sfcbr`, 25h58m | 6310 | 0.78 | 1.81 | 7.77 | 27.60 |
| Cluster CI, 33m (merge run 32597511463) | 313 | 0.56 | 1.72 | 2.19 | 23.96 |

A p90 of 1.8s *is* `IDLE_POLL_MAX_SECONDS`, so the median operation now waits
one dispatcher poll interval and nothing else.

## Three tails, none of them starvation

Each was excluded on evidence rather than argument, which is the part of this
worth reviewing:

* **`user_waiting`, p50 15.78s.** Entirely deferral. Restricted to operations
  which never deferred, the same p50 is **0.77s**, and 962 of 1013 samples had
  deferred at least once. A dependency wait re-enqueues an operation a flat 15
  seconds into the future.
* **`background_high_io`, p90 403s, defer count zero** -- which is the shape
  starvation would have. It is not: during each of the eight worst waits, the
  *same queue* completed between 1,281 and 1,334 seconds of its own work (more
  than the wait, because several workers run concurrently). A starved queue
  does no work during its wait; this one was saturated throughout.
* **`networknode`/`background`, p50 4.45s.** Bursts. In the largest, the
  background lane ran 34.5s of its own work in a 29 second span while
  `networknode`/`user_facing` ran 2.9s in total.

So the `FIELD()` ordering's theoretical starvation risk did not materialise in
26 hours of production traffic which contained exactly the bursty contention it
would appear in. Bounded-staleness ordering and reserved slots are not being
added, and the tool is committed so that reopening the question means bringing
a measurement.

## What is in the change

* `tools/queue-wait-report.py` and its unit tests. It reads Shaken Fist JSON
  log lines on stdin rather than talking to Loki, because the same lines arrive
  from Loki, from `journalctl` on a node, and from the CI artifact bundle, and
  a stdin tool works with all three. Every percentile is reported twice, once
  over all samples and once over operations which never deferred -- that split
  is the point of the tool, not a nicety, since without it a dependency wait
  reads as a queueing problem.
* The phase plan, its findings, and the master plan's outcome section.
* A documentation fix. `docs/operator_guide/networking/overview.md` claimed the
  `execution duration` event is retained for `MAX_USAGE_EVENT_AGE` (30 days).
  It is not: an operation is hard deleted 30 seconds after it completes and
  `hard_delete()` drops the `event_objects` rows joining its events to it, so
  the events are unreachable within a minute and the orphaned rows are pruned
  daily. The page now says that, and says to read the log stream instead.
* The master plan gains an Execution table, so its index arithmetic is
  recomputed by `tools/check-plan-status.py` rather than counted by hand, and
  it leaves the checker's `HAND_COUNTED` list.

## Filed, not fixed

Two latency sources the phase measured and deliberately left alone:

* #3863 -- a dependency wait costs a flat 15 seconds on the `user_waiting`
  queue, and is now the largest user-visible latency in the sample.
* #3864 -- a completed operation's events are unreachable 30 seconds later, so
  its audit trail cannot be read. Working around this is why the measurement
  had to come from the log echo.

A third candidate, the `background_high_io` tail, was conditional on the
measurement confirming it was not self-inflicted. It found that it was, so
there is nothing to file.

## Review notes

* The three exclusions above are load bearing. If one of them is wrong, the
  verdict changes.
* The `background_high_io` exclusion deviates from the plan, which asked for a
  disk-busy correlation. The same-queue-occupancy test answers the same
  question from the log stream alone and is a stronger negative -- it shows the
  queue was busy, not merely that the gate was open.
* No production code changes. The only non-documentation file is a new
  standalone analysis tool which nothing imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G31Z9FWwYcbHYgt7YB3427