### PR TITLE
Let the issue fixer write its own PR description

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -51,6 +51,12 @@
 #   test suite and ended its turn waiting for it, which in -p mode
 #   simply ends the session: the code changes survived, both blocks
 #   did not.
+# - The description is neutralised by tools/neutralise-pr-body.sh
+#   before publication: an @mention notifies a real person when the
+#   draft is created and an issue-closing keyword closes an unrelated
+#   issue on merge. The prompt forbids both, but a side effect which
+#   fires automatically and cannot be undone should not rest on the
+#   model having complied.
 # - Both blocks are pulled out of the captured output by
 #   tools/extract-model-block.sh rather than by sed inline here. That
 #   parsing has more edge cases than it looks (a model which emits a
@@ -723,6 +729,7 @@ jobs:
           # wrapper above: Claude has just edited this checkout and may
           # have touched tools/.
           cp tools/extract-model-block.sh ${{ runner.temp }}/
+          cp tools/neutralise-pr-body.sh ${{ runner.temp }}/
 
           summary_found=false
           description_found=false
@@ -739,6 +746,15 @@ jobs:
               ${{ runner.temp }}/pr-description.txt
           then
             description_found=true
+
+            # The prompt forbids @mentions and issue-closing keywords,
+            # but the description is published verbatim and both act
+            # the instant "gh pr create" runs -- before any human has
+            # looked at the draft, and a notification cannot be taken
+            # back. Prompt compliance is a weaker guarantee than code
+            # for a side effect which is not reversible.
+            ${{ runner.temp }}/neutralise-pr-body.sh \
+              ${{ runner.temp }}/pr-description.txt
           fi
 
           # Neither block is fatal: the publish step falls back to a
@@ -944,6 +960,7 @@ jobs:
             ${{ runner.temp }}/commit-message.txt
             ${{ runner.temp }}/pr-description.txt
             ${{ runner.temp }}/pr-body.md
+            ${{ runner.temp }}/summary-body.txt
             ${{ runner.temp }}/claude-logs/
           retention-days: 14
           if-no-files-found: ignore

--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -51,6 +51,20 @@
 #   test suite and ended its turn waiting for it, which in -p mode
 #   simply ends the session: the code changes survived, both blocks
 #   did not.
+# - Both blocks are pulled out of the captured output by
+#   tools/extract-model-block.sh rather than by sed inline here. That
+#   parsing has more edge cases than it looks (a model which emits a
+#   block twice, a block with no closing marker, a block the model
+#   wrapped in a fence anyway) and each is covered by
+#   shakenfist/tests/test_extract_model_block.py. Extend the tests, not
+#   this step, when a new shape of output turns up.
+# - The model is asked to run tox -ecover and the workflow then runs it
+#   again in "Verify fix". The duplication is deliberate: the model's
+#   run is what lets it fix what it broke while it still has a turn,
+#   and the workflow's run is the gate on publication, which cannot
+#   trust the model's report of its own testing. Paying for the suite
+#   twice is cheaper than publishing a broken fix or burning a whole
+#   run on one.
 # - The description is model output, so it is passed to gh with
 #   --body-file. Never interpolate it into a shell string.
 # - The issue-fix-<N> branches are owned by this workflow and are
@@ -496,8 +510,9 @@ jobs:
           work you were intending to come back to is lost. So:
 
           - Do NOT background a long-running command and end your turn
-            meaning to check on it later. Run the test suite in the
-            foreground and wait for it, however long it takes.
+            meaning to check on it later. The test suite in step 4 below
+            takes a while: run it in the foreground and wait for it,
+            however long it takes.
           - Do NOT end a turn describing what you are about to do. Do
             it instead.
           - The last thing you emit must be the two output blocks
@@ -534,7 +549,9 @@ jobs:
           After completing your work and staging changes, you MUST
           output both of the blocks below, in this order, as the last
           thing you emit. Markers go on their own lines, and neither
-          block is wrapped in a code fence.
+          block is wrapped in a code fence. Inside a block, never write
+          a line whose only content is one of the marker tokens: that
+          ends the block early and the rest is discarded.
 
           ```
           COMMIT_SUMMARY_START
@@ -688,42 +705,31 @@ jobs:
         id: extract_summary
         if: steps.assess.outputs.has_changes == 'true'
         run: |
+          # Both blocks are pulled out by tools/extract-model-block.sh,
+          # which is unit tested in test_extract_model_block.py. The
+          # parsing is subtle enough -- repeated blocks, truncated
+          # blocks, fences the model was told not to emit -- that having
+          # it inline here means having it untested here. Run it from a
+          # copy outside the workspace for the same reason as the model
+          # wrapper above: Claude has just edited this checkout and may
+          # have touched tools/.
+          cp tools/extract-model-block.sh ${{ runner.temp }}/
+
           summary_found=false
           description_found=false
 
-          if grep -q "COMMIT_SUMMARY_START" \
-              ${{ runner.temp }}/claude-output.txt
+          if ${{ runner.temp }}/extract-model-block.sh COMMIT_SUMMARY \
+              ${{ runner.temp }}/claude-output.txt \
+              ${{ runner.temp }}/commit-summary.txt
           then
-            sed -n '/COMMIT_SUMMARY_START/,/COMMIT_SUMMARY_END/p' \
-              ${{ runner.temp }}/claude-output.txt | \
-              grep -v "COMMIT_SUMMARY_START" | \
-              grep -v "COMMIT_SUMMARY_END" | \
-              sed 's/^```$//' | \
-              sed '/^$/N;/^\n$/d' \
-              > ${{ runner.temp }}/commit-summary.txt
-
-            if [ -s ${{ runner.temp }}/commit-summary.txt ]; then
-              summary_found=true
-            fi
+            summary_found=true
           fi
 
-          # A PR description may legitimately contain fenced code, so
-          # unlike the commit summary above only the marker lines are
-          # stripped. Both markers must be present: a truncated block
-          # would otherwise run to the end of the captured output.
-          if grep -q "^PR_DESCRIPTION_START" \
-               ${{ runner.temp }}/claude-output.txt && \
-             grep -q "^PR_DESCRIPTION_END" \
-               ${{ runner.temp }}/claude-output.txt
+          if ${{ runner.temp }}/extract-model-block.sh PR_DESCRIPTION \
+              ${{ runner.temp }}/claude-output.txt \
+              ${{ runner.temp }}/pr-description.txt
           then
-            sed -n '/^PR_DESCRIPTION_START/,/^PR_DESCRIPTION_END/p' \
-              ${{ runner.temp }}/claude-output.txt | \
-              sed '1d;$d' \
-              > ${{ runner.temp }}/pr-description.txt
-
-            if [ -s ${{ runner.temp }}/pr-description.txt ]; then
-              description_found=true
-            fi
+            description_found=true
           fi
 
           # Neither block is fatal: the publish step falls back to a
@@ -804,6 +810,15 @@ jobs:
             PR_TITLE="Fix issue #${ISSUE_NUMBER}"
           fi
 
+          # Second fallback tier: the commit message body, which is a
+          # better summary than nothing. Extracted to a file first so it
+          # can be tested for content -- a commit summary which is a bare
+          # subject line with no body would otherwise publish a "##
+          # Summary" heading with nothing under it, which reads as broken
+          # rather than as terse.
+          tail -n +2 ${{ runner.temp }}/commit-summary.txt 2>/dev/null | \
+            sed '/./,$!d' > ${{ runner.temp }}/summary-body.txt || true
+
           # The description is model output, so it is written to a file
           # and passed with --body-file. It must never be interpolated
           # into a shell string: an unquoted heredoc would execute any
@@ -811,19 +826,16 @@ jobs:
           {
             if [ "${{ steps.extract_summary.outputs.description_found }}" == "true" ]; then
               cat ${{ runner.temp }}/pr-description.txt
-            elif [ "${{ steps.extract_summary.outputs.summary_found }}" == "true" ]; then
-              # No description block, but the commit message body is a
-              # better summary than nothing.
+            elif [ -s ${{ runner.temp }}/summary-body.txt ]; then
               echo "## Summary"
               echo
-              tail -n +2 ${{ runner.temp }}/commit-summary.txt | \
-                sed '/./,$!d'
+              cat ${{ runner.temp }}/summary-body.txt
             else
               echo "## Summary"
               echo
               echo "Automated fix attempt for #${ISSUE_NUMBER}. The model"
-              echo "produced neither a description nor a commit message,"
-              echo "so read the diff rather than this."
+              echo "left no usable prose describing the change, so read"
+              echo "the diff rather than this."
             fi
 
             echo
@@ -921,6 +933,8 @@ jobs:
             ${{ runner.temp }}/verify-output.txt
             ${{ runner.temp }}/commit-summary.txt
             ${{ runner.temp }}/commit-message.txt
+            ${{ runner.temp }}/pr-description.txt
+            ${{ runner.temp }}/pr-body.md
             ${{ runner.temp }}/claude-logs/
           retention-days: 14
           if-no-files-found: ignore

--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -724,12 +724,24 @@ jobs:
           # which is unit tested in test_extract_model_block.py. The
           # parsing is subtle enough -- repeated blocks, truncated
           # blocks, fences the model was told not to emit -- that having
-          # it inline here means having it untested here. Run it from a
-          # copy outside the workspace for the same reason as the model
-          # wrapper above: Claude has just edited this checkout and may
-          # have touched tools/.
-          cp tools/extract-model-block.sh ${{ runner.temp }}/
-          cp tools/neutralise-pr-body.sh ${{ runner.temp }}/
+          # it inline here means having it untested here.
+          #
+          # These come from HEAD rather than from the workspace, which
+          # is NOT the reason the model wrapper above is copied. That
+          # one is copied before Claude runs, because bash reads a
+          # script lazily and an edit mid-run would corrupt it. Here
+          # Claude has already exited and the danger is the opposite:
+          # the fix under test may have edited these very files -- the
+          # extractor's own header calls that out as a plausible
+          # subject for an automated fix -- and the workflow must not
+          # parse the model's output with the untested version the
+          # model just wrote. Nothing is committed until the "Commit
+          # changes" step below, so HEAD is still the pre-fix tree.
+          for script in extract-model-block.sh neutralise-pr-body.sh; do
+            git show "HEAD:tools/${script}" \
+              > "${{ runner.temp }}/${script}"
+            chmod +x "${{ runner.temp }}/${script}"
+          done
 
           summary_found=false
           description_found=false
@@ -848,7 +860,16 @@ jobs:
           # and passed with --body-file. It must never be interpolated
           # into a shell string: an unquoted heredoc would execute any
           # $(...) or backticks the model happened to write.
+          #
+          # The issue reference goes FIRST, above the model prose. An
+          # unbalanced code fence in the description renders everything
+          # after it as preformatted text, and GitHub does not autolink
+          # #NNNN inside a code block -- so a trailing reference would
+          # silently stop closing the issue, with nothing about the
+          # published PR looking wrong.
           {
+            echo "Fixes #${ISSUE_NUMBER}"
+            echo
             if [ "${{ steps.extract_summary.outputs.description_found }}" == "true" ]; then
               cat ${{ runner.temp }}/pr-description.txt
             elif [ -s ${{ runner.temp }}/summary-body.txt ]; then
@@ -863,8 +884,6 @@ jobs:
               echo "the diff rather than this."
             fi
 
-            echo
-            echo "Fixes #${ISSUE_NUMBER}"
             echo
             echo "## Changes"
             echo

--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -42,6 +42,17 @@
 #   workflow token (this prevents recursive workflow triggering), so
 #   the draft PR needs a human nudge -- push to it, or close and
 #   reopen it -- before the full CI suite runs.
+# - The model is asked for two blocks on stdout: a commit message and
+#   a pull request description. The workflow falls back to a generic
+#   template if either is missing, but a missing one is a real loss --
+#   an automated PR whose description is just a diffstat costs the
+#   reviewer the context the model already had. The "single shot"
+#   section of the prompt exists because a run once backgrounded the
+#   test suite and ended its turn waiting for it, which in -p mode
+#   simply ends the session: the code changes survived, both blocks
+#   did not.
+# - The description is model output, so it is passed to gh with
+#   --body-file. Never interpolate it into a shell string.
 # - The issue-fix-<N> branches are owned by this workflow and are
 #   force-updated on each attempt.
 # - Scratch files (prompts, logs, captured output) live in
@@ -477,6 +488,24 @@ jobs:
             without doing the plan's work: that is fine. Say which
             plan and why in the commit summary.
 
+          ## How this run works
+
+          You are a single, non-interactive `claude -p` invocation on
+          a CI runner. Nothing will re-invoke you and nobody will
+          answer you: when your turn ends the process exits, and any
+          work you were intending to come back to is lost. So:
+
+          - Do NOT background a long-running command and end your turn
+            meaning to check on it later. Run the test suite in the
+            foreground and wait for it, however long it takes.
+          - Do NOT end a turn describing what you are about to do. Do
+            it instead.
+          - The last thing you emit must be the two output blocks
+            described below. A run which ends without them still
+            commits the code, but under a placeholder commit message
+            and a contentless pull request description -- which wastes
+            the reviewer's time, not just the prose.
+
           ## Your task
 
           1. Diagnose the root cause of the issue. Fix the root
@@ -497,12 +526,15 @@ jobs:
              ```
           5. Run `pre-commit run --all-files` and fix any issues.
           6. Stage all changes with git add (do NOT commit).
-          7. Output a commit summary (see below).
+          7. Output a commit summary and a pull request description
+             (see below).
 
-          ## REQUIRED: Commit Summary Output
+          ## REQUIRED: Commit summary and PR description
 
           After completing your work and staging changes, you MUST
-          output a commit summary in the following exact format:
+          output both of the blocks below, in this order, as the last
+          thing you emit. Markers go on their own lines, and neither
+          block is wrapped in a code fence.
 
           ```
           COMMIT_SUMMARY_START
@@ -520,6 +552,37 @@ jobs:
 
           Do not include a "Fixes #NNNN" line in the summary -- the
           workflow adds that itself.
+
+          ```
+          PR_DESCRIPTION_START
+          <Markdown, wrapped at 72 chars.>
+          PR_DESCRIPTION_END
+          ```
+
+          This is what a reviewer reads before the diff, so write it
+          for them rather than restating the issue back at them.
+          Under whatever headings suit the change, cover:
+
+          - What was actually wrong, and why. The root cause you
+            found, not the symptom the issue reported. Where the
+            issue's own diagnosis turned out to be incomplete or
+            wrong, say so.
+          - What you changed, and why each piece is needed. Call out
+            anything a reviewer would otherwise have to
+            reverse-engineer: a refactor done to make the fix
+            possible, behaviour which deliberately did not change, a
+            test which pins the old behaviour as a floor.
+          - Anything in the issue you deliberately did NOT do, and
+            why: a second cause you judged out of scope, follow-up
+            work which deserves its own issue, a measurement which
+            should be repeated once this merges.
+          - Any judgement call a reviewer might reasonably make
+            differently.
+
+          Do NOT include a diffstat, a "Fixes #NNNN" line, a link to
+          this workflow run, or a note about CI not starting -- the
+          workflow appends all of those. Do not pad it either: a small
+          mechanical fix deserves a short description.
           TASK_EOF
           } > ${{ runner.temp }}/claude-prompt.txt
 
@@ -621,10 +684,13 @@ jobs:
 
           exit ${verify_exit_code}
 
-      - name: Extract commit summary
+      - name: Extract commit summary and PR description
         id: extract_summary
         if: steps.assess.outputs.has_changes == 'true'
         run: |
+          summary_found=false
+          description_found=false
+
           if grep -q "COMMIT_SUMMARY_START" \
               ${{ runner.temp }}/claude-output.txt
           then
@@ -637,13 +703,40 @@ jobs:
               > ${{ runner.temp }}/commit-summary.txt
 
             if [ -s ${{ runner.temp }}/commit-summary.txt ]; then
-              echo "summary_found=true" >> $GITHUB_OUTPUT
-            else
-              echo "summary_found=false" >> $GITHUB_OUTPUT
+              summary_found=true
             fi
-          else
-            echo "summary_found=false" >> $GITHUB_OUTPUT
           fi
+
+          # A PR description may legitimately contain fenced code, so
+          # unlike the commit summary above only the marker lines are
+          # stripped. Both markers must be present: a truncated block
+          # would otherwise run to the end of the captured output.
+          if grep -q "^PR_DESCRIPTION_START" \
+               ${{ runner.temp }}/claude-output.txt && \
+             grep -q "^PR_DESCRIPTION_END" \
+               ${{ runner.temp }}/claude-output.txt
+          then
+            sed -n '/^PR_DESCRIPTION_START/,/^PR_DESCRIPTION_END/p' \
+              ${{ runner.temp }}/claude-output.txt | \
+              sed '1d;$d' \
+              > ${{ runner.temp }}/pr-description.txt
+
+            if [ -s ${{ runner.temp }}/pr-description.txt ]; then
+              description_found=true
+            fi
+          fi
+
+          # Neither block is fatal: the publish step falls back to a
+          # generic body. Say so in the log, because a PR which turns up
+          # with a contentless description is otherwise a mystery.
+          if [ "${description_found}" != "true" ]; then
+            echo "No usable PR description in the model output. The run"
+            echo "probably ended its turn early -- check the tail of"
+            echo "claude-output.txt in the artifacts."
+          fi
+
+          echo "summary_found=${summary_found}" >> $GITHUB_OUTPUT
+          echo "description_found=${description_found}" >> $GITHUB_OUTPUT
 
       # The triage estimate of fix size is only an estimate. This is
       # the hard cap: an over-budget fix is never published as a PR,
@@ -711,37 +804,58 @@ jobs:
             PR_TITLE="Fix issue #${ISSUE_NUMBER}"
           fi
 
+          # The description is model output, so it is written to a file
+          # and passed with --body-file. It must never be interpolated
+          # into a shell string: an unquoted heredoc would execute any
+          # $(...) or backticks the model happened to write.
+          {
+            if [ "${{ steps.extract_summary.outputs.description_found }}" == "true" ]; then
+              cat ${{ runner.temp }}/pr-description.txt
+            elif [ "${{ steps.extract_summary.outputs.summary_found }}" == "true" ]; then
+              # No description block, but the commit message body is a
+              # better summary than nothing.
+              echo "## Summary"
+              echo
+              tail -n +2 ${{ runner.temp }}/commit-summary.txt | \
+                sed '/./,$!d'
+            else
+              echo "## Summary"
+              echo
+              echo "Automated fix attempt for #${ISSUE_NUMBER}. The model"
+              echo "produced neither a description nor a commit message,"
+              echo "so read the diff rather than this."
+            fi
+
+            echo
+            echo "Fixes #${ISSUE_NUMBER}"
+            echo
+            echo "## Changes"
+            echo
+            echo '```'
+            git diff --stat HEAD~1
+            echo '```'
+            echo
+            echo "## Automated verification"
+            echo
+            echo "The unit test suite (tox -ecover) passes on the runner."
+            echo
+            echo "Note: GitHub does not start CI on pull requests created"
+            echo "with the default workflow token, so push to this PR or"
+            echo "close and reopen it to trigger the full CI suite."
+            echo
+            echo "[Workflow run](${RUN_URL})"
+            echo
+            echo "---"
+            echo "Generated with [Claude Code](https://claude.com/claude-code)"
+          } > ${{ runner.temp }}/pr-body.md
+
           pr_url=$(gh pr create \
             --draft \
             --label automated-fix \
             --assignee mikalstill \
             --reviewer mikalstill \
             --title "${PR_TITLE}" \
-            --body "$(cat <<EOF
-          ## Summary
-
-          Automated fix attempt for #${ISSUE_NUMBER}.
-
-          Fixes #${ISSUE_NUMBER}
-
-          ## Changes
-
-          $(git diff --stat HEAD~1)
-
-          ## Verification
-
-          The unit test suite (tox -ecover) passes on the runner.
-
-          Note: GitHub does not start CI on pull requests created
-          with the default workflow token, so push to this PR or
-          close and reopen it to trigger the full CI suite.
-
-          [Workflow run](${RUN_URL})
-
-          ---
-          Generated with [Claude Code](https://claude.com/claude-code)
-          EOF
-          )" \
+            --body-file ${{ runner.temp }}/pr-body.md \
             --head "issue-fix-${ISSUE_NUMBER}")
 
           gh issue comment "${ISSUE_NUMBER}" \

--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -596,10 +596,19 @@ jobs:
           - Any judgement call a reviewer might reasonably make
             differently.
 
-          Do NOT include a diffstat, a "Fixes #NNNN" line, a link to
-          this workflow run, or a note about CI not starting -- the
-          workflow appends all of those. Do not pad it either: a small
-          mechanical fix deserves a short description.
+          Do NOT include a diffstat, a link to this workflow run, or
+          a note about CI not starting -- the workflow appends all of
+          those. Do not pad it either: a small mechanical fix deserves
+          a short description.
+
+          The description is published verbatim into a pull request
+          body, where GitHub interprets what it finds. So do NOT write
+          an issue-closing keyword for any issue -- "fixes", "closes"
+          and "resolves" followed by #NNNN all close that issue when
+          this merges, and the workflow already appends the one for
+          the issue you are fixing. Refer to other issues as "issue
+          NNNN". Do NOT write "@name": it notifies a real person.
+          Refer to people by name alone.
           TASK_EOF
           } > ${{ runner.temp }}/claude-prompt.txt
 

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -246,6 +246,33 @@ landing across partially implemented plans and having to be unpicked
 (see the step 3 note in
 `docs/plans/PLAN-scheduler-reservations-phase-01-node-metrics-columns.md`).
 
+`issue-fix.yml` asks the model for two marker delimited blocks on
+stdout: a commit message and a pull request description. The commit
+message is pushed and its first line becomes the pull request title;
+the description is published as the pull request body, so an automated
+fix arrives explaining its own root cause, what it deliberately did not
+do, and any judgement call a reviewer might make differently, rather
+than as a diffstat under boilerplate.
+
+Neither block is required. A missing description falls back to the
+commit message body, and a missing commit message to a generic note
+telling the reviewer to read the diff -- a correct fix is worth
+publishing even when the prose is lost. Both cases are logged rather
+than fatal, because the run cannot be retried to recover them.
+
+The parsing lives in `tools/extract-model-block.sh` rather than inline
+in the workflow, and is covered by
+`shakenfist/tests/test_extract_model_block.py`. It takes only the first
+complete block, requires both markers (an unterminated block would
+otherwise run to the end of the captured output and swallow the block
+after it), treats a marker as a terminator only when it is the entire
+line, and strips a code fence only when one wraps the whole block --
+never globally, because a description may legitimately quote code.
+
+The description is model output, so the workflow assembles the pull
+request body into a file and passes it with `gh pr create --body-file`.
+It must never be interpolated into a shell string.
+
 `issue-fix.yml` runs its fix attempt through
 `tools/claude-model-fallback.sh`, which takes a comma-separated
 preference list (`--models`, default `claude-fable-5,claude-opus-5`) and

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -273,6 +273,18 @@ The description is model output, so the workflow assembles the pull
 request body into a file and passes it with `gh pr create --body-file`.
 It must never be interpolated into a shell string.
 
+It is also run through `tools/neutralise-pr-body.sh` before
+publication, which drops the `@` from a mention and separates an
+issue-closing keyword from its reference. Both of those are things
+GitHub acts on rather than renders: a mention notifies a real person
+the instant the draft is created, and a closing keyword closes an
+unrelated issue on merge. The prompt forbids both, and a side effect
+which fires automatically and cannot be undone should not rest on the
+model having complied. Fenced code is passed through untouched --
+GitHub does not linkify inside a fence, and a description quoting a
+decorator or an email address is a normal description.
+`shakenfist/tests/test_neutralise_pr_body.py` covers both halves.
+
 `issue-fix.yml` runs its fix attempt through
 `tools/claude-model-fallback.sh`, which takes a comma-separated
 preference list (`--models`, default `claude-fable-5,claude-opus-5`) and

--- a/shakenfist/tests/test_extract_model_block.py
+++ b/shakenfist/tests/test_extract_model_block.py
@@ -207,6 +207,31 @@ class ExtractModelBlockTestCase(base.ShakenFistTestCase):
             'The PR_DESCRIPTION_END marker needs a line to itself.\n'
             'Still here.\n', got)
 
+    def test_marker_beginning_a_line_of_prose_does_not_terminate(self):
+        # Stricter than an anchored match: only a line which is nothing but
+        # the marker terminates. A fix to this workflow would plausibly
+        # start a sentence of its description with the token.
+        rc, got = self._extract('PR_DESCRIPTION', (
+            'PR_DESCRIPTION_START\n'
+            'PR_DESCRIPTION_END is what terminates the block.\n'
+            'This line must survive.\n'
+            'PR_DESCRIPTION_END\n'))
+        self.assertEqual(0, rc)
+        self.assertEqual(
+            'PR_DESCRIPTION_END is what terminates the block.\n'
+            'This line must survive.\n', got)
+
+    def test_start_marker_beginning_a_line_of_prose_does_not_restart(self):
+        rc, got = self._extract('PR_DESCRIPTION', (
+            'PR_DESCRIPTION_START\n'
+            'The prompt asks for a PR_DESCRIPTION_START block.\n'
+            'That sentence is prose, not a marker.\n'
+            'PR_DESCRIPTION_END\n'))
+        self.assertEqual(0, rc)
+        self.assertEqual(
+            'The prompt asks for a PR_DESCRIPTION_START block.\n'
+            'That sentence is prose, not a marker.\n', got)
+
     def test_indented_markers_are_matched(self):
         # Models indent things. Trailing whitespace on a marker line is the
         # same hazard and is handled by the same trim.

--- a/shakenfist/tests/test_extract_model_block.py
+++ b/shakenfist/tests/test_extract_model_block.py
@@ -1,0 +1,237 @@
+# Copyright 2026 Michael Still and contributors
+
+"""Tests for tools/extract-model-block.sh.
+
+The issue-fix workflow asks Claude Code for two marker delimited blocks on
+stdout -- a commit message and a pull request description -- and publishes
+both. The commit message is pushed and its first line becomes the pull
+request title, so a parsing mistake here is not cosmetic: it lands in git
+history and in a description a human is meant to read before the diff.
+
+The parsing looks trivial and is not. Each test below pins a shape that the
+obvious sed implementation got wrong: a range match prints every occurrence
+rather than the first, an unterminated block runs to the end of the captured
+output and swallows the block after it, and a model which copies the fenced
+illustration from the prompt gets its whole description rendered as one
+preformatted lump. The one thing that must NOT be normalised is fenced code
+inside a description, which is why fences are only stripped when they wrap
+the entire block.
+"""
+
+import os
+import subprocess
+import tempfile
+
+from shakenfist.tests import base
+
+
+def _script_path():
+    here = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.dirname(os.path.dirname(here))
+    return os.path.join(root, 'tools', 'extract-model-block.sh')
+
+
+SCRIPT = _script_path()
+
+
+class ExtractModelBlockTestCase(base.ShakenFistTestCase):
+    def _extract(self, block, output):
+        """Run the extractor over output, returning (exit code, extracted)."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            source = os.path.join(tempdir, 'claude-output.txt')
+            extracted = os.path.join(tempdir, 'block.txt')
+            with open(source, 'w') as f:
+                f.write(output)
+
+            proc = subprocess.run(
+                [SCRIPT, block, source, extracted],
+                capture_output=True, text=True)
+
+            # The output file is always created, so a caller uploading it as
+            # a build artifact does not have to special case the failure.
+            self.assertTrue(os.path.exists(extracted),
+                            'output file was not created')
+            with open(extracted) as f:
+                return proc.returncode, f.read()
+
+    def test_script_is_executable(self):
+        # The workflow copies it and runs it directly rather than via bash.
+        self.assertTrue(os.access(SCRIPT, os.X_OK))
+
+    def test_simple_block(self):
+        rc, got = self._extract('COMMIT_SUMMARY', (
+            'chatter before\n'
+            'COMMIT_SUMMARY_START\n'
+            'Fix the thing.\n'
+            '\n'
+            'Body line.\n'
+            'COMMIT_SUMMARY_END\n'
+            'chatter after\n'))
+        self.assertEqual(0, rc)
+        self.assertEqual('Fix the thing.\n\nBody line.\n', got)
+
+    def test_only_the_first_block_is_taken(self):
+        # A model which emits a block, decides it is wrong and emits another
+        # used to have the interior marker lines published verbatim.
+        rc, got = self._extract('PR_DESCRIPTION', (
+            'PR_DESCRIPTION_START\n'
+            'First attempt.\n'
+            'PR_DESCRIPTION_END\n'
+            'PR_DESCRIPTION_START\n'
+            'Second attempt.\n'
+            'PR_DESCRIPTION_END\n'))
+        self.assertEqual(0, rc)
+        self.assertEqual('First attempt.\n', got)
+        self.assertNotIn('PR_DESCRIPTION_END', got)
+        self.assertNotIn('Second attempt.', got)
+
+    def test_unterminated_block_is_rejected(self):
+        # Without this the range runs to end of file and the commit message
+        # absorbs the pull request description which follows it.
+        rc, got = self._extract('COMMIT_SUMMARY', (
+            'COMMIT_SUMMARY_START\n'
+            'Fix the thing.\n'
+            '\n'
+            'Body line.\n'
+            'PR_DESCRIPTION_START\n'
+            '## What was wrong\n'
+            'PR_DESCRIPTION_END\n'))
+        self.assertEqual(1, rc)
+        self.assertEqual('', got)
+
+    def test_missing_block_is_rejected(self):
+        rc, got = self._extract('PR_DESCRIPTION', 'I have nothing to say.\n')
+        self.assertEqual(1, rc)
+        self.assertEqual('', got)
+
+    def test_empty_block_is_rejected(self):
+        # An empty block is a missing block: the caller must fall back rather
+        # than publish a description consisting of nothing.
+        rc, got = self._extract('PR_DESCRIPTION', (
+            'PR_DESCRIPTION_START\n'
+            '\n'
+            '\n'
+            'PR_DESCRIPTION_END\n'))
+        self.assertEqual(1, rc)
+        self.assertEqual('', got)
+
+    def test_wrapping_fence_is_stripped(self):
+        # The prompt illustrates both blocks inside fences while telling the
+        # model not to use them. A model which copies the illustration would
+        # otherwise have its whole description rendered as preformatted text.
+        rc, got = self._extract('PR_DESCRIPTION', (
+            'PR_DESCRIPTION_START\n'
+            '```\n'
+            '## What was wrong\n'
+            '\n'
+            'The root cause.\n'
+            '```\n'
+            'PR_DESCRIPTION_END\n'))
+        self.assertEqual(0, rc)
+        self.assertEqual('## What was wrong\n\nThe root cause.\n', got)
+
+    def test_wrapping_fence_with_a_language_is_stripped(self):
+        rc, got = self._extract('PR_DESCRIPTION', (
+            'PR_DESCRIPTION_START\n'
+            '```markdown\n'
+            '## What was wrong\n'
+            '```\n'
+            'PR_DESCRIPTION_END\n'))
+        self.assertEqual(0, rc)
+        self.assertEqual('## What was wrong\n', got)
+
+    def test_interior_fenced_code_is_preserved(self):
+        # The reason fences are not stripped globally: a description may
+        # legitimately quote code, and eating those fences would mangle it.
+        rc, got = self._extract('PR_DESCRIPTION', (
+            'PR_DESCRIPTION_START\n'
+            '## What changed\n'
+            '\n'
+            '```python\n'
+            'x = 1\n'
+            '```\n'
+            '\n'
+            'And that is all.\n'
+            'PR_DESCRIPTION_END\n'))
+        self.assertEqual(0, rc)
+        self.assertEqual(
+            '## What changed\n\n```python\nx = 1\n```\n\nAnd that is all.\n',
+            got)
+
+    def test_marker_named_in_prose_does_not_terminate(self):
+        # This workflow is itself a plausible target for an automated fix,
+        # and such a fix would want to name these tokens in its description.
+        rc, got = self._extract('PR_DESCRIPTION', (
+            'PR_DESCRIPTION_START\n'
+            'The PR_DESCRIPTION_END marker needs a line to itself.\n'
+            'Still here.\n'
+            'PR_DESCRIPTION_END\n'))
+        self.assertEqual(0, rc)
+        self.assertEqual(
+            'The PR_DESCRIPTION_END marker needs a line to itself.\n'
+            'Still here.\n', got)
+
+    def test_indented_markers_are_matched(self):
+        # Models indent things. Trailing whitespace on a marker line is the
+        # same hazard and is handled by the same trim.
+        rc, got = self._extract('COMMIT_SUMMARY', (
+            '  COMMIT_SUMMARY_START  \n'
+            'Fix the thing.\n'
+            '\tCOMMIT_SUMMARY_END\n'))
+        self.assertEqual(0, rc)
+        self.assertEqual('Fix the thing.\n', got)
+
+    def test_leading_and_trailing_blank_lines_are_trimmed(self):
+        rc, got = self._extract('COMMIT_SUMMARY', (
+            'COMMIT_SUMMARY_START\n'
+            '\n'
+            'Fix the thing.\n'
+            '\n'
+            '\n'
+            'COMMIT_SUMMARY_END\n'))
+        self.assertEqual(0, rc)
+        self.assertEqual('Fix the thing.\n', got)
+
+    def test_blocks_do_not_interfere(self):
+        # Both blocks come out of one captured output, in either order.
+        output = (
+            'COMMIT_SUMMARY_START\n'
+            'Fix the thing.\n'
+            'COMMIT_SUMMARY_END\n'
+            'PR_DESCRIPTION_START\n'
+            '## What was wrong\n'
+            'PR_DESCRIPTION_END\n')
+        rc, summary = self._extract('COMMIT_SUMMARY', output)
+        self.assertEqual(0, rc)
+        self.assertEqual('Fix the thing.\n', summary)
+        rc, description = self._extract('PR_DESCRIPTION', output)
+        self.assertEqual(0, rc)
+        self.assertEqual('## What was wrong\n', description)
+
+    def test_shell_metacharacters_are_not_evaluated(self):
+        # The extracted description reaches gh via --body-file, but the
+        # extractor itself must not evaluate what it is copying either.
+        rc, got = self._extract('PR_DESCRIPTION', (
+            'PR_DESCRIPTION_START\n'
+            'The fix was $(touch /tmp/PWNED) and `echo also`.\n'
+            'PR_DESCRIPTION_END\n'))
+        self.assertEqual(0, rc)
+        self.assertEqual(
+            'The fix was $(touch /tmp/PWNED) and `echo also`.\n', got)
+        self.assertFalse(os.path.exists('/tmp/PWNED'))
+
+    def test_missing_input_file_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            extracted = os.path.join(tempdir, 'block.txt')
+            proc = subprocess.run(
+                [SCRIPT, 'PR_DESCRIPTION',
+                 os.path.join(tempdir, 'nope.txt'), extracted],
+                capture_output=True, text=True)
+            self.assertEqual(1, proc.returncode)
+            self.assertTrue(os.path.exists(extracted))
+
+    def test_wrong_argument_count_is_a_usage_error(self):
+        proc = subprocess.run(
+            [SCRIPT, 'PR_DESCRIPTION'], capture_output=True, text=True)
+        self.assertEqual(2, proc.returncode)
+        self.assertIn('usage:', proc.stderr)

--- a/shakenfist/tests/test_extract_model_block.py
+++ b/shakenfist/tests/test_extract_model_block.py
@@ -11,7 +11,8 @@ history and in a description a human is meant to read before the diff.
 The parsing looks trivial and is not. Each test below pins a shape that the
 obvious sed implementation got wrong: a range match prints every occurrence
 rather than the first, an unterminated block runs to the end of the captured
-output and swallows the block after it, and a model which copies the fenced
+output and swallows the block after it, a repeated start marker ends up
+embedded in the published prose, and a model which copies the fenced
 illustration from the prompt gets its whole description rendered as one
 preformatted lump. The one thing that must NOT be normalised is fenced code
 inside a description, which is why fences are only stripped when they wrap
@@ -70,9 +71,9 @@ class ExtractModelBlockTestCase(base.ShakenFistTestCase):
         self.assertEqual(0, rc)
         self.assertEqual('Fix the thing.\n\nBody line.\n', got)
 
-    def test_only_the_first_block_is_taken(self):
-        # A model which emits a block, decides it is wrong and emits another
-        # used to have the interior marker lines published verbatim.
+    def test_a_second_complete_block_is_ignored(self):
+        # A range match prints every occurrence, so this used to publish the
+        # interior marker lines verbatim.
         rc, got = self._extract('PR_DESCRIPTION', (
             'PR_DESCRIPTION_START\n'
             'First attempt.\n'
@@ -84,6 +85,41 @@ class ExtractModelBlockTestCase(base.ShakenFistTestCase):
         self.assertEqual('First attempt.\n', got)
         self.assertNotIn('PR_DESCRIPTION_END', got)
         self.assertNotIn('Second attempt.', got)
+
+    def test_a_repeated_start_marker_restarts_the_block(self):
+        # The model narrating what it is about to emit, or abandoning a first
+        # attempt without closing it. Taking the first start marker instead
+        # would leave the second one embedded in the published prose.
+        rc, got = self._extract('PR_DESCRIPTION', (
+            'PR_DESCRIPTION_START\n'
+            'Abandoned attempt.\n'
+            'PR_DESCRIPTION_START\n'
+            'The real description.\n'
+            'PR_DESCRIPTION_END\n'))
+        self.assertEqual(0, rc)
+        self.assertEqual('The real description.\n', got)
+        self.assertNotIn('PR_DESCRIPTION_START', got)
+        self.assertNotIn('Abandoned attempt.', got)
+
+    def test_end_before_any_start_is_not_a_close(self):
+        rc, got = self._extract('PR_DESCRIPTION', (
+            'PR_DESCRIPTION_END\n'
+            'PR_DESCRIPTION_START\n'
+            'The real description.\n'
+            'PR_DESCRIPTION_END\n'))
+        self.assertEqual(0, rc)
+        self.assertEqual('The real description.\n', got)
+
+    def test_whitespace_only_block_is_rejected(self):
+        # As useless to a reader as an empty one, and the caller falls back
+        # for both.
+        rc, got = self._extract('PR_DESCRIPTION', (
+            'PR_DESCRIPTION_START\n'
+            '   \n'
+            '\t\n'
+            'PR_DESCRIPTION_END\n'))
+        self.assertEqual(1, rc)
+        self.assertEqual('', got)
 
     def test_unterminated_block_is_rejected(self):
         # Without this the range runs to end of file and the commit message

--- a/shakenfist/tests/test_extract_model_block.py
+++ b/shakenfist/tests/test_extract_model_block.py
@@ -71,6 +71,39 @@ class ExtractModelBlockTestCase(base.ShakenFistTestCase):
         self.assertEqual(0, rc)
         self.assertEqual('Fix the thing.\n\nBody line.\n', got)
 
+    def test_two_separate_fenced_blocks_keep_their_fences(self):
+        # The wrapping-fence check must confirm the first and last lines
+        # are the ONLY fences. Testing just those two lines deletes the
+        # outer markers of two unrelated fenced blocks, which inverts
+        # every fence after the first in the published body.
+        body = (
+            '```python\n'
+            'x = 1\n'
+            '```\n'
+            '\n'
+            'Some prose here.\n'
+            '\n'
+            '```python\n'
+            'y = 2\n'
+            '```\n')
+        rc, got = self._extract('PR_DESCRIPTION', (
+            'PR_DESCRIPTION_START\n' + body + 'PR_DESCRIPTION_END\n'))
+        self.assertEqual(0, rc)
+        self.assertEqual(body, got)
+
+    def test_an_odd_number_of_fences_is_not_stripped(self):
+        # Ambiguous, so leave it alone rather than guess.
+        body = (
+            '```\n'
+            'x = 1\n'
+            '```\n'
+            '\n'
+            '```\n')
+        rc, got = self._extract('PR_DESCRIPTION', (
+            'PR_DESCRIPTION_START\n' + body + 'PR_DESCRIPTION_END\n'))
+        self.assertEqual(0, rc)
+        self.assertEqual(body, got)
+
     def test_a_second_complete_block_is_ignored(self):
         # A range match prints every occurrence, so this used to publish the
         # interior marker lines verbatim.

--- a/shakenfist/tests/test_issue_fix_workflow_seams.py
+++ b/shakenfist/tests/test_issue_fix_workflow_seams.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Michael Still and contributors
+
+"""Tests for how issue-fix.yml wires up its helper scripts.
+
+`tools/extract-model-block.sh` and `tools/neutralise-pr-body.sh` have their
+own unit tests, but a tested script the workflow does not call is not an
+extraction and not a defence. These pin the seams between the two.
+
+The one worth explaining is the HEAD read. Both scripts are staged outside
+the workspace before use, which looks like the copy of
+`claude-model-fallback.sh` earlier in the same workflow and is there for the
+opposite reason. That one is copied *before* Claude runs, because bash reads
+a script lazily as it executes and an edit mid-run would corrupt it. These
+are staged *after* Claude has exited, and the hazard is that the fix under
+test may have edited them -- the extractor's own header calls that out as a
+plausible subject for an automated fix. Copying from the workspace would
+have the workflow parse the model's output with the untested version the
+model just wrote. Nothing is committed until the "Commit changes" step, so
+HEAD is still the pre-fix tree.
+"""
+
+import os
+
+from shakenfist.tests import base
+
+
+def _workflow_path():
+    here = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.dirname(os.path.dirname(here))
+    return os.path.join(root, '.github', 'workflows', 'issue-fix.yml')
+
+
+class IssueFixWorkflowSeamsTestCase(base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+        with open(_workflow_path()) as f:
+            self.workflow = f.read()
+
+    def test_both_blocks_are_extracted_with_the_tested_script(self):
+        for block in ('COMMIT_SUMMARY', 'PR_DESCRIPTION'):
+            self.assertIn(
+                'extract-model-block.sh %s' % block, self.workflow,
+                'the workflow no longer extracts %s with the tested '
+                'script. If the extraction was rewritten, rewrite '
+                'test_extract_model_block.py against it rather than '
+                'deleting it.' % block)
+
+    def test_the_description_is_neutralised(self):
+        self.assertIn(
+            'neutralise-pr-body.sh \\\n              '
+            '${{ runner.temp }}/pr-description.txt', self.workflow)
+
+    def test_the_commit_summary_is_not_neutralised(self):
+        # A commit message is not published anywhere GitHub acts on a
+        # mention, and the workflow appends its own "Fixes #NNNN" to it
+        # deliberately.
+        self.assertNotIn(
+            'neutralise-pr-body.sh ${{ runner.temp }}/commit-summary.txt',
+            self.workflow)
+
+    def test_the_scripts_are_read_from_head_not_the_workspace(self):
+        self.assertIn('git show "HEAD:tools/${script}"', self.workflow)
+        for script in ('extract-model-block.sh', 'neutralise-pr-body.sh'):
+            self.assertNotIn(
+                'cp tools/%s' % script, self.workflow,
+                '%s is copied from the workspace, which is the tree the '
+                'fix under test just edited. Read it from HEAD instead.'
+                % script)
+
+    def test_the_issue_reference_precedes_the_model_prose(self):
+        # An unbalanced fence in the description renders everything after
+        # it as preformatted text, and GitHub does not autolink #NNNN
+        # inside a code block -- a trailing reference would silently stop
+        # closing the issue.
+        # Scope to the brace group which assembles the body, and to
+        # nothing else: the commit message step also emits a "Fixes"
+        # line, and a window which caught that one would pass whatever
+        # order the publish step used.
+        end = self.workflow.index('} > ${{ runner.temp }}/pr-body.md')
+        start = self.workflow.rindex('\n          {\n', 0, end)
+        body = self.workflow[start:end]
+
+        self.assertIn('cat ${{ runner.temp }}/pr-description.txt', body)
+        reference = body.index('echo "Fixes #${ISSUE_NUMBER}"')
+        description = body.index('cat ${{ runner.temp }}/pr-description.txt')
+        self.assertLess(
+            reference, description,
+            'the appended "Fixes #NNNN" must come before the model '
+            'description, not after it')

--- a/shakenfist/tests/test_neutralise_pr_body.py
+++ b/shakenfist/tests/test_neutralise_pr_body.py
@@ -154,6 +154,17 @@ class NeutralisePrBodyTestCase(base.ShakenFistTestCase):
             'The publish step is still untested shell.\n')
         self.assertEqual(body, self._neutralise(body))
 
+    def test_an_unterminated_fence_is_closed(self):
+        # Otherwise it runs on into the diffstat and footer the workflow
+        # appends after this body, rendering them as one grey lump.
+        self.assertEqual(
+            'Before.\n\n```python\nx = 1\n```\n',
+            self._neutralise('Before.\n\n```python\nx = 1\n'))
+
+    def test_a_balanced_body_gains_no_fence(self):
+        body = 'Before.\n\n```python\nx = 1\n```\n\nAfter.\n'
+        self.assertEqual(body, self._neutralise(body))
+
     def test_a_missing_file_is_rejected(self):
         with tempfile.TemporaryDirectory() as tempdir:
             proc = subprocess.run(

--- a/shakenfist/tests/test_neutralise_pr_body.py
+++ b/shakenfist/tests/test_neutralise_pr_body.py
@@ -1,0 +1,167 @@
+# Copyright 2026 Michael Still and contributors
+
+"""Tests for tools/neutralise-pr-body.sh.
+
+The issue-fix workflow publishes a model-authored pull request description
+verbatim, and GitHub acts on two things it may find there. An @mention
+notifies a real person the instant `gh pr create` runs -- before any human
+has looked at the draft, and a notification cannot be taken back. An
+issue-closing keyword closes an unrelated issue when the pull request
+merges.
+
+The prompt forbids both, and the prompt is not enough: a side effect which
+fires automatically and is irreversible should not rest on the model having
+complied. These tests pin the mechanical defence, and in particular pin
+what it must NOT touch -- a description quoting a decorator, an email
+address or a path is a normal description, and mangling it to defuse a
+hazard that is not there is its own defect.
+"""
+
+import os
+import subprocess
+import tempfile
+
+from shakenfist.tests import base
+
+
+def _script_path():
+    here = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.dirname(os.path.dirname(here))
+    return os.path.join(root, 'tools', 'neutralise-pr-body.sh')
+
+
+SCRIPT = _script_path()
+
+
+class NeutralisePrBodyTestCase(base.ShakenFistTestCase):
+    def _neutralise(self, body):
+        with tempfile.TemporaryDirectory() as tempdir:
+            path = os.path.join(tempdir, 'pr-description.txt')
+            with open(path, 'w') as f:
+                f.write(body)
+
+            proc = subprocess.run(
+                [SCRIPT, path], capture_output=True, text=True)
+            self.assertEqual(0, proc.returncode, proc.stderr)
+
+            with open(path) as f:
+                return f.read()
+
+    def test_script_is_executable(self):
+        self.assertTrue(os.access(SCRIPT, os.X_OK))
+
+    def test_a_mention_loses_its_at_sign(self):
+        # Which is what the prompt asks the model to do itself.
+        self.assertEqual(
+            'Thanks to someone for the diagnosis.\n',
+            self._neutralise('Thanks to @someone for the diagnosis.\n'))
+
+    def test_a_team_mention_loses_its_at_sign(self):
+        self.assertEqual(
+            'Raised by an-org/a-team.\n',
+            self._neutralise('Raised by @an-org/a-team.\n'))
+
+    def test_a_mention_at_the_start_of_a_line_is_caught(self):
+        self.assertEqual(
+            'someone asked for this.\n',
+            self._neutralise('@someone asked for this.\n'))
+
+    def test_an_email_address_is_untouched(self):
+        # The character before the @ is what distinguishes the two.
+        self.assertEqual(
+            'Reported by foo@example.com in passing.\n',
+            self._neutralise('Reported by foo@example.com in passing.\n'))
+
+    def test_a_closing_keyword_is_separated_from_its_reference(self):
+        # "Fixes issue #12" is a citation; GitHub only closes when the
+        # reference immediately follows the keyword.
+        self.assertEqual(
+            'Fixes issue #12 as a side effect.\n',
+            self._neutralise('Fixes #12 as a side effect.\n'))
+
+    def test_every_closing_keyword_inflection_is_caught(self):
+        for keyword in ('Fix', 'Fixes', 'Fixed', 'Close', 'Closes',
+                        'Closed', 'Resolve', 'Resolves', 'Resolved',
+                        'fix', 'fixes', 'closes', 'resolved'):
+            self.assertEqual(
+                '%s issue #12\n' % keyword,
+                self._neutralise('%s #12\n' % keyword),
+                'keyword %s was not defused' % keyword)
+
+    def test_a_cross_repository_reference_keeps_its_repository(self):
+        self.assertEqual(
+            'Closes issue shakenfist/other#34.\n',
+            self._neutralise('Closes shakenfist/other#34.\n'))
+
+    def test_a_url_reference_is_defused(self):
+        self.assertEqual(
+            'This resolves issue https://github.com/o/r/issues/9 too.\n',
+            self._neutralise(
+                'This resolves https://github.com/o/r/issues/9 too.\n'))
+
+    def test_a_keyword_not_followed_by_a_reference_is_prose(self):
+        # Rewriting this would mangle ordinary English.
+        self.assertEqual(
+            'It fixes a typo, and closes the gap in coverage.\n',
+            self._neutralise(
+                'It fixes a typo, and closes the gap in coverage.\n'))
+
+    def test_a_bare_issue_reference_still_links(self):
+        # A citation without a keyword does not close anything, and the
+        # link is useful.
+        self.assertEqual(
+            'See #77 for the original report.\n',
+            self._neutralise('See #77 for the original report.\n'))
+
+    def test_fenced_code_is_untouched(self):
+        # GitHub does not linkify inside a fence, so there is nothing to
+        # defuse, and a quoted decorator must survive intact.
+        body = (
+            'Before.\n'
+            '\n'
+            '```python\n'
+            '@property\n'
+            'def x(self):  # Fixes #99\n'
+            '    pass\n'
+            '```\n'
+            '\n'
+            'After.\n')
+        self.assertEqual(body, self._neutralise(body))
+
+    def test_text_after_a_fence_closes_is_defused_again(self):
+        # The toggle has to survive the block, or everything after the
+        # first fenced example goes unprotected.
+        self.assertEqual(
+            '```\n@property\n```\nThanks someone.\n',
+            self._neutralise('```\n@property\n```\nThanks @someone.\n'))
+
+    def test_several_hazards_on_one_line(self):
+        self.assertEqual(
+            'Thanks someone and someoneelse; fixes issue #1 and '
+            'closes issue #2.\n',
+            self._neutralise(
+                'Thanks @someone and @someoneelse; fixes #1 and '
+                'closes #2.\n'))
+
+    def test_an_ordinary_description_is_returned_unchanged(self):
+        body = (
+            '## What was wrong\n'
+            '\n'
+            'The extraction used a sed address range, which re-matches.\n'
+            '\n'
+            '## What I did not do\n'
+            '\n'
+            'The publish step is still untested shell.\n')
+        self.assertEqual(body, self._neutralise(body))
+
+    def test_a_missing_file_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            proc = subprocess.run(
+                [SCRIPT, os.path.join(tempdir, 'nope.txt')],
+                capture_output=True, text=True)
+            self.assertEqual(1, proc.returncode)
+
+    def test_wrong_argument_count_is_a_usage_error(self):
+        proc = subprocess.run([SCRIPT], capture_output=True, text=True)
+        self.assertEqual(2, proc.returncode)
+        self.assertIn('usage:', proc.stderr)

--- a/tools/extract-model-block.sh
+++ b/tools/extract-model-block.sh
@@ -31,12 +31,17 @@
 #   marker mid-sentence is therefore not a terminator; this file is
 #   itself a plausible subject for an automated fix whose description
 #   would name these tokens.
-# - A code fence is stripped only when it wraps the whole block. The
-#   prompt illustrates the blocks inside fences while telling the model
-#   not to use them, so a model which copies the illustration would
-#   otherwise have its entire pull request body rendered as one
-#   preformatted lump. Stripping fences globally is not an option: a
-#   description may legitimately contain fenced code.
+# - A code fence is stripped only when it wraps the whole block, which
+#   means the first and last lines are a fence pair AND are the only
+#   fences present. The prompt illustrates the blocks inside fences
+#   while telling the model not to use them, so a model which copies
+#   the illustration would otherwise have its entire pull request body
+#   rendered as one preformatted lump. Stripping fences globally is not
+#   an option: a description may legitimately contain fenced code. Nor
+#   is testing only the first and last lines: a description which opens
+#   with one fenced block and closes with a different one would lose
+#   the outer markers of two unrelated fences, inverting every fence
+#   after the first.
 
 set -e
 
@@ -89,9 +94,16 @@ trim_blank_lines() {
 
 trim_blank_lines "${output}"
 
+# The first and last lines looking like a fence pair is not enough:
+# a description which opens with one fenced block and closes with a
+# different one would have its outer markers deleted, inverting every
+# fence after the first. The block is only a wrapped one if those two
+# lines are the ONLY fences in it.
 first=$(head -1 "${output}")
 last=$(tail -1 "${output}")
+fences=$(grep -c '^[[:space:]]*```' "${output}" || true)
 if [ "$(wc -l < "${output}")" -ge 2 ] && \
+   [ "${fences}" -eq 2 ] && \
    [[ "${first}" =~ ^\`\`\`[a-zA-Z0-9_+-]*$ ]] && \
    [ "${last}" == '```' ]
 then

--- a/tools/extract-model-block.sh
+++ b/tools/extract-model-block.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Copyright 2026 Michael Still and contributors
+#
+# Extract a marker delimited block from captured model output.
+#
+#   extract-model-block.sh <BLOCK_NAME> <input file> <output file>
+#
+# Reads <input file> looking for the first complete
+# <BLOCK_NAME>_START ... <BLOCK_NAME>_END pair and writes what lies
+# between them to <output file>. Exits 0 if a non-empty block was
+# written and 1 otherwise; the output file is always created, so a
+# caller uploading it as a build artifact does not have to special
+# case the failure.
+#
+# The rules below each exist because the naive version of this got one
+# of them wrong:
+#
+# - Only the FIRST block is taken. A range match prints every
+#   occurrence, so a model which emits a block, decides it is wrong and
+#   emits another leaves the interior marker lines embedded in the
+#   result.
+# - Both markers must be present. A truncated block would otherwise run
+#   to the end of the captured output and swallow whatever followed it
+#   -- which, now that there are two blocks, is the other one.
+# - A marker matches only a line whose entire content is the marker
+#   token, ignoring surrounding whitespace. Prose which mentions a
+#   marker mid-sentence is therefore not a terminator; this file is
+#   itself a plausible subject for an automated fix whose description
+#   would name these tokens.
+# - A code fence is stripped only when it wraps the whole block. The
+#   prompt illustrates the blocks inside fences while telling the model
+#   not to use them, so a model which copies the illustration would
+#   otherwise have its entire pull request body rendered as one
+#   preformatted lump. Stripping fences globally is not an option: a
+#   description may legitimately contain fenced code.
+
+set -e
+
+if [ $# -ne 3 ]; then
+    echo "usage: $(basename "$0") <BLOCK_NAME> <input file> <output file>" >&2
+    exit 2
+fi
+
+block="$1"
+input="$2"
+output="$3"
+
+: > "${output}"
+
+if [ ! -f "${input}" ]; then
+    echo "extract-model-block: no such input file: ${input}" >&2
+    exit 1
+fi
+
+# Extract the first complete block. awk's exit in a main rule falls
+# through to END, which is where the "no closing marker" status is set.
+if ! awk -v start="${block}_START" -v end="${block}_END" '
+    function trim(s) {
+        sub(/^[[:space:]]+/, "", s)
+        sub(/[[:space:]]+$/, "", s)
+        return s
+    }
+    {
+        line = trim($0)
+        if (!started) {
+            if (line == start) { started = 1 }
+            next
+        }
+        if (line == end) { closed = 1; exit }
+        print
+    }
+    END { if (!closed) { exit 1 } }
+' "${input}" > "${output}"
+then
+    : > "${output}"
+    exit 1
+fi
+
+# Trim blank lines from both ends, strip a wrapping fence, then trim
+# again -- a fence is normally flush against the markers but need not be.
+trim_blank_lines() {
+    sed -e '/./,$!d' -e ':a' -e '/^\n*$/{$d;N;ba' -e '}' "$1" > "$1.trimmed"
+    mv "$1.trimmed" "$1"
+}
+
+trim_blank_lines "${output}"
+
+first=$(head -1 "${output}")
+last=$(tail -1 "${output}")
+if [ "$(wc -l < "${output}")" -ge 2 ] && \
+   [[ "${first}" =~ ^\`\`\`[a-zA-Z0-9_+-]*$ ]] && \
+   [ "${last}" == '```' ]
+then
+    sed -i '1d;$d' "${output}"
+    trim_blank_lines "${output}"
+fi
+
+if [ ! -s "${output}" ]; then
+    exit 1
+fi

--- a/tools/extract-model-block.sh
+++ b/tools/extract-model-block.sh
@@ -15,13 +15,17 @@
 # The rules below each exist because the naive version of this got one
 # of them wrong:
 #
-# - Only the FIRST block is taken. A range match prints every
-#   occurrence, so a model which emits a block, decides it is wrong and
-#   emits another leaves the interior marker lines embedded in the
-#   result.
-# - Both markers must be present. A truncated block would otherwise run
-#   to the end of the captured output and swallow whatever followed it
-#   -- which, now that there are two blocks, is the other one.
+# - The block is the text between the LAST start marker and the FIRST
+#   end marker which follows it, buffered and emitted only once that
+#   end marker is seen. Every awkward shape then fails safe rather than
+#   into the published output: a second complete block is ignored, a
+#   repeated start marker restarts rather than embedding a marker line
+#   in the prose, an end marker before any start is not a close, and a
+#   start which is never closed yields nothing rather than the
+#   remainder of the transcript -- which, now that there are two
+#   blocks, would be the other one. A sed address range does none of
+#   this: it re-matches, so repeated markers concatenate and the
+#   markers themselves survive into the result.
 # - A marker matches only a line whose entire content is the marker
 #   token, ignoring surrounding whitespace. Prose which mentions a
 #   marker mid-sentence is therefore not a terminator; this file is
@@ -52,8 +56,8 @@ if [ ! -f "${input}" ]; then
     exit 1
 fi
 
-# Extract the first complete block. awk's exit in a main rule falls
-# through to END, which is where the "no closing marker" status is set.
+# awk's exit in a main rule falls through to END, which is where the
+# buffer is emitted and the "no closing marker" status is set.
 if ! awk -v start="${block}_START" -v end="${block}_END" '
     function trim(s) {
         sub(/^[[:space:]]+/, "", s)
@@ -62,14 +66,14 @@ if ! awk -v start="${block}_START" -v end="${block}_END" '
     }
     {
         line = trim($0)
-        if (!started) {
-            if (line == start) { started = 1 }
-            next
-        }
-        if (line == end) { closed = 1; exit }
-        print
+        if (line == start) { inblock = 1; body = ""; next }
+        if (inblock && line == end) { closed = 1; exit }
+        if (inblock) { body = body $0 "\n" }
     }
-    END { if (!closed) { exit 1 } }
+    END {
+        if (!closed) { exit 1 }
+        printf "%s", body
+    }
 ' "${input}" > "${output}"
 then
     : > "${output}"
@@ -95,6 +99,9 @@ then
     trim_blank_lines "${output}"
 fi
 
-if [ ! -s "${output}" ]; then
+# Whitespace-only is as useless to a reader as empty, and the caller
+# falls back for both.
+if ! grep -q '[^[:space:]]' "${output}"; then
+    : > "${output}"
     exit 1
 fi

--- a/tools/neutralise-pr-body.sh
+++ b/tools/neutralise-pr-body.sh
@@ -27,7 +27,9 @@
 #
 # Fenced code is passed through untouched: GitHub does not linkify
 # inside a fence, so there is nothing to defuse, and a description
-# quoting a decorator or an email address should survive intact.
+# quoting a decorator or an email address should survive intact. A
+# fence left open at the end of the body is closed, so it cannot run on
+# into the sections the workflow appends after it.
 
 set -e
 
@@ -84,6 +86,11 @@ awk '
     /^[[:space:]]*```/ { infence = !infence; print; next }
     infence { print; next }
     { print defuse_mentions(defuse_closes($0)) }
+
+    # A fence the model opened and never closed would otherwise run on
+    # into the sections the workflow appends after this body, rendering
+    # the diffstat and the footer as one preformatted lump.
+    END { if (infence) { print "```" } }
 ' "${target}" > "${target}.neutralised"
 
 mv "${target}.neutralised" "${target}"

--- a/tools/neutralise-pr-body.sh
+++ b/tools/neutralise-pr-body.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Copyright 2026 Michael Still and contributors
+#
+# Neutralise the parts of a model-authored pull request description
+# which GitHub acts on rather than merely renders.
+#
+#   neutralise-pr-body.sh <file>
+#
+# Rewrites <file> in place. Two constructs are defused:
+#
+# - An @mention notifies a real person the moment "gh pr create" runs,
+#   which is before any human has looked at the draft, and it cannot be
+#   taken back. The "@" is dropped, which is what the prompt asks the
+#   model to do itself.
+# - An issue-closing keyword ("fixes", "closes", "resolves" and their
+#   inflections) followed by an issue reference closes that issue when
+#   the pull request merges. The keyword is separated from the
+#   reference so it reads as a citation instead. The workflow appends
+#   its own "Fixes #NNNN" for the issue actually being fixed after this
+#   pass, so that one is unaffected.
+#
+# The prompt already forbids both. This exists because prompt
+# compliance is a weaker guarantee than code for a side effect which
+# fires automatically and is not reversible -- the same argument this
+# workflow makes for testing its marker parsing rather than trusting
+# that the model emits well-formed blocks.
+#
+# Fenced code is passed through untouched: GitHub does not linkify
+# inside a fence, so there is nothing to defuse, and a description
+# quoting a decorator or an email address should survive intact.
+
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "usage: $(basename "$0") <file>" >&2
+    exit 2
+fi
+
+target="$1"
+
+if [ ! -f "${target}" ]; then
+    echo "neutralise-pr-body: no such file: ${target}" >&2
+    exit 1
+fi
+
+awk '
+    # awk has no backreferences in a replacement, so both rewrites walk
+    # the line with match() and rebuild it rather than using gsub().
+
+    # "Fixes #12" closes issue 12 when this merges. Separating the
+    # keyword from the reference leaves a citation GitHub does not act
+    # on. The reference may be bare, cross-repository, or a full URL.
+    function defuse_closes(s,   out, matched, after) {
+        out = ""
+        while (match(s, /(^|[^[:alnum:]_])([Ff]ix(es|ed)?|[Cc]lose[sd]?|[Rr]esolve[sd]?)[[:space:]]+/)) {
+            matched = substr(s, RSTART, RLENGTH)
+            after = substr(s, RSTART + RLENGTH)
+            if (after ~ /^(#[0-9]|[[:alnum:]._\/-]+#[0-9]|https?:\/\/[^[:space:]]*\/issues\/)/) {
+                sub(/[[:space:]]+$/, " issue ", matched)
+            }
+            out = out substr(s, 1, RSTART - 1) matched
+            s = after
+        }
+        return out s
+    }
+
+    # An @mention notifies the moment the pull request is created. The
+    # character before it must not be one which would make this the
+    # local part of an email address or part of a path.
+    function defuse_mentions(s,   out, matched) {
+        out = ""
+        while (match(s, /(^|[^[:alnum:]_.+\/-])@[[:alnum:]][[:alnum:]-]*(\/[[:alnum:]._-]+)?/)) {
+            matched = substr(s, RSTART, RLENGTH)
+            sub(/@/, "", matched)
+            out = out substr(s, 1, RSTART - 1) matched
+            s = substr(s, RSTART + RLENGTH)
+        }
+        return out s
+    }
+
+    # A fence line is passed through and toggles protection for the
+    # lines after it: GitHub does not linkify inside a fence, so there
+    # is nothing to defuse and a quoted decorator should survive.
+    /^[[:space:]]*```/ { infence = !infence; print; next }
+    infence { print; next }
+    { print defuse_mentions(defuse_closes($0)) }
+' "${target}" > "${target}.neutralised"
+
+mv "${target}.neutralised" "${target}"


### PR DESCRIPTION
## Summary

Every PR the issue-fix workflow opened got the same body: a boilerplate
paragraph and a `git diff --stat`. Everything the model learned while
fixing the issue — what the root cause actually turned out to be, which
half of the issue it deliberately left alone, which judgement calls a
reviewer might make differently — was never asked for, and so never
reached the reviewer.

This teaches the fixer to write its own description. It is the
project's copy of shakenfist/development#53, which makes the same
change to `templates/issue-fix/issue-fix.yml`, the source this workflow
is derived from.

## What prompted it

#3894 arrived with a three-line boilerplate body against an issue
(#3876) carrying a detailed two-cause diagnosis. There turned out to be
two separate problems, only one of which was obvious:

**Systemic:** the body template. It never varied and never used the
model's prose. #3886, #3887 and #3891 all have good *titles* — so their
commit summaries were extracted fine — and identical contentless
bodies.

**Rare:** run 32825930889 also lost its commit summary. The last thing
the model emitted was

> The unit test suite (`tox -ecover`) is running in the background;
> I'll continue when it completes.

Under `claude -p` there is no "when it completes" — ending the turn
ends the session. The fix and its tests were staged and correct, but
`summary_found` was false, so #3894's commit landed under the
placeholder "Claude Code proposed a fix for this issue."

## Changes

All in `.github/workflows/issue-fix.yml`:

- The prompt asks for a `PR_DESCRIPTION_START`/`END` block alongside
  the existing commit summary, with guidance aimed at what a reviewer
  actually needs: root cause rather than reported symptom, what changed
  and why, what was deliberately *not* done, and any judgement call a
  reviewer might make differently. It is explicitly told not to emit a
  diffstat, a `Fixes #NNNN` line or a run link — the workflow appends
  those.
- A new "How this run works" section tells the model it gets exactly
  one turn: do not background a long command and end your turn meaning
  to check back, do not end a turn describing what you are about to do.
  This is the direct fix for the #3894 failure mode.
- The extract step pulls both blocks, computes its outputs into shell
  variables and writes each exactly once rather than defaulting them
  and relying on a later line overwriting the earlier one. The
  description extraction requires *both* markers, so a truncated block
  cannot run to the end of the captured output, and it strips only
  marker lines — a PR body may legitimately contain fenced code, which
  the commit-summary path's fence stripping would have eaten.
- The publish step assembles the body into a file and passes
  `--body-file`. This matters beyond tidiness: the old body was built
  with an *unquoted* heredoc, so dropping model text into it would have
  executed any `$(...)` or backticks it contained. The diffstat is now
  fenced, so it renders as a code block instead of a collapsed
  paragraph.

Both blocks are best-effort by design. A missing description falls back
to the commit message body, and a missing commit message to the old
boilerplate — a correct fix is worth publishing even when the prose is
lost.

## Verification

- `pre-commit run --all-files` passes; the actionlint hook covers this
  file.
- I extracted the rewritten extract and publish steps and ran them
  against synthetic model output for four cases: both blocks present,
  commit summary only, neither (#3894's exact failure mode), and a
  description with a `START` marker but no `END`. All four produce a
  sensible body and the right `summary_found`/`description_found` pair.
- A `$(touch /tmp/PWNED)` planted in the synthetic description does not
  execute.

## Notes for review

- The appended heading is `## Automated verification` rather than
  `## Verification`, so a model that writes its own verification
  section does not collide with it.
- Nothing here changes what the fixer *does*, only what it reports, so
  the blast radius is confined to automated PRs. The next issue-fix run
  is the real test.
- #3894 itself has had its description rewritten by hand; it is not
  affected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkQoWx4NdGWs94DPx3gsb1
