### PR TITLE
Withdraw phase 00a's load-stage discard finding

### DIFF
--- a/docs/plans/PLAN-scheduler-reservations-phase-00a-load-aware-ordering.md
+++ b/docs/plans/PLAN-scheduler-reservations-phase-00a-load-aware-ordering.md
@@ -405,6 +405,63 @@ every decision observed.
 
 ### One finding this raises, for phase 6
 
+**Withdrawn on 2026-08-29 — the discard half of it was wrong.**
+The original text is kept below the correction, because a
+finding handed forward to another phase should show what it
+claimed as well as what it turned out to be.
+
+The load stage does **not** discard anything. `find_candidates()`
+builds its result with `for bucket in sorted(by_load)`, extending
+`ordered` with every bucket's tier in turn
+(`shakenfist/scheduler.py:741-756`), so every candidate that
+passed admission is returned, ranked. The comment directly above
+that loop says so explicitly and says why: a bucket "says a node
+looks busier right now, not that it cannot host the instance",
+and discarding the tail "turns one refusal into a failed create
+on a cluster with room". That is not a recent subtlety -- it is
+the fix for the merge-CI single-candidate lockout, `108a0cdbd`,
+landed 2026-08-15, **twelve days before this observation was
+made**.
+
+What was actually being read is the `schedule have lowest cpu
+load` audit event, whose `candidates` field is `by_load[
+lowest_load]` by construction (`:712-720`) -- the lowest bucket
+alone. The complete ranking is in the `schedule final
+candidates` event. Counting the first event's list and calling
+the remainder "eliminated" counts a log line, not a behaviour,
+which is why the "8 of 60" and "34 left a single survivor"
+numbers below should not be reused.
+
+The finding is refuted by its own evidence, which is the part
+worth noticing. It quotes headroom weights for the two nodes it
+says were eliminated -- sf-5 at 9.55 and sf-6 at 7.64. `weights`
+is populated only inside the loop that builds `ordered`, for
+every candidate in every bucket. A node with a weight was in the
+returned list. The numbers cited to show the discard are proof
+there was none.
+
+**What survives, and still belongs to phase 6.** `cpu_load_1`
+measures activity, not occupancy, so a node packed with idle CI
+runners ranks ahead of a busier node with more room -- sf-1, at
+89% of its hard max by commitment, sat in bucket 0 with the
+lowest normalised load in the cluster. That is real, and it is a
+mis-*ordering* rather than a mis-elimination: the emptier node is
+still reachable, just later in a list the caller only walks on
+refusal. Phase 6 owns the ranking model and should decide
+deliberately whether an activity metric belongs in it at all,
+now that the capacity counters give it an occupancy one.
+
+Also for phase 6, and *not* an argument for reworking the
+ranking: the `507 ... sufficient_idle_cpu` refusals that recur in
+merge CI (#3772) come from the admission stage, which runs
+*before* ranking and reads the capacity counters. When it refuses
+every candidate, no ranking model would have helped. That family
+belongs to `PLAN-ci-cloud-sizing`, and phase 6 should not adopt
+it as evidence about ordering.
+
+<details>
+<summary>The original finding, as written on 2026-08-27</summary>
+
 The load stage narrows to the lowest occupied bucket *before*
 headroom weighting, so it can discard nodes with far more room
 than the ones it keeps. In one observed decision the survivors
@@ -430,6 +487,8 @@ ranking is reworked. Recorded here rather than fixed: phase 6
 owns the ranking model, and D6's open question about whether a
 preference may bid against a hard ceiling is the same question
 in a different coat.
+
+</details>
 
 ### Method
 

--- a/docs/plans/PLAN-scheduler-reservations.md
+++ b/docs/plans/PLAN-scheduler-reservations.md
@@ -637,19 +637,39 @@ exists to collect calibration data, so what phase 5 waits on is
 that data existing, not time elapsing. Phase 5 does not start
 until phase 4c's observation record is written.
 
-*Input from phase 00a's post-deploy observation (2026-08-27):*
-the load stage narrows to the lowest occupied bucket before
-headroom weighting, so it can discard nodes with far more room
-than the ones it keeps -- 8 of 60 observed decisions on sfcbr
-did exactly that, and 34 left a single survivor. The mechanism
-is that `cpu_load_1` measures activity rather than occupancy,
-so a node packed with idle CI runners ranks as the emptiest in
-the cluster. It is not concentrating placement today only
-because the capacity filters reject the over-committed node
-before ranking runs, which is a weaker guarantee than it looks.
-Phase 6 owns the ranking model and should decide this
-deliberately; the detail is in
+*Input from phase 00a's post-deploy observation (2026-08-27),
+corrected 2026-08-29:* this paragraph used to say the load stage
+"can discard nodes with far more room than the ones it keeps",
+citing 8 of 60 observed decisions and 34 leaving a single
+survivor. **That is withdrawn.** The load stage discards
+nothing: `find_candidates()` extends its result with every
+bucket's tier (`shakenfist/scheduler.py:741-756`), which is the
+merge-CI single-candidate lockout fix `108a0cdbd` from
+2026-08-15 -- twelve days before the observation. The counts came
+from the `schedule have lowest cpu load` audit event, which
+publishes the lowest bucket alone by construction; the full
+ranking is in `schedule final candidates`. The finding also
+quoted headroom weights for the nodes it called eliminated, and
+a node only has a weight if it is in the returned list, so its
+own evidence refutes it.
+
+What survives for phase 6 is real but weaker: `cpu_load_1`
+measures activity rather than occupancy, so a node packed with
+idle CI runners *ranks ahead of* a busier node with more room.
+That is a mis-ordering, not a mis-elimination -- the emptier node
+is still reachable, later in a list the caller walks only on
+refusal. Phase 6 owns the ranking model and should decide
+whether an activity metric belongs in it now that the capacity
+counters supply an occupancy one. Detail and the withdrawn text
+are in
 [PLAN-scheduler-reservations-phase-00a-load-aware-ordering.md](PLAN-scheduler-reservations-phase-00a-load-aware-ordering.md).
+
+*Not evidence for phase 6:* the recurring
+`507 ... sufficient_idle_cpu` refusals in merge CI (#3772) come
+from the admission stage, which runs before ranking and reads
+the capacity counters. When it refuses every candidate no
+ranking model would have helped, so that family belongs to
+`PLAN-ci-cloud-sizing` and phase 6 should not adopt it.
 
 **Phase 6 — affinity rework.** Binary soft affinity plus
 hard require constraints, weighted-form deprecation mapping,


### PR DESCRIPTION
Documentation only, one commit. Corrects a finding phase 00a handed to
phase 6, before phase 6 is planned against it.

## The claim

> The load stage narrows to the lowest occupied bucket *before* headroom
> weighting, so it can discard nodes with far more room than the ones it
> keeps. […] Across 60 decisions on 30 live runners, 8 (13%) discarded a node
> whose headroom weight was higher than the best survivor's, and 34 left only
> a single survivor.

## The load stage discards nothing

`find_candidates()` builds its result with `for bucket in sorted(by_load)`,
extending `ordered` with **every** bucket's tier
(`shakenfist/scheduler.py:741-756`). The comment immediately above that loop
states the intent and the reason:

> The bucketing orders rather than filters, because a bucket says a node looks
> busier right now, not that it cannot host the instance […] discarding the
> rest turns one refusal into a failed create on a cluster with room.

That is `108a0cdbd`, *Fix the merge CI single-candidate 507 lockout*, landed
**2026-08-15 — twelve days before the observation was made.**

What the observation actually read is the `schedule have lowest cpu load`
audit event, whose `candidates` field is `by_load[lowest_load]` by
construction (`:712-720`). The complete ranking is published separately as
`schedule final candidates`. Counting the first and calling the remainder
eliminated counts a log line, not a behaviour, so the 8-of-60 and
single-survivor numbers should not be reused.

**The finding is refuted by its own evidence.** It quotes headroom weights for
the two nodes it says were eliminated — sf-5 at 9.55, sf-6 at 7.64. `weights`
is populated only inside the loop that builds the returned list, for every
candidate in every bucket. A node with a weight was in the list.

## What survives, and stays with phase 6

`cpu_load_1` measures activity rather than occupancy, so a node packed with
idle CI runners *ranks ahead of* a busier node with more room. Real, but a
mis-**ordering** rather than a mis-elimination: the emptier node is still
reachable, further down a list the caller walks on refusal. Phase 6 should
decide deliberately whether an activity metric belongs in the ranking now that
the capacity counters supply an occupancy one.

## What is *not* evidence for phase 6

Also recorded, because it was about to be adopted as evidence: the recurring
`507 ... sufficient_idle_cpu` refusals in merge CI (#3772) come from the
admission stage, which runs *before* ranking and reads the capacity counters.
When it refuses every candidate, no ranking model would have helped. That
family belongs to `PLAN-ci-cloud-sizing`.

## Note on presentation

The original finding is kept verbatim in a `<details>` block rather than
deleted. A finding handed forward to another phase should show what it claimed
as well as what it turned out to be.

`pre-commit run` passes on the changed set: documentation links and anchors
resolve, plan statuses and index arithmetic agree.