### PR TITLE
Size the node lifecycle runner.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -525,7 +525,12 @@ jobs:
       (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
       && needs.check_paths.outputs.code_changed != 'false'
     needs: [check_paths]
-    runs-on: [self-hosted, vm, debian-12]
+    # Carries a size element for the same reason smoke-cluster.yml does:
+    # without one the conductor falls back to xs (1 vCPU / 2048 MB), and
+    # this job drives a full ansible deploy from the runner. Measured
+    # demand is ~2.5-2.7 GB against 1927 MB usable and no swap. See
+    # shakenfist/shakenfist#3696.
+    runs-on: [self-hosted, vm, debian-12, s]
     # The deploy and test steps below are capped at 90 and 60 minutes;
     # this is the backstop for the setup and teardown around them, and
     # is still far short of GitHub's six hour default.


### PR DESCRIPTION
Adds the size element to `node_lifecycle_collection`'s `runs-on`.

Like the cluster jobs that reach their runner through
`shakenfist/actions`' reusable `smoke-cluster.yml`, this one named no size,
so the conductor had nothing to match and fell back to the first entry in
`CI_SIZES` — **`xs`, one vCPU and 2048 MB**. The flavour was never chosen;
it was the alphabetically first thing in a dict.

Node lifecycle deploys a cluster with ansible from the runner. The
conductor's per-instance cost samples put its unconstrained demand at
**2537 – 2719 MB** across the 16 runs that landed on a larger runner by
accident. On `xs` it is clamped to ~1.85 GB of the 1927 MB the guest can
address, with ~112 MB minimum free across 100 runs and **no swap device**
to absorb anything it cannot reclaim in time.

The companion PR shakenfist/actions#44 carries the full measurements, the
reason the sizing recommender cannot see this (both its upsize triggers are
swap-based, and there is no swap), and the cost analysis. It also covers
`smoke_collection`, the four-way `functional_matrix_merge_collection` and
`ansible_modules_collection`, which take their runner from that reusable
workflow rather than from here.

**Merge shakenfist/actions#44 first.** `functional-tests.yml` pins
`smoke-cluster.yml@main`, so this change is inert on its own.

## Deliberately left on `xs`

`Schema ENUM widening` installs MariaDB and runs tests on the runner, but
it builds no cluster and drives no deploy, and there is no measurement
saying it needs more. `pin-indirect-dependencies` likewise. Worth noting
`release.yml:90` was already asking for `s`, so the convention existed —
these jobs just never picked it up.

## Relationship to #3696

Refs #3696. The lost-runner failures in that issue are the conductor
reaping busy runners on a flapping GitHub `offline` reading, root-caused
and fixed in shakenfist/private-ci#18; this is the secondary finding from
the same investigation. Not closing the issue — see
[the analysis comment](https://github.com/shakenfist/shakenfist/issues/3696#issuecomment-5460824570)
for what is fixed, what is still open, and why the saturation reading in
the issue title was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hketun8nDHtGsPx4Medtf
