### PR TITLE
Stop the sidechannel executor draining its operation

### DIFF
--- a/docs/developer_guide/coding_rules.md
+++ b/docs/developer_guide/coding_rules.md
@@ -478,6 +478,55 @@ against a mocked engine cannot do that, and neither can a test that
 rewrites the query to suit sqlite -- register the missing SQL functions
 instead, so the statement under test is the statement that ships.
 
+## A frozen model is not a deep frozen model
+
+`mariadb.get_<type>()` returns a Pydantic model with
+`model_config = ConfigDict(frozen=True)`, and that model is the one
+entry the process-wide static object value cache holds for its whole
+TTL. Every reader in the process gets the same object. `frozen=True`
+stops attribute *assignment* on it; it does not stop mutation of the
+*contents* of a list or dict field. So `data.commands.pop(0)` succeeds,
+and it edits what every other reader on the node is about to see.
+
+Two obligations follow, and they are two different obligations:
+
+* **Copy the container you hand out.** A `_db_get()` or
+  `_static_values_to_dict()` copying `list(data.commands)` is the
+  containment boundary. Without it, every object built from one cache
+  hit shares one list, so a mutation anywhere is a mutation everywhere
+  until the entry ages out.
+* **Do not mutate an element of a container you were handed.** The copy
+  above is shallow, which is deliberate -- a deep copy would defend
+  against a mutation no code performs and would cost an allocation per
+  element per read -- so the dicts inside a copied list are still the
+  cache's. Consume a command list by copying it and popping the copy,
+  the way `SideChannelExecutorJob.__init__` does; build the dict you
+  intend to edit locally, the way `add_result()`'s callers do.
+
+`SideChannelExecutorJob` did the popping (issue #3516, PR #3970). It
+aliased `agentop.commands` as its work queue and popped each command as
+it dispatched, which drained the operation and, through it, the cache.
+The visible damage was an inverted decision: `operation_is_retryable()`
+opens by refusing an empty command list, so a single-command `get-file`
+declared itself unretryable the instant its only command went out --
+precisely the operation shape the retry path exists for. The second
+consequence was quieter: `NodeAgentopOp._preflight()` iterates the same
+list looking for `put-blob` commands whose blobs it must make local, and
+against a drained cache entry it would find none and skip the
+preparation with nothing logged.
+
+Note what did *not* catch this. The class is covered by unit tests which
+build the executor and drive a dispatch, but they hand-set
+`job.commands` rather than going through the constructor, so the alias
+was created in a line no test executed. A regression test for this class
+of bug has to build the object the way production does and then assert
+on what a *second* reader sees.
+
+The static-values models with container fields today are
+`AgentOperationData.commands` and `InstanceData`'s `disk_spec`, `video`
+and `side_channels`; all four are copied at their boundary. A new
+container field on a cached model joins that list.
+
 ## A per-item convenience wrapper does not belong in a loop
 
 `instance_usage_for_blob_uuid()` answers "which instances use this

--- a/docs/developer_guide/database_internals.md
+++ b/docs/developer_guide/database_internals.md
@@ -95,12 +95,17 @@ it serves both compute nodes (avoiding a gRPC round trip) and the `sf-database`
 daemon's own worker threads (avoiding a SQL query); it is a single
 process-global dict keyed `(object_type, uuid)` under a lock.
 
-Correctness rests on three rules: only present rows are cached (never a miss,
+Correctness rests on four rules: only present rows are cached (never a miss,
 so a create-after-lookup or delete-then-lookup is never masked); every public
 `update_<type>`/`delete_<type>` evicts, and because the lazy online-upgrade
 persist routes through the public `update_<type>`, the cache self-heals after
-an upgrade; and every entry is TTL-bounded, which is the only bound on
-staleness from a write made by another process. Two tiers set the TTL —
+an upgrade; every entry is TTL-bounded, which is the only bound on
+staleness from a write made by another process; and a `_db_get()` copies any
+list or dict field it hands out, because `frozen=True` on the cached model
+stops attribute *assignment* rather than mutation of a container field's
+*contents*, so one reader mutating an uncopied list would be mutating every
+reader's — see "A frozen model is not a deep frozen model" in
+[coding_rules.md](coding_rules.md). Two tiers set the TTL —
 `OBJECT_CACHE_TTL_IMMUTABLE` (default 300 s) for types whose static row
 changes only on create, delete, or a version-upgrade persist (instance,
 network, networkinterface, agentoperation, ipam) and

--- a/shakenfist/daemons/sidechannel/main.py
+++ b/shakenfist/daemons/sidechannel/main.py
@@ -603,7 +603,22 @@ class SideChannelExecutorJob(SideChannelJob):
         self.affected_objects = [self.instance, self.agentop]
         self.thread_name = f'{self.instance.uuid}-{self.agentop.uuid}'
 
-        self.commands = agentop.commands
+        # The executor's own working copy, deliberately not the
+        # operation's list. AgentOperation.commands returns the
+        # underlying list by reference, and that list is the one the
+        # process wide object cache holds: get_agent_operation() caches
+        # the AgentOperationData model, and frozen=True on that model
+        # stops attribute assignment rather than mutation of a list
+        # field's contents. Popping through an alias of it therefore
+        # drained the operation itself, and two things broke.
+        # operation_is_retryable() opens by refusing an empty command
+        # list, so a single command get-file -- the case issue #3516 is
+        # about -- called itself unretryable the moment its only
+        # command went out, inverting the decision this exists to make.
+        # And every later reader on the node saw the drained list for
+        # as long as the cache entry lived, the reaper's own
+        # AgentOperation.from_db() included.
+        self.commands = list(agentop.commands)
         self.command_count = 0
         self.num_results = 0
         self.command_cache = {}

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -333,23 +333,33 @@ class Instance(dbowo):
     @staticmethod
     def _static_values_to_dict(data):
         """Convert InstanceData to the dict format used internally."""
+        # The three container fields are copied rather than referenced,
+        # for the reason set out under "A frozen model is not a deep
+        # frozen model" in docs/developer_guide/coding_rules.md: data is
+        # the model mariadb.get_instance() parks in the process wide
+        # object cache, and frozen=True on it stops attribute assignment
+        # rather than mutation of a list or dict field's contents.
+        # Nothing mutates these today, but sidechannel's
+        # instance_sidechannel_cache holds side_channels for the
+        # daemon's lifetime, which is the shared ownership that made the
+        # agentoperation case bite.
         return {
             'uuid': str(data.uuid),
             'cpus': data.cpus,
-            'disk_spec': data.disk_spec,
+            'disk_spec': list(data.disk_spec),
             'memory': data.memory,
             'name': data.name,
             'namespace': data.namespace,
             'requested_placement': data.requested_placement,
             'ssh_key': data.ssh_key,
             'user_data': data.user_data,
-            'video': data.video,
+            'video': dict(data.video),
             'uefi': data.uefi,
             'configdrive': data.configdrive,
             'nvram_template': data.nvram_template,
             'secure_boot': data.secure_boot,
             'machine_type': data.machine_type,
-            'side_channels': data.side_channels,
+            'side_channels': list(data.side_channels),
             'version': data.version,
         }
 

--- a/shakenfist/operations/agentoperation.py
+++ b/shakenfist/operations/agentoperation.py
@@ -132,7 +132,13 @@ class AgentOperation(BaseOperation):
                 'uuid': str(data.uuid),
                 'namespace': data.namespace,
                 'instance_uuid': str(data.instance_uuid),
-                'commands': data.commands,
+                # Copied rather than referenced: data is the shared
+                # model the object cache holds, and its frozen=True
+                # prevents attribute assignment, not mutation of a list
+                # field's contents. Handing the same list to every
+                # AgentOperation built from a cache hit would make one
+                # object's mutation everybody's.
+                'commands': list(data.commands),
                 'deadline': data.deadline,
                 'progress_timeout': data.progress_timeout,
                 'version': data.version

--- a/shakenfist/operations/agentoperation.py
+++ b/shakenfist/operations/agentoperation.py
@@ -224,6 +224,15 @@ class AgentOperation(BaseOperation):
 
     @property
     def commands(self):
+        # Returned by reference, like every other static value property
+        # in the tree. Static values are immutable after construction,
+        # so the contract for a caller which needs to consume this list
+        # is to take its own copy -- see SideChannelExecutorJob's, and
+        # "A frozen model is not a deep frozen model" in
+        # docs/developer_guide/coding_rules.md. _db_get() copies at the
+        # cache boundary so a caller who breaks that rule corrupts only
+        # its own object rather than every reader in the process, but
+        # the boundary is containment, not permission.
         return self.__commands
 
     @property

--- a/shakenfist/tests/test_agent_operation_retry.py
+++ b/shakenfist/tests/test_agent_operation_retry.py
@@ -7,6 +7,7 @@ from shakenfist import exceptions
 from shakenfist.baseobject import DatabaseBackedObject as dbo
 from shakenfist.config import SFConfig
 from shakenfist.operations.agentoperation import AgentOperation
+from shakenfist.schema.agentoperation_data import AgentOperationData
 from shakenfist.tests import base
 from shakenfist.tests.mock_mariadb import MockMariaDB
 
@@ -142,3 +143,47 @@ class AgentOperationRetryTestCase(base.ShakenFistTestCase):
         mock_event.assert_called_once()
         self.assertEqual('clear results', mock_event.call_args.args[1])
         self.assertEqual(2, mock_event.call_args.kwargs['extra']['cleared'])
+
+
+class AgentOperationCommandListTestCase(base.ShakenFistTestCase):
+    """_db_get() must not hand out the cached model's own command list.
+
+    mariadb.get_agent_operation() caches the AgentOperationData model
+    for OBJECT_CACHE_TTL_IMMUTABLE seconds, and pydantic's frozen=True
+    stops attribute assignment rather than mutation of a list field's
+    contents. While _db_get() referenced data.commands, every
+    AgentOperation built from a cache hit shared one list with the
+    cache and with every other such object, so a single mutation
+    anywhere on the node was visible everywhere until the entry aged
+    out.
+    """
+
+    def _data(self):
+        return AgentOperationData(
+            uuid=uuid.uuid4(), namespace='ns', instance_uuid=uuid.uuid4(),
+            commands=[{'command': 'get-file', 'path': '/tmp/x'}],
+            deadline=None, progress_timeout=None,
+            version=AgentOperation.current_version)
+
+    def test_the_static_values_do_not_alias_the_cached_model(self):
+        data = self._data()
+        with mock.patch('shakenfist.operations.agentoperation.mariadb.'
+                        'get_agent_operation', return_value=data):
+            first = AgentOperation._db_get(str(data.uuid))
+            second = AgentOperation._db_get(str(data.uuid))
+
+        self.assertIsNot(data.commands, first['commands'])
+        self.assertIsNot(first['commands'], second['commands'])
+
+    def test_mutating_one_reader_leaves_the_others_alone(self):
+        data = self._data()
+        with mock.patch('shakenfist.operations.agentoperation.mariadb.'
+                        'get_agent_operation', return_value=data):
+            first = AgentOperation._db_get(str(data.uuid))
+            second = AgentOperation._db_get(str(data.uuid))
+
+        first['commands'].pop(0)
+
+        expected = [{'command': 'get-file', 'path': '/tmp/x'}]
+        self.assertEqual(expected, data.commands)
+        self.assertEqual(expected, second['commands'])

--- a/shakenfist/tests/test_agent_operation_retry.py
+++ b/shakenfist/tests/test_agent_operation_retry.py
@@ -187,3 +187,29 @@ class AgentOperationCommandListTestCase(base.ShakenFistTestCase):
         expected = [{'command': 'get-file', 'path': '/tmp/x'}]
         self.assertEqual(expected, data.commands)
         self.assertEqual(expected, second['commands'])
+
+    def test_two_objects_from_one_cache_entry_do_not_share_a_list(self):
+        # The two above pin the mechanism at the dict _db_get() returns.
+        # This pins the behaviour readers actually depend on: every
+        # AgentOperation built while one cache entry is live owns its
+        # own command list. Without it a reader could be reverted onto
+        # shared static values as an allocation saving and the tests
+        # above would still pass.
+        data = self._data()
+        with mock.patch('shakenfist.operations.agentoperation.mariadb.'
+                        'get_agent_operation', return_value=data):
+            first = AgentOperation.from_db(str(data.uuid))
+            second = AgentOperation.from_db(str(data.uuid))
+
+        self.assertIsNot(first.commands, second.commands)
+        self.assertIsNot(data.commands, first.commands)
+
+        # The second consequence the fix comment names: a later reader
+        # on the node still sees the put-blob command it has to make
+        # local before dispatch. NodeAgentopOp._preflight iterates
+        # exactly this list.
+        first.commands.pop(0)
+        self.assertEqual(
+            [{'command': 'get-file', 'path': '/tmp/x'}], second.commands)
+        self.assertEqual(
+            [{'command': 'get-file', 'path': '/tmp/x'}], data.commands)

--- a/shakenfist/tests/test_daemon_sidechannel_executor.py
+++ b/shakenfist/tests/test_daemon_sidechannel_executor.py
@@ -1118,12 +1118,16 @@ class ExecutorDispatchTerminalGuardTestCase(base.ShakenFistTestCase):
             AgentOperation.STATE_EXECUTING, job.agentop.state.value)
 
 
-class _GetFileDispatchHandler:
-    """A retryable handler whose dispatch() always produces one request."""
+class _GetFileDispatchHandler(sidechannel.AgentCommandHandler):
+    """A retryable handler whose dispatch() always produces one request.
+
+    Subclassed rather than duck typed so it inherits retryable,
+    register_as_outstanding and anything the base class grows later.
+    Only the two things this test needs to control are overridden.
+    """
 
     name = 'get-file'
     reports_progress = True
-    register_as_outstanding = False
 
     def dispatch(self, command_id, cmd):
         return ['a-request']
@@ -1152,7 +1156,7 @@ class ExecutorCommandListOwnershipTestCase(base.ShakenFistTestCase):
             commands=[{'command': 'get-file', 'path': '/tmp/x'}])
         with mock.patch.object(sidechannel.daemon, 'clear_abort_path'):
             job = sidechannel.SideChannelExecutorJob(_FakeInstance(), agentop)
-        job.command_handlers = {'get-file': _GetFileDispatchHandler()}
+        job.command_handlers = {'get-file': _GetFileDispatchHandler(job)}
         job._send_commands_single_envelope = mock.MagicMock()
         return job
 

--- a/shakenfist/tests/test_daemon_sidechannel_executor.py
+++ b/shakenfist/tests/test_daemon_sidechannel_executor.py
@@ -1118,6 +1118,72 @@ class ExecutorDispatchTerminalGuardTestCase(base.ShakenFistTestCase):
             AgentOperation.STATE_EXECUTING, job.agentop.state.value)
 
 
+class _GetFileDispatchHandler:
+    """A retryable handler whose dispatch() always produces one request."""
+
+    name = 'get-file'
+    reports_progress = True
+    register_as_outstanding = False
+
+    def dispatch(self, command_id, cmd):
+        return ['a-request']
+
+
+class ExecutorCommandListOwnershipTestCase(base.ShakenFistTestCase):
+    """The executor's work queue must be its own list, not the operation's.
+
+    AgentOperation.commands returns the operation's list by reference,
+    and that list is the one the process wide object cache holds, so an
+    executor which aliased it drained the operation as it dispatched.
+    The visible consequence was in the retry decision:
+    operation_is_retryable() refuses an empty command list, so a single
+    command get-file called itself unretryable the moment its only
+    command went out -- the exact operation shape issue #3516 is about,
+    and the opposite of what the retry path was built to do.
+
+    These build a real executor through its real constructor. The
+    dispatch tests above hand-set job.commands, which is precisely why
+    they could not see this: the alias was made in __init__.
+    """
+
+    def _executor(self):
+        agentop = _FakeAgentOp(
+            AgentOperation.STATE_QUEUED,
+            commands=[{'command': 'get-file', 'path': '/tmp/x'}])
+        with mock.patch.object(sidechannel.daemon, 'clear_abort_path'):
+            job = sidechannel.SideChannelExecutorJob(_FakeInstance(), agentop)
+        job.command_handlers = {'get-file': _GetFileDispatchHandler()}
+        job._send_commands_single_envelope = mock.MagicMock()
+        return job
+
+    def test_the_executor_does_not_share_the_operations_list(self):
+        job = self._executor()
+        self.assertEqual(job.commands, job.agentop.commands)
+        self.assertIsNot(job.commands, job.agentop.commands)
+
+    def test_dispatch_does_not_drain_the_operation(self):
+        job = self._executor()
+        with mock.patch.object(sidechannel, 'add_event_multi'):
+            job._dispatch_next_command(mock.MagicMock())
+
+        # The executor consumed its own queue, which is what makes the
+        # socket loop exit once the replies are in...
+        self.assertEqual([], job.commands)
+        # ...while the operation still knows what it was asked to do.
+        self.assertEqual(
+            [{'command': 'get-file', 'path': '/tmp/x'}], job.agentop.commands)
+
+    def test_a_dispatched_get_file_is_still_retryable(self):
+        # The consequence, asserted where it was actually observed. A
+        # stall is only reachable after dispatch, so this is the state
+        # every caller of operation_is_retryable() sees.
+        job = self._executor()
+        with mock.patch.object(sidechannel, 'add_event_multi'):
+            job._dispatch_next_command(mock.MagicMock())
+
+        self.assertTrue(sidechannel.operation_is_retryable(job.agentop))
+
+
 class OperationRetryabilityTestCase(base.ShakenFistTestCase):
     """Retryability is a property of the whole command list.
 

--- a/shakenfist/tests/test_instance_static_value_ownership.py
+++ b/shakenfist/tests/test_instance_static_value_ownership.py
@@ -1,0 +1,68 @@
+# Copyright 2019 Michael Still and contributors
+
+# Instance._static_values_to_dict() must not hand out the cached model's
+# own container fields.
+#
+# This is the same defect that was found and fixed for AgentOperation:
+# mariadb.get_instance() parks the InstanceData model in the process
+# wide object cache under OBJECT_CACHE_TTL_IMMUTABLE, and pydantic's
+# frozen=True on that model stops attribute assignment rather than
+# mutation of a list or dict field's contents. No in-tree reader mutates
+# disk_spec, video or side_channels today, so unlike the agentoperation
+# case this pins a latent hazard rather than a live bug -- but
+# sidechannel's instance_sidechannel_cache holds side_channels for the
+# daemon's lifetime, which is the shared ownership that made the other
+# case bite.
+
+import uuid
+from unittest import mock
+
+from shakenfist.instance import Instance
+from shakenfist.schema.instance_data import InstanceData
+from shakenfist.tests import base
+
+
+_DISK_SPEC = [{'size': 8, 'base': 'ubuntu:22.04', 'type': 'disk',
+               'bus': 'virtio'}]
+
+
+class InstanceStaticValueOwnershipTestCase(base.ShakenFistTestCase):
+    def _data(self):
+        return InstanceData(
+            uuid=uuid.uuid4(), cpus=1, disk_spec=list(_DISK_SPEC),
+            memory=1024, name='foo', namespace='tenant-a',
+            video={'model': 'cirrus', 'memory': 16384},
+            side_channels=['sf-agent2'],
+            version=Instance.current_version)
+
+    def test_the_container_fields_do_not_alias_the_cached_model(self):
+        data = self._data()
+
+        first = Instance._static_values_to_dict(data)
+        second = Instance._static_values_to_dict(data)
+
+        for field in ('disk_spec', 'video', 'side_channels'):
+            self.assertEqual(getattr(data, field), first[field])
+            self.assertIsNot(getattr(data, field), first[field])
+            self.assertIsNot(first[field], second[field])
+
+    def test_two_objects_from_one_cache_entry_do_not_share_them(self):
+        # Asserted at the object level because that is what readers hold
+        # onto: sidechannel parks inst.side_channels in a dict which
+        # outlives the cache entry it came from.
+        data = self._data()
+        with mock.patch('shakenfist.instance.mariadb.get_instance',
+                        return_value=data):
+            first = Instance.from_db(str(data.uuid))
+            second = Instance.from_db(str(data.uuid))
+
+        first.side_channels.append('sf-agent3')
+        first.disk_spec.pop(0)
+        first.video['model'] = 'qxl'
+
+        self.assertEqual(['sf-agent2'], second.side_channels)
+        self.assertEqual(['sf-agent2'], data.side_channels)
+        self.assertEqual(_DISK_SPEC, second.disk_spec)
+        self.assertEqual(_DISK_SPEC, data.disk_spec)
+        self.assertEqual('cirrus', second.video['model'])
+        self.assertEqual('cirrus', data.video['model'])


### PR DESCRIPTION
Phase 5 of the agent operation deadlines plan merged as #3941 with a
third automated review round unaddressed. This is its one confirmed
defect, fixed on its own rather than folded into phase 6.

## The bug

`SideChannelExecutorJob.__init__` took its working command queue
straight from `agentop.commands`. `AgentOperation.commands` returns
the operation's own list by reference (`agentoperation.py:220`), so
`self.commands.pop(0)` in `_dispatch_next_command()`
(`main.py:1132`) mutated the operation as it dispatched.

That list reaches further than the operation. `_db_get()` referenced
`data.commands` from the `AgentOperationData` which
`mariadb.get_agent_operation()` caches, and pydantic's
`frozen=True` on that model prevents attribute assignment rather
than mutation of a list field's contents, so the pop reached the
process-wide object cache and every `AgentOperation` later built
from a hit on it.

Reproduced against the merged tree before fixing:

```
retryable before dispatch: True
retryable after dispatch:  False
cached model commands:     []
fresh from_db commands:    []
```

## Why it matters

`operation_is_retryable()` opens by refusing an empty command list,
so a single-command `get-file` -- the operation shape #3516 is
actually about -- called itself unretryable the moment its only
command went out. Both executor exit paths and the reaper took the
terminal branch instead of requeueing, which is the inverse of the
decision phase 5 exists to make. A retry which did happen would also
have redispatched with nothing left to send, since the reaper's own
`AgentOperation.from_db()` reads through the same poisoned cache
entry.

## The fix

Both ends, because each is wrong on its own terms:

- `SideChannelExecutorJob.__init__` copies the list. The executor
  owns its work queue; the operation's record of what it was asked
  to do is not that queue.
- `_db_get()` copies rather than handing every reader the cache's
  interior.

Either alone would have prevented one half. `_db_get()` alone leaves
the retry decision inverted, because the executor and
`operation_is_retryable()` read the same object; the executor fix
alone leaves the sharp edge in place for the next caller.

## Tests

Five new tests, all of which fail against the unfixed code
(verified by reverting each change in turn):

- Three in `test_daemon_sidechannel_executor.py` building a real
  executor through its real constructor. The existing dispatch tests
  hand-set `job.commands`, which is exactly why they could not see
  this -- the alias was made in `__init__`.
- Two in `test_agent_operation_retry.py` covering the cache
  containment.

Full suite: 4009 tests, 118 skipped, 0 failures. `pre-commit
run --all-files` clean.

*(Review assisted by Claude Code)*