### PR TITLE
Add binary affinity constraints, and stop asserting co-location

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -166,14 +166,18 @@ HTTP push; otherwise it logs to the local systemd journal. See
 
 The scheduler (`shakenfist/scheduler.py`) is in-process in each `sf-api`
 worker; there is no scheduler daemon. It filters candidate hypervisors
-against the `node_metrics` table (hard pre-filters: hypervisor role, queue
-health, CPU/RAM/disk headroom, disk bandwidth, and hard affinity
-constraints), scores soft affinity, then
-ranks by **load per schedulable thread** in coarse buckets with
+against the `node_metrics` table (hard pre-filters: hypervisor role,
+CPU/RAM/disk headroom, and hard affinity constraints), scores soft
+affinity, sheds load (queue health, disk bandwidth), then ranks by
+**load per schedulable thread** in coarse buckets with
 headroom-weighted selection so differently sized machines share work
-proportionally. These pre-filters order and prune the candidate list from
-a metrics snapshot up to a minute stale; they are not themselves the
-admission decision.
+proportionally. Affinity sits between the pre-filters and load
+shedding deliberately: a node that cannot fit the instance is never
+scored, while a busy node is still one the user asked for, so load
+shedding may narrow the winning affinity group but never moves
+placement out of it. These stages order and prune the candidate list
+from a metrics snapshot up to a minute stale; they are not themselves
+the admission decision.
 
 Admission is a separate, atomic step. Once the pipeline has picked a
 candidate, `Instance.place_instance()` makes one guarded capacity claim

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -167,7 +167,8 @@ HTTP push; otherwise it logs to the local systemd journal. See
 The scheduler (`shakenfist/scheduler.py`) is in-process in each `sf-api`
 worker; there is no scheduler daemon. It filters candidate hypervisors
 against the `node_metrics` table (hard pre-filters: hypervisor role, queue
-health, CPU/RAM/disk headroom, disk bandwidth), scores affinity, then
+health, CPU/RAM/disk headroom, disk bandwidth, and hard affinity
+constraints), scores soft affinity, then
 ranks by **load per schedulable thread** in coarse buckets with
 headroom-weighted selection so differently sized machines share work
 proportionally. These pre-filters order and prune the candidate list from

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -239,6 +239,16 @@ reporting either one is a real signal: the cluster is smaller than it
 should be, or the scheduler is ejecting nodes it should not. Treat it
 as a failure to investigate rather than a pass.
 
+This expectation is **documentation, not enforcement**, and that is a
+deliberate trade rather than an oversight. A skip is green, so nothing
+in CI fails if `slim-primary` starts skipping too -- the "does not skip
+on a healthy three-node run" check was made once by hand. The obvious
+automation, failing rather than skipping when `get_nodes()` returns
+three or more, would fail every `slim-tier` run, and `slim-tier` is
+expected to skip until `PLAN-ci-cloud-sizing` lands. Once it does, and
+neither topology is expected to skip, that guard becomes worth adding:
+fail rather than skip on any cluster with three or more hypervisors.
+
 `test_binary_affinity_prefers_the_tagged_node` shares both skips and
 reads the same way, since it asserts the binary model's soft half
 through the same helper.

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -213,6 +213,32 @@ like an idle cluster rather than a broken query.
 
 ## Coverage the functional suite does not have
 
+### Affinity test skips are topology dependent
+
+`cluster_ci_tests/test_scheduler.py`'s `test_affinity` skips rather
+than passes on two degeneracies, because in both the assertion could
+not have failed and a pass would be a false green. The two carry
+different messages, and which one is expected depends on the
+topology -- so a permanently skipping run cannot be read as a healthy
+one:
+
+- **`only N candidates`** -- the scorer considered fewer than two
+  nodes, so affinity was never consulted. Expected on any cluster
+  with fewer than three hypervisors, where the test's own
+  `len(nodes) < 3` guard usually fires first.
+- **`affine node not a candidate`** -- the node the test is affine to
+  was ejected by an admission filter (CPU, memory or disk) before
+  scoring. This is issue #3565's real mechanism and is not an
+  affinity defect. **Expected on `slim-tier` until
+  `PLAN-ci-cloud-sizing` lands**, since that topology runs the same
+  suite on roughly half the resources and the admission filters bind
+  there.
+
+Neither skip is expected on `slim-primary`. A `slim-primary` run
+reporting either one is a real signal: the cluster is smaller than it
+should be, or the scheduler is ejecting nodes it should not. Treat it
+as a failure to investigate rather than a pass.
+
 ### Upgrade data verification
 
 Every functional job deploys a fresh cluster, so nothing in the suite

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -239,6 +239,14 @@ reporting either one is a real signal: the cluster is smaller than it
 should be, or the scheduler is ejecting nodes it should not. Treat it
 as a failure to investigate rather than a pass.
 
+`test_binary_affinity_prefers_the_tagged_node` shares both skips and
+reads the same way, since it asserts the binary model's soft half
+through the same helper.
+`test_unsatisfiable_require_with_tag_is_refused` shares neither: it
+asserts a refusal, needs no successful create and no candidate count,
+and so is expected to run on every topology including a single-node
+one. A skip there is a bug in the test.
+
 ### Upgrade data verification
 
 Every functional job deploys a fresh cluster, so nothing in the suite

--- a/docs/operator_guide/scheduler.md
+++ b/docs/operator_guide/scheduler.md
@@ -730,7 +730,14 @@ tells the whole story:
   `affinity_detail`. The two are easy to confuse and answer
   different questions. `schedule keeping affinity despite
   transient load` follows it when load shedding was ignored to
-  honour that group.
+  honour that group. **The event has a second shape**: an instance
+  which requested no soft affinity at all -- which is most of them
+  -- gets `affinity_detail: {}` and `highest_affinity: 0`, with
+  `candidates` and `by_affinity` still holding every candidate.
+  The scorer is skipped outright when there is nothing to score,
+  because walking every candidate's placed instances is not free,
+  so an empty breakdown there means "nothing was asked for" and
+  not "the events went missing".
 - `schedule have lowest cpu load` includes per-node `load_detail`:
   raw `cpu_load_1`, the denominator used, the normalised load, the
   committed-RAM fraction and the bucket.
@@ -784,6 +791,12 @@ that was given no choice.
 
 Then, in that pass's `schedule have highest affinity`:
 
+- **Is `affinity_detail` empty?** Then this instance requested no
+  soft affinity, the scorer was skipped, and there is nothing here
+  to diagnose. Check the instance's `affinity` metadata before
+  reading any further: a specification of nothing but `require_*`
+  constraints also lands here, and its story is in the `schedule at
+  stage affinity_constraints` event instead.
 - **How many entries does `affinity_detail` have?** That is how many
   nodes the scorer actually considered. If it is 1, affinity was
   never consulted: the placement is neither honoured nor violated,

--- a/docs/operator_guide/scheduler.md
+++ b/docs/operator_guide/scheduler.md
@@ -41,14 +41,24 @@ a placement decision can be reconstructed after the fact (see
    filesystems. The candidate node publishes its own reservation as
    the `disk_reservation_gb` metric, so admission honours that
    node's per-host value rather than the evaluator's own config.
-6. **Affinity** -- surviving nodes are scored against the
+6. **Hard affinity constraints** -- if the instance requested
+   `require_with_tag` or `require_without_tag`, nodes which do not
+   satisfy them are excluded. This is admission, not ranking: a node
+   without a matching co-located instance cannot host this instance
+   at all. If it empties the candidate set the create fails with a
+   **409**, not a 507, because the cluster is not full -- it simply
+   has nowhere that satisfies the constraint, and no amount of added
+   capacity would change that. The stage is skipped entirely when no
+   hard constraint was requested.
+7. **Affinity** -- surviving nodes are scored against the
    instance's affinity tags and only the highest-scoring group
-   continues.
-7. **Queue health** -- nodes with more than 20 waiting queue jobs
+   continues. Skipped when the instance requested no affinity, since
+   a scorer with nothing to score cannot change the ordering.
+8. **Queue health** -- nodes with more than 20 waiting queue jobs
    are excluded; they are not keeping up.
-8. **Disk bandwidth** -- nodes whose disks are saturated (busy
+9. **Disk bandwidth** -- nodes whose disks are saturated (busy
    more than 120% of wall time across spindles) are excluded.
-9. **Load ordering and weighted selection** -- the survivors are
+10. **Load ordering and weighted selection** -- the survivors are
    ordered by CPU load and committed RAM, best first, and a
    weighted-random shuffle spreads work across similar nodes. No
    node is dropped here. See below.
@@ -60,7 +70,7 @@ atomic capacity claim made once a candidate is chosen (see [Admission
 is a guarded capacity claim](#admission-is-a-guarded-capacity-claim)
 below), so a node that survives every pre-filter here can still be
 refused there if another concurrent create took the last slot first.
-Stages 7 and 8 are **load shedding**: they answer whether a node is a
+Stages 8 and 9 are **load shedding**: they answer whether a node is a
 good idea right now. Affinity sits between the two deliberately. A
 busy node is still a node the user asked for, so load shedding may
 narrow the winning affinity group but never moves placement out of it
@@ -708,9 +718,17 @@ tells the whole story:
   compared against the hard maximum; for RAM it includes the
   reservation subtracted, or the committed memory compared against
   the counters' limit.
+- `schedule at stage affinity_constraints` is the hard constraint
+  filter, with a `dropped` map naming which of `require_with_tag` or
+  `require_without_tag` ejected each node. It is absent when no hard
+  constraint was requested.
 - `schedule have highest affinity` includes the winning score and
   a per-candidate `affinity_detail` breakdown of which neighbouring
-  instances contributed what. `schedule keeping affinity despite
+  instances contributed what. Its `candidates` field is the
+  **winning tier after scoring**, not the set the scorer was given;
+  the size of the set it considered is the number of entries in
+  `affinity_detail`. The two are easy to confuse and answer
+  different questions. `schedule keeping affinity despite
   transient load` follows it when load shedding was ignored to
   honour that group.
 - `schedule have lowest cpu load` includes per-node `load_detail`:
@@ -743,6 +761,102 @@ It also breaks the CPU decision out into `cpu_hard_max`,
 guarded capacity claim](#admission-is-a-guarded-capacity-claim) for what
 `cpu_committed` and its `cpu_committed_row_present` companion actually
 mean.
+
+### Was affinity ignored, or was there no choice?
+
+This is the question almost every affinity report turns out to be,
+and the events answer it directly. Read them at the API's maximum
+limit, because the scheduling events are the *oldest* an instance has
+and a default read of 100 returns the newest:
+
+```
+sf-client instance events ...uuid... | head -50
+```
+
+Two events decide it, and they must come from the **create-path**
+scheduling pass. `find_candidates()` runs more than once per
+instance -- once unforced from the create path, and again forced
+against a single node by preflight -- so pick the pass whose
+`schedule inputs` event has `forced_candidates` false. The forced
+passes each publish an affinity event with exactly one candidate,
+which looks like a scorer that ignored you and is really a scorer
+that was given no choice.
+
+Then, in that pass's `schedule have highest affinity`:
+
+- **How many entries does `affinity_detail` have?** That is how many
+  nodes the scorer actually considered. If it is 1, affinity was
+  never consulted: the placement is neither honoured nor violated,
+  and the answer lies in the earlier `schedule at stage ...` events,
+  whose `dropped` maps say which filter removed everything else.
+- **Is the node you expected present in `affinity_detail` at all?**
+  If not, it was removed by an admission filter -- CPU, memory or
+  disk -- *before* scoring. Again the `dropped` maps name the stage.
+  This is the common case, and it is a capacity story rather than an
+  affinity one.
+- **If it is present, what did it score?** Now the scoring is the
+  subject, and `affinity_detail`'s per-candidate `considered` list
+  names each neighbouring instance and what it contributed.
+
+Do not read `candidates` from that event as the size of the choice.
+It is the winning tier after scoring, so it is frequently 1 exactly
+when affinity worked.
+
+### Finding instances that still use weighted affinity
+
+The weighted form is deprecated and will be removed in a future
+release. Setting one records a `deprecated weighted affinity
+specification accepted` event on the instance -- but only at the
+moment it is accepted, so instances which already carried a weighted
+specification before the upgrade never emit one. Those have to be
+found by inspection:
+
+```bash
+#!/bin/bash
+BINARY='require_with_tag require_without_tag prefer_with_tag prefer_without_tag'
+for uuid in $(sf-client --simple instance list | tail -n +2 | cut -d, -f1); do
+    sf-client --simple instance show "$uuid" 2>/dev/null \
+        | grep '^metadata,affinity,' | head -1 | cut -d, -f3- \
+        | BINARY="$BINARY" UUID="$uuid" python3 -c '
+import ast, os, sys
+raw = sys.stdin.read().strip()
+if not raw:
+    sys.exit()
+try:
+    spec = ast.literal_eval(raw)
+except (ValueError, SyntaxError):
+    sys.exit()
+binary = set(os.environ["BINARY"].split())
+if isinstance(spec, dict) and spec and not (set(spec) & binary):
+    print("%s %s" % (os.environ["UUID"], spec))
+'
+done
+```
+
+The test is the same one the server uses: a dictionary which uses none
+of the four reserved names is the weighted form. Note that
+`instance show` renders metadata values as Python literals rather than
+JSON -- `{'static-runner': -10}`, with single quotes -- which is why
+this parses with `ast.literal_eval` and not `json.loads`.
+
+Run it before upgrading to the release that removes the weighted form,
+and convert what it finds: a positive weight becomes
+`prefer_with_tag`, a negative weight becomes `prefer_without_tag`, and
+zero can be dropped. Output looks like this (from a real cluster, 2026-08-30):
+
+```
+27a969a1-189f-4161-a201-97149a4b7f48 {'static-runner': -10}
+aae1c884-0878-4f36-b88a-dd32e95590e7 {'hypervisor': -50}
+```
+
+Check the magnitudes while you are there. Every weight in each of
+those specifications shares a magnitude -- they are single-tag
+specifications -- so the mapping preserves their ordering exactly and
+converting them changes nothing. A specification mixing magnitudes,
+such as `{"a": 100, "b": 1}`, is the one to look at twice: the mapping
+already discards the difference, so its ordering changed at the
+release which introduced the mapping rather than at the one which
+removes the weighted form.
 
 ## Mixed-version clusters
 

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -152,6 +152,11 @@
   entry -- that is, `{"affinity": {"first-node": ["a"]}}` -- previously
   escaped the validator and produced a server error on instance create
   and on both instance metadata endpoints.
+* **Behaviour change:** a boolean affinity value is now refused with a
+  400. `{"affinity": {"first-node": true}}` was previously accepted as a
+  weight of one, because Python's `int(True)` is 1. If you relied on
+  that, send `1` instead. Numeric strings such as `"3"` are still
+  accepted, unchanged.
 
 ## Supported distributions
 

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -146,6 +146,12 @@
   instruction to base64 encode on the caller's behalf — check that a
   regenerated client does not double encode content you already encode
   yourself, as the API has always required.
+* Malformed values inside the reserved `affinity` instance metadata key
+  are now refused with a 400 instead of returning a 500. A list, a
+  dictionary, `null` or `Infinity` used as the *value* of an affinity
+  entry -- that is, `{"affinity": {"first-node": ["a"]}}` -- previously
+  escaped the validator and produced a server error on instance create
+  and on both instance metadata endpoints.
 
 ## Supported distributions
 

--- a/docs/user_guide/affinity.md
+++ b/docs/user_guide/affinity.md
@@ -109,15 +109,26 @@ Or on the command line:
 
 Each name takes a JSON list of tags, and you may use any subset of the four.
 
-`require_with_tag` and `require_without_tag` are **hard**. A hypervisor
-which does not satisfy them cannot host the instance at all, so they are
-applied alongside the CPU, memory and disk filters rather than as a
-ranking. If no hypervisor satisfies them, the create fails with a **409
-Conflict** naming the constraint -- where the weighted form would have
-silently placed the instance anywhere.
+All four match the tags of instances **already placed on a candidate
+hypervisor**, and only instances in **your own namespace**:
 
-`prefer_with_tag` and `prefer_without_tag` are **soft**, and behave exactly
-as weights did: they rank the hypervisors that survived the hard filters.
+| Name | Strength | Effect on a hypervisor hosting a matching instance |
+|------|----------|---------------------------------------------------|
+| `require_with_tag` | hard | Hypervisors hosting *no* matching instance cannot host yours at all |
+| `require_without_tag` | hard | Hypervisors hosting a matching instance cannot host yours at all |
+| `prefer_with_tag` | soft | +1 to the hypervisor's score, per matching instance |
+| `prefer_without_tag` | soft | -1 from the hypervisor's score, per matching instance |
+
+The hard pair is applied alongside the CPU, memory and disk filters rather
+than as a ranking. If no hypervisor satisfies them, the create fails with a
+**409 Conflict** naming the constraint -- where the weighted form would have
+silently placed the instance anywhere. The soft pair behaves exactly as
+weights did: it ranks the hypervisors that survived the hard filters.
+
+Two things about that table are easy to read past, and both are covered in
+detail below. The soft forms are terms in a **sum** and not soft vetoes, so
+`prefer_without_tag` can be outvoted. And the namespace scope applies to the
+hard forms too, so `require_without_tag` is **not** an isolation primitive.
 
 ???+ warning "`prefer_*` terms are a sum, not a veto"
 
@@ -141,6 +152,22 @@ as weights did: they rank the hypervisors that survived the hard filters.
     instance away from another tenant's workload, because it cannot see
     it. It is a placement constraint within your namespace, not a security
     or isolation boundary.
+
+???+ warning "The first member of a `require_with_tag` group"
+
+    The constraints match instances *already placed*, so the first
+    instance of a group cannot be created under the constraint that
+    defines the group. Ask for `require_with_tag: ["web"]` on a cluster
+    where nothing in your namespace carries the `web` tag and every
+    hypervisor is ejected, so you get a 409 -- including when the
+    instance you are trying to create is the one that would carry the
+    tag. This is the constraint working, not a bug, but it has no way
+    out on its own.
+
+    Seed the group first: create one instance carrying the tag and
+    *without* the `require_with_tag` constraint, then create the rest
+    with it. Or use `prefer_with_tag`, where having nothing to rank is
+    harmless.
 
 The two value shapes cannot be mixed in one specification. A dictionary of
 tag weights is the weighted form; a dictionary using the four reserved

--- a/docs/user_guide/affinity.md
+++ b/docs/user_guide/affinity.md
@@ -39,15 +39,31 @@ preference value are, although generally we recommend they range from -100 to 10
 where 100 means you'd really really love to be on the same hypervisor, and -100
 means you'd be very unhappy to be on the same hypervisor.
 
+!!! warning
+
+    This weighted form is **deprecated**, and the magnitude is already
+    ignored by the scheduler -- only the sign is read. It still works and
+    will for at least one more release, but new specifications should use
+    the constraint form described in
+    [Constraints, not just preferences](#constraints-not-just-preferences).
+    See [The weighted form is deprecated](#the-weighted-form-is-deprecated).
+
 ???+ info
 
-    Under the hood, Shaken Fist filters possible candidate hypervisors based on
-    the affinity coefficients specified. Only tags from within your namespace are
-    considered for this filtration. This decision is only made on the original
-    start up of an instance, and does not apply later. That is, if you change
-    the tags or affinity of an instance after instance creation it will not
-    affect that instance in any way, although it might affect scheduling decisions
-    for future instances.
+    Under the hood, weights **rank** the candidate hypervisors rather than
+    filtering them. Every hypervisor which can host your instance at all
+    remains a candidate whatever the weights say; the weights decide which
+    of them is preferred. That distinction is the whole of the next
+    section, and it is the difference between a preference and a promise.
+    The constraint form described below does filter, and is how you ask
+    for a hypervisor to be ruled out rather than merely disfavoured.
+
+    Only tags from within your namespace are considered, for both forms.
+    The decision is only made on the original start up of an instance, and
+    does not apply later. That is, if you change the tags or affinity of
+    an instance after instance creation it will not affect that instance
+    in any way, although it might affect scheduling decisions for future
+    instances.
 
 You can of course have more than one tag and affinity preference set at a time.
 So to extend our example, let's say that web servers do not prefer sharing with

--- a/docs/user_guide/affinity.md
+++ b/docs/user_guide/affinity.md
@@ -65,6 +65,119 @@ Or on the command line:
 
 `sf-client instance set-metadata ...uuid... affinity '{"webserver": -10, "cache": 10}'`
 
+## What a preference promises, and what it does not
+
+A preference is consulted **when the scheduler has a choice**. It is not a
+guarantee, and it is not a constraint.
+
+That distinction matters more than it sounds. The scheduler first decides
+which hypervisors *can* host your instance at all -- enough CPU, enough
+memory, enough disk -- and only then ranks the survivors by affinity. If
+that first step leaves exactly one candidate, there is no ranking to do:
+your instance is placed on the only node available, whether your affinity
+wanted it there or not.
+
+So a single-candidate placement is **neither a preference honoured nor a
+preference violated**. It is a placement made without consulting your
+preference, because there was nothing to consult it about. If you look at
+where two instances landed and conclude that affinity was ignored, check
+first how many candidates the scheduler actually had.
+
+The scheduling events tell you which happened. See
+[the scheduler operator guide](/operator_guide/scheduler/) for how to read
+`schedule have highest affinity` and `schedule final candidates` to tell
+"scored wrong" apart from "had no choice".
+
+## Constraints, not just preferences
+
+Weights answer "would you rather", and there are times you need to answer
+"you must". Affinity therefore accepts a second value shape, using four
+reserved names instead of tag weights:
+
+```
+{
+    "require_with_tag": ["database"],
+    "require_without_tag": ["batch"],
+    "prefer_with_tag": ["cache"],
+    "prefer_without_tag": ["webserver"]
+}
+```
+
+Or on the command line:
+
+`sf-client instance set-metadata ...uuid... affinity '{"require_without_tag": ["batch"]}'`
+
+Each name takes a JSON list of tags, and you may use any subset of the four.
+
+`require_with_tag` and `require_without_tag` are **hard**. A hypervisor
+which does not satisfy them cannot host the instance at all, so they are
+applied alongside the CPU, memory and disk filters rather than as a
+ranking. If no hypervisor satisfies them, the create fails with a **409
+Conflict** naming the constraint -- where the weighted form would have
+silently placed the instance anywhere.
+
+`prefer_with_tag` and `prefer_without_tag` are **soft**, and behave exactly
+as weights did: they rank the hypervisors that survived the hard filters.
+
+???+ warning "`prefer_*` terms are a sum, not a veto"
+
+    Each matching neighbouring instance contributes +1 (for
+    `prefer_with_tag`) or -1 (for `prefer_without_tag`), and the totals are
+    summed **across neighbours and across tags**. So `prefer_without_tag`
+    is a term in a sum rather than a soft veto, and a match on it can be
+    outvoted by neighbour count on the other axis.
+
+    Concretely, with `prefer_with_tag: ["web"]` and
+    `prefer_without_tag: ["batch"]` both set: a hypervisor hosting three
+    `web` instances and one `batch` scores +2, and beats a hypervisor
+    hosting one `web` and no `batch` at +1 -- even though the first one
+    has the tag you asked to avoid. If you need the avoidance honoured
+    regardless of neighbour count, use `require_without_tag`.
+
+???+ info "`require_without_tag` is not an isolation primitive"
+
+    Like the weighted form, the constraints only consider instances in
+    **your own namespace**. `require_without_tag` will not keep your
+    instance away from another tenant's workload, because it cannot see
+    it. It is a placement constraint within your namespace, not a security
+    or isolation boundary.
+
+The two value shapes cannot be mixed in one specification. A dictionary of
+tag weights is the weighted form; a dictionary using the four reserved
+names is the constraint form; a dictionary containing both is rejected with
+a 400, because either way of resolving it would silently discard half of
+what you asked for.
+
+## The weighted form is deprecated
+
+Tag weights still work, and will keep working for at least one more
+release. They are mapped onto the constraint form when the scheduler reads
+them: a positive weight becomes `prefer_with_tag`, a negative weight
+becomes `prefer_without_tag`, and zero becomes nothing, which is what zero
+always meant.
+
+**The magnitude is discarded by that mapping.** `{"webserver": -10}` and
+`{"webserver": -100}` now behave identically. This is deliberate: a weight
+was a multiplier on a count of neighbouring instances that you could not
+predict when you wrote it, so two weights were never really comparable.
+What replaces it is a quantity that is defined -- how many matching
+neighbours a hypervisor has.
+
+Ordering is unchanged whenever every weight in a specification shares a
+magnitude, which includes every single-tag specification. Where magnitudes
+differ, ordering can change: `{"a": 100, "b": 1}` maps to
+`prefer_with_tag: ["a", "b"]`, so a hypervisor carrying only `b` now ties
+with one carrying only `a`.
+
+Setting a weighted specification records a deprecation event against the
+instance. Note that this happens when the specification is **accepted**, so
+instances that were already carrying a weighted specification before the
+upgrade do not produce one -- see
+[the scheduler operator guide](/operator_guide/scheduler/) for how to find
+them.
+
+## Debugging
+
 Shaken Fist emits a series of events while making a scheduling decision for an
 instance, and those events are useful for debugging affinity operations. You can
 see the events for an instance with this command:

--- a/docs/user_guide/affinity.md
+++ b/docs/user_guide/affinity.md
@@ -59,11 +59,16 @@ means you'd be very unhappy to be on the same hypervisor.
     for a hypervisor to be ruled out rather than merely disfavoured.
 
     Only tags from within your namespace are considered, for both forms.
-    The decision is only made on the original start up of an instance, and
-    does not apply later. That is, if you change the tags or affinity of
-    an instance after instance creation it will not affect that instance
-    in any way, although it might affect scheduling decisions for future
-    instances.
+
+    The specification is re-read **every time the instance is scheduled**,
+    which includes every restart and reschedule and not only the original
+    create. So a specification you change later applies from the next
+    restart onwards, and a hard constraint no hypervisor can satisfy by
+    then will refuse that restart -- after trying every hypervisor in the
+    cluster, not only the one it was on. If you have an instance which
+    must always be able to start, prefer `prefer_*` over `require_*`: a
+    ranking with nothing to rank is harmless, and a constraint with
+    nothing to satisfy it is not.
 
 You can of course have more than one tag and affinity preference set at a time.
 So to extend our example, let's say that web servers do not prefer sharing with
@@ -140,6 +145,23 @@ than as a ranking. If no hypervisor satisfies them, the create fails with a
 **409 Conflict** naming the constraint -- where the weighted form would have
 silently placed the instance anywhere. The soft pair behaves exactly as
 weights did: it ranks the hypervisors that survived the hard filters.
+
+???+ warning "Hard constraints are re-checked on every restart"
+
+    A `require_*` constraint is not a create-time decision. The scheduler
+    runs the same filter whenever the instance is scheduled, restarts and
+    reschedules included, so an instance placed under
+    `require_with_tag: ["database"]` can be refused later if the tagged
+    neighbour it was placed beside has since been deleted. The refusal
+    happens only after every hypervisor in the cluster has been tried, and
+    the error names the constraint rather than reporting a full cluster.
+
+    This is deliberate: a constraint which applied once and then stopped
+    would be a create-time hint with a misleading name, and
+    `require_without_tag` in particular is not something an instance stops
+    needing on its second boot. But it does mean `require_*` trades some
+    of an instance's ability to restart for the guarantee, where
+    `prefer_*` does not.
 
 Two things about that table are easy to read past, and both are covered in
 detail below. The soft forms are terms in a **sum** and not soft vetoes, so

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_scheduler.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_scheduler.py
@@ -16,7 +16,24 @@ class TestAffinity(base.BaseNamespacedTestCase):
             '192.168.242.0/24', True, True, '%s-net' % self.namespace)
         self._await_networks_ready([self.net['uuid']])
 
-    def _add_scheduler_detail(self, name, instance_uuid):
+    def _scheduler_events(self, instance_uuid):
+        """The scheduler's audit trail for an instance.
+
+        Read with event_type='audit' and the API's maximum limit rather
+        than its default of 100. The rows come back newest first, and
+        the scheduling events are the *oldest* an instance has -- behind
+        all of its networking, image, boot and agent events -- so a
+        default read returns the newest hundred and drops exactly the
+        ones this test needs. Both arguments matter: 1000 is the
+        endpoint's hard cap, so the audit filter is what keeps a busy
+        create inside it rather than being tidiness.
+        """
+        return [
+            e for e in self.system_client.get_instance_events(
+                instance_uuid, event_type='audit', limit=1000)
+            if str(e.get('message', '')).startswith('schedule')]
+
+    def _add_scheduler_detail(self, name, events):
         """Attach the scheduler's audit trail for an instance.
 
         The scheduler records its candidate set, each filter stage's
@@ -26,13 +43,73 @@ class TestAffinity(base.BaseNamespacedTestCase):
         without it a placement assertion failure dies with the ephemeral
         CI cluster and cannot be diagnosed afterwards.
         """
-        events = [
-            e for e in self.system_client.get_instance_events(instance_uuid)
-            if str(e.get('message', '')).startswith('schedule')]
         self.addDetail(
             '%s scheduler events' % name,
             content.text_content(json.dumps(
                 events, indent=4, sort_keys=True, default=str)))
+
+    def _unforced_affinity_event(self, name, events):
+        """The 'schedule have highest affinity' event of the create pass.
+
+        find_candidates() runs more than once per instance: unforced
+        from the create path, forced when the instance is already
+        placed, and forced again by preflight against the node it landed
+        on. Each forced call publishes its own affinity event carrying a
+        single candidate, so matching on the message alone finds a pass
+        that had no choice to make and reads as a degenerate run.
+
+        The unforced pass is identified by its 'schedule inputs' event,
+        which publishes forced_candidates=False, and then paired to the
+        affinity event by request_id. That id is set for every API
+        request by the RequestID WSGI middleware, and is absent for the
+        preflight calls because they run in the queue daemon with no
+        flask request at all -- which is what makes it a discriminator
+        rather than merely an identifier.
+        """
+        inputs = [
+            e for e in events
+            if str(e.get('message', '')) == 'schedule inputs'
+            and not (e.get('extra') or {}).get('forced_candidates')]
+        affinity = [
+            e for e in events
+            if str(e.get('message', '')) == 'schedule have highest affinity']
+
+        if not inputs or not affinity:
+            self.fail(
+                '%s: no unforced scheduling pass in its events (%d inputs, '
+                '%d affinity). A missing event means the read is wrong, not '
+                'that the run was degenerate.' % (
+                    name, len(inputs), len(affinity)))
+
+        # Pair on request_id where there is one to pair on. A null id on
+        # both sides would match every candidate event, and taking the
+        # first or last could select a forced pass -- whose single-entry
+        # affinity_detail then reads as a degenerate run and skips
+        # forever. Fall back to adjacency only when there is no id, and
+        # fail rather than skip if that cannot identify a pass either.
+        request_id = inputs[0].get('request_id')
+        if request_id:
+            matched = [
+                e for e in affinity if e.get('request_id') == request_id]
+            if matched:
+                return matched[0]
+            self.fail(
+                '%s: no affinity event shares request_id %s with the '
+                'unforced schedule inputs event' % (name, request_id))
+
+        ordered = sorted(events, key=lambda e: e.get('timestamp') or 0)
+        try:
+            index = ordered.index(inputs[0])
+        except ValueError:
+            index = -1
+        for candidate in ordered[index + 1:]:
+            if str(candidate.get('message', '')) == \
+                    'schedule have highest affinity':
+                return candidate
+
+        self.fail(
+            '%s: the unforced schedule inputs event carries no request_id '
+            'and no affinity event follows it' % name)
 
     def test_affinity(self):
         nodes = self.system_client.get_nodes()
@@ -116,16 +193,72 @@ class TestAffinity(base.BaseNamespacedTestCase):
         self.addDetail('inst3', content.text_content(json.dumps(
             inst3, indent=4, sort_keys=True)))
 
+        events = {}
         for name, inst in [('inst1', inst1), ('inst2', inst2),
                            ('inst3', inst3)]:
-            self._add_scheduler_detail(name, inst['uuid'])
+            events[name] = self._scheduler_events(inst['uuid'])
+            self._add_scheduler_detail(name, events[name])
 
-        # inst1 and inst2 should share a node, inst3 should not
-        self.assertEqual(
-            inst1['node'], inst2['node'],
-            'Instances %s and %s should be on the same node but are not'
-            % (inst1['uuid'], inst2['uuid']))
-        self.assertNotEqual(
-            inst1['node'], inst3['node'],
-            'Instances %s and %s should not be on the same node but are'
-            % (inst1['uuid'], inst3['uuid']))
+        # What follows asserts what soft affinity actually promises: that
+        # the scorer preferred, or avoided, the node inst1 is on. It does
+        # not assert final co-location. A preference is consulted when
+        # there is a choice, and the scheduler is free to place elsewhere
+        # when there is not -- so an assertion on where inst2 landed passes or
+        # fails on whether the cluster happened to offer a choice, which
+        # is what made issue 3565 look like an affinity bug for months.
+        self._assert_affinity_tier(
+            'inst2', events['inst2'], inst1['node'], expected=True)
+        self._assert_affinity_tier(
+            'inst3', events['inst3'], inst1['node'], expected=False)
+
+    def _assert_affinity_tier(self, name, events, affine_node, expected):
+        """Assert whether the scorer put affine_node in the winning tier.
+
+        Two degeneracies make a run say nothing about affinity, and both
+        skip rather than pass. A pass would be a false green: the
+        assertion cannot fail, so it is not evidence.
+        """
+        event = self._unforced_affinity_event(name, events)
+        extra = event.get('extra') or {}
+        detail = extra.get('affinity_detail') or {}
+
+        # The candidate count comes from affinity_detail, which has one
+        # entry per node the scorer actually considered. It does not come
+        # from extra['candidates'], which is the *winning tier* after
+        # scoring and is 1 whenever affinity works -- the trap being that
+        # 'candidates' means a real candidate list in the sibling events.
+        if len(detail) < 2:
+            self.skipTest(
+                '%s: the scorer had only %d candidate(s), so affinity was '
+                'never consulted and this run carries no information about '
+                'it' % (name, len(detail)))
+
+        # The other degeneracy: the affinity target itself was ejected by
+        # an admission filter before scoring ran. The count guard does not
+        # catch this, because two or three other candidates can remain.
+        # This is issue 3565's real mechanism and it is not an affinity
+        # defect, so the run is uninformative rather than failing.
+        if affine_node not in detail:
+            self.skipTest(
+                '%s: affine node %s was not a candidate, having been '
+                'dropped by an admission filter before affinity scoring; '
+                'this run says nothing about affinity in either direction'
+                % (name, affine_node))
+
+        # extra['candidates'] is the winning tier, which is the wrong
+        # source for the count above and the right one for this.
+        tier = extra.get('candidates') or []
+        if expected:
+            self.assertIn(
+                affine_node, tier,
+                '%s asked to be near %s, and the scorer had a choice of %d '
+                'nodes, but that node is not in the winning affinity tier '
+                '%s (scoring detail: %s)' % (
+                    name, affine_node, len(detail), tier, detail))
+        else:
+            self.assertNotIn(
+                affine_node, tier,
+                '%s asked to avoid %s, and the scorer had a choice of %d '
+                'nodes, but that node is in the winning affinity tier %s '
+                '(scoring detail: %s)' % (
+                    name, affine_node, len(detail), tier, detail))

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_scheduler.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_scheduler.py
@@ -67,10 +67,19 @@ class TestAffinity(base.BaseNamespacedTestCase):
         flask request at all -- which is what makes it a discriminator
         rather than merely an identifier.
         """
-        inputs = [
-            e for e in events
-            if str(e.get('message', '')) == 'schedule inputs'
-            and not (e.get('extra') or {}).get('forced_candidates')]
+        # Oldest first, because there can be more than one unforced
+        # pass. forced_candidates is bool(candidates) and not "was an
+        # argument supplied", so the preflight redirect -- which builds
+        # its list by excluding the current node -- publishes a second
+        # unforced event whenever that exclusion empties the list, as it
+        # does on a single node cluster. The create path's pass is
+        # always the oldest of them. _scheduler_events() returns the
+        # API's newest-first order, so sort rather than index into it.
+        inputs = sorted(
+            [e for e in events
+             if str(e.get('message', '')) == 'schedule inputs'
+             and not (e.get('extra') or {}).get('forced_candidates')],
+            key=lambda e: e.get('timestamp') or 0)
         affinity = [
             e for e in events
             if str(e.get('message', '')) == 'schedule have highest affinity']

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_scheduler.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_scheduler.py
@@ -3,6 +3,7 @@ import json
 from testtools import content
 
 from shakenfist_ci import base
+from shakenfist_client import apiclient
 
 
 class TestAffinity(base.BaseNamespacedTestCase):
@@ -262,3 +263,60 @@ class TestAffinity(base.BaseNamespacedTestCase):
                 'nodes, but that node is in the winning affinity tier %s '
                 '(scoring detail: %s)' % (
                     name, affine_node, len(detail), tier, detail))
+
+    def _disks(self):
+        return [{'size': 8, 'base': base.CLUSTER_CI_IMAGE, 'type': 'disk'}]
+
+    def _networks(self):
+        return [{'network_uuid': self.net['uuid']}]
+
+    def test_binary_affinity_prefers_the_tagged_node(self):
+        """prefer_with_tag ranks, exactly as a positive weight did.
+
+        The binary model's soft half, asserted the same way
+        test_affinity asserts the weighted one -- from the scorer's own
+        event, with the same two skips, because the same two
+        degeneracies make a run uninformative.
+        """
+        nodes = self.system_client.get_nodes()
+        if len(nodes) < 3:
+            self.skipTest('Insufficient nodes for test')
+
+        inst1 = self.test_client.create_instance(
+            'binst1', 1, 1024, self._networks(), self._disks(), None, None,
+            metadata={'tags': ['binary-tag']})
+        self._await_instance_create(inst1['uuid'])
+
+        inst2 = self.test_client.create_instance(
+            'binst2', 1, 1024, self._networks(), self._disks(), None, None,
+            metadata={'affinity': {'prefer_with_tag': ['binary-tag']}})
+        self._await_instance_create(inst2['uuid'])
+
+        inst1 = self.test_client.get_instance(inst1['uuid'])
+        inst2 = self.test_client.get_instance(inst2['uuid'])
+
+        events = self._scheduler_events(inst2['uuid'])
+        self._add_scheduler_detail('binst2', events)
+        self._assert_affinity_tier(
+            'binst2', events, inst1['node'], expected=True)
+
+    def test_unsatisfiable_require_with_tag_is_refused(self):
+        """require_with_tag names a tag nothing carries, so nothing fits.
+
+        This is the bootstrapping case documented in the user guide, and
+        it is the cheapest possible functional assertion of the hard
+        half: no instance has to be created successfully, and no
+        candidate count matters, because a constraint no instance in the
+        namespace can satisfy ejects every node on any cluster of any
+        size. The weighted form would have placed this anywhere.
+
+        409 rather than 507 is the whole point. A 507 would report the
+        cluster as full, which it is not.
+        """
+        self.assertRaises(
+            apiclient.ResourceStateConflictException,
+            self.test_client.create_instance,
+            'binst-refused', 1, 1024, self._networks(), self._disks(),
+            None, None,
+            metadata={'affinity': {
+                'require_with_tag': ['no-instance-carries-this-tag']}})

--- a/shakenfist/exceptions.py
+++ b/shakenfist/exceptions.py
@@ -98,6 +98,23 @@ class LowResourceException(SchedulerException):
     ...
 
 
+class AffinityConstraintUnsatisfiable(LowResourceException):
+    """No candidate node satisfies a hard affinity constraint.
+
+    A subclass of LowResourceException rather than a sibling, because
+    preflight catches LowResourceException to redirect an instance to
+    another node, and that is exactly the right behaviour for a
+    constraint some other node may satisfy. A sibling would escape that
+    handler as a traceback.
+
+    The create path distinguishes them, because the two mean different
+    things to a caller: LowResourceException is 507, the cluster is
+    full, while this is 409, the request conflicts with the current
+    state of the cluster. Answering 507 here would tell an operator to
+    add capacity for a tag nothing carries.
+    """
+
+
 class CapacityAdmissionDenied(SchedulerException):
     """The atomic placement admission refused to place an instance.
 

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -837,6 +837,11 @@ class InstancesEndpoint(api_base.Resource):
         if metadata:
             for k, v in metadata.items():
                 inst.add_metadata_key(k, v)
+                # Emitted here rather than in the validator: that runs
+                # before Instance.new(), so there is no object to hang
+                # an event on, and the create path is the one a caller
+                # of the weighted form is most likely to be using.
+                _warn_if_weighted_affinity(inst, k, v)
 
         # Allocate IP addresses
         order = 0
@@ -1390,7 +1395,58 @@ class InstanceMetadatasEndpoint(api_base.Resource):
         instance_from_db.add_event(
             EVENT_TYPE_AUDIT, 'set metadata key request from REST API',
             extra={'key': key, 'value': value, 'method': 'post'})
+        _warn_if_weighted_affinity(instance_from_db, key, value)
         instance_from_db.add_metadata_key(key, value)
+
+
+AFFINITY_DEPRECATION_MESSAGE = (
+    'deprecated weighted affinity specification accepted')
+
+
+def _affinity_spec_is_weighted(value):
+    """Is this affinity value the deprecated weighted form?
+
+    The shape test lives here so that the validator and the deprecation
+    warning cannot disagree about which form a caller sent.
+    """
+    if not isinstance(value, dict) or not value:
+        return False
+    return not (set(value) & set(instance.Instance.AFFINITY_BINARY_KEYS))
+
+
+def _warn_if_weighted_affinity(inst, key, value):
+    """Warn, once per acceptance, that the weighted form is deprecated.
+
+    Emitted where the specification is *accepted* rather than where it
+    is consumed. Per-schedule would fire on every create and every
+    reschedule, and would need either an attribute write or a read of
+    the instance's own event history on the scheduling hot path; both
+    are the kind of addition the database load budget exists to catch.
+    Per-process would reset on every daemon restart.
+
+    Accept time also puts the warning where the caller can act on it,
+    at the moment they submit the deprecated form.
+
+    The limit this accepts, deliberately: it covers new acceptances
+    only. Every instance already carrying a weighted specification when
+    this shipped warns nobody, ever. The discovery recipe in the
+    operator guide is what covers those, and it is what the eventual
+    removal release will need.
+    """
+    if key != instance.Instance.METADATA_KEY_AFFINITY:
+        return
+    if not _affinity_spec_is_weighted(value):
+        return
+
+    inst.add_event(
+        EVENT_TYPE_AUDIT, AFFINITY_DEPRECATION_MESSAGE,
+        extra={
+            'affinity': value,
+            'mapped_to': instance.map_weighted_affinity(value),
+            'note': ('weighted affinity values are deprecated and will be '
+                     'removed in a future release; the magnitude is already '
+                     'ignored by the scheduler'),
+        })
 
 
 def _validate_instance_metadata(key, value):
@@ -1488,6 +1544,7 @@ class InstanceMetadataEndpoint(api_base.Resource):
         instance_from_db.add_event(
             EVENT_TYPE_AUDIT, 'set metadata key request from REST API',
             extra={'key': key, 'value': value, 'method': 'put'})
+        _warn_if_weighted_affinity(instance_from_db, key, value)
         instance_from_db.add_metadata_key(key, value)
 
     @swag_from(api_base.swagger_helper(

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -1400,6 +1400,14 @@ def _validate_instance_metadata(key, value):
                 400, 'value for "affinity" key should be a valid JSON dictionary')
 
         for key_type, dv in value.items():
+            # isinstance(True, int) is true in Python, so int(True) is 1 and a
+            # JSON true would be accepted as a weight of one. Nobody writing
+            # true means "weight 1", and the binary affinity model gives it a
+            # meaning nobody asked for, so refuse it explicitly.
+            if isinstance(dv, bool):
+                return sf_api.error(
+                    400, 'affinity dictionary values should be integers, not booleans')
+
             # int() raises TypeError -- not ValueError -- for a list, a dict or
             # None, and OverflowError for infinity. json.loads() accepts the
             # bare Infinity and NaN literals by default, so flask hands them

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -544,7 +544,8 @@ class InstancesEndpoint(api_base.Resource):
                 'configuration.', None),
             (404, 'Namespace, network, node, blob, snapshot, or label not found.', None),
             (406, 'Network not ready.', None),
-            (409, 'Network address in use.', None),
+            (409, 'Network address in use, or no node satisfies a hard '
+                'affinity constraint.', None),
             (507, 'Unable to allocate resources for the instance.', None)
          ]))
     @api_base.requires_namespace_exist_if_specified
@@ -868,6 +869,17 @@ class InstancesEndpoint(api_base.Resource):
             else:
                 candidates = SCHEDULER.find_candidates(
                     inst, candidates=[placed_on])
+
+        # This clause must stay *above* the LowResourceException one:
+        # AffinityConstraintUnsatisfiable is a subclass of it, and
+        # except clauses match in order, so reversing these two silently
+        # turns every 409 back into a 507.
+        except exceptions.AffinityConstraintUnsatisfiable as e:
+            inst.add_event(
+                EVENT_TYPE_AUDIT, 'schedule failed, affinity unsatisfiable',
+                extra={'message': str(e)})
+            inst.enqueue_delete_due_error('scheduling failed')
+            return sf_api.error(409, str(e), suppress_traceback=True)
 
         except exceptions.LowResourceException as e:
             inst.add_event(
@@ -1398,6 +1410,40 @@ def _validate_instance_metadata(key, value):
         if not isinstance(value, dict):
             return sf_api.error(
                 400, 'value for "affinity" key should be a valid JSON dictionary')
+
+        # The binary model is a second value shape under the same key,
+        # not a second key, so the two are told apart here by type. A
+        # dict whose keys are the four reserved names is the binary
+        # form; anything else is read as the weighted form and has to
+        # coerce to integers below. A spec mixing the two is refused
+        # rather than guessed at, because either guess silently
+        # discards half of what the caller asked for.
+        binary_keys = set(instance.Instance.AFFINITY_BINARY_KEYS)
+        present = set(value.keys())
+        if present & binary_keys:
+            unknown = present - binary_keys
+            if unknown:
+                return sf_api.error(
+                    400,
+                    'affinity keys %s are not valid alongside the binary '
+                    'affinity constraints; the weighted and binary forms '
+                    'cannot be mixed' % sorted(unknown))
+
+            for constraint, tags in value.items():
+                if not isinstance(tags, list):
+                    return sf_api.error(
+                        400,
+                        'value for affinity constraint "%s" should be a JSON '
+                        'list of tags' % constraint)
+                for tag in tags:
+                    # isinstance(True, str) is false, so booleans are
+                    # already excluded here, unlike in the weighted form.
+                    if not isinstance(tag, str) or not tag:
+                        return sf_api.error(
+                            400,
+                            'affinity constraint "%s" should contain only '
+                            'non-empty tag names' % constraint)
+            return
 
         for key_type, dv in value.items():
             # isinstance(True, int) is true in Python, so int(True) is 1 and a

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -1400,9 +1400,15 @@ def _validate_instance_metadata(key, value):
                 400, 'value for "affinity" key should be a valid JSON dictionary')
 
         for key_type, dv in value.items():
+            # int() raises TypeError -- not ValueError -- for a list, a dict or
+            # None, and OverflowError for infinity. json.loads() accepts the
+            # bare Infinity and NaN literals by default, so flask hands them
+            # straight through and a bare ValueError handler returns a 500 to
+            # the caller. NaN is already covered: int(float('nan')) is a
+            # ValueError.
             try:
                 int(dv)
-            except ValueError:
+            except (TypeError, ValueError, OverflowError):
                 return sf_api.error(400, 'affinity dictionary values should be integers')
 
 

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -246,6 +246,20 @@ class Instance(dbowo):
     METADATA_KEY_TAGS = 'tags'
     METADATA_KEY_AFFINITY = 'affinity'
 
+    # The binary affinity model's four reserved names. They are keys
+    # *inside* the value of METADATA_KEY_AFFINITY, not metadata keys of
+    # their own: a second top level key would let a caller supply both
+    # models at once and mean nothing coherent. The two value shapes are
+    # told apart by type -- a dict of integers is the weighted form, a
+    # dict of these names mapping to lists is the binary one.
+    AFFINITY_REQUIRE_WITH = 'require_with_tag'
+    AFFINITY_REQUIRE_WITHOUT = 'require_without_tag'
+    AFFINITY_PREFER_WITH = 'prefer_with_tag'
+    AFFINITY_PREFER_WITHOUT = 'prefer_without_tag'
+    AFFINITY_BINARY_KEYS = (
+        AFFINITY_REQUIRE_WITH, AFFINITY_REQUIRE_WITHOUT,
+        AFFINITY_PREFER_WITH, AFFINITY_PREFER_WITHOUT)
+
     # Per-call memo of the instance_attributes row, only populated inside
     # an attribute_memo() block. Class level defaults so that an attribute
     # read during object construction doesn't need __init__ to have run.

--- a/shakenfist/instance.py
+++ b/shakenfist/instance.py
@@ -161,6 +161,45 @@ class ConnectedVSockChannel():
         self.sock.close()
 
 
+def map_weighted_affinity(spec):
+    """Map a weighted affinity specification onto the binary form.
+
+    Positive weights become prefer_with_tag, negative become
+    prefer_without_tag, and zero maps to nothing -- which is what it
+    already meant, since a zero contribution never changed a score.
+
+    The magnitude is discarded. A caller choosing 100 rather than 1 was
+    choosing a multiplier on a neighbour count they cannot predict, so
+    the two were never comparable to each other or to anything else.
+    What survives is a quantity that is defined: how many matching
+    neighbours a node has.
+
+    That makes the mapping order preserving whenever every weight in a
+    specification shares a magnitude -- with uniform magnitude M the
+    weighted score is exactly M times the binary score for every
+    candidate -- which includes every single-tag specification. With
+    mixed magnitudes it demonstrably is not, and that divergence is
+    intended rather than an unstated exception.
+    """
+    prefer_with = []
+    prefer_without = []
+    for tag, weight in (spec or {}).items():
+        try:
+            weight = int(weight)
+        except (TypeError, ValueError, OverflowError):
+            continue
+        if weight > 0:
+            prefer_with.append(tag)
+        elif weight < 0:
+            prefer_without.append(tag)
+    return {
+        Instance.AFFINITY_REQUIRE_WITH: [],
+        Instance.AFFINITY_REQUIRE_WITHOUT: [],
+        Instance.AFFINITY_PREFER_WITH: prefer_with,
+        Instance.AFFINITY_PREFER_WITHOUT: prefer_without,
+    }
+
+
 class Instance(dbowo):
     object_type = ObjectType.INSTANCE
     initial_version = 19

--- a/shakenfist/operations/node_inst_netdesc_op.py
+++ b/shakenfist/operations/node_inst_netdesc_op.py
@@ -8,6 +8,7 @@ from shakenfist.eventlog import add_event_multi
 from shakenfist.exceptions import CapacityAdmissionDenied
 from shakenfist.exceptions import ImagesCannotShrinkException
 from shakenfist.exceptions import InvalidStateException
+from shakenfist.exceptions import AffinityConstraintUnsatisfiable
 from shakenfist.exceptions import LowResourceException
 from shakenfist.instance import Instance
 from shakenfist.network.bridged_vxlan_network import BridgedVXLanNetwork
@@ -152,6 +153,8 @@ class NodeInstNetdescOp(BaseClusterOperation):
 
         # Try to place on this node
         s = scheduler.Scheduler()
+        affinity_failure = False
+        affinity_message = ''
         try:
             s.find_candidates(inst, candidates=[config.NODE_UUID])
             return None
@@ -160,14 +163,31 @@ class NodeInstNetdescOp(BaseClusterOperation):
             inst.add_event(
                 EVENT_TYPE_AUDIT, 'schedule failed, insufficient resources',
                 extra={'message': str(e)})
+            # Carried out of the except suite deliberately. Python
+            # deletes the "as" target when the suite exits (PEP 3110),
+            # and the two guards below are dedented back to the try
+            # level, so reading e there is a NameError -- which this
+            # path would only discover in the merge queue, since it
+            # runs under cluster CI and not on a pull request.
+            affinity_failure = isinstance(e, AffinityConstraintUnsatisfiable)
+            affinity_message = str(e)
 
         # Unsuccessful placement, check if reached placement attempt limit
         db_placement = inst.placement
         if db_placement['placement_attempts'] > 3:
+            if affinity_failure:
+                raise AbortInstanceStart(
+                    self, 'Too many start attempts, and no node satisfies '
+                    'the requested affinity constraints: %s'
+                    % affinity_message)
             raise AbortInstanceStart(self, 'Too many start attempts')
 
         # Or if the user asked for a specific node which is now at capacity
         if inst.requested_placement:
+            if affinity_failure:
+                raise AbortInstanceStart(
+                    self, 'Requested node does not satisfy the requested '
+                    'affinity constraints: %s' % affinity_message)
             raise AbortInstanceStart(self, 'Requested node lacks resources')
 
         # Try placing on another node
@@ -268,6 +288,18 @@ class NodeInstNetdescOp(BaseClusterOperation):
                 self.add_event(EVENT_TYPE_AUDIT, 'failed to abort operation')
 
         except LowResourceException as e:
+            # Unlike the two guards above, this raise is inside the
+            # except suite, so it can test the exception directly.
+            if isinstance(e, AffinityConstraintUnsatisfiable):
+                add_event_multi(
+                    EVENT_TYPE_AUDIT,
+                    [self, inst],
+                    'reschedule failed, affinity unsatisfiable',
+                    extra={'message': str(e)})
+                raise AbortInstanceStart(
+                    self, 'No node satisfies the requested affinity '
+                    'constraints: %s' % e)
+
             add_event_multi(
                 EVENT_TYPE_AUDIT,
                 [self, inst],

--- a/shakenfist/scheduler.py
+++ b/shakenfist/scheduler.py
@@ -118,6 +118,45 @@ def _hard_affinity_constraints(requested_affinity):
             spec[instance.Instance.AFFINITY_REQUIRE_WITHOUT])
 
 
+def _affinity_neighbour_skip(inst, instance_uuid, i):
+    """Should this co-located instance be ignored when matching tags?
+
+    Returns the audit record describing why it was skipped, or None if
+    it is a neighbour whose tags count. Both the hard require_* filter
+    and the soft scoring loop call this rather than restating the four
+    conditions, because a filter and a scorer which disagreed about
+    what counts as a neighbour would place an instance somewhere its
+    own audit trail says it should not be (coding_rules.md, "Never
+    restate a visibility predicate").
+
+    The namespace skip is the trust boundary: crossing it would let a
+    caller learn what another tenant is running by watching where
+    their own instances refuse to land.
+    """
+    if not i:
+        return {
+            'instance_uuid': instance_uuid,
+            'skipped': 'instance row not found',
+        }
+    if i.uuid == inst.uuid:
+        return {
+            'instance_uuid': instance_uuid,
+            'skipped': 'self',
+        }
+    if not i.tags:
+        return {
+            'instance_uuid': instance_uuid,
+            'skipped': 'no tags',
+        }
+    if i.namespace != inst.namespace:
+        return {
+            'instance_uuid': instance_uuid,
+            'skipped': 'different namespace',
+            'namespace': i.namespace,
+        }
+    return None
+
+
 def _hard_affinity_description(require_with, require_without):
     """Human readable text naming the constraints, for the 409 body."""
     parts = []
@@ -217,26 +256,26 @@ class Scheduler:
         """Does this node satisfy the instance's hard affinity constraints?
 
         Constraints match the tags of *instances already placed on the
-        node*, within the requesting namespace only, exactly as the
-        scorer does. Shaken Fist has no node capability tags, so there
-        is nothing else they could match. The namespace scope is
-        inherited rather than chosen: crossing it would let a caller
-        learn what another tenant is running by watching where their
-        own instances refuse to land, which is why require_without_tag
-        is a within-namespace constraint and not an isolation
-        primitive.
+        node*, exactly as the scorer does -- which here means calling
+        the same _affinity_neighbour_skip() rather than restating its
+        four conditions, so a filter and a scorer cannot disagree about
+        what counts as a neighbour. Shaken Fist has no node capability
+        tags, so there is nothing else they could match. The namespace
+        scope is inherited rather than chosen: crossing it would let a
+        caller learn what another tenant is running by watching where
+        their own instances refuse to land, which is why
+        require_without_tag is a within-namespace constraint and not an
+        isolation primitive.
         """
         node_instances = self._placed_instances(node, memo)
         if node_instances is None:
             return False, {'reason': 'node row not found'}
 
         present = set()
-        for _, i in node_instances:
-            if i is None or i.uuid == inst.uuid:
+        for instance_uuid, i in node_instances:
+            if _affinity_neighbour_skip(inst, instance_uuid, i):
                 continue
-            if i.namespace != inst.namespace:
-                continue
-            for tag in (i.tags or []):
+            for tag in i.tags:
                 present.add(tag)
 
         missing = [t for t in require_with if t not in present]
@@ -705,30 +744,9 @@ class Scheduler:
                     continue
 
                 for instance_uuid, i in node_instances:
-                    if not i:
-                        considered.append({
-                            'instance_uuid': instance_uuid,
-                            'skipped': 'instance row not found',
-                        })
-                        continue
-                    if i.uuid == inst.uuid:
-                        considered.append({
-                            'instance_uuid': instance_uuid,
-                            'skipped': 'self',
-                        })
-                        continue
-                    if not i.tags:
-                        considered.append({
-                            'instance_uuid': instance_uuid,
-                            'skipped': 'no tags',
-                        })
-                        continue
-                    if i.namespace != inst.namespace:
-                        considered.append({
-                            'instance_uuid': instance_uuid,
-                            'skipped': 'different namespace',
-                            'namespace': i.namespace,
-                        })
+                    skipped = _affinity_neighbour_skip(inst, instance_uuid, i)
+                    if skipped:
+                        considered.append(skipped)
                         continue
 
                     # Count proportional, not set membership: a node

--- a/shakenfist/scheduler.py
+++ b/shakenfist/scheduler.py
@@ -82,6 +82,49 @@ def get_active_node_metrics():
     return metrics
 
 
+def _binary_affinity_spec(requested_affinity):
+    """The binary constraints in a spec, or None if it is the weighted form.
+
+    The two shapes live under one metadata key and are told apart by
+    their keys. Anything the validator would have refused is treated
+    here as "not the binary form" rather than raising: the scheduler
+    reads specs which were validated when they were accepted, and a
+    spec which predates a validation rule should degrade to the old
+    behaviour rather than making an instance unschedulable.
+    """
+    if not isinstance(requested_affinity, dict):
+        return None
+    if not set(requested_affinity) & set(instance.Instance.AFFINITY_BINARY_KEYS):
+        return None
+
+    spec = {}
+    for k in instance.Instance.AFFINITY_BINARY_KEYS:
+        v = requested_affinity.get(k)
+        if not isinstance(v, list):
+            v = []
+        spec[k] = [t for t in v if isinstance(t, str) and t]
+    return spec
+
+
+def _hard_affinity_constraints(requested_affinity):
+    """The (require_with, require_without) tag lists for a spec."""
+    spec = _binary_affinity_spec(requested_affinity)
+    if spec is None:
+        return [], []
+    return (spec[instance.Instance.AFFINITY_REQUIRE_WITH],
+            spec[instance.Instance.AFFINITY_REQUIRE_WITHOUT])
+
+
+def _hard_affinity_description(require_with, require_without):
+    """Human readable text naming the constraints, for the 409 body."""
+    parts = []
+    if require_with:
+        parts.append('require_with_tag=%s' % sorted(require_with))
+    if require_without:
+        parts.append('require_without_tag=%s' % sorted(require_without))
+    return ', '.join(parts)
+
+
 class Scheduler:
     def __init__(self):
         # This UUID doesn't really mean much, except as a way of tracing the
@@ -165,6 +208,49 @@ class Scheduler:
         """
         return {row['node_uuid']: row
                 for row in mariadb.get_scheduler_node_capacity()}
+
+    def _satisfies_hard_affinity(self, inst, node, memo,
+                                 require_with, require_without):
+        """Does this node satisfy the instance's hard affinity constraints?
+
+        Constraints match the tags of *instances already placed on the
+        node*, within the requesting namespace only, exactly as the
+        scorer does. Shaken Fist has no node capability tags, so there
+        is nothing else they could match. The namespace scope is
+        inherited rather than chosen: crossing it would let a caller
+        learn what another tenant is running by watching where their
+        own instances refuse to land, which is why require_without_tag
+        is a within-namespace constraint and not an isolation
+        primitive.
+        """
+        node_instances = self._placed_instances(node, memo)
+        if node_instances is None:
+            return False, {'reason': 'node row not found'}
+
+        present = set()
+        for _, i in node_instances:
+            if i is None or i.uuid == inst.uuid:
+                continue
+            if i.namespace != inst.namespace:
+                continue
+            for tag in (i.tags or []):
+                present.add(tag)
+
+        missing = [t for t in require_with if t not in present]
+        if missing:
+            return False, {
+                'reason': 'no co-located instance carries a required tag',
+                'require_with_tag': missing,
+            }
+
+        excluded = [t for t in require_without if t in present]
+        if excluded:
+            return False, {
+                'reason': 'a co-located instance carries an excluded tag',
+                'require_without_tag': excluded,
+            }
+
+        return True, None
 
     def _placed_instances(self, node, memo):
         """The instances placed on a node, as (uuid, Instance or None) pairs.
@@ -378,7 +464,22 @@ class Scheduler:
         return True, None
 
     def _log_and_raise_on_error(
-            self, related_objects, stage, candidates, dropped=None):
+            self, related_objects, stage, candidates, dropped=None,
+            exception_class=exceptions.LowResourceException,
+            detail=None):
+        """Publish a filter stage's outcome, and raise if it emptied the set.
+
+        exception_class is defaulted so that every pre-existing caller
+        is unchanged. The hard affinity stage passes
+        AffinityConstraintUnsatisfiable, because "no node carries the
+        tag you required" is a conflict with the state of the cluster
+        and not a shortage of resources, and the create path answers
+        the two with different status codes.
+
+        detail is appended to the raised message. The message is built
+        here rather than by the caller, so a stage which wants to name
+        the constraint it refused on has to hand that text in.
+        """
         extra = {'candidates': candidates}
         if dropped:
             extra['dropped'] = dropped
@@ -388,8 +489,10 @@ class Scheduler:
                 EVENT_TYPE_AUDIT, related_objects,
                 f'schedule has no candidates at stage {stage}, aborting',
                 extra=extra)
-            raise exceptions.LowResourceException(
-                f'No nodes remaining at scheduling stage {stage}')
+            message = f'No nodes remaining at scheduling stage {stage}'
+            if detail:
+                message = f'{message}: {detail}'
+            raise exception_class(message)
 
         add_event_multi(
             EVENT_TYPE_AUDIT, related_objects,
@@ -526,6 +629,41 @@ class Scheduler:
                 related_objects, 'sufficient_free_disk', candidates,
                 dropped=dropped)
 
+            # Each candidate's placements are read once and memoised, so
+            # a node considered twice is only fetched once. The memo is
+            # shared by the hard constraint stage below and the scorer
+            # after it, so a create which uses both pays for one read.
+            placements = {}
+
+            requested_affinity = inst.affinity
+            require_with, require_without = _hard_affinity_constraints(
+                requested_affinity)
+
+            # Hard affinity constraints are admission, not ranking: a node
+            # which does not satisfy them cannot host the instance at all,
+            # so they filter here rather than contributing to a score.
+            #
+            # This stage returns without touching the placements memo when
+            # no hard constraint was requested. That matters because it
+            # runs before the load shedding filters have pruned anything,
+            # so populating the memo here would read placements for the
+            # full candidate set on every create -- including the great
+            # majority which request no affinity at all.
+            if require_with or require_without:
+                dropped = {}
+                for c in list(candidates):
+                    ok, reason = self._satisfies_hard_affinity(
+                        inst, c, placements, require_with, require_without)
+                    if not ok:
+                        dropped[c] = reason
+                        candidates.remove(c)
+                self._log_and_raise_on_error(
+                    related_objects, 'affinity_constraints', candidates,
+                    dropped=dropped,
+                    exception_class=exceptions.AffinityConstraintUnsatisfiable,
+                    detail=_hard_affinity_description(
+                        require_with, require_without))
+
             # Filter by affinity, if any has been specified. This runs on the
             # set of nodes which can actually fit the instance, but before the
             # queue depth and disk bandwidth filters below, which describe how
@@ -534,11 +672,8 @@ class Scheduler:
             # breakdown so that incorrect placement decisions (e.g. a tagged
             # neighbour being invisible) can be diagnosed from audit events.
             by_affinity = defaultdict(list)
-            requested_affinity = inst.affinity
             affinity_detail = {}
-            # Each candidate's placements are read once and memoised, so
-            # a node considered twice in this pass is only fetched once.
-            placements = {}
+            binary_spec = _binary_affinity_spec(requested_affinity)
 
             for c in list(candidates):
                 node_instances = self._placed_instances(c, placements)
@@ -581,10 +716,30 @@ class Scheduler:
 
                     matched = {}
                     contribution = 0
-                    for tag, val in requested_affinity.items():
-                        if tag in i.tags:
-                            matched[tag] = int(val)
-                            contribution += int(val)
+                    if binary_spec is not None:
+                        # Count proportional, not set membership: a node
+                        # carrying five instances of a group really is
+                        # more "with the group" than one carrying a
+                        # single instance, and the same in reverse for
+                        # the avoid direction. Note the score is a sum
+                        # across neighbours *and* across tags, so a
+                        # prefer_without_tag match can be outweighed by
+                        # neighbour count on the other axis.
+                        for tag in binary_spec[
+                                instance.Instance.AFFINITY_PREFER_WITH]:
+                            if tag in i.tags:
+                                matched[tag] = matched.get(tag, 0) + 1
+                                contribution += 1
+                        for tag in binary_spec[
+                                instance.Instance.AFFINITY_PREFER_WITHOUT]:
+                            if tag in i.tags:
+                                matched[tag] = matched.get(tag, 0) - 1
+                                contribution -= 1
+                    else:
+                        for tag, val in requested_affinity.items():
+                            if tag in i.tags:
+                                matched[tag] = int(val)
+                                contribution += int(val)
                     considered.append({
                         'instance_uuid': instance_uuid,
                         'tags': list(i.tags),

--- a/shakenfist/scheduler.py
+++ b/shakenfist/scheduler.py
@@ -83,19 +83,24 @@ def get_active_node_metrics():
 
 
 def _binary_affinity_spec(requested_affinity):
-    """The binary constraints in a spec, or None if it is the weighted form.
+    """Any affinity specification, as the binary form.
 
     The two shapes live under one metadata key and are told apart by
-    their keys. Anything the validator would have refused is treated
-    here as "not the binary form" rather than raising: the scheduler
-    reads specs which were validated when they were accepted, and a
-    spec which predates a validation rule should degrade to the old
-    behaviour rather than making an instance unschedulable.
+    their keys. A weighted specification is mapped here, at the point
+    the scheduler reads it, so that there is exactly one scoring path
+    rather than two which can drift apart.
+
+    Anything the validator would have refused is dropped rather than
+    raising: the scheduler reads specifications which were validated
+    when they were accepted, and one which predates a validation rule
+    should place somewhere rather than making an instance
+    unschedulable.
     """
-    if not isinstance(requested_affinity, dict):
-        return None
+    if not isinstance(requested_affinity, dict) or not requested_affinity:
+        return instance.map_weighted_affinity({})
+
     if not set(requested_affinity) & set(instance.Instance.AFFINITY_BINARY_KEYS):
-        return None
+        return instance.map_weighted_affinity(requested_affinity)
 
     spec = {}
     for k in instance.Instance.AFFINITY_BINARY_KEYS:
@@ -109,8 +114,6 @@ def _binary_affinity_spec(requested_affinity):
 def _hard_affinity_constraints(requested_affinity):
     """The (require_with, require_without) tag lists for a spec."""
     spec = _binary_affinity_spec(requested_affinity)
-    if spec is None:
-        return [], []
     return (spec[instance.Instance.AFFINITY_REQUIRE_WITH],
             spec[instance.Instance.AFFINITY_REQUIRE_WITHOUT])
 
@@ -674,8 +677,22 @@ class Scheduler:
             by_affinity = defaultdict(list)
             affinity_detail = {}
             binary_spec = _binary_affinity_spec(requested_affinity)
+            scoring_tags = (
+                binary_spec[instance.Instance.AFFINITY_PREFER_WITH]
+                + binary_spec[instance.Instance.AFFINITY_PREFER_WITHOUT])
 
-            for c in list(candidates):
+            # A scorer with no tags to score cannot change the ordering,
+            # but the walk below reads every candidate's placements --
+            # one Node.from_db() plus one Instance.from_db() per placed
+            # instance -- so running it for the great majority of creates
+            # which request no affinity at all was pure cost. Skipping it
+            # reduces the measured database load rather than holding it
+            # flat. Everything downstream sees what it saw before: one
+            # tier, containing every candidate, scoring zero.
+            if not scoring_tags:
+                by_affinity[0] = list(candidates)
+
+            for c in (list(candidates) if scoring_tags else []):
                 node_instances = self._placed_instances(c, placements)
                 affinity = 0
                 considered = []
@@ -714,32 +731,29 @@ class Scheduler:
                         })
                         continue
 
+                    # Count proportional, not set membership: a node
+                    # carrying five instances of a group really is more
+                    # "with the group" than one carrying a single
+                    # instance, and the same in reverse for the avoid
+                    # direction. Note the score is a sum across
+                    # neighbours *and* across tags, so a
+                    # prefer_without_tag match can be outweighed by
+                    # neighbour count on the other axis.
+                    #
+                    # Weighted specifications reach here already mapped,
+                    # so there is one scoring path and not two.
                     matched = {}
                     contribution = 0
-                    if binary_spec is not None:
-                        # Count proportional, not set membership: a node
-                        # carrying five instances of a group really is
-                        # more "with the group" than one carrying a
-                        # single instance, and the same in reverse for
-                        # the avoid direction. Note the score is a sum
-                        # across neighbours *and* across tags, so a
-                        # prefer_without_tag match can be outweighed by
-                        # neighbour count on the other axis.
-                        for tag in binary_spec[
-                                instance.Instance.AFFINITY_PREFER_WITH]:
-                            if tag in i.tags:
-                                matched[tag] = matched.get(tag, 0) + 1
-                                contribution += 1
-                        for tag in binary_spec[
-                                instance.Instance.AFFINITY_PREFER_WITHOUT]:
-                            if tag in i.tags:
-                                matched[tag] = matched.get(tag, 0) - 1
-                                contribution -= 1
-                    else:
-                        for tag, val in requested_affinity.items():
-                            if tag in i.tags:
-                                matched[tag] = int(val)
-                                contribution += int(val)
+                    for tag in binary_spec[
+                            instance.Instance.AFFINITY_PREFER_WITH]:
+                        if tag in i.tags:
+                            matched[tag] = matched.get(tag, 0) + 1
+                            contribution += 1
+                    for tag in binary_spec[
+                            instance.Instance.AFFINITY_PREFER_WITHOUT]:
+                        if tag in i.tags:
+                            matched[tag] = matched.get(tag, 0) - 1
+                            contribution -= 1
                     considered.append({
                         'instance_uuid': instance_uuid,
                         'tags': list(i.tags),

--- a/shakenfist/tests/external_api/test_instance_metadata_validation.py
+++ b/shakenfist/tests/external_api/test_instance_metadata_validation.py
@@ -66,6 +66,12 @@ class ValidateInstanceMetadataTestCase(base.ShakenFistTestCase):
         # silently.
         self._assert_refused({'first-node': float('nan')}, 'should be integers')
 
+    def test_boolean_valued_entry_is_refused(self):
+        # A deliberate behaviour change: int(True) is 1, so this used to be
+        # accepted as a weight of one.
+        self._assert_refused({'first-node': True}, 'not booleans')
+        self._assert_refused({'first-node': False}, 'not booleans')
+
     def test_numeric_string_entry_is_still_accepted(self):
         # int('3') succeeds, so this is accepted today. Asserted so that a
         # later tightening of the check to a type test is a deliberate

--- a/shakenfist/tests/external_api/test_instance_metadata_validation.py
+++ b/shakenfist/tests/external_api/test_instance_metadata_validation.py
@@ -1,0 +1,102 @@
+# Copyright 2019 Michael Still and contributors
+
+"""Validation of the reserved instance metadata keys.
+
+``_validate_instance_metadata()`` is the only place a caller is told
+they got the ``affinity`` key wrong, and it is shared by instance
+create and both metadata endpoints, so a value it fails to refuse
+becomes a 500 on three public paths rather than one.
+
+The affinity cases below are all about the *inner* per-tag value.
+The outer cases already work -- a non-dict is refused by the
+isinstance check above the loop, and None by the falsiness check at
+the top of the function -- and stating that here is the point: the
+hole was one level down from where it looked.
+"""
+
+from shakenfist.external_api.instance import _validate_instance_metadata
+from shakenfist.instance import Instance
+from shakenfist.tests import base
+
+
+AFFINITY = Instance.METADATA_KEY_AFFINITY
+TAGS = Instance.METADATA_KEY_TAGS
+
+
+class ValidateInstanceMetadataTestCase(base.ShakenFistTestCase):
+    def _assert_refused(self, value, expected_fragment):
+        resp = _validate_instance_metadata(AFFINITY, value)
+        self.assertIsNotNone(
+            resp, 'value %r was accepted, expected a 400' % (value,))
+        self.assertEqual(400, resp.status_code)
+        self.assertIn(expected_fragment, resp.get_data(as_text=True))
+
+    def test_valid_weighted_spec_is_accepted(self):
+        self.assertIsNone(
+            _validate_instance_metadata(AFFINITY, {'first-node': 100}))
+        self.assertIsNone(
+            _validate_instance_metadata(AFFINITY, {'db': -50, 'web': 1}))
+
+    def test_list_valued_entry_is_refused(self):
+        # int(['a']) raises TypeError, which the original handler did not
+        # catch. This is also the shape the binary affinity model uses, so
+        # a caller guessing the new syntax early hits exactly this.
+        self._assert_refused({'first-node': ['a']}, 'should be integers')
+
+    def test_dict_valued_entry_is_refused(self):
+        self._assert_refused({'first-node': {'x': 1}}, 'should be integers')
+
+    def test_none_valued_entry_is_refused(self):
+        # Note this is the *inner* value being None. An outer None is
+        # refused by the falsiness check and never reaches the loop.
+        self._assert_refused({'first-node': None}, 'should be integers')
+
+    def test_infinite_valued_entry_is_refused(self):
+        # int(float('inf')) raises OverflowError, not TypeError or
+        # ValueError. json.loads() accepts the bare Infinity literal by
+        # default, so flask hands this straight through from a request
+        # body and it is reachable without a client doing anything odd.
+        self._assert_refused({'first-node': float('inf')}, 'should be integers')
+        self._assert_refused({'first-node': float('-inf')}, 'should be integers')
+
+    def test_nan_valued_entry_is_refused(self):
+        # NaN was already handled -- int(float('nan')) raises ValueError --
+        # but it arrives by the same route as Infinity, so it is asserted
+        # here so a later narrowing of the except clause cannot drop it
+        # silently.
+        self._assert_refused({'first-node': float('nan')}, 'should be integers')
+
+    def test_numeric_string_entry_is_still_accepted(self):
+        # int('3') succeeds, so this is accepted today. Asserted so that a
+        # later tightening of the check to a type test is a deliberate
+        # decision with a failing test behind it, rather than an unnoticed
+        # compatibility break.
+        self.assertIsNone(
+            _validate_instance_metadata(AFFINITY, {'first-node': '3'}))
+
+    def test_non_numeric_string_entry_is_refused(self):
+        self._assert_refused({'first-node': 'banana'}, 'should be integers')
+
+    def test_outer_affinity_value_cases_are_unchanged(self):
+        # The two outer refusals this fix is not about, asserted so that
+        # widening the inner handler cannot be mistaken for having moved
+        # them.
+        resp = _validate_instance_metadata(AFFINITY, ['a'])
+        self.assertEqual(400, resp.status_code)
+        self.assertIn('valid JSON dictionary', resp.get_data(as_text=True))
+
+        resp = _validate_instance_metadata(AFFINITY, None)
+        self.assertEqual(400, resp.status_code)
+        self.assertIn('no value specified', resp.get_data(as_text=True))
+
+    def test_tags_key_is_unaffected(self):
+        self.assertIsNone(_validate_instance_metadata(TAGS, ['a', 'b']))
+
+        resp = _validate_instance_metadata(TAGS, {'a': 1})
+        self.assertEqual(400, resp.status_code)
+        self.assertIn('should be a JSON list', resp.get_data(as_text=True))
+
+    def test_no_key_is_refused(self):
+        resp = _validate_instance_metadata('', 'value')
+        self.assertEqual(400, resp.status_code)
+        self.assertIn('no key specified', resp.get_data(as_text=True))

--- a/shakenfist/tests/external_api/test_instance_metadata_validation.py
+++ b/shakenfist/tests/external_api/test_instance_metadata_validation.py
@@ -106,3 +106,71 @@ class ValidateInstanceMetadataTestCase(base.ShakenFistTestCase):
         resp = _validate_instance_metadata('', 'value')
         self.assertEqual(400, resp.status_code)
         self.assertIn('no key specified', resp.get_data(as_text=True))
+
+
+class ValidateBinaryAffinityTestCase(base.ShakenFistTestCase):
+    """The binary affinity value shape.
+
+    The binary model is a second value shape under the same ``affinity``
+    key rather than a key of its own, so that a caller cannot supply
+    both models at once and mean nothing coherent. The two are told
+    apart by type: a dict of integers is the weighted form, a dict of
+    the four reserved names mapping to lists is the binary one.
+    """
+
+    def _assert_refused(self, value, expected_fragment):
+        resp = _validate_instance_metadata(AFFINITY, value)
+        self.assertIsNotNone(
+            resp, 'value %r was accepted, expected a 400' % (value,))
+        self.assertEqual(400, resp.status_code)
+        self.assertIn(expected_fragment, resp.get_data(as_text=True))
+
+    def test_all_four_constraints_are_accepted(self):
+        self.assertIsNone(_validate_instance_metadata(AFFINITY, {
+            'require_with_tag': ['web'],
+            'require_without_tag': ['batch'],
+            'prefer_with_tag': ['cache'],
+            'prefer_without_tag': ['noisy'],
+        }))
+
+    def test_a_subset_of_constraints_is_accepted(self):
+        self.assertIsNone(_validate_instance_metadata(
+            AFFINITY, {'require_with_tag': ['web']}))
+
+    def test_empty_tag_lists_are_accepted(self):
+        self.assertIsNone(_validate_instance_metadata(
+            AFFINITY, {'prefer_with_tag': []}))
+
+    def test_non_list_constraint_value_is_refused(self):
+        self._assert_refused(
+            {'require_with_tag': 'web'}, 'should be a JSON list of tags')
+        self._assert_refused(
+            {'require_with_tag': {'a': 1}}, 'should be a JSON list of tags')
+
+    def test_non_string_tag_is_refused(self):
+        self._assert_refused(
+            {'require_with_tag': [1]}, 'non-empty tag names')
+        self._assert_refused(
+            {'require_with_tag': [None]}, 'non-empty tag names')
+        self._assert_refused(
+            {'require_with_tag': ['']}, 'non-empty tag names')
+        # isinstance(True, str) is false, so a boolean is caught by the
+        # tag name check here rather than needing its own clause.
+        self._assert_refused(
+            {'require_with_tag': [True]}, 'non-empty tag names')
+
+    def test_mixing_the_two_forms_is_refused(self):
+        # Either way of resolving this silently discards half of what the
+        # caller asked for, so it is refused rather than guessed at.
+        self._assert_refused(
+            {'require_with_tag': ['web'], 'socialite': 100}, 'cannot be mixed')
+
+    def test_a_misspelled_constraint_alone_reads_as_the_weighted_form(self):
+        # 'require_with_tags' is not a reserved name, so this is not the
+        # binary shape at all and falls through to the weighted
+        # validation -- which refuses it, because a list is not an
+        # integer. The caller still gets a 400; this asserts which one,
+        # so that the shape discrimination is pinned rather than
+        # incidental.
+        self._assert_refused(
+            {'require_with_tags': ['web']}, 'should be integers')

--- a/shakenfist/tests/external_api/test_instance_metadata_validation.py
+++ b/shakenfist/tests/external_api/test_instance_metadata_validation.py
@@ -14,7 +14,12 @@ the top of the function -- and stating that here is the point: the
 hole was one level down from where it looked.
 """
 
+from unittest import mock
+
+from shakenfist.external_api.instance import AFFINITY_DEPRECATION_MESSAGE
+from shakenfist.external_api.instance import _affinity_spec_is_weighted
 from shakenfist.external_api.instance import _validate_instance_metadata
+from shakenfist.external_api.instance import _warn_if_weighted_affinity
 from shakenfist.instance import Instance
 from shakenfist.tests import base
 
@@ -174,3 +179,56 @@ class ValidateBinaryAffinityTestCase(base.ShakenFistTestCase):
         # incidental.
         self._assert_refused(
             {'require_with_tags': ['web']}, 'should be integers')
+
+
+class WeightedAffinityDeprecationTestCase(base.ShakenFistTestCase):
+    """The deprecation warning for the weighted affinity form.
+
+    Emitted where a specification is accepted rather than where it is
+    consumed, so it reaches the caller at the moment they submit the
+    deprecated form rather than at some later reschedule.
+
+    The site matters and is easy to get wrong. It cannot live in
+    _validate_instance_metadata: that is module level with a
+    (key, value) signature and, on the create path, runs before
+    Instance.new(), so there would be no object to hang an event on and
+    the create path -- the one a weighted caller is most likely using --
+    would emit nothing at all.
+    """
+
+    def _emitted(self, key, value):
+        inst = mock.MagicMock()
+        _warn_if_weighted_affinity(inst, key, value)
+        return [c for c in inst.add_event.call_args_list
+                if c[0][1] == AFFINITY_DEPRECATION_MESSAGE]
+
+    def test_weighted_spec_warns(self):
+        emitted = self._emitted(AFFINITY, {'first-node': 100})
+        self.assertEqual(1, len(emitted))
+        # The warning has to say what the spec was mapped to, or an
+        # operator cannot act on it without rederiving the mapping.
+        extra = emitted[0][1]['extra']
+        self.assertEqual({'first-node': 100}, extra['affinity'])
+        self.assertEqual(['first-node'], extra['mapped_to']['prefer_with_tag'])
+
+    def test_binary_spec_does_not_warn(self):
+        self.assertEqual(
+            [], self._emitted(AFFINITY, {'prefer_with_tag': ['first-node']}))
+
+    def test_another_metadata_key_does_not_warn(self):
+        # 'tags' values are lists, and a list is not a weighted affinity
+        # spec, but the key check should stop it before the shape check
+        # ever runs.
+        self.assertEqual([], self._emitted(TAGS, ['first-node']))
+
+    def test_empty_affinity_does_not_warn(self):
+        self.assertEqual([], self._emitted(AFFINITY, {}))
+        self.assertEqual([], self._emitted(AFFINITY, None))
+
+    def test_the_predicate_matches_the_validator(self):
+        # The shape test is shared so that the validator and the warning
+        # cannot disagree about which form a caller sent.
+        self.assertTrue(_affinity_spec_is_weighted({'a': 1}))
+        self.assertFalse(_affinity_spec_is_weighted({'prefer_with_tag': ['a']}))
+        self.assertFalse(_affinity_spec_is_weighted({}))
+        self.assertFalse(_affinity_spec_is_weighted(['a']))

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -858,6 +858,65 @@ class ExternalApiCreateAdmissionWalkTestCase(ExternalApiTestCase):
         self.assertEqual(500, resp.status_code)
 
 
+class ExternalApiAffinityRefusalTestCase(
+        ExternalApiCreateAdmissionWalkTestCase):
+    """The create path answers 409 for an unsatisfiable hard affinity.
+
+    ``AffinityConstraintUnsatisfiable`` is a *subclass* of
+    ``LowResourceException``, chosen so that preflight's redirect keeps
+    working unchanged. Python matches ``except`` clauses in source
+    order, so the only thing standing between a 409 and a 507 is that
+    the subclass clause sits above the parent one in
+    ``external_api/instance.py``. That is invisible to a scheduler-level
+    test: one asserting the exception type passes identically whichever
+    clause caught it. These tests are here because this is the only
+    level at which the ordering is observable.
+    """
+
+    def _raises(self, exc):
+        fake = mock.MagicMock()
+        fake.find_candidates.side_effect = exc
+        return mock.patch(
+            'shakenfist.external_api.instance.SCHEDULER', fake)
+
+    def test_unsatisfiable_affinity_is_a_409(self):
+        constraint = ('no node satisfies require_with_tag=[\'database\'] '
+                      'at stage affinity_constraints')
+
+        with self._raises(
+                exceptions.AffinityConstraintUnsatisfiable(constraint)):
+            resp = self._post('affinity-nowhere')
+
+        self.assertEqual(409, resp.status_code, resp.get_json())
+        # The body has to name the constraint, or a 409 is no more
+        # actionable than the 507 it replaced.
+        self.assertIn('require_with_tag', resp.get_json()['error'])
+        self.assertIn('affinity_constraints', resp.get_json()['error'])
+
+    def test_a_real_capacity_refusal_is_still_a_507(self):
+        # The other half of the ordering. Reversing the two clauses
+        # turns every 409 into a 507 and this test keeps passing, so it
+        # is the pair that pins the behaviour, not either one alone.
+        with self._raises(exceptions.LowResourceException('cluster is full')):
+            resp = self._post('really-full')
+
+        self.assertEqual(507, resp.status_code, resp.get_json())
+        self.assertIn('cluster is full', resp.get_json()['error'])
+
+    def test_the_refused_instance_is_deleted(self):
+        # The instance exists only because it is created before
+        # scheduling runs. A 409 that left it behind would leak one per
+        # refused create, and the 507 path has always deleted.
+        with mock.patch('shakenfist.instance.Instance.'
+                        'enqueue_delete_due_error') as delete:
+            with self._raises(
+                    exceptions.AffinityConstraintUnsatisfiable('nope')):
+                resp = self._post('affinity-cleanup')
+
+        self.assertEqual(409, resp.status_code, resp.get_json())
+        delete.assert_called_once_with('scheduling failed')
+
+
 class ExternalApiExceptionRecordingTestCase(ExternalApiTestCase):
     """Test that exceptions during JSON serialization are recorded."""
 

--- a/shakenfist/tests/test_node_inst_netdesc_op_preflight.py
+++ b/shakenfist/tests/test_node_inst_netdesc_op_preflight.py
@@ -271,6 +271,106 @@ class PreflightRedirectTestCase(base.ShakenFistTestCase):
         mock_enqueue.assert_not_called()
         self.assertEqual([], inst.disk_fetch_calls)
 
+    def _redirect_raising(self, inst, exc, candidates=()):
+        """As _redirect(), but choosing what the local placement raised.
+
+        The three aborts below are reached after the ``except
+        LowResourceException as e:`` suite has exited, so they cannot
+        read ``e`` -- Python deletes the ``as`` target when the suite
+        ends (PEP 3110), and reading it there is a NameError. They test
+        an ``affinity_failure`` flag captured inside the suite instead.
+        That flag is only exercised in the queue daemon, which runs
+        under cluster CI and not on a pull request, so these tests are
+        the only thing between a mistake in it and the merge queue.
+        """
+        op = self._make_op()
+        fake_scheduler = mock.MagicMock()
+        fake_scheduler.find_candidates.side_effect = [
+            exc, list(candidates)]
+        fake_scheduler.metrics = {c: {} for c in candidates}
+
+        with mock.patch(
+                'shakenfist.operations.node_inst_netdesc_op.scheduler.'
+                'Scheduler', return_value=fake_scheduler):
+            with mock.patch(
+                    'shakenfist.operations.node_inst_netdesc_op.schema.'
+                    'create_and_enqueue'):
+                with mock.patch(
+                        'shakenfist.operations.node_inst_netdesc_op.'
+                        'add_event_multi'):
+                    try:
+                        op._instance_preflight(inst)
+                        return None
+                    except AbortInstanceStart as e:
+                        return e
+
+    def test_attempt_limit_abort_names_affinity(self):
+        # The ":166" guard. Without the flag this abort says "Too many
+        # start attempts", which reads as a busy cluster to an operator
+        # whose constraint simply cannot be met anywhere.
+        inst = FakeInstance('created')
+        inst.placement = {'placement_attempts': 4}
+
+        raised = self._redirect_raising(
+            inst,
+            exceptions.AffinityConstraintUnsatisfiable(
+                'no node carries require_with_tag=[\'database\']'))
+
+        self.assertIsNotNone(raised)
+        self.assertIn('affinity constraints', str(raised))
+        self.assertIn('require_with_tag', str(raised))
+
+    def test_attempt_limit_abort_still_says_attempts_for_capacity(self):
+        inst = FakeInstance('created')
+        inst.placement = {'placement_attempts': 4}
+
+        raised = self._redirect_raising(
+            inst, exceptions.LowResourceException('full here'))
+
+        self.assertIsNotNone(raised)
+        self.assertIn('Too many start attempts', str(raised))
+        self.assertNotIn('affinity', str(raised))
+
+    def test_requested_placement_abort_names_affinity(self):
+        # The ":170" guard. An operator who pinned a node is otherwise
+        # told it lacks resources when what it lacks is a matching tag.
+        inst = FakeInstance('created')
+        inst.requested_placement = str(uuid4())
+
+        raised = self._redirect_raising(
+            inst,
+            exceptions.AffinityConstraintUnsatisfiable(
+                'node carries require_without_tag=[\'batch\']'))
+
+        self.assertIsNotNone(raised)
+        self.assertIn('affinity constraints', str(raised))
+        self.assertNotIn('lacks resources', str(raised))
+
+    def test_requested_placement_abort_still_says_resources_for_capacity(self):
+        inst = FakeInstance('created')
+        inst.requested_placement = str(uuid4())
+
+        raised = self._redirect_raising(
+            inst, exceptions.LowResourceException('full here'))
+
+        self.assertIsNotNone(raised)
+        self.assertIn('Requested node lacks resources', str(raised))
+
+    def test_the_redirect_itself_is_unchanged_by_the_subclass(self):
+        # AffinityConstraintUnsatisfiable subclasses
+        # LowResourceException precisely so this keeps working: another
+        # node may satisfy a constraint this one does not, so preflight
+        # must still redirect rather than escaping as a traceback.
+        inst = FakeInstance('created')
+        target_node = str(uuid4())
+
+        raised = self._redirect_raising(
+            inst, exceptions.AffinityConstraintUnsatisfiable('not here'),
+            candidates=[target_node])
+
+        self.assertIsNone(raised)
+        self.assertEqual([target_node], inst.placed_on)
+
     def _dispatch_failing_preflight(self, op):
         inst = FakeInstance('created')
         with mock.patch(

--- a/shakenfist/tests/test_node_inst_netdesc_op_preflight.py
+++ b/shakenfist/tests/test_node_inst_netdesc_op_preflight.py
@@ -271,7 +271,7 @@ class PreflightRedirectTestCase(base.ShakenFistTestCase):
         mock_enqueue.assert_not_called()
         self.assertEqual([], inst.disk_fetch_calls)
 
-    def _redirect_raising(self, inst, exc, candidates=()):
+    def _redirect_raising(self, inst, exc, candidates=(), second=None):
         """As _redirect(), but choosing what the local placement raised.
 
         The three aborts below are reached after the ``except
@@ -286,7 +286,7 @@ class PreflightRedirectTestCase(base.ShakenFistTestCase):
         op = self._make_op()
         fake_scheduler = mock.MagicMock()
         fake_scheduler.find_candidates.side_effect = [
-            exc, list(candidates)]
+            exc, second if second is not None else list(candidates)]
         fake_scheduler.metrics = {c: {} for c in candidates}
 
         with mock.patch(
@@ -355,6 +355,36 @@ class PreflightRedirectTestCase(base.ShakenFistTestCase):
 
         self.assertIsNotNone(raised)
         self.assertIn('Requested node lacks resources', str(raised))
+
+    def test_exhausted_redirect_abort_names_affinity(self):
+        # The third abort site, and the only one of the three inside an
+        # except suite -- so it tests the exception directly rather than
+        # a carried flag. It is reached when the redirect walks every
+        # other node and the last find_candidates() refuses them all,
+        # which for a require_with_tag naming a tag nothing in the
+        # namespace carries is every node, always.
+        inst = FakeInstance('created')
+
+        raised = self._redirect_raising(
+            inst,
+            exceptions.AffinityConstraintUnsatisfiable('first'),
+            second=exceptions.AffinityConstraintUnsatisfiable(
+                'no node carries require_with_tag=[\'database\']'))
+
+        self.assertIsNotNone(raised)
+        self.assertIn('affinity constraints', str(raised))
+        self.assertNotIn('Unable to find suitable node', str(raised))
+
+    def test_exhausted_redirect_still_says_suitable_node_for_capacity(self):
+        inst = FakeInstance('created')
+
+        raised = self._redirect_raising(
+            inst, exceptions.LowResourceException('full here'),
+            second=exceptions.LowResourceException('all full'))
+
+        self.assertIsNotNone(raised)
+        self.assertIn('Unable to find suitable node', str(raised))
+        self.assertNotIn('affinity', str(raised))
 
     def test_the_redirect_itself_is_unchanged_by_the_subclass(self):
         # AffinityConstraintUnsatisfiable subclasses

--- a/shakenfist/tests/test_scheduler.py
+++ b/shakenfist/tests/test_scheduler.py
@@ -3,6 +3,7 @@ import time
 from unittest import mock
 
 from shakenfist import exceptions
+from shakenfist import instance
 from shakenfist import scheduler
 from shakenfist.config import SFConfig
 from shakenfist.constants import DISK_BUSY_PER_SECOND_METRIC
@@ -1544,5 +1545,97 @@ class BinaryAffinityTestCase(SchedulerTestCase):
             metadata={'affinity': {'require_with_tag': [],
                                    'prefer_with_tag': []}})
 
+        nodes = scheduler.Scheduler().find_candidates(inst)
+        self.assertSetEqual(self._all_hypervisor_uuids(), set(nodes))
+
+
+class WeightedAffinityMappingTestCase(SchedulerTestCase):
+    """The weighted form, mapped onto the binary one.
+
+    The weighted form stays working for one more release by being
+    mapped mechanically at the point the scheduler reads it, so there is
+    one scoring path rather than two which can drift apart.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.mock_mariadb.set_node_metrics_same()
+
+    def test_positive_maps_to_prefer_with(self):
+        self.assertEqual(
+            {'require_with_tag': [], 'require_without_tag': [],
+             'prefer_with_tag': ['a'], 'prefer_without_tag': []},
+            instance.map_weighted_affinity({'a': 100}))
+
+    def test_negative_maps_to_prefer_without(self):
+        self.assertEqual(
+            {'require_with_tag': [], 'require_without_tag': [],
+             'prefer_with_tag': [], 'prefer_without_tag': ['a']},
+            instance.map_weighted_affinity({'a': -100}))
+
+    def test_zero_maps_to_nothing(self):
+        # Zero already meant nothing: a zero contribution never changed
+        # a score, so mapping it to a preference would invent a request
+        # the caller did not make.
+        self.assertEqual(
+            {'require_with_tag': [], 'require_without_tag': [],
+             'prefer_with_tag': [], 'prefer_without_tag': []},
+            instance.map_weighted_affinity({'a': 0}))
+
+    def test_mixed_signs_map_to_both_lists(self):
+        mapped = instance.map_weighted_affinity({'a': 5, 'b': -5, 'c': 0})
+        self.assertEqual(['a'], mapped['prefer_with_tag'])
+        self.assertEqual(['b'], mapped['prefer_without_tag'])
+
+    def test_uniform_magnitude_preserves_ordering(self):
+        # With uniform magnitude M the weighted score is exactly M times
+        # the binary score for every candidate, so the ordering cannot
+        # differ. This is the real condition, and it is about magnitude
+        # rather than tag count -- every single-tag spec satisfies it,
+        # but so does any spec whose weights all share a magnitude.
+        self.mock_mariadb.create_instance(
+            'instance-1', place_on_node='node3', metadata={'tags': ['a']})
+        self.mock_mariadb.create_instance(
+            'instance-2', place_on_node='node2', metadata={'tags': ['b']})
+
+        weighted = self.mock_mariadb.create_instance(
+            'instance-3', metadata={'affinity': {'a': 50, 'b': -50}})
+        binary = self.mock_mariadb.create_instance(
+            'instance-4',
+            metadata={'affinity': {'prefer_with_tag': ['a'],
+                                   'prefer_without_tag': ['b']}})
+
+        self.assertEqual(
+            scheduler.Scheduler().find_candidates(weighted),
+            scheduler.Scheduler().find_candidates(binary))
+
+    def test_mixed_magnitudes_diverge_and_that_is_intended(self):
+        # {'a': 100, 'b': 1} maps to prefer_with_tag ['a', 'b'], so a
+        # node carrying only b ties with a node carrying only a, where
+        # the weighted form ranked them 1 against 100. F4 discards the
+        # magnitude deliberately, so this divergence is asserted rather
+        # than left as an unstated exception -- a test demanding
+        # identical ordering in every case would be a gate the mapping
+        # could only pass by not existing.
+        self.mock_mariadb.create_instance(
+            'instance-1', place_on_node='node3', metadata={'tags': ['a']})
+        self.mock_mariadb.create_instance(
+            'instance-2', place_on_node='node2', metadata={'tags': ['b']})
+
+        inst = self.mock_mariadb.create_instance(
+            'instance-3', metadata={'affinity': {'a': 100, 'b': 1}})
+
+        # Both nodes now score +1, so both are in the winning tier --
+        # where the unmapped weighted form would have preferred node3
+        # outright.
+        nodes = scheduler.Scheduler().find_candidates(inst)
+        self.assertSetEqual(
+            self._node_uuids_set('node2', 'node3'), set(nodes))
+
+    def test_no_affinity_still_places_anywhere(self):
+        # The scorer is skipped entirely when there is nothing to score,
+        # so this asserts the skip left the outcome unchanged: one tier,
+        # every candidate, rather than an empty tier and an IndexError.
+        inst = self.mock_mariadb.create_instance('instance-1')
         nodes = scheduler.Scheduler().find_candidates(inst)
         self.assertSetEqual(self._all_hypervisor_uuids(), set(nodes))

--- a/shakenfist/tests/test_scheduler.py
+++ b/shakenfist/tests/test_scheduler.py
@@ -1653,6 +1653,43 @@ class WeightedAffinityMappingTestCase(SchedulerTestCase):
         self.assertSetEqual(
             self._all_hypervisor_uuids(), set(extra['candidates']))
 
+    def test_a_binary_spec_does_not_reach_the_weighted_coercion(self):
+        # The scorer coerces weighted values with int(). This phase
+        # teaches the same metadata key to hold lists, so a binary
+        # specification reaching that coercion is a TypeError raised
+        # inside find_candidates() -- which the create path does not
+        # catch, making it a 500 on instance create: the failure class
+        # the validator fix exists to remove, one layer down.
+        inst = self.mock_mariadb.create_instance(
+            'instance-1',
+            metadata={'affinity': {'prefer_with_tag': ['a'],
+                                   'require_without_tag': ['b']}})
+
+        nodes = scheduler.Scheduler().find_candidates(inst)
+        self.assertSetEqual(self._all_hypervisor_uuids(), set(nodes))
+
+    def test_a_stored_spec_the_validator_would_refuse_still_places(self):
+        # Every instance whose affinity metadata was written before the
+        # validator fix landed was never validated at all, so the
+        # scheduler has to survive shapes the API now refuses. Skipping
+        # the value rather than raising is what keeps such an instance
+        # schedulable instead of permanently stuck -- a 500 here would
+        # be on both create and every later reschedule.
+        inst = self.mock_mariadb.create_instance(
+            'instance-1',
+            metadata={'affinity': {'a': ['not-an-int'], 'b': None,
+                                   'c': float('inf'), 'd': 5}})
+
+        with mock.patch('shakenfist.scheduler.add_event_multi') as events:
+            nodes = scheduler.Scheduler().find_candidates(inst)
+
+        self.assertSetEqual(self._all_hypervisor_uuids(), set(nodes))
+        # 'd' is the only coercible entry, so it is the only one which
+        # survives the mapping -- the rest are dropped, not guessed at.
+        published = [c for c in events.call_args_list
+                     if c[0][2] == 'schedule have highest affinity']
+        self.assertEqual(1, len(published), events.call_args_list)
+
     def test_a_weighted_spec_still_populates_affinity_detail(self):
         # The other edge of the short-circuit, and the one that fails
         # silently. The skip is keyed on the prefer_* lists, which are

--- a/shakenfist/tests/test_scheduler.py
+++ b/shakenfist/tests/test_scheduler.py
@@ -1336,3 +1336,213 @@ class AffinityVersusLoadSheddingTestCase(SchedulerTestCase):
         nodes = scheduler.Scheduler().find_candidates(inst)
         self.assertSetEqual(
             self._node_uuids_set('node2', 'node4'), set(nodes))
+
+
+class BinaryAffinityTestCase(SchedulerTestCase):
+    """The four binary affinity constraints.
+
+    require_* are admission: a node which does not satisfy them cannot
+    host the instance, so they filter. prefer_* are ranking: they
+    contribute +/-1 per matching co-located instance into the score the
+    weighted form already produced.
+
+    Every tag here is an *instance* tag carried by an instance already
+    placed on a candidate node. Shaken Fist has no node capability tags,
+    so a constraint naming a property of the hardware would be naming
+    something that does not exist.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.mock_mariadb.set_node_metrics_same()
+
+    def test_require_with_tag_narrows_to_matching_nodes(self):
+        self.mock_mariadb.create_instance(
+            'instance-1', place_on_node='node3',
+            metadata={'tags': ['database']})
+
+        inst = self.mock_mariadb.create_instance(
+            'instance-2',
+            metadata={'affinity': {'require_with_tag': ['database']}})
+
+        nodes = scheduler.Scheduler().find_candidates(inst)
+        self.assertSetEqual(self._node_uuids_set('node3'), set(nodes))
+
+    def test_require_without_tag_excludes_matching_nodes(self):
+        self.mock_mariadb.create_instance(
+            'instance-1', place_on_node='node3',
+            metadata={'tags': ['batch']})
+
+        inst = self.mock_mariadb.create_instance(
+            'instance-2',
+            metadata={'affinity': {'require_without_tag': ['batch']}})
+
+        nodes = scheduler.Scheduler().find_candidates(inst)
+        self.assertSetEqual(
+            self._node_uuids_set('node2', 'node4'), set(nodes))
+
+    def test_unsatisfiable_require_raises_the_affinity_subclass(self):
+        # No instance anywhere carries this tag, so every candidate is
+        # ejected. The exception must be the affinity subclass and not a
+        # bare LowResourceException, because the create path answers the
+        # two with different status codes -- 409 for a constraint nothing
+        # satisfies, 507 for a cluster that is genuinely full.
+        inst = self.mock_mariadb.create_instance(
+            'instance-2',
+            metadata={'affinity': {'require_with_tag': ['nonexistent']}})
+
+        self.assertRaises(
+            exceptions.AffinityConstraintUnsatisfiable,
+            scheduler.Scheduler().find_candidates, inst)
+
+    def test_the_affinity_subclass_is_still_a_low_resource_exception(self):
+        # Preflight catches LowResourceException to redirect the instance
+        # to another node, which is the right behaviour for a constraint
+        # some other node may satisfy. A sibling exception would escape
+        # that handler as a traceback, so the subclassing is load bearing
+        # rather than tidiness.
+        self.assertTrue(issubclass(
+            exceptions.AffinityConstraintUnsatisfiable,
+            exceptions.LowResourceException))
+
+    def test_unsatisfiable_require_names_the_constraint(self):
+        inst = self.mock_mariadb.create_instance(
+            'instance-2',
+            metadata={'affinity': {'require_with_tag': ['nonexistent']}})
+
+        try:
+            scheduler.Scheduler().find_candidates(inst)
+            self.fail('expected AffinityConstraintUnsatisfiable')
+        except exceptions.AffinityConstraintUnsatisfiable as e:
+            # The caller has to be able to tell which constraint refused
+            # them, and at which stage, or a 409 is no more actionable
+            # than the 507 it replaces.
+            self.assertIn('affinity_constraints', str(e))
+            self.assertIn('nonexistent', str(e))
+
+    def test_require_ignores_instances_in_another_namespace(self):
+        # The hard filter inherits the scorer's namespace scope. Crossing
+        # it would let a caller learn what another tenant is running by
+        # watching where their own instances refuse to land.
+        self.mock_mariadb.create_instance(
+            'instance-1', place_on_node='node3',
+            metadata={'tags': ['database']}, namespace='other')
+
+        inst = self.mock_mariadb.create_instance(
+            'instance-2',
+            metadata={'affinity': {'require_with_tag': ['database']}})
+
+        self.assertRaises(
+            exceptions.AffinityConstraintUnsatisfiable,
+            scheduler.Scheduler().find_candidates, inst)
+
+    def test_prefer_with_tag_ranks_matching_nodes_first(self):
+        self.mock_mariadb.create_instance(
+            'instance-1', place_on_node='node3',
+            metadata={'tags': ['socialite']})
+
+        inst = self.mock_mariadb.create_instance(
+            'instance-2',
+            metadata={'affinity': {'prefer_with_tag': ['socialite']}})
+
+        nodes = scheduler.Scheduler().find_candidates(inst)
+        self.assertSetEqual(self._node_uuids_set('node3'), set(nodes))
+
+    def test_prefer_without_tag_ranks_matching_nodes_last(self):
+        self.mock_mariadb.create_instance(
+            'instance-1', place_on_node='node3',
+            metadata={'tags': ['nerd']})
+
+        inst = self.mock_mariadb.create_instance(
+            'instance-2',
+            metadata={'affinity': {'prefer_without_tag': ['nerd']}})
+
+        nodes = scheduler.Scheduler().find_candidates(inst)
+        self.assertSetEqual(
+            self._node_uuids_set('node2', 'node4'), set(nodes))
+
+    def test_prefer_scoring_is_count_proportional(self):
+        # Two instances carrying the tag on node3, one on node2. A node
+        # carrying more of the group really is more "with the group", so
+        # node3 wins outright rather than tying at set membership.
+        self.mock_mariadb.create_instance(
+            'instance-1', place_on_node='node3',
+            metadata={'tags': ['socialite']})
+        self.mock_mariadb.create_instance(
+            'instance-2', place_on_node='node3',
+            metadata={'tags': ['socialite']})
+        self.mock_mariadb.create_instance(
+            'instance-3', place_on_node='node2',
+            metadata={'tags': ['socialite']})
+
+        inst = self.mock_mariadb.create_instance(
+            'instance-4',
+            metadata={'affinity': {'prefer_with_tag': ['socialite']}})
+
+        nodes = scheduler.Scheduler().find_candidates(inst)
+        self.assertSetEqual(self._node_uuids_set('node3'), set(nodes))
+
+    def test_prefer_terms_sum_across_tags(self):
+        # node3 hosts two 'web' and one 'batch', scoring +2 -1 = +1.
+        # node2 hosts one 'web' and no 'batch', scoring +1. They tie, so
+        # a prefer_without_tag match really can be outvoted by neighbour
+        # count on the other axis. This is the intended consequence of
+        # count proportional scoring, and it is asserted rather than left
+        # for an operator to discover from a placement.
+        self.mock_mariadb.create_instance(
+            'instance-1', place_on_node='node3', metadata={'tags': ['web']})
+        self.mock_mariadb.create_instance(
+            'instance-2', place_on_node='node3', metadata={'tags': ['web']})
+        self.mock_mariadb.create_instance(
+            'instance-3', place_on_node='node3', metadata={'tags': ['batch']})
+        self.mock_mariadb.create_instance(
+            'instance-4', place_on_node='node2', metadata={'tags': ['web']})
+
+        inst = self.mock_mariadb.create_instance(
+            'instance-5',
+            metadata={'affinity': {'prefer_with_tag': ['web'],
+                                   'prefer_without_tag': ['batch']}})
+
+        nodes = scheduler.Scheduler().find_candidates(inst)
+        self.assertSetEqual(
+            self._node_uuids_set('node2', 'node3'), set(nodes))
+
+    def test_require_and_prefer_compose(self):
+        # node2 and node3 both satisfy the requirement; only node3 also
+        # attracts the preference.
+        self.mock_mariadb.create_instance(
+            'instance-1', place_on_node='node2',
+            metadata={'tags': ['database']})
+        self.mock_mariadb.create_instance(
+            'instance-2', place_on_node='node3',
+            metadata={'tags': ['database', 'socialite']})
+
+        inst = self.mock_mariadb.create_instance(
+            'instance-3',
+            metadata={'affinity': {'require_with_tag': ['database'],
+                                   'prefer_with_tag': ['socialite']}})
+
+        nodes = scheduler.Scheduler().find_candidates(inst)
+        self.assertSetEqual(self._node_uuids_set('node3'), set(nodes))
+
+    def test_weighted_form_is_untouched_by_the_binary_model(self):
+        # The two shapes share one metadata key, so the weighted path has
+        # to keep behaving exactly as it did.
+        self.mock_mariadb.create_instance(
+            'instance-1', place_on_node='node3',
+            metadata={'tags': ['socialite']})
+
+        inst = self.mock_mariadb.create_instance(
+            'instance-2', metadata={'affinity': {'socialite': 100}})
+
+        nodes = scheduler.Scheduler().find_candidates(inst)
+        self.assertSetEqual(self._node_uuids_set('node3'), set(nodes))
+
+    def test_empty_binary_spec_places_anywhere(self):
+        inst = self.mock_mariadb.create_instance(
+            'instance-1',
+            metadata={'affinity': {'require_with_tag': [],
+                                   'prefer_with_tag': []}})
+
+        nodes = scheduler.Scheduler().find_candidates(inst)
+        self.assertSetEqual(self._all_hypervisor_uuids(), set(nodes))

--- a/shakenfist/tests/test_scheduler.py
+++ b/shakenfist/tests/test_scheduler.py
@@ -1632,6 +1632,27 @@ class WeightedAffinityMappingTestCase(SchedulerTestCase):
         self.assertSetEqual(
             self._node_uuids_set('node2', 'node3'), set(nodes))
 
+    def test_the_affinity_event_is_still_published_when_skipped(self):
+        # The skip must not take the event with it. It is what step 1's
+        # cluster test reads and what the operator guide's diagnostic
+        # recipe reads, and a create requesting no affinity is the one
+        # an operator diagnosing an unexpected placement looks at
+        # first. So: published, with candidates and a zero tier, and an
+        # empty affinity_detail because there was nothing to score.
+        inst = self.mock_mariadb.create_instance('instance-1')
+
+        with mock.patch('shakenfist.scheduler.add_event_multi') as events:
+            scheduler.Scheduler().find_candidates(inst)
+
+        published = [c for c in events.call_args_list
+                     if c[0][2] == 'schedule have highest affinity']
+        self.assertEqual(1, len(published), events.call_args_list)
+        extra = published[0][1]['extra']
+        self.assertEqual({}, extra['affinity_detail'])
+        self.assertEqual(0, extra['highest_affinity'])
+        self.assertSetEqual(
+            self._all_hypervisor_uuids(), set(extra['candidates']))
+
     def test_no_affinity_still_places_anywhere(self):
         # The scorer is skipped entirely when there is nothing to score,
         # so this asserts the skip left the outcome unchanged: one tier,

--- a/shakenfist/tests/test_scheduler.py
+++ b/shakenfist/tests/test_scheduler.py
@@ -1437,6 +1437,36 @@ class BinaryAffinityTestCase(SchedulerTestCase):
             exceptions.AffinityConstraintUnsatisfiable,
             scheduler.Scheduler().find_candidates, inst)
 
+    def test_require_without_ignores_the_rescheduling_instance_itself(self):
+        # find_candidates() is not create-only: preflight calls it on
+        # every restart, by which time the instance is placed and is one
+        # of its own node's neighbours. Counting itself would make an
+        # instance carrying an excluded tag refuse the node it is
+        # already running on, and every other node too once it moved.
+        inst = self.mock_mariadb.create_instance(
+            'instance-1', place_on_node='node3',
+            metadata={'tags': ['batch'],
+                      'affinity': {'require_without_tag': ['batch']}})
+
+        nodes = scheduler.Scheduler().find_candidates(inst)
+        self.assertIn(self._node_uuid('node3'), nodes)
+
+    def test_require_without_ignores_instances_in_another_namespace(self):
+        # The other direction of the same trust boundary, and the one
+        # which leaks if it is ever crossed: a caller who could trip
+        # require_without_tag on another tenant's instances would learn
+        # their tags by watching which nodes refuse to take theirs.
+        self.mock_mariadb.create_instance(
+            'instance-1', place_on_node='node3',
+            metadata={'tags': ['batch']}, namespace='other')
+
+        inst = self.mock_mariadb.create_instance(
+            'instance-2',
+            metadata={'affinity': {'require_without_tag': ['batch']}})
+
+        nodes = scheduler.Scheduler().find_candidates(inst)
+        self.assertIn(self._node_uuid('node3'), nodes)
+
     def test_prefer_with_tag_ranks_matching_nodes_first(self):
         self.mock_mariadb.create_instance(
             'instance-1', place_on_node='node3',

--- a/shakenfist/tests/test_scheduler.py
+++ b/shakenfist/tests/test_scheduler.py
@@ -1653,6 +1653,30 @@ class WeightedAffinityMappingTestCase(SchedulerTestCase):
         self.assertSetEqual(
             self._all_hypervisor_uuids(), set(extra['candidates']))
 
+    def test_a_weighted_spec_still_populates_affinity_detail(self):
+        # The other edge of the short-circuit, and the one that fails
+        # silently. The skip is keyed on the prefer_* lists, which are
+        # empty for a weighted specification until the mapping fills
+        # them -- so a short circuit shipped without the mapping stops
+        # scoring affinity for every existing caller, with no create
+        # failing and test_affinity merely skipping green. This is why
+        # the two belong in one commit.
+        self.mock_mariadb.create_instance(
+            'instance-1', place_on_node='node3',
+            metadata={'tags': ['first-node']})
+        inst = self.mock_mariadb.create_instance(
+            'instance-2', metadata={'affinity': {'first-node': 100}})
+
+        with mock.patch('shakenfist.scheduler.add_event_multi') as events:
+            scheduler.Scheduler().find_candidates(inst)
+
+        published = [c for c in events.call_args_list
+                     if c[0][2] == 'schedule have highest affinity']
+        self.assertEqual(1, len(published), events.call_args_list)
+        extra = published[0][1]['extra']
+        self.assertNotEqual({}, extra['affinity_detail'])
+        self.assertEqual(1, extra['highest_affinity'])
+
     def test_no_affinity_still_places_anywhere(self):
         # The scorer is skipped entirely when there is nothing to score,
         # so this asserts the skip left the outcome unchanged: one tier,


### PR DESCRIPTION
Phase 6 of the scheduler-reservations series, implementing
[PLAN-scheduler-reservations-phase-06-affinity.md](https://github.com/shakenfist/shakenfist/pull/3957)
(steps 1, 4, 5 and 6).

**Stacked on #3972.** That PR is a standalone fix for a live 500 and
should merge first; its single commit appears in this diff until it
does. Everything from `tests: assert what soft affinity actually
promises.` onwards belongs to this PR.

## What this does

**Affinity gains a binary value shape.** The `affinity` metadata key
accepts a second form using four reserved names, alongside the existing
tag weights:

```json
{
    "require_with_tag": ["database"],
    "require_without_tag": ["batch"],
    "prefer_with_tag": ["cache"],
    "prefer_without_tag": ["webserver"]
}
```

`require_*` are **hard**: they run as a filter stage beside the CPU,
memory and disk admission filters, and a create no candidate satisfies
fails with a **409**, naming the constraint and the stage.
`prefer_*` are **soft** and rank the survivors, contributing +/-1 per
matching co-located instance.

**The weighted form is deprecated but keeps working**, mapped onto the
binary one where the scheduler reads it -- positive to
`prefer_with_tag`, negative to `prefer_without_tag`, zero to nothing.
The magnitude is discarded, which is deliberate and documented: a weight
was a multiplier on a neighbour count the caller could not predict, so
two weights were never comparable. Ordering is unchanged wherever every
weight in a spec shares a magnitude, which covers every single-tag spec.
Setting a weighted spec records a deprecation event at accept time.

**`test_affinity` no longer asserts co-location.** Per the plan's F2,
that is a guarantee the product does not make: soft affinity is
consulted only when the scheduler has a choice, and issue #3565's traced
failure was a single-candidate run where affinity was never consulted at
all. The test now reads the scheduler's own audit events, pairs the
unforced scheduling pass by `request_id`, and **skips rather than
passes** on a degenerate run -- with two distinct messages, so
"only N candidates" and "affine node not a candidate" are separable in
CI output.

**A load reduction, not just a wash.** The affinity scorer called
`_placed_instances()` unconditionally -- one `Node.from_db()` plus one
`Instance.from_db()` per placed instance per candidate -- for every
create, including the majority which request no affinity at all. It is
now skipped when there is nothing to score, with `by_affinity[0]` seeded
so everything downstream sees what it saw before.
`database_load_budget.yaml` is unchanged: nothing added here runs on a
poll loop.

## Notes for the reviewer

- `AffinityConstraintUnsatisfiable` **subclasses**
  `LowResourceException` deliberately, so preflight's redirect keeps
  working -- another node may satisfy a constraint this one does not. The
  consequence is that the create path's `except` clauses are
  order-sensitive, and that ordering is the whole mechanism behind the
  409. `ExternalApiAffinityRefusalTestCase` pins it: reversing the two
  clauses fails two of its tests while the 507 case keeps passing.
- The three preflight aborts carry a flag out of the `except` suite
  rather than reading the exception. Python deletes the `as` target when
  the suite exits (PEP 3110), and two of the three sites are dedented
  back to the `try` level -- so reading `e` there is a `NameError` on a
  path that runs only under cluster CI, which would pass this PR and
  fail in the merge queue.
- `require_with_tag` has a **bootstrapping dead end**: the first member
  of a group cannot be created under the constraint that defines the
  group. That is the constraint working, and it is documented with its
  workaround in `docs/user_guide/affinity.md`.
- Cluster CI is the only thing that exercises the rewritten
  `test_affinity`, and it runs on `merge_group` rather than
  `pull_request`.

*(Authored with Claude Code)*
