### PR TITLE
Refuse malformed affinity values with a 400.

### DIFF
--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -152,6 +152,11 @@
   entry -- that is, `{"affinity": {"first-node": ["a"]}}` -- previously
   escaped the validator and produced a server error on instance create
   and on both instance metadata endpoints.
+* **Behaviour change:** a boolean affinity value is now refused with a
+  400. `{"affinity": {"first-node": true}}` was previously accepted as a
+  weight of one, because Python's `int(True)` is 1. If you relied on
+  that, send `1` instead. Numeric strings such as `"3"` are still
+  accepted, unchanged.
 
 ## Supported distributions
 

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -146,6 +146,12 @@
   instruction to base64 encode on the caller's behalf — check that a
   regenerated client does not double encode content you already encode
   yourself, as the API has always required.
+* Malformed values inside the reserved `affinity` instance metadata key
+  are now refused with a 400 instead of returning a 500. A list, a
+  dictionary, `null` or `Infinity` used as the *value* of an affinity
+  entry -- that is, `{"affinity": {"first-node": ["a"]}}` -- previously
+  escaped the validator and produced a server error on instance create
+  and on both instance metadata endpoints.
 
 ## Supported distributions
 

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -1400,6 +1400,14 @@ def _validate_instance_metadata(key, value):
                 400, 'value for "affinity" key should be a valid JSON dictionary')
 
         for key_type, dv in value.items():
+            # isinstance(True, int) is true in Python, so int(True) is 1 and a
+            # JSON true would be accepted as a weight of one. Nobody writing
+            # true means "weight 1", and the binary affinity model gives it a
+            # meaning nobody asked for, so refuse it explicitly.
+            if isinstance(dv, bool):
+                return sf_api.error(
+                    400, 'affinity dictionary values should be integers, not booleans')
+
             # int() raises TypeError -- not ValueError -- for a list, a dict or
             # None, and OverflowError for infinity. json.loads() accepts the
             # bare Infinity and NaN literals by default, so flask hands them

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -1400,9 +1400,15 @@ def _validate_instance_metadata(key, value):
                 400, 'value for "affinity" key should be a valid JSON dictionary')
 
         for key_type, dv in value.items():
+            # int() raises TypeError -- not ValueError -- for a list, a dict or
+            # None, and OverflowError for infinity. json.loads() accepts the
+            # bare Infinity and NaN literals by default, so flask hands them
+            # straight through and a bare ValueError handler returns a 500 to
+            # the caller. NaN is already covered: int(float('nan')) is a
+            # ValueError.
             try:
                 int(dv)
-            except ValueError:
+            except (TypeError, ValueError, OverflowError):
                 return sf_api.error(400, 'affinity dictionary values should be integers')
 
 

--- a/shakenfist/tests/external_api/test_instance_metadata_validation.py
+++ b/shakenfist/tests/external_api/test_instance_metadata_validation.py
@@ -66,6 +66,12 @@ class ValidateInstanceMetadataTestCase(base.ShakenFistTestCase):
         # silently.
         self._assert_refused({'first-node': float('nan')}, 'should be integers')
 
+    def test_boolean_valued_entry_is_refused(self):
+        # A deliberate behaviour change: int(True) is 1, so this used to be
+        # accepted as a weight of one.
+        self._assert_refused({'first-node': True}, 'not booleans')
+        self._assert_refused({'first-node': False}, 'not booleans')
+
     def test_numeric_string_entry_is_still_accepted(self):
         # int('3') succeeds, so this is accepted today. Asserted so that a
         # later tightening of the check to a type test is a deliberate

--- a/shakenfist/tests/external_api/test_instance_metadata_validation.py
+++ b/shakenfist/tests/external_api/test_instance_metadata_validation.py
@@ -1,0 +1,102 @@
+# Copyright 2019 Michael Still and contributors
+
+"""Validation of the reserved instance metadata keys.
+
+``_validate_instance_metadata()`` is the only place a caller is told
+they got the ``affinity`` key wrong, and it is shared by instance
+create and both metadata endpoints, so a value it fails to refuse
+becomes a 500 on three public paths rather than one.
+
+The affinity cases below are all about the *inner* per-tag value.
+The outer cases already work -- a non-dict is refused by the
+isinstance check above the loop, and None by the falsiness check at
+the top of the function -- and stating that here is the point: the
+hole was one level down from where it looked.
+"""
+
+from shakenfist.external_api.instance import _validate_instance_metadata
+from shakenfist.instance import Instance
+from shakenfist.tests import base
+
+
+AFFINITY = Instance.METADATA_KEY_AFFINITY
+TAGS = Instance.METADATA_KEY_TAGS
+
+
+class ValidateInstanceMetadataTestCase(base.ShakenFistTestCase):
+    def _assert_refused(self, value, expected_fragment):
+        resp = _validate_instance_metadata(AFFINITY, value)
+        self.assertIsNotNone(
+            resp, 'value %r was accepted, expected a 400' % (value,))
+        self.assertEqual(400, resp.status_code)
+        self.assertIn(expected_fragment, resp.get_data(as_text=True))
+
+    def test_valid_weighted_spec_is_accepted(self):
+        self.assertIsNone(
+            _validate_instance_metadata(AFFINITY, {'first-node': 100}))
+        self.assertIsNone(
+            _validate_instance_metadata(AFFINITY, {'db': -50, 'web': 1}))
+
+    def test_list_valued_entry_is_refused(self):
+        # int(['a']) raises TypeError, which the original handler did not
+        # catch. This is also the shape the binary affinity model uses, so
+        # a caller guessing the new syntax early hits exactly this.
+        self._assert_refused({'first-node': ['a']}, 'should be integers')
+
+    def test_dict_valued_entry_is_refused(self):
+        self._assert_refused({'first-node': {'x': 1}}, 'should be integers')
+
+    def test_none_valued_entry_is_refused(self):
+        # Note this is the *inner* value being None. An outer None is
+        # refused by the falsiness check and never reaches the loop.
+        self._assert_refused({'first-node': None}, 'should be integers')
+
+    def test_infinite_valued_entry_is_refused(self):
+        # int(float('inf')) raises OverflowError, not TypeError or
+        # ValueError. json.loads() accepts the bare Infinity literal by
+        # default, so flask hands this straight through from a request
+        # body and it is reachable without a client doing anything odd.
+        self._assert_refused({'first-node': float('inf')}, 'should be integers')
+        self._assert_refused({'first-node': float('-inf')}, 'should be integers')
+
+    def test_nan_valued_entry_is_refused(self):
+        # NaN was already handled -- int(float('nan')) raises ValueError --
+        # but it arrives by the same route as Infinity, so it is asserted
+        # here so a later narrowing of the except clause cannot drop it
+        # silently.
+        self._assert_refused({'first-node': float('nan')}, 'should be integers')
+
+    def test_numeric_string_entry_is_still_accepted(self):
+        # int('3') succeeds, so this is accepted today. Asserted so that a
+        # later tightening of the check to a type test is a deliberate
+        # decision with a failing test behind it, rather than an unnoticed
+        # compatibility break.
+        self.assertIsNone(
+            _validate_instance_metadata(AFFINITY, {'first-node': '3'}))
+
+    def test_non_numeric_string_entry_is_refused(self):
+        self._assert_refused({'first-node': 'banana'}, 'should be integers')
+
+    def test_outer_affinity_value_cases_are_unchanged(self):
+        # The two outer refusals this fix is not about, asserted so that
+        # widening the inner handler cannot be mistaken for having moved
+        # them.
+        resp = _validate_instance_metadata(AFFINITY, ['a'])
+        self.assertEqual(400, resp.status_code)
+        self.assertIn('valid JSON dictionary', resp.get_data(as_text=True))
+
+        resp = _validate_instance_metadata(AFFINITY, None)
+        self.assertEqual(400, resp.status_code)
+        self.assertIn('no value specified', resp.get_data(as_text=True))
+
+    def test_tags_key_is_unaffected(self):
+        self.assertIsNone(_validate_instance_metadata(TAGS, ['a', 'b']))
+
+        resp = _validate_instance_metadata(TAGS, {'a': 1})
+        self.assertEqual(400, resp.status_code)
+        self.assertIn('should be a JSON list', resp.get_data(as_text=True))
+
+    def test_no_key_is_refused(self):
+        resp = _validate_instance_metadata('', 'value')
+        self.assertEqual(400, resp.status_code)
+        self.assertIn('no key specified', resp.get_data(as_text=True))


### PR DESCRIPTION
_validate_instance_metadata() coerced affinity dictionary values with int(dv) inside a try that caught only ValueError. int() raises TypeError for a list, a dict or None, and OverflowError for infinity, so all four escaped the handler and reached the caller as a 500 -- from instance create and from both instance metadata endpoints, since the validator is shared by all three.

The Infinity case needs no unusual client. req.get_json(force=True, silent=True) uses json.loads defaults, which accept the bare Infinity and NaN literals, so flask hands them straight through. The same trap is already documented and handled thirty lines away for durations, at external_api/base.py:308-320. NaN needed nothing, since int(float('nan')) raises ValueError, but it is asserted anyway so a later narrowing of the except clause cannot drop it silently.

The level is deliberate. A malformed outer affinity value is already refused correctly -- a list by the isinstance(value, dict) check, and None by the falsiness check at the top of the function. Only the inner per-tag coercion leaked.

This also refuses booleans, which is a behaviour change rather than a 500 being fixed: isinstance(True, int) is true in Python, so int(True) is 1 and {'affinity': {'first-node': true}} has been accepted as a weight of one. Nobody writing true means "weight 1", and the binary affinity model in PLAN-scheduler-reservations-phase-06-affinity.md would give it a meaning nobody asked for. It is recorded in the release notes as well as here, because the shared validator makes it three public entry points. It mirrors the existing boolean refusal at external_api/base.py:299-301.

Numeric strings are left working. int('3') succeeds today, so tightening the check to a type test would refuse them too; that is a separate decision and does not belong in a fix for a 500.

The five proof-of-fix tests were mutation tested against the unfixed validator and all five fail there; the seven remaining cases are regression guards which pass either way, including one asserting that numeric strings stay accepted.

Fixes #3967

Prompt: Mikal asked for phase 6 of the scheduler reservations plan to be implemented. Steps 1 and 4 are gated on his agreement per the plan's back brief, but step 3 is explicitly ungated -- it is a live 500 on a public API which the plan deliberately separated so it would not wait behind an API surface, a new scheduler stage and a back-brief gate -- so it is landed first and on its own.


Assisted-By: Claude Code