### PR TITLE
ci: exempt the CI headroom probe's own polling

### DIFF
--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -84,10 +84,13 @@ Phase 1 of `docs/plans/PLAN-ci-cloud-sizing.md` (see
 decisions behind it) added two data-gathering instruments to every
 functional cluster job, so that later phases can size CI's clouds from
 a distribution instead of the handful of hand-collected numbers the
-plan started from. Neither instrument gates anything -- see "Nothing
-here is a quality gate" below -- so a reader troubleshooting a CI
-failure can skip this section; it matters when reading a job's bundle
-afterwards, or when working on the sizing plan itself.
+plan started from. Neither instrument gates anything itself -- see
+"Nothing here is a quality gate" below -- but the poller's own traffic
+does interact with a check that gates, which is the one reason a
+reader troubleshooting a CI failure might need this section; see "The
+probe's traffic is exempted from the idle-load check". Otherwise it
+matters when reading a job's bundle afterwards, or when working on the
+sizing plan itself.
 
 ### Two instruments, not one
 
@@ -182,7 +185,58 @@ it prints (committed vCPU as a fraction of the admission ledger,
 against bounds of 0.35 and 0.70) is explicitly labelled PROVISIONAL:
 phase 0 set those bounds with no distribution to check them against,
 phase 2 replaces or defends them, and any enforcement is phase 5's to
-add. Nothing in CI today can fail because of this instrumentation.
+add. No verdict this instrumentation prints can fail a job.
+
+That is not the same as the instrumentation being invisible to the
+checks that do gate, which is what this section used to say and what
+issue 3975 disproved -- see below.
+
+### The probe's traffic is exempted from the idle-load check
+
+The probe polls, and `test_no_unbudgeted_fixed_rate_database_polling`
+in the functional suite exists to notice polling. Each sample's `GET
+/nodes` runs `Node.external_view()` per node, which is one
+`GetNodeAttributes` and one `GetAllNodeDaemonStates` each, and its
+`GET /admin/resources` reads node metrics per node, which is one
+`GetNodeMetrics` each. On an N node cluster at the default 15 second
+interval that is N/15 per second for all three, from the `api` caller,
+flat across windows and indifferent to what the suite is doing --
+which is exactly the signature of the server-side polling loop the
+check is built to catch. It clears the unbudgeted ceiling, `max(0.25,
+0.05N)` per second, from four nodes upwards; it was found on the six
+node merge queue cluster, where all three read 0.3997/s against
+0.30/s and failed the build (issue 3975).
+
+Those three `(operation, caller)` pairs are therefore listed in
+`HARNESS_DRIVEN_PAIRS` in
+`shakenfist/deploy/shakenfist_ci/load_budget.py`, alongside the events
+reads the suite's own await helpers make. The budget file is
+deliberately not the home for them: no deployed cluster runs the
+probe, so a budget entry would model load that exists nowhere outside
+a CI job, and it would have to be a per-node term, raising every real
+cluster's ceiling in proportion to its size.
+
+Two consequences worth knowing:
+
+* **The exemption costs coverage.** CI can no longer see a *new*
+  fixed-rate poll of node state made through sf-api, whatever its
+  rate. The blind spot is CI's alone -- none of the three pairs is
+  budgeted for the `api` caller, so the
+  `ShakenFistUnbudgetedDatabasePolling` alert, which reads its
+  exclusions from the budget file rather than from that set, still
+  watches all three at the unbudgeted ceiling on every real cluster.
+  The pairs also stay visible in a run's `harness_driven` list rather
+  than being dropped from the report.
+* **Retiring the probe means trimming the exemption.** It outlives
+  its justification otherwise, and no test can catch that on its own:
+  the launcher (`ci_headroom_launch.sh`) and the workflow steps live
+  in `shakenfist/actions`, so a decommission done there stops the
+  probe without touching anything in this repository.
+  `test_the_suite_still_probes_cluster_headroom` covers what it can --
+  it fails if the probe is deleted here, stops sampling on a timer,
+  stops reading one of the two endpoints, or loses the note in its
+  docstring that records this obligation -- but a probe that is simply
+  never launched again looks identical to a running one from here.
 
 An absent census is not zero refusals. When the Loki query failed or
 log shipping was unhealthy, the report says so explicitly rather than

--- a/docs/plans/PLAN-ci-cloud-sizing.md
+++ b/docs/plans/PLAN-ci-cloud-sizing.md
@@ -806,6 +806,22 @@ sure none of them is closed by accident:
   cloud may quieten it, may not, and either way decides nothing
   about whether the scheduler was right. It needs a disposition in
   phase 0 before phase 4.
+- **#3975** (closed) -- the phase 1 headroom probe failed a merge
+  queue build. Its per-sample `GET /nodes` and `GET
+  /admin/resources` read node state once per node, so at the default
+  15s interval it produces N/15 per second of `GetNodeAttributes`,
+  `GetAllNodeDaemonStates` and `GetNodeMetrics` from the `api`
+  caller, which clears the idle-load check's unbudgeted ceiling from
+  four nodes upwards. D15 said nothing in this phase can fail a
+  build; that was true of the phase's own verdicts and false of its
+  traffic. Fixed by exempting the three pairs in
+  `HARNESS_DRIVEN_PAIRS`, not by lengthening the interval or
+  widening the budget. **This carries an obligation into whichever
+  phase retires the probe: trim those three pairs from
+  `shakenfist/deploy/shakenfist_ci/load_budget.py` at the same
+  time.** Nothing enforces it, because the launcher and the workflow
+  steps are in `shakenfist/actions` and a decommission done there
+  leaves this repository untouched.
 - **#3882** (open) -- reconciler drift is not provable from logs.
   Phase 2 wants to compare the live ledger derivation against the
   reconciled `cluster_capacity` figure; if they disagree, this is

--- a/shakenfist/deploy/shakenfist_ci/load_budget.py
+++ b/shakenfist/deploy/shakenfist_ci/load_budget.py
@@ -199,12 +199,49 @@ POLL_OVERCOUNT_TOLERANCE = 1.60
 # file and not from here, so the same pair is still watched at the same
 # ceiling on every real cluster.
 #
-# Anything added here needs the same two things: a named loop in this
-# suite which produces it, and a reason the budget is the wrong home for
-# it. test_harness_driven_pairs_are_not_budgeted and
-# test_the_suite_still_polls_an_events_endpoint hold both ends of that up.
+# The CI headroom probe is the same shape of thing, one layer further out.
+# tools/ci_headroom_probe.py samples GET /nodes and GET /admin/resources on
+# an --interval timer for the whole of the functional test step, started by
+# ci_headroom_launch.sh in shakenfist/actions rather than by this suite (see
+# docs/plans/PLAN-ci-cloud-sizing-phase-01-headroom-probe.md). Reading the
+# roster runs Node.external_view() per node, which is one GetNodeAttributes
+# and one GetAllNodeDaemonStates each, and /admin/resources refreshes node
+# metrics, which is one GetNodeMetrics each. On a cluster of N nodes at a
+# 15s interval that is N/15 per second for all three, and on the six node
+# merge queue cluster which found this all three read 0.3997/s against the
+# same 0.30/s ceiling -- flat across windows and indifferent to what the
+# suite was doing, because a poller started by the workflow and paced by a
+# constant is precisely what the check is built to notice (issue 3975).
+#
+# The budget is the wrong home for these for the reason above and one more:
+# no deployed cluster runs the headroom probe at all, so an entry would
+# model load which exists nowhere outside a CI job. It would also have to be
+# a per_node term, since the traffic scales with node count, and that raises
+# every real cluster's ceiling in proportion to its size.
+#
+# What it costs, again said plainly: this check can no longer see a new
+# fixed-rate poll of node state made through sf-api, whatever its rate. That
+# is a wider blind spot than the events one. It is still CI's alone -- none
+# of these three pairs is budgeted for the api caller, so
+# ShakenFistUnbudgetedDatabasePolling goes on watching all three at the
+# unbudgeted ceiling on every real cluster. The exemption is also load
+# bearing only while the probe is: phase 1 instrumentation comes out once
+# the sizing question it answers is closed, and
+# test_the_suite_still_probes_cluster_headroom fails when it does, so this
+# gets revisited rather than quietly outliving its reason.
+#
+# Anything added here needs the same two things: a named loop which produces
+# it, and a reason the budget is the wrong home for it.
+# test_harness_driven_pairs_are_not_budgeted,
+# test_the_suite_still_polls_an_events_endpoint and
+# test_the_suite_still_probes_cluster_headroom hold both ends of that up.
 HARNESS_DRIVEN_PAIRS = frozenset([
+    # shakenfist_ci/base.py's await helpers, on a time.sleep(5) timer.
     ('GetObjectEvents', 'api'),
+    # tools/ci_headroom_probe.py, on its --interval timer.
+    ('GetAllNodeDaemonStates', 'api'),
+    ('GetNodeAttributes', 'api'),
+    ('GetNodeMetrics', 'api'),
 ])
 
 

--- a/shakenfist/deploy/shakenfist_ci/load_budget.py
+++ b/shakenfist/deploy/shakenfist_ci/load_budget.py
@@ -203,15 +203,27 @@ POLL_OVERCOUNT_TOLERANCE = 1.60
 # tools/ci_headroom_probe.py samples GET /nodes and GET /admin/resources on
 # an --interval timer for the whole of the functional test step, started by
 # ci_headroom_launch.sh in shakenfist/actions rather than by this suite (see
-# docs/plans/PLAN-ci-cloud-sizing-phase-01-headroom-probe.md). Reading the
-# roster runs Node.external_view() per node, which is one GetNodeAttributes
-# and one GetAllNodeDaemonStates each, and /admin/resources refreshes node
-# metrics, which is one GetNodeMetrics each. On a cluster of N nodes at a
-# 15s interval that is N/15 per second for all three, and on the six node
-# merge queue cluster which found this all three read 0.3997/s against the
-# same 0.30/s ceiling -- flat across windows and indifferent to what the
-# suite was doing, because a poller started by the workflow and paced by a
-# constant is precisely what the check is built to notice (issue 3975).
+# docs/plans/PLAN-ci-cloud-sizing-phase-01-headroom-probe.md). The producers
+# are named rather than left as "reading the roster", because the step from
+# two endpoints to exactly these three pairs is the load bearing part:
+# Node.external_view() runs per node behind GET /nodes and makes one
+# GetNodeAttributes (via _load_attributes()) and one GetAllNodeDaemonStates
+# each, and scheduler.get_active_node_metrics() reads per node behind
+# GET /admin/resources and makes one GetNodeMetrics each. The remaining
+# per-node reads external_view() makes -- GetObjectState, GetObjectMetadata,
+# and GetReferencesTo/GetReferencesFrom twice each -- are not listed below
+# because they already carry api entries in the budget, so they reach the
+# budgeted branch and never ask this set anything. If either producer grows
+# a per-node read of an operation with no api budget entry, issue 3975 comes
+# back wearing a different operation name, and this set is what to extend.
+#
+# On a cluster of N nodes at the default 15s interval that is N/15 per
+# second for all three, which clears the unbudgeted ceiling -- max(0.25,
+# 0.05N) -- from four nodes upwards. On the six node merge queue cluster
+# which found this all three read 0.3997/s against a 0.30/s ceiling, flat
+# across windows and indifferent to what the suite was doing, because a
+# poller started by the workflow and paced by a constant is precisely what
+# the check is built to notice (issue 3975).
 #
 # The budget is the wrong home for these for the reason above and one more:
 # no deployed cluster runs the headroom probe at all, so an entry would
@@ -224,11 +236,21 @@ POLL_OVERCOUNT_TOLERANCE = 1.60
 # is a wider blind spot than the events one. It is still CI's alone -- none
 # of these three pairs is budgeted for the api caller, so
 # ShakenFistUnbudgetedDatabasePolling goes on watching all three at the
-# unbudgeted ceiling on every real cluster. The exemption is also load
-# bearing only while the probe is: phase 1 instrumentation comes out once
-# the sizing question it answers is closed, and
-# test_the_suite_still_probes_cluster_headroom fails when it does, so this
-# gets revisited rather than quietly outliving its reason.
+# unbudgeted ceiling on every real cluster.
+#
+# The exemption is load bearing only while the probe is: phase 1
+# instrumentation comes out once the sizing question it answers is closed.
+# test_the_suite_still_probes_cluster_headroom watches for part of that --
+# it fails if tools/ci_headroom_probe.py is deleted, stops sampling on a
+# timer, or stops reading one of the two endpoints -- but it cannot watch
+# for all of it, and the comment should not claim otherwise. The launcher
+# and the workflow steps live in shakenfist/actions, so a decommission done
+# there, which is the likely way it happens because that is where the wiring
+# is, stops the probe running while leaving this file, that test and this
+# exemption exactly as they are. The obligation to trim these three is
+# therefore written where whoever retires the tool will actually be reading:
+# in ci_headroom_probe.py's own docstring, in the CI headroom section of
+# docs/developer_guide/ci.md, and against #3975 in PLAN-ci-cloud-sizing.md.
 #
 # Anything added here needs the same two things: a named loop which produces
 # it, and a reason the budget is the wrong home for it.

--- a/shakenfist/tests/test_database_tier_harness.py
+++ b/shakenfist/tests/test_database_tier_harness.py
@@ -257,6 +257,93 @@ class DatabaseTierHarnessTestCase(base.ShakenFistTestCase):
             'GetObjectEvents/api in HARNESS_DRIVEN_PAIRS -- drop the '
             'exemption and let the idle load check see the pair again.')
 
+    def test_the_headroom_probe_pairs_are_exempt(self):
+        # The other half of the contract that
+        # test_the_suite_still_probes_cluster_headroom holds up. That one
+        # fails if the probe goes while these stay; this one fails if these
+        # go while the probe stays, which is how issue 3975 read in merge CI
+        # -- all three at N/15 per second, over the unbudgeted ceiling, on
+        # every cluster job big enough to reach it.
+        for operation in ('GetAllNodeDaemonStates', 'GetNodeAttributes',
+                          'GetNodeMetrics'):
+            self.assertTrue(
+                harness.harness_driven((operation, 'api')),
+                '%s/api is not exempt, so the node roster sampling done by '
+                'tools/ci_headroom_probe.py will fail '
+                'test_no_unbudgeted_fixed_rate_database_polling again on any '
+                'merge queue cluster of six nodes or more (issue 3975).'
+                % operation)
+
+        # Scoped to the caller which actually makes them. The same operations
+        # from a daemon are ordinary server side traffic and stay budgeted.
+        for operation in ('GetAllNodeDaemonStates', 'GetNodeAttributes',
+                          'GetNodeMetrics'):
+            self.assertFalse(
+                harness.harness_driven((operation, 'queues')),
+                '%s/queues is exempt, but no part of the CI harness makes '
+                'that call -- sf-queues does, and the budget is its home.'
+                % operation)
+
+    def test_the_suite_still_probes_cluster_headroom(self):
+        # The argument for exempting the three node-state pairs is that
+        # tools/ci_headroom_probe.py reads the node roster and the cluster
+        # resources on a timer for the whole functional test step. That probe
+        # is phase 1 instrumentation and is meant to come out once the sizing
+        # question it answers is closed, so derive the justification from the
+        # file rather than trusting the comment beside the exemption: when the
+        # probe goes, or stops reading those two endpoints, the exemption
+        # stops being an explanation and becomes a hole.
+        here = os.path.dirname(os.path.abspath(__file__))
+        root = os.path.dirname(os.path.dirname(here))
+        path = os.path.join(root, 'tools', 'ci_headroom_probe.py')
+
+        self.assertTrue(
+            os.path.exists(path),
+            'tools/ci_headroom_probe.py is gone, so nothing polls the node '
+            'roster on a timer during a CI run any more. That is the entire '
+            'justification for exempting GetNodeAttributes/api, '
+            'GetAllNodeDaemonStates/api and GetNodeMetrics/api in '
+            'HARNESS_DRIVEN_PAIRS -- drop those three and let the idle load '
+            'check see the pairs again.')
+
+        with open(path, encoding='utf-8') as f:
+            tree = ast.parse(f.read())
+
+        # Two findings rather than one loop carrying both, unlike the events
+        # check above: the probe's sleeping loop and the calls it samples with
+        # live in different functions, because the loop body is take_sample().
+        sleeping_loops = []
+        for loop in ast.walk(tree):
+            if not isinstance(loop, (ast.While, ast.For)):
+                continue
+            for node in ast.walk(loop):
+                if (isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and node.func.attr == 'sleep'):
+                    sleeping_loops.append(loop.lineno)
+                    break
+
+        sampled = set()
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr in ('get_nodes',
+                                           'get_cluster_resources')):
+                sampled.add(node.func.attr)
+
+        self.assertNotEqual(
+            [], sleeping_loops,
+            'No loop in tools/ci_headroom_probe.py sleeps, so it no longer '
+            'samples on a timer and its traffic is not the fixed-rate poll '
+            'the api entries in HARNESS_DRIVEN_PAIRS are exempted as.')
+
+        self.assertEqual(
+            {'get_cluster_resources', 'get_nodes'}, sampled,
+            'tools/ci_headroom_probe.py no longer reads both the node roster '
+            'and the cluster resources, so the set of pairs its sampling '
+            'explains has changed. Re-derive the api entries in '
+            'HARNESS_DRIVEN_PAIRS from what it actually calls.')
+
     def test_harness_reads_the_shipped_budget_not_a_copy(self):
         # If the harness ever grows its own copy of the numbers this stops
         # being true, which is the failure decision 2 of the phase plan is

--- a/shakenfist/tests/test_database_tier_harness.py
+++ b/shakenfist/tests/test_database_tier_harness.py
@@ -39,10 +39,42 @@ def _load_harness():
 
 harness = _load_harness()
 
+# The operations tools/ci_headroom_probe.py's sampling produces, one per
+# node per sample, which have no api entry in the budget. Bound once
+# because both halves of test_the_headroom_probe_pairs_are_exempt read it
+# and a drift between them would quietly stop testing the caller scoping.
+PROBE_OPERATIONS = ('GetAllNodeDaemonStates', 'GetNodeAttributes',
+                    'GetNodeMetrics')
+
 
 def _repository_root():
     here = os.path.dirname(os.path.abspath(__file__))
     return os.path.dirname(os.path.dirname(here))
+
+
+def _sleeping_loops(tree):
+    """Every loop in a parsed module which calls something named sleep().
+
+    Shared by the two derivation tests below, which both start from "does
+    this file still poll?" and then ask different follow-up questions about
+    the loops that do.
+    """
+    found = []
+    for loop in ast.walk(tree):
+        if not isinstance(loop, (ast.While, ast.For)):
+            continue
+        for node in ast.walk(loop):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == 'sleep'):
+                found.append(loop)
+                break
+    return found
+
+
+def _parse(*parts):
+    with open(os.path.join(_repository_root(), *parts), encoding='utf-8') as f:
+        return ast.parse(f.read())
 
 
 def _daemon_modules():
@@ -222,32 +254,19 @@ class DatabaseTierHarnessTestCase(base.ShakenFistTestCase):
         # Derived from base.py rather than asserted about it, for the same
         # reason test_non_polling_daemons_do_not_reach_the_tier derives its
         # list: a comment cannot notice that it went stale.
-        here = os.path.dirname(os.path.abspath(__file__))
-        root = os.path.dirname(os.path.dirname(here))
-        path = os.path.join(root, 'shakenfist', 'deploy', 'shakenfist_ci',
-                            'base.py')
-        with open(path, encoding='utf-8') as f:
-            tree = ast.parse(f.read())
+        tree = _parse('shakenfist', 'deploy', 'shakenfist_ci', 'base.py')
 
         polling_loops = []
-        for loop in ast.walk(tree):
-            if not isinstance(loop, (ast.While, ast.For)):
-                continue
-            sleeps = False
-            events = False
+        for loop in _sleeping_loops(tree):
             for node in ast.walk(loop):
                 if not isinstance(node, ast.Call):
                     continue
                 func = node.func
                 if (isinstance(func, ast.Attribute)
-                        and func.attr == 'sleep'):
-                    sleeps = True
-                if (isinstance(func, ast.Attribute)
                         and func.attr.endswith('_events')
                         and func.attr.startswith('get_')):
-                    events = True
-            if sleeps and events:
-                polling_loops.append(loop.lineno)
+                    polling_loops.append(loop.lineno)
+                    break
 
         self.assertNotEqual(
             [], polling_loops,
@@ -264,20 +283,20 @@ class DatabaseTierHarnessTestCase(base.ShakenFistTestCase):
         # go while the probe stays, which is how issue 3975 read in merge CI
         # -- all three at N/15 per second, over the unbudgeted ceiling, on
         # every cluster job big enough to reach it.
-        for operation in ('GetAllNodeDaemonStates', 'GetNodeAttributes',
-                          'GetNodeMetrics'):
+        for operation in PROBE_OPERATIONS:
             self.assertTrue(
                 harness.harness_driven((operation, 'api')),
                 '%s/api is not exempt, so the node roster sampling done by '
                 'tools/ci_headroom_probe.py will fail '
                 'test_no_unbudgeted_fixed_rate_database_polling again on any '
-                'merge queue cluster of six nodes or more (issue 3975).'
-                % operation)
+                'cluster of four nodes or more at the probe\'s default 15s '
+                'interval, where N/15 clears the max(0.25, 0.05N) unbudgeted '
+                'ceiling (observed on the six node merge queue cluster, '
+                'issue 3975).' % operation)
 
-        # Scoped to the caller which actually makes them. The same operations
-        # from a daemon are ordinary server side traffic and stay budgeted.
-        for operation in ('GetAllNodeDaemonStates', 'GetNodeAttributes',
-                          'GetNodeMetrics'):
+            # Scoped to the caller which actually makes them. The same
+            # operations from a daemon are ordinary server side traffic and
+            # stay budgeted.
             self.assertFalse(
                 harness.harness_driven((operation, 'queues')),
                 '%s/queues is exempt, but no part of the CI harness makes '
@@ -293,9 +312,8 @@ class DatabaseTierHarnessTestCase(base.ShakenFistTestCase):
         # file rather than trusting the comment beside the exemption: when the
         # probe goes, or stops reading those two endpoints, the exemption
         # stops being an explanation and becomes a hole.
-        here = os.path.dirname(os.path.abspath(__file__))
-        root = os.path.dirname(os.path.dirname(here))
-        path = os.path.join(root, 'tools', 'ci_headroom_probe.py')
+        path = os.path.join(_repository_root(), 'tools',
+                            'ci_headroom_probe.py')
 
         self.assertTrue(
             os.path.exists(path),
@@ -306,22 +324,12 @@ class DatabaseTierHarnessTestCase(base.ShakenFistTestCase):
             'HARNESS_DRIVEN_PAIRS -- drop those three and let the idle load '
             'check see the pairs again.')
 
-        with open(path, encoding='utf-8') as f:
-            tree = ast.parse(f.read())
+        tree = _parse('tools', 'ci_headroom_probe.py')
 
         # Two findings rather than one loop carrying both, unlike the events
         # check above: the probe's sleeping loop and the calls it samples with
         # live in different functions, because the loop body is take_sample().
-        sleeping_loops = []
-        for loop in ast.walk(tree):
-            if not isinstance(loop, (ast.While, ast.For)):
-                continue
-            for node in ast.walk(loop):
-                if (isinstance(node, ast.Call)
-                        and isinstance(node.func, ast.Attribute)
-                        and node.func.attr == 'sleep'):
-                    sleeping_loops.append(loop.lineno)
-                    break
+        sleeping_loops = _sleeping_loops(tree)
 
         sampled = set()
         for node in ast.walk(tree):
@@ -343,6 +351,20 @@ class DatabaseTierHarnessTestCase(base.ShakenFistTestCase):
             'and the cluster resources, so the set of pairs its sampling '
             'explains has changed. Re-derive the api entries in '
             'HARNESS_DRIVEN_PAIRS from what it actually calls.')
+
+        # The rest of the removal obligation is not something this repository
+        # can see: the launcher and the workflow steps are in
+        # shakenfist/actions, so the probe can stop running without this file
+        # changing. What can be held is the note that tells whoever retires
+        # the tool to trim the exemption, which is in the probe's docstring
+        # precisely because that is the file they will have open.
+        self.assertIn(
+            'HARNESS_DRIVEN_PAIRS', ast.get_docstring(tree) or '',
+            'tools/ci_headroom_probe.py\'s docstring no longer names '
+            'HARNESS_DRIVEN_PAIRS, so nothing in the file a decommission '
+            'starts from says that retiring the probe means trimming three '
+            'pairs from shakenfist/deploy/shakenfist_ci/load_budget.py. Put '
+            'the note back, or drop the exemption with the probe.')
 
     def test_harness_reads_the_shipped_budget_not_a_copy(self):
         # If the harness ever grows its own copy of the numbers this stops

--- a/tools/ci_headroom_probe.py
+++ b/tools/ci_headroom_probe.py
@@ -54,6 +54,19 @@ percentiles a later phase reads would be biased toward idle. That bias
 points the wrong way: it would argue for shrinking a cloud which was in
 fact tight.
 
+Retiring this tool takes one more step than deleting it and its workflow
+steps. Its sampling reads to the functional idle-load check as a fixed-rate
+poll of node state -- `N / --interval` per second of GetNodeAttributes,
+GetAllNodeDaemonStates and GetNodeMetrics from the `api` caller on an N node
+cluster -- so those three (operation, caller) pairs are exempted in
+HARNESS_DRIVEN_PAIRS in `shakenfist/deploy/shakenfist_ci/load_budget.py`
+(issue 3975). Trim them when this tool goes, or the check keeps a blind spot
+which nothing produces the traffic for any more. This is worth saying here
+rather than only beside the exemption because the launcher
+(`ci_headroom_launch.sh`) and the workflow steps live in `shakenfist/actions`:
+a decommission done there stops the probe running without touching either
+this file or the exemption, and no test in this repository can see it happen.
+
 Run it with /etc/sf/sfrc sourced, using the SF venv python so
 shakenfist_client is importable, for example:
 


### PR DESCRIPTION
Fixes #3975

## What was wrong

`tools/ci_headroom_probe.py`, added by ci-cloud-sizing phase 1 (#3940) and
started for every cluster deploy by `ci_headroom_launch.sh` in
`shakenfist/actions`, samples `GET /nodes` and `GET /admin/resources` on a
15s timer for the whole of the functional test step. Reading the roster runs
`Node.external_view()` per node, so each sample is one `GetNodeAttributes`
and one `GetAllNodeDaemonStates` per node, and `/admin/resources` is one
`GetNodeMetrics` per node.

On a cluster of N nodes that is N/15 per second for all three — paced by a
constant and indifferent to what the suite is doing, which is exactly the
signature `test_no_unbudgeted_fixed_rate_database_polling` is built to call a
new polling loop. On the six-node merge queue cluster all three read
0.3997/s against a 0.30/s ceiling and failed the build:

```
reference = []
actual    = [(('GetAllNodeDaemonStates', 'api'), 0.39972509425618863),
 (('GetNodeAttributes', 'api'), 0.39972509425618863),
 (('GetNodeMetrics', 'api'), 0.39972509425618863)]
```

It only surfaced once #3940 was on the merge base: `ci_headroom_launch.sh`
skips silently when the probe file is absent, and PR CI runs a single-node
cluster where 1/15 = 0.067/s sits under the threshold. Only the merge-group
cluster jobs are large enough to trip it, so it was reachable by any PR
entering the queue, not by the one that hit it.

## The change

The check is right, and the probe is the measuring instrument rather than the
thing measured — so the exemption goes in `HARNESS_DRIVEN_PAIRS` beside the
events reads the await helpers make, not in the budget.

Rejected alternatives, both recorded in the comment beside the entries:

- **A budget entry.** It would have to carry a `per_node` term to cover this,
  raising every real cluster's ceiling in proportion to its size to model load
  that exists nowhere outside a CI job.
- **Lengthening the probe interval** until it sits under the ceiling. That is
  hand-editing a level to make a check pass, which the budget file's own
  header forbids.

## What it costs

Said plainly in the comment, because a silent exemption reads as coverage: CI
can no longer see a new fixed-rate poll of node state made through sf-api.
That blind spot is CI's alone — none of the three pairs is budgeted for the
`api` caller, so `ShakenFistUnbudgetedDatabasePolling` goes on watching all
three at the unbudgeted ceiling on every real cluster. The pairs are also
still reported in the run detail's `harness_driven` list rather than dropped.

## Two tests hold the exemption to its justification

Phase 1 instrumentation is meant to come out once the sizing question it
answers is closed, so the exemption must not outlive the probe:

- `test_the_suite_still_probes_cluster_headroom` derives the argument from
  `tools/ci_headroom_probe.py` by AST, and fails when it stops reading those
  two endpoints, stops sampling on a timer, or goes away entirely.
- `test_the_headroom_probe_pairs_are_exempt` is the other half of the
  contract: it fails if the pairs are dropped while the probe remains.

## Verification

- `pre-commit run --all-files` passes (`tox -e py3`, `flake8`, `mypy` and the
  five custom checks), each hook confirmed with its own exit code.
- All five new assertions were mutation-tested — probe file removed, `sleep`
  removed, `get_nodes()` removed, `get_cluster_resources()` removed, and a
  pair dropped from the set. **Every one fails**; the baseline passes.
- The exact failing measurement (0.3997/s, 6 nodes, 0.30/s ceiling) replayed
  through the real `load_budget` classifier now lands in `harness_driven`,
  and `assertEqual([], unbudgeted)` passes.

## Deliberately not done

- **#3976 is untouched.** The same merge group's Debian 12 tier job failed
  the same test on a different assertion (`GetNetworkAttributes`/`net` at
  ~4x budget on `slim-tier`). That is an unrelated defect with its own fix,
  so this PR does not clear that job.
- **No change to the probe itself.** Its `/admin/resources` call constructs a
  Scheduler and refreshes node metrics, so it is not free on exactly the
  busiest clusters — worth watching against the #3772 family, but a
  behaviour change to phase 1 instrumentation is not this fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01514djiwuwDUi56vC48PWNc
