### PR TITLE
ci: bound the headroom probe's load exemption to what it explains

### DIFF
--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -182,7 +182,52 @@ it prints (committed vCPU as a fraction of the admission ledger,
 against bounds of 0.35 and 0.70) is explicitly labelled PROVISIONAL:
 phase 0 set those bounds with no distribution to check them against,
 phase 2 replaces or defends them, and any enforcement is phase 5's to
-add. Nothing in CI today can fail because of this instrumentation.
+add. No verdict this instrumentation *prints* can fail a build.
+
+That is not the same as the instrumentation being invisible, and
+issue #3975 is the difference. The probe is a poll against the API,
+and the API reads the database, so the probe adds database load like
+anything else does -- and the idle-load check in
+`cluster_ci_tests/test_database_tier.py` is built to notice exactly
+that shape of traffic. It duly noticed the probe and failed every
+merge-queue cluster job until the allowance below was added. An
+instrument that perturbs what another check measures is a real cost of
+having it, so weigh it before adding the next one.
+
+### The probe's own load, and the allowance for it
+
+Each sample makes two API calls, and both fan out per node:
+`GET /nodes` reads every node's attributes row and daemon-state rows,
+and `GET /admin/resources` reads every node's metrics. So on an
+N-node cluster the probe produces `GetNodeAttributes`,
+`GetAllNodeDaemonStates` and `GetNodeMetrics` from `api` at N/15 per
+second each -- 0.4/s on a six-node merge-queue cluster, against the
+0.30/s ceiling the idle-load check applies to traffic that has no
+budget entry. PR CI never sees it, because its single-node cluster
+runs the same probe at 1/15 = 0.067/s.
+
+Those three pairs are therefore exempted, in
+`HEADROOM_PROBE_PAIRS` in `shakenfist_ci/load_budget.py` -- but as an
+*allowance* rather than a blanket skip. The check subtracts what the
+probe is known to produce and reports the residual, so a pair running
+above the probe's own rate still fails the build. That distinction is
+the point: `GetNodeMetrics` from `api` is not only the probe, since
+instance creation constructs a Scheduler and reads node metrics too,
+and skipping the pair outright would have hidden a genuine regression
+in order to silence a synthetic one. The blind spot that remains is
+bounded, CI-only, and named in the comment on those constants; the
+same pairs are watched at the same ceiling on every real cluster,
+because `ShakenFistUnbudgetedDatabasePolling` takes its exclusions
+from `shakenfist/data/database_load_budget.yaml` and not from the CI
+suite.
+
+The allowance divides by the probe's sampling interval, which is a
+constant in the CI suite copied from the probe's own `--interval`
+default. `test_database_tier_harness.py` reads that default back out
+of `tools/ci_headroom_probe.py` and fails if the two drift, and
+asserts the probe still samples both endpoints on a timer -- because
+the day it stops, the allowance stops being an explanation and
+becomes a hole.
 
 An absent census is not zero refusals. When the Loki query failed or
 log shipping was unhealthy, the report says so explicitly rather than

--- a/shakenfist/deploy/shakenfist_ci/database_tier.py
+++ b/shakenfist/deploy/shakenfist_ci/database_tier.py
@@ -17,6 +17,7 @@ slim-tier topology has, so it stays in the cluster suite.
 """
 
 import json
+import math
 import time
 
 import requests
@@ -87,6 +88,21 @@ def scrape_database_counters(mesh_ip):
         except ValueError:
             continue
     return counters
+
+
+def _allowance_json(allowance):
+    """Render a harness allowance for the run summary.
+
+    math.inf is what lb.harness_allowance() returns for a pair the
+    harness drives at a rate it cannot predict. json.dumps() will write
+    that as a bare Infinity, which no strict JSON reader accepts, and
+    this summary is meant to be read by tools as well as by people. None
+    means the same thing here as it does in the allowance itself -- no
+    number to compare against -- and survives a round trip.
+    """
+    if allowance is None or allowance == math.inf:
+        return None
+    return round(allowance, 3)
 
 
 def scrape_operation_requests(mesh_ip, operation, caller_daemon):
@@ -642,13 +658,23 @@ class DatabaseTierTestsMixin:
                 # Traffic this suite polls for itself looks exactly like a
                 # server side poll to everything above, because it is one
                 # -- it is just on the wrong side of the API. Listed and
-                # argued in lb.HARNESS_DRIVEN_PAIRS, and reported below
-                # rather than dropped, because an exemption nobody can see
-                # in the run detail is an exemption nobody will revisit.
-                if lb.harness_driven(key):
-                    harness.append((key, measured))
+                # argued in lb.HARNESS_DRIVEN_PAIRS and
+                # lb.HEADROOM_PROBE_PAIRS, and reported below rather than
+                # dropped, because an exemption nobody can see in the run
+                # detail is an exemption nobody will revisit.
+                #
+                # Bounded by what the harness can actually account for,
+                # not by the name of the pair. The headroom probe's rate
+                # is arithmetic, so a pair running above it is carrying
+                # traffic the probe does not explain and still fails --
+                # otherwise exempting a pair like GetNodeMetrics/api,
+                # which real API work also produces, would hide the
+                # regression this check exists to find.
+                allowance = lb.harness_allowance(key, node_count)
+                if allowance is not None and measured <= allowance:
+                    harness.append((key, measured, allowance))
                 else:
-                    unbudgeted.append((key, measured))
+                    unbudgeted.append((key, measured, allowance))
                 continue
             modelled = lb.expected_qps(entry, node_count, standing_instances)
             ceiling = (modelled * defaults['tolerance_multiplier']
@@ -679,11 +705,13 @@ class DatabaseTierTestsMixin:
                 {'operation': k[0], 'caller_daemon': k[1], 'measured': m,
                  'modelled': mod, 'ceiling': c} for k, m, mod, c in over],
             'unbudgeted': [
-                {'operation': k[0], 'caller_daemon': k[1], 'measured': m}
-                for k, m in unbudgeted],
+                {'operation': k[0], 'caller_daemon': k[1], 'measured': m,
+                 'harness_allowance': _allowance_json(a)}
+                for k, m, a in unbudgeted],
             'harness_driven': [
-                {'operation': k[0], 'caller_daemon': k[1], 'measured': m}
-                for k, m in harness],
+                {'operation': k[0], 'caller_daemon': k[1], 'measured': m,
+                 'allowance': _allowance_json(a)}
+                for k, m, a in harness],
             'over_budget_but_not_enforced': [
                 {'operation': k[0], 'caller_daemon': k[1], 'measured': m,
                  'modelled': mod} for k, m, mod, _ in reported],
@@ -728,7 +756,10 @@ class DatabaseTierTestsMixin:
             'note naming the loop which produces it -- or, if this suite '
             'is what produces it rather than the cluster, to '
             'HARNESS_DRIVEN_PAIRS in load_budget.py, which says what such '
-            'an entry has to argue. summary=%s'
+            'an entry has to argue. A pair carrying a harness_allowance '
+            'here is one this suite does drive, running above everything '
+            'that traffic accounts for, so the excess is the cluster\'s '
+            'and the allowance is not the thing to raise. summary=%s'
             % (unbudgeted_ceiling, json.dumps(summary, sort_keys=True)))
 
         self.assertEqual(

--- a/shakenfist/deploy/shakenfist_ci/load_budget.py
+++ b/shakenfist/deploy/shakenfist_ci/load_budget.py
@@ -14,6 +14,7 @@ the server -- and keeping it that way matters, because it runs wherever the
 harness puts it. What must not be duplicated is the data.
 """
 
+import math
 import os
 import re
 
@@ -207,6 +208,93 @@ HARNESS_DRIVEN_PAIRS = frozenset([
     ('GetObjectEvents', 'api'),
 ])
 
+# The CI headroom probe, tools/ci_headroom_probe.py, is the second thing
+# this suite runs which the checks below cannot tell from a server side
+# poll -- and unlike the await helpers, its rate is predictable, so it is
+# exempted as an allowance rather than as a blanket skip.
+#
+# shakenfist/actions starts one probe per cluster deploy and it samples on
+# a timer until the run ends. Each sample makes exactly two API calls:
+# GET /admin/resources (client.get_cluster_resources()) and GET /nodes
+# (client.get_nodes()). Both fan out per node -- Node.external_view()
+# reads its own attributes row and its own daemon state rows for each
+# node in the roster, and summarize_resources() reads each node's metrics
+# -- so on a cluster of N nodes each of the three pairs below runs at
+# N/interval per second, set by configuration and not by what the suite
+# is doing. That is the exact signature of fixed_rate() and
+# independent_of_activity(), which is why #3975 failed every merge queue
+# cluster job once #3940 landed: 6 nodes over a 15s interval is 0.4/s
+# against a 0.30/s ceiling. PR CI never saw it because its single node
+# cluster runs the same probe at 1/15 = 0.067/s.
+#
+# Why not simply list these in HARNESS_DRIVEN_PAIRS. A blanket skip drops
+# the pair whatever its rate, and node state read from sf-api is exactly
+# the class of regression this check exists to find: an endpoint which
+# starts reading every node's attributes on a timer would be invisible
+# forever after. GetNodeMetrics/api is the clearest case, because it is
+# not only the probe -- instance creation constructs a Scheduler, so real
+# API traffic reads node metrics too, and in the merge group for #3970
+# that pair did not even reach the unbudgeted branch because the suite's
+# own activity moved it. Exempting it outright would hide a real signal
+# to silence a synthetic one.
+#
+# So the exemption is bounded: subtract what the probe is known to
+# produce and report the residual. A pair which runs at the probe's rate
+# passes; the same pair at twice the probe's rate still fails, and says
+# by how much it exceeded what the harness explains.
+#
+# Why not in shakenfist/data/database_load_budget.yaml, on the same
+# argument as GetObjectEvents above: no deployed cluster runs a headroom
+# probe, and writing CI's measuring instrument into the model would raise
+# a real cluster's ceiling for load only CI produces. Every consumer of
+# that file -- sf-ctl database-load, the generated Prometheus rules, the
+# nightly report -- would inherit the fiction.
+#
+# What it still costs, said plainly: a genuine new poll of node state
+# from sf-api is invisible while it stays under the probe's own rate.
+# That floor is a fraction of a request per second per node and it is
+# CI's alone; ShakenFistUnbudgetedDatabasePolling takes its exclusions
+# from the budget file and not from here, so the same pairs are watched
+# at the same ceiling on every real cluster.
+HEADROOM_PROBE_PAIRS = frozenset([
+    ('GetNodeAttributes', 'api'),
+    ('GetAllNodeDaemonStates', 'api'),
+    ('GetNodeMetrics', 'api'),
+])
+
+# The probe's sampling interval, in seconds. Duplicated from the
+# --interval default in tools/ci_headroom_probe.py, because this suite is
+# standalone and imports nothing from the server checkout at runtime;
+# test_headroom_probe_interval_matches_the_probe reads that default back
+# out of the source and fails if the two drift, on the same argument as
+# DAEMON_STATE_POLL_INTERVAL above.
+#
+# The workflow which starts the probe passes --interval explicitly, and
+# it lives in another repository (shakenfist/actions), so this constant
+# can be wrong in a way no test here can see. It fails safe: a workflow
+# sampling *faster* than this leaves a residual above the allowance and
+# the pair is reported, which is a visible failure naming the measured
+# rate rather than a silent hole.
+HEADROOM_PROBE_INTERVAL_SECONDS = 15.0
+
+# How far above the probe's arithmetic rate a pair may still read as just
+# the probe. The allowance is derived from a node count and an interval,
+# and the measurement it is compared against is a counter difference over
+# a wall clock window, so the two agree to about a part in a thousand and
+# not exactly -- the run in #3975 measured 0.39981792260485516/s against
+# an arithmetic 0.4/s, which is 0.9995 of it. A window which starts or
+# ends mid-sample can land one extra sample in a window, which on a four
+# minute measurement is a few percent.
+#
+# Set well above both, because the cost of the two errors is not
+# symmetric. Too tight and the merge queue fails on a rounding difference
+# in the measuring instrument, which is the failure this whole change is
+# undoing. Too loose and the blind spot grows by the same factor -- but
+# it is a blind spot in CI only, on a pair whose real ceiling on a
+# deployed cluster is unaffected. This is the same reasoning, and the
+# same value, as POLL_OVERCOUNT_TOLERANCE above.
+HEADROOM_PROBE_TOLERANCE = 1.60
+
 
 def load_budget():
     """The shipped database load budget, as plain dicts.
@@ -290,8 +378,41 @@ def harness_driven(key):
     high is worth failing on, this asks whether an unbudgeted pair is the
     measuring instrument rather than the thing measured. See
     HARNESS_DRIVEN_PAIRS for why the answer is not simply a budget entry.
+
+    Says only whether the harness produces the pair at all. How much of
+    the pair's measured rate that explains is harness_allowance(), and
+    the caller wants that one: a pair this suite drives can still be
+    running well above anything this suite can account for.
     """
-    return tuple(key) in HARNESS_DRIVEN_PAIRS
+    return (tuple(key) in HARNESS_DRIVEN_PAIRS
+            or tuple(key) in HEADROOM_PROBE_PAIRS)
+
+
+def harness_allowance(key, node_count):
+    """How much of a pair's rate this suite's own traffic explains.
+
+    Returns None for a pair the harness does not produce, which is the
+    ordinary case and means the measured rate is entirely the cluster's.
+    Returns math.inf for a pair the harness produces at a rate it cannot
+    predict, which is a blanket exemption. Otherwise returns the rate in
+    requests per second, above which the pair is reporting more traffic
+    than the harness can account for and is worth failing on.
+
+    Only the headroom probe gets a number, because it is the only one of
+    the two whose rate is arithmetic rather than emergent: it samples on
+    a fixed interval and fans out over a known roster, so N/interval is
+    the whole of its contribution. The await helpers behind
+    GetObjectEvents run once per worker currently waiting on an object,
+    which is a property of which tests happen to be in flight, so there
+    is no number to subtract and the exemption stays blanket.
+    """
+    key = tuple(key)
+    if key in HEADROOM_PROBE_PAIRS:
+        return (node_count / HEADROOM_PROBE_INTERVAL_SECONDS
+                * HEADROOM_PROBE_TOLERANCE)
+    if key in HARNESS_DRIVEN_PAIRS:
+        return math.inf
+    return None
 
 
 def enforced(entry):

--- a/shakenfist/tests/test_database_tier_harness.py
+++ b/shakenfist/tests/test_database_tier_harness.py
@@ -17,6 +17,7 @@ for every entry in the shipped budget, at four cluster shapes.
 import ast
 import importlib.util
 import json
+import math
 import os
 import textwrap
 import tomllib
@@ -131,6 +132,19 @@ class FakeResponse:
         pass
 
 
+# The headroom probe is phase 1 instrumentation of
+# docs/plans/PLAN-ci-cloud-sizing.md and is meant to come out once the
+# sizing question it answers is closed. Both guards below read it by
+# path, so say what its absence means rather than letting them die on a
+# FileNotFoundError which names no consequence.
+_PROBE_IS_GONE = (
+    'tools/ci_headroom_probe.py is gone, so nothing samples the node '
+    'roster on a timer during a CI run any more. That is the entire '
+    'justification for the HEADROOM_PROBE_PAIRS allowance in '
+    'load_budget.py -- drop those three pairs and let the idle load check '
+    'see them at the ordinary unbudgeted ceiling again.')
+
+
 class DatabaseTierHarnessTestCase(base.ShakenFistTestCase):
     def test_scrape_request_pairs_reads_both_label_orders(self):
         # Prometheus does not promise a label order, and the sample which
@@ -196,9 +210,9 @@ class DatabaseTierHarnessTestCase(base.ShakenFistTestCase):
         # HARNESS_DRIVEN_PAIRS exists to avoid rather than cause.
         budgeted = {e['operation'] + '/' + e['caller_daemon']
                     for e in harness.load_budget()['entries']}
+        exempted = harness.HARNESS_DRIVEN_PAIRS | harness.HEADROOM_PROBE_PAIRS
         overlap = sorted(
-            {'%s/%s' % pair for pair in harness.HARNESS_DRIVEN_PAIRS}
-            & budgeted)
+            {'%s/%s' % pair for pair in exempted} & budgeted)
         self.assertEqual(
             [], overlap,
             'These pairs are exempted as harness traffic and are also in '
@@ -212,6 +226,146 @@ class DatabaseTierHarnessTestCase(base.ShakenFistTestCase):
         self.assertTrue(harness.harness_driven(['GetObjectEvents', 'api']))
         self.assertFalse(harness.harness_driven(('GetObjectEvents', 'net')))
         self.assertFalse(harness.harness_driven(('GetNodeDaemonState', 'net')))
+        # The probe pairs are harness driven too, and are the reason
+        # harness_driven() is no longer the question the caller wants.
+        self.assertTrue(harness.harness_driven(('GetNodeMetrics', 'api')))
+        self.assertFalse(harness.harness_driven(('GetNodeMetrics', 'queues')))
+
+    def test_allowance_is_none_for_a_pair_the_harness_does_not_produce(self):
+        # None rather than zero, because the two say different things: a
+        # zero allowance would read as "the harness produces this and
+        # explains none of it", which would make every ordinary cluster
+        # pair look like a harness pair running over.
+        self.assertIsNone(
+            harness.harness_allowance(('GetNodeMetrics', 'queues'), 6))
+        self.assertIsNone(
+            harness.harness_allowance(('GetInstance', 'api'), 6))
+
+    def test_allowance_is_unbounded_for_the_events_poll(self):
+        # GetObjectEvents has no arithmetic rate to subtract -- it is set
+        # by how many workers happen to be waiting -- so it stays a
+        # blanket exemption, expressed as an infinite allowance so the
+        # caller needs only one comparison.
+        self.assertEqual(
+            math.inf,
+            harness.harness_allowance(('GetObjectEvents', 'api'), 6))
+
+    def test_allowance_covers_the_rate_the_probe_actually_produced(self):
+        # The numbers from the two runs in #3975. Both are a shade under
+        # the arithmetic N/interval, because the measurement is a counter
+        # difference over a wall clock window and the allowance is
+        # division; the allowance has to cover them or the merge queue
+        # fails on the measuring instrument, which is the bug being
+        # fixed here.
+        for measured in (0.39981792260485516, 0.39972509425618863):
+            for pair in sorted(harness.HEADROOM_PROBE_PAIRS):
+                self.assertLessEqual(
+                    measured, harness.harness_allowance(pair, 6),
+                    '%s/%s at %r on the six node cluster' % (pair + (measured,)))
+
+    def test_allowance_scales_with_the_cluster_and_still_bounds_the_pair(self):
+        # The point of an allowance rather than a blanket skip: it grows
+        # with the roster the probe walks, and a pair running clear of it
+        # is still reported. Were this a plain membership test, the 4.0/s
+        # case below would pass silently and a genuine new poll of node
+        # state from sf-api would never be seen again.
+        pair = ('GetNodeAttributes', 'api')
+        one_node = harness.harness_allowance(pair, 1)
+        six_nodes = harness.harness_allowance(pair, 6)
+        self.assertLess(one_node, six_nodes)
+        self.assertAlmostEqual(6.0, six_nodes / one_node)
+        self.assertGreater(4.0, six_nodes)
+
+    def test_headroom_probe_interval_matches_the_probe(self):
+        # HEADROOM_PROBE_INTERVAL_SECONDS is the divisor in every
+        # allowance above, and it is a copy of a default which lives in
+        # another file. Read that default back out rather than trusting
+        # the comment beside the copy, on the same argument as
+        # test_daemon_state_poll_interval_matches_the_daemon: a comment
+        # cannot notice that it went stale, and this one going stale
+        # silently widens the blind spot the allowance exists to keep
+        # narrow.
+        here = os.path.dirname(os.path.abspath(__file__))
+        root = os.path.dirname(os.path.dirname(here))
+        path = os.path.join(root, 'tools', 'ci_headroom_probe.py')
+        self.assertTrue(os.path.exists(path), _PROBE_IS_GONE)
+        with open(path, encoding='utf-8') as f:
+            tree = ast.parse(f.read())
+
+        defaults = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (isinstance(func, ast.Attribute)
+                    and func.attr == 'add_argument'):
+                continue
+            if not any(isinstance(a, ast.Constant) and a.value == '--interval'
+                       for a in node.args):
+                continue
+            for keyword in node.keywords:
+                if (keyword.arg == 'default'
+                        and isinstance(keyword.value, ast.Constant)):
+                    defaults.append(keyword.value.value)
+
+        self.assertEqual(
+            [harness.HEADROOM_PROBE_INTERVAL_SECONDS],
+            [float(d) for d in defaults],
+            'The --interval default in tools/ci_headroom_probe.py no '
+            'longer matches HEADROOM_PROBE_INTERVAL_SECONDS in '
+            'load_budget.py. Every headroom allowance divides by that '
+            'constant, so while they disagree the allowance is wrong by '
+            'the ratio between them.')
+
+    def test_the_headroom_probe_still_samples_node_state_on_a_timer(self):
+        # The whole argument for allowing these three pairs is that the
+        # probe walks the node roster on a fixed interval. If it stops --
+        # because it samples something cheaper, or caches the roster, or
+        # goes away with the sizing plan that asked for it -- the
+        # allowance stops being an explanation and becomes a hole, and
+        # the pairs should go back to failing the build. Derived from the
+        # probe rather than asserted about it, exactly as
+        # test_the_suite_still_polls_an_events_endpoint is.
+        here = os.path.dirname(os.path.abspath(__file__))
+        root = os.path.dirname(os.path.dirname(here))
+        path = os.path.join(root, 'tools', 'ci_headroom_probe.py')
+        self.assertTrue(os.path.exists(path), _PROBE_IS_GONE)
+        with open(path, encoding='utf-8') as f:
+            tree = ast.parse(f.read())
+
+        # The sleep and the sampling calls are in different functions --
+        # main() paces the loop, take_sample() makes the calls -- so this
+        # asks the module rather than a single loop body.
+        sleeps_in_a_loop = False
+        for loop in ast.walk(tree):
+            if not isinstance(loop, (ast.While, ast.For)):
+                continue
+            for node in ast.walk(loop):
+                if (isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and node.func.attr == 'sleep'):
+                    sleeps_in_a_loop = True
+
+        sampled = set()
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr in ('get_nodes',
+                                           'get_cluster_resources')):
+                sampled.add(node.func.attr)
+
+        self.assertTrue(
+            sleeps_in_a_loop,
+            'tools/ci_headroom_probe.py no longer sleeps inside a loop, so '
+            'it is not a fixed rate sampler any more. The headroom '
+            'allowances in load_budget.py assume it is.')
+        self.assertEqual(
+            {'get_nodes', 'get_cluster_resources'}, sampled,
+            'tools/ci_headroom_probe.py no longer calls both get_nodes() '
+            'and get_cluster_resources(), which are what produce the '
+            'GetNodeAttributes, GetAllNodeDaemonStates and GetNodeMetrics '
+            'traffic HEADROOM_PROBE_PAIRS exempts. Drop the pairs it no '
+            'longer produces and let the idle load check see them again.')
 
     def test_the_suite_still_polls_an_events_endpoint(self):
         # The whole argument for exempting GetObjectEvents/api is that this


### PR DESCRIPTION
## ⚠️ This overlaps #3985 — only one of the two should land

[#3985](https://github.com/shakenfist/shakenfist/pull/3985) is already open
against this issue and fixes the same failure a different way. Both carry
`Fixes #3975`, and both edit the same comment block in `load_budget.py`, so
they will conflict. **Pick one and close the other.** I did not know #3985
existed when this branch was written; it is offered as the alternative the
issue body asked for, not as a replacement decided on.

| | #3985 | this PR |
|---|---|---|
| Mechanism | adds the three pairs to `HARNESS_DRIVEN_PAIRS` | adds them to `HEADROOM_PROBE_PAIRS` with a computed allowance |
| Unblocks the merge queue | yes | yes |
| Blind spot afterwards | unbounded for those pairs | above ~0.64/s on a six-node cluster |
| New machinery | none | `harness_allowance()`, two constants, a summary field |

The issue body argued against the blanket form: it "permanently blinds the
detector to a *genuine* future fixed-rate poll of node state from sf-api,
which is exactly the class of regression this check exists to find", and
listed subtracting the probe's contribution as an alternative. This PR is
that alternative. #3985 is simpler, already written up, and already green —
if the wider blind spot is acceptable, it is the cheaper landing.

## What was wrong

`tools/ci_headroom_probe.py`, added by ci-cloud-sizing phase 1 (#3940) and
started for every cluster deploy by `ci_headroom_launch.sh` in
`shakenfist/actions`, samples `GET /nodes` and `GET /admin/resources` on a
15s timer for the whole functional test step. Reading the roster runs
`Node.external_view()` per node — one `GetNodeAttributes` and one
`GetAllNodeDaemonStates` each — and `/admin/resources` is one
`GetNodeMetrics` per node.

On an N-node cluster that is N/15 per second for all three, paced by a
constant and indifferent to what the suite is doing, which is exactly the
signature `test_no_unbudgeted_fixed_rate_database_polling` is built to call
a new polling loop. PR CI never sees it: its single-node cluster runs the
same probe at 1/15 = 0.067/s, under the 0.30/s ceiling. Only merge-group
cluster jobs are big enough to trip it, so it was reachable by any PR
entering the queue.

## The change

Exempt the three pairs, but as an **allowance** rather than a blanket skip:
subtract the rate the probe is known to produce and report the residual, so
a pair running above the probe's own rate still fails.

The distinction is the point. `GetNodeMetrics/api` is not only the probe —
instance creation constructs a Scheduler and reads node metrics too, and in
the merge group for #3970 that pair did not even reach the unbudgeted branch
because the suite's own activity moved it. Skipping it outright would hide a
real signal in order to silence a synthetic one.

The budget is the wrong home on the same argument as `GetObjectEvents`: no
deployed cluster runs a headroom probe, so an entry would model load that
exists nowhere outside a CI job, and it would have to be a `per_node` term
that raises every real cluster's ceiling in proportion to its size.

## What it still costs

Said plainly: a new fixed-rate poll of node state from sf-api is invisible
below the probe's own rate — 0.64/s on a six-node cluster. That floor is
CI's alone. None of the three pairs is budgeted for the `api` caller, so
`ShakenFistUnbudgetedDatabasePolling` goes on watching all three at the
unbudgeted ceiling on every real cluster.

## Verification

- `pre-commit run --all-files` passes, exit 0, all ten hooks.
- Full unit suite: 4012 tests, 3894 passed, 118 skipped, **0 failed**.
- The real measurements from **both** failing runs replayed through the real
  `load_budget` classifier now land in `harness_driven` with
  `unbudgeted == []`:
  - run 33346719231 (`pr-3970`, 6 nodes, 0.39981792260485516/s)
  - run 33300049893 (`pr-3968`, 6 nodes, 0.39972509425618863/s, all three pairs)
- Regression controls: the same pair at 1.7x, 2x and 3.5x the probe's rate is
  still **caught**; `GetNodeMetrics/queues` at 0.9/s is untouched;
  `GetObjectEvents/api` keeps its blanket exemption.
- Guards mutation-tested individually — `--interval` default changed,
  `get_nodes()` removed, the loop's `sleep` removed. Each fails; the baseline
  passes; the probe is byte-identical to HEAD afterwards.

## Known limitation

`HEADROOM_PROBE_INTERVAL_SECONDS` mirrors a default that the workflow in
`shakenfist/actions` overrides explicitly with `--interval 15`, and no test
here can see that repository. It fails safe: a workflow sampling *faster*
than this leaves a residual above the allowance, which is a visible failure
naming the measured rate rather than a silent hole.

The "probe file deleted entirely" branch in the two guards is belt-and-braces
rather than load-bearing — `test_ci_headroom_probe.py` imports the probe at
module scope, so removing it fails test *discovery* before either guard runs.

## Also in this PR

`docs/developer_guide/ci.md` claimed "Nothing in CI today can fail because of
this instrumentation." #3975 is precisely that happening, so the claim is
corrected and the probe's own load and its allowance are documented.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pjfk5vQtwP1NNHY55VCgv
