### PR TITLE
Tolerate either agent operation failure exception in the CI suite

### DIFF
--- a/docs/plans/PLAN-agent-operation-deadlines.md
+++ b/docs/plans/PLAN-agent-operation-deadlines.md
@@ -614,7 +614,7 @@ the slot at all.
 | 4 | [PLAN-agent-operation-deadlines-phase-04-enforcement.md](PLAN-agent-operation-deadlines-phase-04-enforcement.md) | Complete | Enforcement: dequeue expiry, preflight expiry, executor deadline + progress timeout, `observe_progress()` hooks; remove `AGENT_OPERATION_EXECUTION_TIMEOUT`; the `expired` state with its audit-enumerated obligations (`state_targets`, `FINAL_OBJECT_STATES`, guarded error writes, command-abort check). Survey corrections applied at source: every address in decision 1 was refreshed after phase 1's refactor, the reaper is phase 5's rather than this phase's, and preflight is a fourth enforcement point the design sketch never listed. The phase plan also decides that an expiry records its reason as a state message and an audit event rather than as `.error`, which the `error` setter refuses from a non-`error` state |
 | 5 | [PLAN-agent-operation-deadlines-phase-05-retry.md](PLAN-agent-operation-deadlines-phase-05-retry.md) | Complete | Retry: `EXECUTING -> QUEUED` edge, terminal-only lazy pop, attempt bound, partial-result cleanup; the node-local reaper, covering a dead executor thread, no executor at all after a daemon restart, and a live executor wedged in the pre-connection wait. Survey corrections applied at source: decision 5's address for `reap_instance_executors()`, that retryability is evaluated over the whole command list rather than the command in flight, and that partial-result cleanup has a registered-blob case the design sketch did not cover. The phase plan also decides that the terminal-only pop and the reaper must land in one commit, because the pop rule alone turns a daemon restart from a leak into a wedge |
 | 6 | `PLAN-agent-operation-deadlines-phase-06-client.md` (in shakenfist/client-python, branch `agent-operation-deadlines-phase-06-client`) | Complete | client-python: deadline from await timeout, CLI flags, terminal-state handling (includes fixing client-python#363: await loops poll to their full timeout on terminal failure states instead of failing fast). The plan file lives in the client repository because the code does, following the `PLAN-vdi-console-tokens.md` precedent; a relative link cannot cross repositories, so it is named here rather than linked. Survey corrections applied at source: the new parameters need a capability token before a client can send them safely, which phase 3 did not add and phase 6 does. The phase plan also decides to repair `await_agent_fetch()`'s three hardcoded timeout windows, which make its `timeout` argument a lie, because the phase rewrites those same loops |
-| 7 | | Not started | Docs (operator + developer guides, and the `v07-v08` release note for the deadline parameters and config options -- deferred from phase 3 so it is written once, after enforcement exists), functional CI coverage in `shakenfist_ci`; make the suite's agent-operation await loops fail fast on terminal states (audit finding: they spin on `!= 'complete'`, one with no timeout at all); and give the CI base class's instance and agent-state awaits an absolute ceiling as well as a progress window (#3770 — see below). Note `docs/developer_guide/state_machine.md` is **not** this phase's: it is a rendering of `state_targets`, so phase 4 updated it when it added `expired` rather than leaving the tree self-contradictory for three phases, and phase 5 adds its one further edge |
+| 7 | | Not started | Docs (operator + developer guides, and the `v07-v08` release note for the deadline parameters and config options -- deferred from phase 3 so it is written once, after enforcement exists), functional CI coverage in `shakenfist_ci`; make the suite's agent-operation await loops fail fast on terminal states, and narrow `base.AGENT_OPERATION_FAILURES` to a plain `AgentOperationFailed` reference now that both client generations no longer need tolerating (audit finding: they spin on `!= 'complete'`, one with no timeout at all); and give the CI base class's instance and agent-state awaits an absolute ceiling as well as a progress window (#3770 — see below). Note `docs/developer_guide/state_machine.md` is **not** this phase's: it is a rendering of `state_targets`, so phase 4 updated it when it added `expired` rather than leaving the tree self-contradictory for three phases, and phase 5 adds its one further edge |
 | 8 | | Not started | Push audit: runs `PUSH-AUDIT.md` over the accumulated diff of every phase in this plan against `develop`, not the last phase's diff alone. Findings land as their own pull request, and the plan is not complete until each is resolved or declined in writing here; if the audit finds nothing, that is recorded in one sentence |
 
 Each phase gets its own detailed plan file before implementation.
@@ -680,3 +680,23 @@ see the second review response in
 `PLAN-agent-operation-deadlines-phase-04-enforcement.md`. The
 event-renewed loops above are untouched and remain phase 7's, as does
 restricting renewal to events that represent progress.
+
+**A second slice pulled forward, by CI ordering rather than by
+choice.** Phase 6's client change (client-python#380) makes a
+terminal agent operation state raise the new `AgentOperationFailed`
+on the first poll, where every await loop previously spun out its
+budget and raised `AgentCommandError`. Three places in this suite
+were written against the old behaviour: `test_get_missing_file` in
+both `smoke_ci_tests/test_agentops.py` and
+`guest_ci_tests/test_agentops.py` asserts `AgentCommandError`, and
+`_await_instance_ready`'s cloud-init retry loop (`base.py`) catches
+it twice -- so under the new client a failed health check would
+escape the retry rather than being retried. Neither repository could
+switch first, because this repository's CI builds the client from
+client-python's `develop` and client-python's CI builds the server
+from this repository's `develop`. The deadlock is broken by
+`base.AGENT_OPERATION_FAILURES`, a tuple which accepts either
+exception and resolves the new one through `getattr()` so it still
+imports against an old client. Phase 7 narrows it to a plain
+reference once the client change has merged and the ordering
+constraint is gone.

--- a/shakenfist/deploy/shakenfist_ci/base.py
+++ b/shakenfist/deploy/shakenfist_ci/base.py
@@ -25,6 +25,27 @@ TRACE_PATH = '/srv/ci/traces'
 CLUSTER_CI_IMAGE = 'sf://upload/system/debian-12'
 
 
+# An agent operation which ends in a terminal state other than "complete"
+# reaches the caller as one of these. Historically the client had no way to
+# say "this operation definitively failed": every await loop spun out its
+# whole budget and then raised AgentCommandError, so that is what the suite
+# caught and asserted. client-python#380 (agent operation deadlines phase 6)
+# teaches those loops to recognise a terminal state on the first poll and
+# raise the new, more precise AgentOperationFailed instead.
+#
+# Both client versions are in circulation while that lands: this repository's
+# CI builds the client from client-python's develop, and client-python's CI
+# builds the server from this repository's develop, so neither side can
+# switch first. Accepting either exception is what breaks that deadlock. The
+# getattr() is what makes an old client work -- AgentOperationFailed simply
+# does not exist there -- and can be narrowed to a plain reference once the
+# client change has merged. Phase 7 owns that cleanup, along with the rest of
+# this suite's await work.
+AGENT_OPERATION_FAILURES = (
+    apiclient.AgentCommandError,
+    getattr(apiclient, 'AgentOperationFailed', apiclient.AgentCommandError))
+
+
 # Some functional assertions need to observe real host state (network
 # namespaces, links, iptables, libvirt) on a *specific* cluster node, which is
 # not necessarily the node running the suite. The node-exec helpers on
@@ -445,7 +466,7 @@ class BaseTestCase(testtools.TestCase):
                 time.sleep(30)
                 retries += 1
 
-            except apiclient.AgentCommandError as e:
+            except AGENT_OPERATION_FAILURES as e:
                 self._emit_tracing_event({
                     'msg': 'Instance ready (cloud-init status) attempt failed',
                     'instance_uuid': instance_uuid,
@@ -474,7 +495,7 @@ class BaseTestCase(testtools.TestCase):
                     'msg': f'Debug data from {log_file}',
                     'data': data
                 })
-            except apiclient.AgentCommandError as e:
+            except AGENT_OPERATION_FAILURES as e:
                 self._emit_tracing_event({
                     'msg': f'Failed to gather debug data from {log_file}',
                     'error': e

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_agentops.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_agentops.py
@@ -2,7 +2,6 @@ import json
 import os
 import time
 
-from shakenfist_client import apiclient
 from testtools import content
 
 from shakenfist_ci import base
@@ -313,7 +312,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
 
         # Run a fetch command which should fail
         self.assertRaises(
-            apiclient.AgentCommandError, self.test_client.await_agent_fetch,
+            base.AGENT_OPERATION_FAILURES, self.test_client.await_agent_fetch,
             inst['uuid'], '/tmp/nosuch')
 
     def test_interface_plug_and_exec_dhcp(self):

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
@@ -2,7 +2,6 @@ import json
 import os
 import time
 
-from shakenfist_client import apiclient
 from testtools import content
 
 from shakenfist_ci import base
@@ -304,7 +303,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
 
         # Run a fetch command which should fail
         self.assertRaises(
-            apiclient.AgentCommandError, self.test_client.await_agent_fetch,
+            base.AGENT_OPERATION_FAILURES, self.test_client.await_agent_fetch,
             inst['uuid'], '/tmp/nosuch')
 
     def test_interface_plug_and_exec_dhcp(self):


### PR DESCRIPTION
Unblocks [client-python#380](https://github.com/shakenfist/client-python/pull/380), whose smoke CI is red on this repository's own test suite.

## What broke

Phase 6 of the agent operation deadlines plan teaches the client's agent-operation await loops to recognise a terminal state on the *first* poll and raise a new, more precise `AgentOperationFailed`. Previously every one of those loops spun out its entire await budget on a `!= 'complete'` test and then raised `AgentCommandError`. Three places in `shakenfist_ci` were written against the old behaviour.

**The visible one.** `test_get_missing_file`, in both `smoke_ci_tests/test_agentops.py` and `guest_ci_tests/test_agentops.py`, asserts `AgentCommandError`. Under the new client, fetching a missing file raises `AgentOperationFailed` from `_await_agentop` before `await_agent_fetch`'s own loop is ever reached, so the assertion misses:

```
FAIL: shakenfist_ci.smoke_ci_tests.test_agentops.TestAgentOperations.test_get_missing_file
shakenfist_client.apiclient.AgentOperationFailed: Agent operation
cebfc8a8-da07-4a60-9f45-28f37d767d96 entered terminal state "error"
```

**The quieter one**, which nothing has hit yet. `_await_instance_ready`'s cloud-init retry loop in `base.py` catches `AgentCommandError` twice. Under the new client, a health check whose agent operation ends in `error` escapes the retry entirely rather than being retried — turning a recoverable hiccup into a test failure. Worth fixing in the same change, since it is the same break.

## Why it accepts both exceptions rather than switching

Neither repository can switch first. This repository's CI builds the client from client-python's `develop`; client-python's CI builds the server from this repository's `develop`. A test here asserting `AgentOperationFailed` fails against today's client, which has no such attribute to reference.

So the four sites share one constant in `shakenfist_ci/base.py`:

```python
AGENT_OPERATION_FAILURES = (
    apiclient.AgentCommandError,
    getattr(apiclient, 'AgentOperationFailed', apiclient.AgentCommandError))
```

The `getattr()` is the part that keeps the module importable against an old client. This merges green now and makes client-python#380 green on a re-run.

Phase 7 narrows it to a plain `AgentOperationFailed` reference once the client change has merged and the ordering constraint is gone. The phase 7 row of `PLAN-agent-operation-deadlines.md` records that cleanup, and a new paragraph in the plan's CI-suite section records the pull-forward, following the shape of the "Partly pulled forward into phase 4" note already there.

## Verification

- `testtools.assertRaises` accepts a tuple — confirmed in the installed `MatchesException` docstring ("If a tuple is given, then as with isinstance, any of the types in the tuple matching is sufficient to match"), not assumed.
- Exercised the constant's logic with a five-case harness: old client, new client, both exception types, the degenerate same-class-twice tuple that an old client produces, and that an unrelated `ValueError` still propagates rather than being swallowed. All pass.
- `pre-commit run --all-files`: all ten hooks pass.

Not verified against a real cluster — the assertion only re-runs meaningfully in smoke CI, which is what this PR exists to unblock.

## Merge order

This lands first. Then client-python#380 re-runs and goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Th2MPjs3zYoF4ieE2Wcthi
