### PR TITLE
Declare what we import: oslo.concurrency and the JSON formatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,13 +71,10 @@ dependencies = [
     # Imported directly, rather than reached through whichever package
     # happens to require them today, so what keeps them installed is a
     # declaration and not a transitive pin the reconciler could drop.
-    # logship.py imports pylogrus (which arrives via
-    # shakenfist-utilities), tools/render-review.py imports jsonschema
-    # (via flasgger) and tools/build-collection.py imports packaging
-    # (via the oslo stack).
+    # tools/render-review.py imports jsonschema (via flasgger) and
+    # tools/build-collection.py imports packaging (via the oslo stack).
     "jsonschema==4.26.0",                 # mit
     "packaging==26.3",                    # apache2
-    "pylogrus==0.4.0",                    # mit
 
     "gunicorn[gevent]==26.2.0",           # mit
 
@@ -156,6 +153,7 @@ dependencies = [
     "oslo.utils==10.2.0",
     "pbr==7.0.3",
     "pycparser==3.0",
+    "pylogrus==0.4.0",
     "pyparsing==3.3.2",
     "python-dotenv==1.2.3",
     "pytz==2026.3.post1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 
     # Our requirements -- we specify exact versions here and let renovate update
     # them for the develop branch as required. Releases never update requirements.
-    "shakenfist-utilities==0.8.6",        # apache2
+    "shakenfist-utilities==0.8.8",        # apache2
 
     # not-imported: clingwrap -- a CLI, installed into the node
     # virtualenv so that debug bundles can be collected on a node with

--- a/shakenfist/logship.py
+++ b/shakenfist/logship.py
@@ -42,8 +42,8 @@ import json
 import logging
 from typing import Any
 
-from pylogrus import JsonFormatter
 from shakenfist_utilities import logs
+from shakenfist_utilities.logs import JsonFormatter
 
 from shakenfist.config import config
 
@@ -51,29 +51,17 @@ from shakenfist.config import config
 LOG, _ = logs.setup(__name__)
 
 
-# The library installs a ``JsonFormatter`` on each per-module
-# logger when running with structured logging (v0.8.5+). We reuse
-# that instance so the field list is a single source of truth.
-# Under older library versions the per-module handlers carry a
-# ``TextFormatter`` instead, so no ``JsonFormatter`` exists to
-# lift; this fallback list reconstructs the library's field list.
+# The library installs a ``JsonFormatter`` on each per-module logger
+# when running with structured logging (v0.8.5+). We reuse that
+# instance so the field list is a single source of truth. Under older
+# library versions the per-module handlers carry a ``TextFormatter``
+# instead, so no ``JsonFormatter`` exists to lift and we build one from
+# ``logs.ENABLED_FIELDS``.
 #
-# IMPORTANT: keep this list in sync with
-# ``shakenfist_utilities/logs.py`` ``setup()`` ``enabled_fields``
-# until the library exposes the list directly (future work). It is
-# only used when no library ``JsonFormatter`` is found.
-_FALLBACK_ENABLED_FIELDS = [
-    ('name', 'logger_name'),
-    ('asctime', 'ts'),
-    ('levelname', 'level'),
-    ('process', 'pid'),
-    ('threadName', 'thread_name'),
-    'message',
-    ('exception', 'exception_class'),
-    ('stacktrace', 'stack_trace'),
-    'module',
-    ('funcName', 'function'),
-]
+# That list used to be duplicated here, with a comment asking for the
+# library to expose it directly. It now does, so there is no longer a
+# copy that can drift out of step with the field-name contract in the
+# library's docs/log-record-fields.md.
 
 
 def _json_safe_fields(fields: dict[str, Any]) -> dict[str, Any]:
@@ -149,7 +137,7 @@ def _find_library_json_formatter() -> 'JsonFormatter | None':
     pattern) and returns the first ``JsonFormatter`` found. Under
     v0.8.5+ the library installs one on each per-module handler;
     under older versions the handlers carry a ``TextFormatter`` and
-    this returns None so the caller uses the fallback field list.
+    this returns None so the caller builds one instead.
     """
     for name in list(logging.root.manager.loggerDict.keys()) + ['']:
         for handler in logging.getLogger(name).handlers:
@@ -163,15 +151,13 @@ def _build_formatter() -> JsonFormatter:
 
     Reuse the library's ``JsonFormatter`` instance if one is
     already installed (single source of truth, no field drift);
-    otherwise fall back to reconstructing the documented field
-    list (the v0.8.4 case, where per-module handlers carry a
-    ``TextFormatter``).
+    otherwise build one from the library's exported field list (the
+    v0.8.4 case, where per-module handlers carry a ``TextFormatter``).
     """
     existing = _find_library_json_formatter()
     if existing is not None:
         return existing
-    return JsonFormatter(
-        datefmt='Z', enabled_fields=_FALLBACK_ENABLED_FIELDS)
+    return JsonFormatter(datefmt='Z', enabled_fields=logs.ENABLED_FIELDS)
 
 
 def start(daemon_name: str) -> None:

--- a/shakenfist/tests/test_logship.py
+++ b/shakenfist/tests/test_logship.py
@@ -14,7 +14,7 @@ import uuid
 from logging.handlers import SysLogHandler
 from unittest import mock
 
-from pylogrus import JsonFormatter
+from shakenfist_utilities.logs import JsonFormatter
 
 from shakenfist import logship
 from shakenfist import logship_spool


### PR DESCRIPTION
Two commits: `logship.py` had an import resting on a dependency nobody
declared, and the `shakenfist-utilities` pin bump that makes the replacement
work.

### The JSON formatter

`logship.py` imported `JsonFormatter` straight from `pylogrus` while declaring
`pylogrus` nowhere -- the pin existed only in the generated indirect block,
because `shakenfist-utilities` required it. The moment the library dropped
that requirement and reached a release, the reconciler would have dropped the
pin and this would have failed at import time, in a repository that had
changed nothing.

`shakenfist-utilities` now owns the formatter, so the import moves there. It
also exports `ENABLED_FIELDS`, which retires `_FALLBACK_ENABLED_FIELDS`: a
hand-maintained copy of the field list that carried a comment asking for
exactly this, and that could drift from the contract in the library's
`docs/log-record-fields.md` without anything noticing.

`test_dnsmasq.py` stops using `six.moves.builtins` in favour of `builtins`.
`six` was installed only because `pylogrus` required it, so it leaves with
`pylogrus`; the nine call sites are a rename.

The generated pins for `pylogrus` and `six` are deliberately untouched. That
block is regenerated, so a hand edit survives only until the next reconcile;
now that the pin is bumped the reconciler drops both, because nothing requires
them any more.

### The pin bump

The second commit bumps `shakenfist-utilities` to 0.8.8, which is what makes
the first one work.

Against 0.8.6 the import still resolves -- 0.8.6 re-exports pylogrus's class
under the same name, so flake8 and mypy are happy -- but `logs.ENABLED_FIELDS`
does not exist, and
`test_logship.FormatterTestCase.test_fallback_when_no_library_json_formatter`
fails on the one path that reaches it: the fallback taken when no library
`JsonFormatter` is already installed. That was the only failure in CI here, and
`Can enqueue` was just the gate reporting it.

This pull request originally carried a "do not merge until
shakenfist/library-utilities#44 is released and the pin is bumped" warning.
That release is out. 0.8.7 reimplements `JsonFormatter` in the library, exports
`ENABLED_FIELDS`, and drops the `pylogrus` and `oslo.concurrency` requirements;
0.8.8 is that same code with a version bump and nothing else changed, verified
by diffing the two wheels. So the blocker is resolved and this is mergeable.

### What happened to the `oslo.concurrency` commit

It is gone from this branch, and this description used to describe it. It
declared `oslo.concurrency`, which `shakenfist/deploy/shakenfist_ci/` imported
in four files for `processutils.execute()` and `ProcessExecutionError` without
declaring. That was the correct fix rather than the good one, as it said at the
time -- those ten call sites are `subprocess.run()` with extra steps.

The good one landed separately on develop instead, as 8d6bb6f4b "Stop importing
oslo_concurrency in the CI harness", which removes the usage rather than
declaring the dependency. Nothing in the repository imports `oslo_concurrency`
any more, so there is nothing left here to declare. Note that this does not
remove the oslo stack from an install: `clingwrap` both requires and uses it,
so all twelve packages stay until it makes the same change.

### Testing

Full unit suite against 0.8.8: **4177 run, 4059 passed, 0 failed**. Every
pre-commit hook passes, run over all files rather than the changed ones, with
the `py3` hook no longer skipped -- against 0.8.6 it had to be, which is what
this was waiting on.

### How this was found

By two new consistency audit criteria in shakenfist/development --
`unused-declared-dependency` and `undeclared-direct-dependency`. The latter
still reports four here (`jsonschema`, `marshmallow`, `packaging`, `PyJWT`),
which are left for a follow-up: `marshmallow` in `external_api/validation.py`
and `PyJWT` in `external_api/base.py` are runtime code resting on the same kind
of coincidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUVKns216NBW9wpmhSGvXN
https://claude.ai/code/session_01Kwaink2rEvm4xnMneSh9Bi
