### PR TITLE
Declare marshmallow and PyJWT, which we import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,11 @@ dependencies = [
     "cryptography==50.0.1",               # apache2
     "python-magic==0.4.27",               # mit
     "webargs==8.7.1",                     # mit
+
+    # Imported directly by external_api/validation.py, not merely reached
+    # through webargs, so it is declared rather than left to arrive as a
+    # transitive pin webargs could drop at any release.
+    "marshmallow==4.3.1",                 # mit
     "py-cpuinfo==9.0.0",                  # mit
     "distro==1.9.0",                      # apache2
     "pbr==7.0.3",                         # apache2
@@ -66,6 +71,12 @@ dependencies = [
     "Flask-RESTful==0.3.10",              # bsd
     "flasgger==0.9.7.1",                  # mit
     "Flask-JWT-Extended==4.7.4",          # mit
+
+    # Imported directly for jwt.PyJWKClient in federation.py and the
+    # jwt.exceptions types in external_api/base.py. Flask-JWT-Extended
+    # happens to require it too, but that is its choice to revisit, not a
+    # dependency of ours to inherit.
+    "PyJWT==2.13.0",                      # mit
     "flask-request-id-middleware==1.1",   # mit
 
     # The 2026-06 grpcio bisect (1.81 -> 1.75.1 -> 1.72.2 -> 1.70.0)
@@ -122,7 +133,6 @@ dependencies = [
     "jsonschema-specifications==2025.9.1",
     "jsonschema==4.26.0",
     "MarkupSafe==3.0.3",
-    "marshmallow==4.3.1",
     "mistune==3.3.4",
     "netaddr==1.3.0",
     "oslo.concurrency==7.6.1",
@@ -131,7 +141,6 @@ dependencies = [
     "oslo.utils==10.2.0",
     "packaging==26.3",
     "pycparser==3.0",
-    "PyJWT==2.13.0",
     "pylogrus==0.4.0",
     "pyparsing==3.3.2",
     "python-dotenv==1.2.3",


### PR DESCRIPTION
Two runtime imports that were declared only inside the generated indirect
dependency block.

| package | imported by | arrived via |
|---|---|---|
| `marshmallow` | `external_api/validation.py` (`marshmallow`, `fields`, `validate`) | `webargs` |
| `PyJWT` | `federation.py` (`jwt`, `jwt.PyJWKClient`), `external_api/base.py` (three types from `jwt.exceptions`) | `Flask-JWT-Extended` |

Neither is a dependency we have. They are dependencies somebody else has, that
we have been reading over their shoulder. The pins exist for exactly as long as
`webargs` and `Flask-JWT-Extended` keep requiring them, and
`tools/pin-indirect-dependencies.sh` removes a pin the moment nothing resolves
to it.

This is the shape that already bit us once: `oslo_concurrency` was imported by
the CI harness on an edge that existed only because `shakenfist-utilities`
declared a dependency it never used, and it would have broken at import time
the day that line was removed.

The generated copies go in the same change, the way `pbr` is already handled --
the reconciler leaves out anything declared above the marker, so the two never
fight over a name.

### This changes nothing about what gets installed

The versions are exactly what the block already pinned, so this moves two lines.
Resolving the direct dependencies before and after yields the same 87 packages,
with no symmetric difference at all.

### Still reported after this

`jsonschema` and `packaging`, imported by `tools/render-review.py` and
`tools/build-collection.py` rather than by the package. That is a weaker case
and a separate decision about whether tool scripts should pull the runtime
dependency list around, so they are deliberately left.

### Interaction with #4035

Independent of it and mergeable on its own, but both edit the generated block
within three lines of each other, so whichever lands second needs a trivial
rebase there. #4035 is blocked on a library-utilities release and a pin bump
anyway, so this one landing first is the cheaper order.

### Testing

`pre-commit run --all-files` clean. `undeclared-direct-dependency` drops both
findings.

### How this was found

By the `undeclared-direct-dependency` criterion in shakenfist/development#84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUVKns216NBW9wpmhSGvXN