### PR TITLE
Group the oslo libraries for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,13 +39,10 @@
       ]
     },
     {
-      "description": "Group oslo updates together. The OpenStack oslo libraries are released in lockstep and share internal interfaces, so they must update together",
+      "description": "Group oslo updates together. The OpenStack oslo libraries are released in lockstep and share internal interfaces, so they must update together. The pattern matches the family rather than listing today's members, so a fifth oslo library arriving as a transitive pin is grouped without anyone having to notice",
       "groupName": "oslo",
       "matchPackageNames": [
-        "oslo.concurrency",
-        "oslo.config",
-        "oslo.i18n",
-        "oslo.utils"
+        "/^oslo\\./"
       ]
     },
     {


### PR DESCRIPTION
The oslo libraries cut coordinated releases. `oslo.concurrency`,
`oslo.config`, `oslo.i18n` and `oslo.utils` go out together, so ungrouped they
arrive as four pull requests on the same evening for one upstream event: four
reviews, four CI runs, and four chances to land half of a coordinated upgrade.
Twenty of the oslo bumps merged here in the year to September 2026 were exactly
that.

```json
{
  "description": "Group oslo updates together...",
  "groupName": "oslo",
  "matchPackageNames": ["/^oslo\\./"]
}
```

A regex rather than the four names, so a fifth oslo library arriving as a
transitive pin is grouped without anyone having to notice. No
`matchUpdateTypes`: grouping only minor and patch would leave the majors
arriving one by one, which for a lockstep family is the whole problem.

This does not make us depend on less. It makes one upstream release arrive as
one reviewable change. Whether to depend on oslo at all is the separate
question, and the answer to it is to stop importing `processutils` in the CI
harness -- coming separately.

### Testing

`pre-commit run --all-files` clean; `renovate.json` still parses. The new
`renovate-lockstep-groups` criterion (shakenfist/development#84) goes from fail
to pass for this repository.

kerbside is the only other repository the criterion flags, and its oslo pins
disappear entirely once it bumps `shakenfist-utilities` past
shakenfist/library-utilities#44, so it needs no equivalent rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUVKns216NBW9wpmhSGvXN