### PR TITLE
Stop importing oslo_concurrency in the CI harness

### DIFF
--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -77,6 +77,56 @@ from another plan. If you find yourself about to do something similar, check
 this section first, and check the install path itself rather than a
 description of it.
 
+## Running commands from the functional suite
+
+`shakenfist_ci/process.py` is how the functional suite shells out. It is
+`subprocess.run()` with an acceptable-exit-code list, and it replaced
+`oslo_concurrency.processutils.execute()` -- which the harness was importing
+without declaring, and which nothing else in this repository used.
+
+Three things about it are load-bearing, and are the reason it is a module
+rather than ten inline `subprocess` calls:
+
+* **Output is returned unstripped, and decoded with `os.fsdecode`.** Callers
+  split on newlines and parse JSON, so a trailing newline is data. `ip`, `ssh`
+  and the client run against real hosts and occasionally emit a byte that is
+  not UTF-8; `fsdecode` maps it to a surrogate instead of losing the test to a
+  `UnicodeDecodeError`.
+* **stdin is `/dev/null`.** `ssh` reads stdin, and a command that inherited
+  the test runner's would block rather than fail.
+* **`ProcessTimeoutError` subclasses `ProcessExecutionError`.** A node that
+  accepts an ssh connection and then wedges is exactly as untestable as one
+  that refuses it, so `_require_node_exec()` skips on both without being
+  taught the difference.
+
+### Credentials go through the environment, not argv
+
+`_exec()` in the command-line tests writes every command it runs to stderr,
+and the harness prints it again on failure. So the namespace key reaches
+`sf-client` as `SHAKENFIST_KEY` in the child's environment -- along with
+`SHAKENFIST_NAMESPACE` and `SHAKENFIST_API_URL`, which the client has honoured
+since v0.2.5 -- and never appears on a command line at all.
+
+`process.mask_secrets()` exists as well, and rewrites the value of
+`--key`-shaped flags to `***` before a command or its output goes into an
+exception. It is a backstop and not the protection. Name-based redaction is
+the technique this repository already abandoned once in the API layer, for the
+reason recorded under "Credential-carrying routes are not logged, not
+redacted" in `coding_rules.md`: it silently starts leaking the day somebody
+adds a name it has not heard of. It cannot match a short option, a positional
+secret, or a flag nobody thought of. Keep the credential out of the string.
+
+### Node-exec commands have a timeout
+
+`_node_exec()` passes `SF_CI_NODE_EXEC_TIMEOUT` (seconds, default 300) to
+every command it runs, local or over ssh. These are introspection commands --
+`ip`, `iptables`, `virsh` -- so one of them taking minutes means the node is
+wedged, which is a state a test may well have just put it in. ssh's
+`ConnectTimeout=10` bounds the TCP connect only, and does nothing for a session
+that connects and then stops responding; without this the job would stall
+until the CI runner's own timeout killed it, with no indication of which test
+was to blame.
+
 ## CI headroom instrumentation
 
 Phase 1 of `docs/plans/PLAN-ci-cloud-sizing.md` (see

--- a/shakenfist/deploy/shakenfist_ci/base.py
+++ b/shakenfist/deploy/shakenfist_ci/base.py
@@ -12,9 +12,10 @@ import sys
 import time
 
 import testtools
-from oslo_concurrency import processutils
 from prettytable import PrettyTable
 from shakenfist_client import apiclient
+
+from shakenfist_ci import process
 
 
 logging.basicConfig(level=logging.INFO, format='%(message)s')
@@ -54,6 +55,16 @@ AGENT_OPERATION_FAILURES = (
 SF_CI_SSH_USER = os.environ.get('SF_CI_SSH_USER', 'debian')
 SF_CI_SSH_KEY = os.environ.get(
     'SF_CI_SSH_KEY', os.path.expanduser('~/.ssh/id_rsa'))
+
+# How long a node-exec command may run before it is killed. These are
+# introspection commands -- ip, iptables, virsh -- so any of them taking
+# minutes means the node is wedged, which is a thing a test may well have
+# just done to it. ssh's ConnectTimeout bounds the TCP connect only: a
+# session which connects and then stops responding, because the node's
+# storage has hung, would otherwise stall the job until the CI runner's
+# own timeout killed it with no indication of which test was to blame.
+SF_CI_NODE_EXEC_TIMEOUT = int(
+    os.environ.get('SF_CI_NODE_EXEC_TIMEOUT', '300'))
 
 
 # The delete endpoint refuses a namespace which still owns a live
@@ -237,10 +248,9 @@ class BaseTestCase(testtools.TestCase):
         """Log the current net namespaces."""
         sys.stderr.write(
             '----------------------- netns -----------------------\n')
-        out, err = processutils.execute('sudo ip netns', shell=True,
-                                        check_exit_code=[0, 1])
-        for line in out:
-            sys.stderr.write(line)
+        out, _ = process.execute('sudo ip netns', shell=True,
+                                 check_exit_code=[0, 1])
+        sys.stderr.write(out)
         sys.stderr.write(
             '----------------------- end netns -----------------------\n')
 
@@ -286,7 +296,7 @@ class BaseTestCase(testtools.TestCase):
 
     def _local_ipv4_addresses(self):
         """The set of IPv4 addresses configured on the local host."""
-        out, _ = processutils.execute('ip', '-json', 'addr', 'show')
+        out, _ = process.execute('ip', '-json', 'addr', 'show')
         addresses = set()
         for link in json.loads(out):
             for addr in link.get('addr_info', []):
@@ -308,9 +318,11 @@ class BaseTestCase(testtools.TestCase):
 
         args is a list of command arguments. The command runs directly when
         node is this host, otherwise over ssh to the node's mesh IP. Raises
-        processutils.ProcessExecutionError on an unexpected exit code;
+        process.ProcessExecutionError on an unexpected exit code;
         check_exit_code may be True (only 0), False (any), or a list of
-        acceptable codes.
+        acceptable codes. A command which runs longer than
+        SF_CI_NODE_EXEC_TIMEOUT is killed and raises
+        process.ProcessTimeoutError, which is a subclass of the same.
         """
         if sudo:
             args = ['sudo', *args]
@@ -323,17 +335,18 @@ class BaseTestCase(testtools.TestCase):
             acceptable = check_exit_code
 
         if self._node_is_local(node):
-            return processutils.execute(*args, check_exit_code=acceptable)
+            return process.execute(*args, check_exit_code=acceptable,
+                                   timeout=SF_CI_NODE_EXEC_TIMEOUT)
 
         remote = ' '.join(shlex.quote(a) for a in args)
-        return processutils.execute(
+        return process.execute(
             'ssh', '-i', SF_CI_SSH_KEY,
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'LogLevel=ERROR',
             '-o', 'ConnectTimeout=10',
             '%s@%s' % (SF_CI_SSH_USER, node['ip']), '--', remote,
-            check_exit_code=acceptable)
+            check_exit_code=acceptable, timeout=SF_CI_NODE_EXEC_TIMEOUT)
 
     def _require_node_exec(self, node):
         """Skip the test loudly if commands cannot be run on node.
@@ -349,7 +362,7 @@ class BaseTestCase(testtools.TestCase):
 
         try:
             self._node_exec(node, ['true'])
-        except processutils.ProcessExecutionError as e:
+        except process.ProcessExecutionError as e:
             self.skipTest(
                 'Cannot exec on node %s (%s) over the mesh: %s. See '
                 'docs/plans/PLAN-ci-node-exec-assertions.md for the deploy '

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_commandline_artifacts.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_commandline_artifacts.py
@@ -2,21 +2,25 @@ import json
 import sys
 import time
 
-from oslo_concurrency import processutils
 from testtools import content
 
 from shakenfist_ci import base
+from shakenfist_ci import process
 
 
-def _exec(cmd):
-    sys.stderr.write('\n----- Exec: %s -----\n' % cmd)
-    out, err = processutils.execute(cmd, shell=True)
+def _exec(cmd, env=None):
+    # mask_secrets() on the way to stderr is a backstop, not the
+    # protection: _exec_client() hands the namespace key to sf-client
+    # through env rather than building it into cmd, so there is nothing
+    # here to mask. See process.SECRET_FLAG_RE.
+    sys.stderr.write('\n----- Exec: %s -----\n' % process.mask_secrets(cmd))
+    out, err = process.execute(cmd, shell=True, env=env)
     for line in out.split('\n'):
         sys.stderr.write('out: %s\n' % line)
     sys.stderr.write('\n')
     for line in err.split('\n'):
         sys.stderr.write('err: %s\n' % line)
-    sys.stderr.write('\n----- End: %s -----\n' % cmd)
+    sys.stderr.write('\n----- End: %s -----\n' % process.mask_secrets(cmd))
     return out
 
 
@@ -28,9 +32,16 @@ class TestArtifactCommandLine(base.BaseNamespacedTestCase):
         super().__init__(*args, **kwargs)
 
     def _exec_client(self, cmd):
-        return _exec('sf-client --apiurl %s --namespace %s --key %s %s'
-                     % (self.test_client.base_url, self.namespace,
-                        self.namespace_key, cmd))
+        # sf-client has read SHAKENFIST_API_URL, SHAKENFIST_NAMESPACE and
+        # SHAKENFIST_KEY since v0.2.5. Using them keeps the namespace key
+        # out of the command line, which _exec() writes to stderr on every
+        # invocation and which the harness prints again on failure.
+        return _exec('sf-client %s' % cmd,
+                     env={
+                         'SHAKENFIST_API_URL': self.test_client.base_url,
+                         'SHAKENFIST_NAMESPACE': self.namespace,
+                         'SHAKENFIST_KEY': self.namespace_key,
+                     })
 
     def test_artifact_commands(self):
         # Ensure we have a version of cirros in the cache

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_commandline_network.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_commandline_network.py
@@ -2,21 +2,25 @@ import json
 import sys
 import time
 
-from oslo_concurrency import processutils
 from testtools import content
 
 from shakenfist_ci import base
+from shakenfist_ci import process
 
 
-def _exec(cmd):
-    sys.stderr.write('\n----- Exec: %s -----\n' % cmd)
-    out, err = processutils.execute(cmd, shell=True)
+def _exec(cmd, env=None):
+    # mask_secrets() on the way to stderr is a backstop, not the
+    # protection: _exec_client() hands the namespace key to sf-client
+    # through env rather than building it into cmd, so there is nothing
+    # here to mask. See process.SECRET_FLAG_RE.
+    sys.stderr.write('\n----- Exec: %s -----\n' % process.mask_secrets(cmd))
+    out, err = process.execute(cmd, shell=True, env=env)
     for line in out.split('\n'):
         sys.stderr.write('out: %s\n' % line)
     sys.stderr.write('\n')
     for line in err.split('\n'):
         sys.stderr.write('err: %s\n' % line)
-    sys.stderr.write('\n----- End: %s -----\n' % cmd)
+    sys.stderr.write('\n----- End: %s -----\n' % process.mask_secrets(cmd))
     return out
 
 
@@ -28,14 +32,21 @@ class TestNetworkCommandLine(base.BaseNamespacedTestCase):
         super().__init__(*args, **kwargs)
 
     def _exec_client(self, cmd):
-        return _exec('sf-client --apiurl %s --namespace %s --key %s %s'
-                     % (self.test_client.base_url, self.namespace,
-                        self.namespace_key, cmd))
+        # sf-client has read SHAKENFIST_API_URL, SHAKENFIST_NAMESPACE and
+        # SHAKENFIST_KEY since v0.2.5. Using them keeps the namespace key
+        # out of the command line, which _exec() writes to stderr on every
+        # invocation and which the harness prints again on failure.
+        return _exec('sf-client %s' % cmd,
+                     env={
+                         'SHAKENFIST_API_URL': self.test_client.base_url,
+                         'SHAKENFIST_NAMESPACE': self.namespace,
+                         'SHAKENFIST_KEY': self.namespace_key,
+                     })
 
     def test_network_commands(self):
         # An invalid netblock
         self.assertRaises(
-            processutils.ProcessExecutionError, self._exec_client,
+            process.ProcessExecutionError, self._exec_client,
             'network create %s-net 192.168.1.2/24' % self.namespace)
 
         # Create

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_stray_vxlan.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_stray_vxlan.py
@@ -2,10 +2,10 @@ import json
 import random
 import time
 
-from oslo_concurrency import processutils
 from testtools import content
 
 from shakenfist_ci import base
+from shakenfist_ci import process
 
 
 class StrayVxlanHostMixin:
@@ -58,7 +58,7 @@ class StrayVxlanHostMixin:
                 self._node_exec(
                     self.node, ['ip', 'link', 'delete', device],
                     sudo=True, check_exit_code=False)
-            except processutils.ProcessExecutionError:
+            except process.ProcessExecutionError:
                 pass
 
     def _plant_orphan(self, vxid, mesh_nic, with_bridge=True):

--- a/shakenfist/deploy/shakenfist_ci/process.py
+++ b/shakenfist/deploy/shakenfist_ci/process.py
@@ -1,0 +1,195 @@
+# Copyright 2026 Michael Still and contributors
+"""Running commands for the CI harness.
+
+This replaces the harness's use of
+``oslo_concurrency.processutils.execute()``. Ten call sites wanted
+``subprocess.run()`` with an acceptable-exit-code list, which is what
+this is.
+
+It does not, on its own, remove the oslo stack from an install, and
+nothing in ``pyproject.toml`` changes because of it. ``oslo.concurrency``
+and its eleven companions (oslo.config, oslo.i18n, oslo.utils,
+debtcollector, fasteners, iso8601, netaddr, pyparsing, rfc3986,
+stevedore and wrapt) are pulled in by two *declared* dependencies, and a
+source-level import has no say in pip's resolution:
+
+* ``shakenfist-utilities`` requires it. Removed on that project's
+  develop branch by shakenfist/library-utilities#44, so this one is
+  waiting on a release and a pin bump here.
+* ``clingwrap`` requires it, and uses it -- ``clingwrap/main.py``
+  imports ``processutils`` for the same reason this file existed to
+  serve. Until clingwrap makes the same change, the twelve packages
+  stay.
+
+So this is one of three steps, and the last of the three to be
+identified rather than the last to land. What it buys today is that the
+harness no longer depends on a package it does not declare, which is
+what ``undeclared-direct-dependency`` in the consistency audit asks of
+it.
+
+Like ``safe_headers``, this module deliberately imports nothing beyond
+the standard library, so the unit suite can load it from source. The CI
+harness itself is a client of a running cluster and is not importable
+from ``shakenfist/tests``.
+"""
+
+import os
+import re
+import subprocess
+
+
+#: A backstop for credentials on a command line, not the mechanism that
+#: keeps them off one.
+#:
+#: docs/developer_guide/coding_rules.md ("Credential-carrying routes are
+#: not logged, not redacted") records why name-based redaction is not
+#: allowed to be the protection: the API layer tried it and leaked
+#: identity tokens for as long as it took somebody to add a field the
+#: lists had not heard of. The same hole is here -- this matches
+#: ``--key``, ``--ssh-key`` and ``--token=`` but cannot match ``-k``, a
+#: positional secret, or a flag nobody thought of.
+#:
+#: The commands that carry a namespace key therefore pass it through the
+#: environment instead (``SHAKENFIST_KEY``), and never build it into
+#: argv. This regex is what catches the case somebody gets wrong later.
+SECRET_FLAG_RE = re.compile(
+    r'(--?[\w-]*(?:key|password|passwd|token|secret)(?:=|\s+))(\S+)',
+    re.IGNORECASE)
+
+
+def mask_secrets(command):
+    """Replace the value of any credential-bearing flag with '***'."""
+    return SECRET_FLAG_RE.sub(r'\1***', command)
+
+
+class ProcessExecutionError(Exception):
+    """A command exited with a code the caller did not accept.
+
+    The attribute names match the oslo exception this replaces, because
+    callers read `.exit_code` and interpolate the exception into skip
+    messages.
+
+    `.cmd`, `.stdout` and `.stderr` have all been through
+    `mask_secrets()`, so they are not byte-identical to what `execute()`
+    returns on the success path. That is deliberate -- this object is
+    built to be printed -- but it does mean the exception is the wrong
+    place to read a command's exact output from.
+    """
+
+    def __init__(self, cmd, exit_code, stdout, stderr):
+        self.cmd = cmd
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+        super().__init__(cmd, exit_code, stdout, stderr)
+
+    def __str__(self):
+        return (
+            'Unexpected error while running command.\n'
+            'Command: %s\n'
+            'Exit code: %s\n'
+            'Stdout: %r\n'
+            'Stderr: %r'
+            % (self.cmd, self.exit_code, self.stdout, self.stderr))
+
+
+class ProcessTimeoutError(ProcessExecutionError):
+    """A command did not finish inside its timeout, and was killed.
+
+    A subclass so that the handlers which already treat "the command did
+    not work" as a reason to skip -- `_require_node_exec()` most of all,
+    where a wedged node is exactly as untestable as an unreachable one
+    -- catch this without being taught about it. `.exit_code` is None,
+    because the command was killed rather than exiting.
+    """
+
+    def __init__(self, cmd, timeout, stdout, stderr):
+        self.timeout = timeout
+        super().__init__(cmd, None, stdout, stderr)
+
+    def __str__(self):
+        return (
+            'Command did not complete within %s seconds and was killed.\n'
+            'Command: %s\n'
+            'Stdout: %r\n'
+            'Stderr: %r'
+            % (self.timeout, self.cmd, self.stdout, self.stderr))
+
+
+def execute(*args, shell=False, check_exit_code=True, env=None, timeout=None):
+    """Run a command and return its (stdout, stderr) as text.
+
+    With ``shell=False`` the arguments are the argv of the command. With
+    ``shell=True`` a single string is handed to the shell.
+
+    ``check_exit_code`` is True for "only 0", False for "any", an int
+    for a single acceptable code, or a collection of acceptable codes.
+    Any exit code which is not acceptable raises ProcessExecutionError.
+
+    ``env`` is a mapping laid over this process' environment, not a
+    replacement for it -- the commands here need PATH. It is how a
+    credential is handed to a child without putting it on a command line
+    somebody is going to log.
+
+    ``timeout`` is in seconds, and None means wait forever, which is
+    what oslo did. Exceeding it kills the command and raises
+    ProcessTimeoutError regardless of ``check_exit_code``, there being
+    no exit code to accept.
+
+    Output is decoded with ``os.fsdecode``, which cannot fail, rather
+    than a strict UTF-8 decode: this runs ``ip``, ``ssh`` and the
+    client against real hosts, and a test must not disappear into a
+    UnicodeDecodeError because a command emitted a stray byte. Nothing
+    is stripped, because callers split the output on newlines and parse
+    it as JSON.
+
+    stdin is /dev/null. ssh reads stdin, and a command inheriting the
+    test runner's would block rather than fail.
+    """
+    if shell:
+        if len(args) != 1:
+            raise ValueError(
+                'shell=True takes exactly one command string, got %d '
+                'arguments' % len(args))
+        command = str(args[0])
+        rendered = command
+    else:
+        command = [str(a) for a in args]
+        rendered = ' '.join(command)
+
+    child_env = None
+    if env is not None:
+        child_env = dict(os.environ)
+        child_env.update(env)
+
+    try:
+        completed = subprocess.run(
+            command, shell=shell, stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            close_fds=True, check=False, env=child_env, timeout=timeout)
+    except subprocess.TimeoutExpired as e:
+        raise ProcessTimeoutError(
+            cmd=mask_secrets(rendered), timeout=timeout,
+            stdout=mask_secrets(os.fsdecode(e.stdout or b'')),
+            stderr=mask_secrets(os.fsdecode(e.stderr or b'')))
+
+    stdout = os.fsdecode(completed.stdout)
+    stderr = os.fsdecode(completed.stderr)
+
+    if check_exit_code is True:
+        acceptable = [0]
+    elif check_exit_code is False:
+        acceptable = None
+    elif isinstance(check_exit_code, int):
+        # After the identity checks above, so True and False are already
+        # gone -- they are ints too, and would land here otherwise.
+        acceptable = [check_exit_code]
+    else:
+        acceptable = list(check_exit_code)
+
+    if acceptable is not None and completed.returncode not in acceptable:
+        raise ProcessExecutionError(
+            cmd=mask_secrets(rendered), exit_code=completed.returncode,
+            stdout=mask_secrets(stdout), stderr=mask_secrets(stderr))
+
+    return stdout, stderr

--- a/shakenfist/tests/test_ci_process.py
+++ b/shakenfist/tests/test_ci_process.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Michael Still and contributors
+import importlib.util
+import os
+
+from shakenfist.tests import base
+
+
+# The functional CI suite is a client of the cluster and is not
+# importable from here, but process.py deliberately imports nothing
+# beyond the standard library so its logic can be loaded from source and
+# covered by the unit suite -- the same arrangement safe_headers uses.
+MODULE_PATH = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), '..', 'deploy', 'shakenfist_ci',
+    'process.py'))
+
+
+def _load_process():
+    spec = importlib.util.spec_from_file_location('ci_process', MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class CiProcessTestCase(base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+        self.process = _load_process()
+
+    def test_a_command_returns_its_output(self):
+        out, err = self.process.execute('echo', 'hello')
+        self.assertEqual('hello\n', out)
+        self.assertEqual('', err)
+
+    def test_arguments_are_not_shell_interpreted(self):
+        """Without shell=True the argv is passed through untouched."""
+        out, _ = self.process.execute('echo', 'a b; echo c')
+        self.assertEqual('a b; echo c\n', out)
+
+    def test_a_shell_command_is_interpreted(self):
+        out, _ = self.process.execute('echo one && echo two', shell=True)
+        self.assertEqual('one\ntwo\n', out)
+
+    def test_shell_refuses_more_than_one_argument(self):
+        self.assertRaises(ValueError, self.process.execute,
+                          'echo', 'hello', shell=True)
+
+    def test_stderr_is_captured_separately(self):
+        out, err = self.process.execute(
+            'sh', '-c', 'echo to-out; echo to-err >&2')
+        self.assertEqual('to-out\n', out)
+        self.assertEqual('to-err\n', err)
+
+    def test_output_is_not_stripped(self):
+        """Callers split on newlines and parse JSON; trailing bytes matter."""
+        out, _ = self.process.execute('printf', 'a\nb\n')
+        self.assertEqual('a\nb\n', out)
+
+    def test_undecodable_output_does_not_raise(self):
+        """A stray byte must not lose the test to a UnicodeDecodeError."""
+        out, _ = self.process.execute('sh', '-c', "printf '\\377'")
+        # os.fsdecode maps the undecodable byte to a surrogate rather
+        # than raising, which is what a strict decode would have done.
+        self.assertEqual('\udcff', out)
+
+    def test_a_nonzero_exit_raises(self):
+        e = self.assertRaises(
+            self.process.ProcessExecutionError,
+            self.process.execute, 'sh', '-c', 'exit 7')
+        self.assertEqual(7, e.exit_code)
+
+    def test_an_accepted_exit_code_does_not_raise(self):
+        out, _ = self.process.execute(
+            'sh', '-c', 'echo hi; exit 1', check_exit_code=[0, 1])
+        self.assertEqual('hi\n', out)
+
+    def test_check_exit_code_false_accepts_anything(self):
+        _, _ = self.process.execute(
+            'sh', '-c', 'exit 42', check_exit_code=False)
+
+    def test_the_error_carries_the_output(self):
+        e = self.assertRaises(
+            self.process.ProcessExecutionError, self.process.execute,
+            'sh', '-c', 'echo out; echo err >&2; exit 2')
+        self.assertEqual('out\n', e.stdout)
+        self.assertEqual('err\n', e.stderr)
+        self.assertIn('Exit code: 2', str(e))
+
+    def test_stdin_is_not_the_test_runners(self):
+        """ssh reads stdin; inheriting the runner's would block."""
+        out, _ = self.process.execute('cat')
+        self.assertEqual('', out)
+
+    def test_a_credential_flag_is_masked_in_the_error(self):
+        """The backstop for a credential which reached a command line."""
+        e = self.assertRaises(
+            self.process.ProcessExecutionError, self.process.execute,
+            'sf-client --key SUPERSECRET network create; exit 1', shell=True)
+        self.assertNotIn('SUPERSECRET', str(e))
+        self.assertIn('--key ***', str(e))
+
+    def test_masking_covers_the_usual_flags(self):
+        for flag in ('--key', '--password', '--passwd', '--token', '--secret'):
+            for form in ('%s VALUE', '%s=VALUE'):
+                rendered = self.process.mask_secrets('cmd ' + form % flag)
+                self.assertNotIn('VALUE', rendered, rendered)
+
+    def test_masking_leaves_ordinary_arguments_alone(self):
+        self.assertEqual(
+            'cmd --apiurl http://x network create',
+            self.process.mask_secrets('cmd --apiurl http://x network create'))
+
+    def test_masking_covers_hyphenated_and_prefixed_flags(self):
+        """--ssh-key and friends are the shape a caller actually writes."""
+        for flag in ('--ssh-key', '--api-key', '--namespace-key',
+                     '--auth-token', '--client-secret'):
+            for form in ('%s VALUE', '%s=VALUE'):
+                rendered = self.process.mask_secrets('cmd ' + form % flag)
+                self.assertNotIn('VALUE', rendered, rendered)
+
+    def test_masking_does_not_cover_short_options(self):
+        """The documented hole, pinned so it is not mistaken for coverage.
+
+        A single-letter option carries no evidence that its value is a
+        credential -- -k is --insecure to curl. This is why the namespace
+        key goes to sf-client through the environment rather than argv,
+        and why mask_secrets() is described as a backstop.
+        """
+        self.assertEqual('cmd -k SECRET',
+                         self.process.mask_secrets('cmd -k SECRET'))
+
+    def test_the_error_masks_the_output_streams_too(self):
+        """A command which echoes its own argv must not undo the masking."""
+        e = self.assertRaises(
+            self.process.ProcessExecutionError, self.process.execute,
+            'echo "ran --token SUPERSECRET" >&2; exit 1', shell=True)
+        self.assertNotIn('SUPERSECRET', e.stderr)
+        self.assertIn('--token ***', e.stderr)
+
+    def test_check_exit_code_accepts_a_bare_int(self):
+        """oslo took an int here, so a caller eventually will too."""
+        out, _ = self.process.execute(
+            'sh', '-c', 'echo hi; exit 3', check_exit_code=3)
+        self.assertEqual('hi\n', out)
+
+    def test_a_bare_int_still_rejects_other_codes(self):
+        e = self.assertRaises(
+            self.process.ProcessExecutionError, self.process.execute,
+            'sh', '-c', 'exit 4', check_exit_code=3)
+        self.assertEqual(4, e.exit_code)
+
+    def test_env_is_laid_over_the_environment_not_a_replacement(self):
+        """The commands run here need PATH; only the additions are new."""
+        out, _ = self.process.execute(
+            'sh', '-c', 'echo "$SF_TEST_VALUE"; echo "${PATH:+haspath}"',
+            env={'SF_TEST_VALUE': 'from-env'})
+        self.assertEqual('from-env\nhaspath\n', out)
+
+    def test_env_does_not_leak_into_this_process(self):
+        self.process.execute('true', env={'SF_TEST_VALUE': 'from-env'})
+        self.assertIsNone(os.environ.get('SF_TEST_VALUE'))
+
+    def test_a_command_which_overruns_its_timeout_is_killed(self):
+        e = self.assertRaises(
+            self.process.ProcessTimeoutError, self.process.execute,
+            'sleep', '30', timeout=0.2)
+        self.assertIsNone(e.exit_code)
+        self.assertIn('did not complete within', str(e))
+
+    def test_a_timeout_is_a_process_execution_error(self):
+        """So the handlers which already skip on exec failure catch it."""
+        self.assertTrue(issubclass(self.process.ProcessTimeoutError,
+                                   self.process.ProcessExecutionError))
+
+    def test_a_timeout_fires_regardless_of_check_exit_code(self):
+        """There is no exit code to accept when the command was killed."""
+        self.assertRaises(
+            self.process.ProcessTimeoutError, self.process.execute,
+            'sleep', '30', timeout=0.2, check_exit_code=False)


### PR DESCRIPTION
The CI harness was the last thing in this repository importing
`oslo_concurrency`, for ten calls to `processutils.execute()`. What those calls
needed was `subprocess.run()` with an acceptable-exit-code list, which is now
`shakenfist_ci/process.py`.

### What this does and does not do

**It does not remove anything from an install**, and `pyproject.toml` is
untouched. The first version of this description claimed it shed twelve
packages; that was wrong, and the automated review caught it. An import has no
say in pip's resolution, and two *declared* dependencies pull the oslo stack in
regardless:

- `shakenfist-utilities` requires it. Removed on that project's develop branch
  by shakenfist/library-utilities#44, so this is waiting on a release and a pin
  bump here.
- `clingwrap` requires **and uses** it -- `clingwrap/main.py:12` imports
  `processutils` for the same reason this file existed to serve. Until
  clingwrap makes the same change, all twelve stay: `oslo.concurrency`,
  `oslo.config`, `oslo.i18n`, `oslo.utils`, `debtcollector`, `fasteners`,
  `iso8601`, `netaddr`, `pyparsing`, `rfc3986`, `stevedore`, `wrapt`. Fifteen
  percent of the dependency closure, and 34 of the 248 dependency bumps merged
  here in the year to September 2026.

So this is one of three steps, not the whole thing.

**What it buys today** is that the harness no longer depends on a package it
does not declare, which is what `undeclared-direct-dependency` in the
consistency audit asks of it.

### Behaviour preserved

The semantics the callers relied on, kept deliberately:

- `(stdout, stderr)` as text, **nothing stripped** -- callers split on newlines
  and parse the output as JSON.
- `check_exit_code` as `True` (only 0), `False` (any), an int, or a list.
- Decoding via `os.fsdecode` rather than a strict UTF-8 decode, so a stray byte
  from `ip` or `ssh` cannot lose a test to a `UnicodeDecodeError`.
- stdin is `/dev/null`. `ssh` reads stdin, and a command inheriting the test
  runner's would block rather than fail.

### The namespace key is off the command line entirely

The command line tests logged every `sf-client` invocation to stderr, key
included, on success as well as failure -- so masking it inside the exception
bought nothing at the one call site it was written for.

`sf-client` has honoured `SHAKENFIST_KEY`, `SHAKENFIST_NAMESPACE` and
`SHAKENFIST_API_URL` since v0.2.5, so `execute()` grew an `env` argument -- laid
over the environment, not replacing it, because these commands need `PATH` --
and `_exec_client()` uses it. The key never reaches an argv.

`mask_secrets()` stays as a backstop, now applied at the logging site as well
as in the exception, and widened to catch hyphenated forms like `--ssh-key`.
It is documented as a backstop rather than as the protection: name-based
redaction is the technique `coding_rules.md` records this project abandoning in
the API layer after it leaked identity tokens, and it cannot match a short
option, a positional secret, or a flag nobody thought of. A test pins that gap
so it is not mistaken for coverage.

### Node-exec commands have a timeout

`SF_CI_NODE_EXEC_TIMEOUT`, 300 seconds by default. `ssh`'s `ConnectTimeout`
bounds the TCP connect only, and a node whose storage has hung will accept a
connection and then stop responding -- so a wedged node stalled the whole job
until the runner's own timeout killed it, naming no test.
`ProcessTimeoutError` subclasses `ProcessExecutionError`, so
`_require_node_exec()` skips on a wedged node the same way it already skips on
an unreachable one.

### Also

`_log_netns` iterated a string and wrote it one character at a time. It writes
the string. Same bytes.

### Interaction with the other open PRs

#4035 has been rebased and its `oslo.concurrency` declaration commit dropped,
so there is no longer a conflict between the two. It remains blocked on a
`shakenfist-utilities` release.

### Testing

`pre-commit run --all-files` clean, unit suite included, no skips. 25 tests in
`shakenfist/tests/test_ci_process.py`, loading the module from source the way
`test_safe_headers.py` does -- `process.py` imports nothing beyond the standard
library, so the harness stays coverable from the unit suite.

New documentation in `docs/developer_guide/ci.md` ("Running commands from the
functional suite").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUVKns216NBW9wpmhSGvXN
