### PR TITLE
Agent operation deadlines phase 7: docs and CI coverage

### DIFF
--- a/docs/developer_guide/api_reference/instances.md
+++ b/docs/developer_guide/api_reference/instances.md
@@ -694,11 +694,17 @@ is meaningful.
 
 !!! note "What happens when a budget runs out"
 
-    An operation which exhausts either budget moves to `expired`, a
-    terminal state distinct from `error`. `error` means the operation
-    itself failed; `expired` means a budget you set ran out, and the
-    state's message says which. Nothing is retried and no further
-    command in the operation runs.
+    An operation which exhausts either budget, and for which no retry is
+    possible (see below), moves to `expired`, a terminal state distinct
+    from `error`. `error` means the operation itself failed; `expired`
+    means a budget you set ran out, and the state's message says which.
+    A wall-clock deadline running out is always final -- there is no
+    time left for a further attempt to deliver anything in -- but a
+    progress-timeout stall may be retried a bounded number of times
+    before landing in `expired`; see
+    [Agent Operations](../../operator_guide/agent_operations.md#retry-and-the-executor-reaper)
+    in the operator guide for the retry rules and the node-local reaper
+    that backs them up.
 
     Three places enforce this, so an abandoned operation is retired
     wherever it happens to be sitting: when it reaches the head of the

--- a/docs/operator_guide/agent_operations.md
+++ b/docs/operator_guide/agent_operations.md
@@ -1,0 +1,203 @@
+# Agent Operations
+
+An agent operation is a request handled by the in-guest `sf-agent2`
+process rather than by the hypervisor directly: executing a command,
+copying a blob into the instance, or fetching a file out of it. The
+API server creates an `AgentOperation` object for each request, which
+is enqueued against the target instance and dispatched by the
+sidechannel daemon once the instance's agent channel is ready. For the
+request parameters themselves -- `deadline_seconds`,
+`progress_timeout_seconds`, and what each of the three creating calls
+accepts -- see
+[the API reference](../developer_guide/api_reference/instances.md#bounding-how-long-an-agent-operation-may-take).
+This page is about what happens operationally once a request is
+enqueued.
+
+## One executor per instance
+
+The sidechannel daemon runs at most one executor thread per instance
+at a time: its dispatch loop skips any instance that already has a
+live executor, and `Instance.agent_operation_next()` leaves an
+executing operation at the head of the queue rather than handing out a
+second one. This is deliberate -- it is what makes dispatch crash
+safe, since the queue entry survives a daemon restart -- but it has an
+operational consequence worth knowing: an operation that wedges takes
+out that instance's *entire* agent surface until something ends it.
+Every other queued operation against the same instance, however
+unrelated, waits behind it. Nothing about this is per-command; it is
+per-instance.
+
+This is why the timing budgets below exist, and why the reaper further
+down exists too: a wedged operation with no budget and no reaper would
+block an instance's agent operations indefinitely.
+
+## The two budgets
+
+Every agent operation carries two independent timing budgets, either
+of which the caller may set explicitly per request. If they do not,
+the server applies a default.
+
+- **`AGENT_OPERATION_DEFAULT_DEADLINE`** (default 600 seconds,
+  `shakenfist/config.py:240`) is a wall-clock budget. It is counted
+  from the moment the API server received the request, not from when
+  the agent picked the work up -- so time spent queued behind another
+  operation on the same instance, and any preflight work such as
+  fetching a blob onto the hypervisor, both count against it before
+  the operation ever executes.
+- **`AGENT_OPERATION_DEFAULT_PROGRESS_TIMEOUT`** (default 30 seconds,
+  `shakenfist/config.py:259`) is how long a transfer may go without
+  making forward progress. It applies only to the commands that can
+  report progress at all -- the transfers behind `agent/get` and
+  `agent/put` -- and never to `agent/execute`: nothing an executed
+  command does is observable as progress, so the API refuses a
+  `progress_timeout_seconds` on that endpoint rather than accept one
+  that could never fire.
+
+A caller may send `0` for either parameter to disable it entirely;
+omitting the parameter takes the default instead. See the API
+reference linked above for the full three-way distinction between
+omitted, zero and a positive value.
+
+## Where the budgets are enforced
+
+Three points enforce these budgets, so an operation that has run out
+of time is retired wherever it happens to be sitting rather than only
+when something next looks at it directly:
+
+1. **At dequeue** -- `Instance.agent_operation_next()` expires a
+   queued head whose deadline has already passed before it is ever
+   handed to an executor, and moves on to consider the next entry in
+   the same pass.
+2. **During preflight** -- the task that promotes an operation from
+   `preflight` to `queued` (fetching a blob onto the hypervisor, for
+   `agent/put`) also checks the deadline either side of that work.
+3. **Inside the executor** -- once running, the executor checks both
+   budgets roughly once a second.
+
+`agent/execute` never goes through preflight at all; the endpoint
+queues it directly. So if you see an expired `execute` operation, it
+was expired either at dequeue (it sat in the queue too long) or inside
+the executor (it ran too long) -- never during preflight, because that
+stage does not apply to it.
+
+## Telling `expired` from `error`
+
+An agent operation that fails ends in `error`. An agent operation that
+runs out of one of the two budgets above ends in `expired` -- a
+distinct terminal state. The distinction matters operationally:
+`error` means the operation itself went wrong (the agent reported a
+failure, the command was unrecognised); `expired` means a budget the
+caller (or the server default) set simply ran out.
+
+*Which* budget expired an operation is not on the operation's own
+external view -- it is in the state row's message, which is not
+surfaced as a separate field. The reliable place to read it is the
+instance's event log: `expire()` always writes an audit event against
+both the operation and the instance recording the reason, and because
+an expired operation is swept for hard deletion once the cleaner's
+delay elapses (the same as a completed one), the instance's copy of
+that event is the one that survives to be read later. When
+`instance execute`/`upload`/`download` on a current client hits a
+terminal state, it now raises `AgentOperationFailed` immediately
+rather than continuing to poll -- see the client behaviour note in the
+[v0.7 to v0.8 release notes](../release_notes/v07-v08.md).
+
+## Retry and the executor reaper
+
+An operation that fails while `executing`, for a retryable reason, is
+not necessarily abandoned. It can be returned to the *head* of its
+instance's queue for another attempt, provided all of the following
+hold:
+
+- **The failure is retryable at all.** Retryability is a property of
+  the whole command list for the operation, not of whichever command
+  happened to be in flight when the attempt was abandoned -- because a
+  retry restarts the command list from index 0, and re-running an
+  earlier command in the list would repeat a side effect the agent
+  cannot take back. `agent/execute` operations are never retryable for
+  exactly this reason: executing a command is a side effect that
+  cannot be undone, so re-running it from the start would double it.
+  `agent/get` and `agent/put` are retryable.
+- **The wall-clock deadline has not passed.** A stalled attempt can be
+  retried; an operation whose caller-set deadline has already been
+  used up cannot -- there is no time left for a further attempt to
+  deliver anything in, so it goes straight to `expired` instead.
+- **The attempt cap has not been reached.** Bounded by
+  `AGENT_OPERATION_MAX_ATTEMPTS` (default 3, `shakenfist/config.py:303`)
+  -- the number of times an operation may be dispatched to the agent
+  in total, counting the first attempt plus retries. Once that many
+  attempts have been made, the operation is retired instead of tried
+  again.
+
+When none of those conditions can be met, the operation reaches a
+terminal state instead: `expired` for a stall that cannot be retried
+(the caller's timing budget is still the reason), `error` for the case
+where an executor simply went away with nothing else to blame it on.
+
+Separately, a **node-local reaper**
+(`Monitor.reap_instance_executors()`,
+`shakenfist/daemons/sidechannel/main.py:1559`) runs on every dispatch
+pass and resolves operations that the queue itself cannot tell are
+stuck. Nothing in the queue can distinguish a live executor from a
+dead one, but the node the instance is placed on can, because the
+executor is a thread in that node's own process. The reaper recovers
+three situations:
+
+- **An executor thread that died without resolving its operation** --
+  the sidechannel daemon restarted while an operation was executing
+  (so no `finally` block ever ran), or a dead thread was swept without
+  cleaning up after itself. The operation is `fail()`-ed: something
+  was actively running it and stopped being able to, which is treated
+  as an executor failure rather than a budget running out.
+- **An operation left `executing` with no executor at all**, most
+  commonly a daemon restart. Same outcome as above: `fail()`, via
+  `resolve_abandoned_operation()`, so it may still retry if the usual
+  retry conditions hold.
+- **An executor wedged before it ever connected to the agent**, once
+  its operation's deadline has passed. This is the one case the
+  executor's own budget checks cannot catch, because it only checks
+  its budgets once it is running its main loop -- a hang in the
+  pre-connection wait never reaches that code. The reaper detects it
+  from the outside, purely on the deadline having passed, and
+  `expire()`s the operation before aborting the wedged executor
+  thread.
+
+The reaper is rate-limited to once every 30 seconds per instance, and
+cannot help in two situations by design: an instance with no live
+monitor (it waits for the monitor to restart instead, normally within
+30 seconds), and an operation created with `deadline_seconds=0` whose
+executor wedges before connecting -- with no wall-clock budget at all,
+there is no evidence available to declare it stuck.
+
+## What to tune, and when
+
+The most likely complaint you will see after upgrading is a long agent
+command being killed partway through. This is expected: the effective
+default deadline (600 seconds, counted from request receipt) is
+*tighter* than the fixed 900-second backstop it replaced, which only
+started counting once the executor connected. A command that used to
+comfortably fit under 900 seconds of execution time can now be cut off
+by queue time and preflight time eating into its 600-second budget
+before it even starts running.
+
+If that happens:
+
+- **For a one-off long command**, pass an explicit `deadline_seconds`
+  on the request rather than changing cluster-wide configuration.
+- **If long agent commands are routine for your workload**, raise
+  `AGENT_OPERATION_DEFAULT_DEADLINE`. The trade-off is that a genuinely
+  wedged operation -- one that never made progress and never will --
+  now occupies its instance's single executor slot for longer before
+  anything notices, since the wall-clock deadline is the backstop that
+  eventually catches a hang the progress timeout cannot see (an
+  `agent/execute` in particular has no progress signal at all).
+- **`AGENT_OPERATION_DEFAULT_PROGRESS_TIMEOUT`** rarely needs raising
+  for the same reason: it only governs transfers that report progress,
+  and 30 seconds is generous relative to real transfer times. Raise it
+  only if you have evidence of transfers that are healthy but slow
+  enough to trip it -- a very constrained network path, for example.
+- **`AGENT_OPERATION_MAX_ATTEMPTS`** is a retry budget, not a timing
+  budget; raising it gives a flaky agent channel more chances to
+  recover but also lets a genuinely broken operation occupy an
+  instance's executor slot for more attempts before it is finally
+  retired.

--- a/docs/operator_guide/database.md
+++ b/docs/operator_guide/database.md
@@ -1159,10 +1159,12 @@ outlives either moves to the terminal `expired` state, checked at
 dequeue, during preflight and in the sidechannel executor. A NULL
 `deadline` has no request receipt time to anchor its default against,
 so it is anchored on the current state's transition time instead, which
-means a legacy row's budget restarts at each transition. `attempts` and
-`last_progress` are recorded but not yet consumed; the retry bound and
-the node-local reaper which reads them arrive with the rest of
-`docs/plans/PLAN-agent-operation-deadlines.md`.
+means a legacy row's budget restarts at each transition. `attempts`
+counts dispatches against `AGENT_OPERATION_MAX_ATTEMPTS` and
+`last_progress` backs the progress timeout; both are read by the retry
+decision and by the node-local executor reaper. See
+[Agent Operations](agent_operations.md) for what an operator sees as a
+result of any of this.
 
 Namespace keys used to be anonymous entries inside that row's `keys`
 JSON dict. They are now objects in their own right, so that a key can

--- a/docs/plans/PLAN-agent-operation-deadlines-phase-07-docs-and-ci.md
+++ b/docs/plans/PLAN-agent-operation-deadlines-phase-07-docs-and-ci.md
@@ -263,24 +263,58 @@ timeout and none has a terminal-state check.
 3. **The three event-renewed loops keep the progress window and gain a
    ceiling.** Both numbers are named constants on `BaseTestCase`, so
    the ceiling is one place to change and the timeout message can
-   quote the real number. Renewal is restricted by passing
-   `event_type` to the events call rather than by filtering the
-   returned list, so the narrowing happens in SQL.
+   quote the real number.
+
+   Renewal is restricted **client-side**, by reading a small window of
+   recent events per poll and picking the newest one whose type
+   represents progress. Step 7c rejected this plan's original
+   instruction to narrow in SQL by passing `event_type` to the events
+   call, and the reason is that the call takes one type, not a set:
+   `get_instance_events`, `get_network_events`, `get_artifact_events`
+   and `get_blob_events` all funnel into `_get_events(...,
+   event_type, limit)` (`client-python:shakenfist_client/apiclient.py:542`),
+   and the server is `Optional[str]` the whole way down
+   (`external_api/base.py:object_events_response` into
+   `mariadb.get_object_events`). Narrowing to a three-type set
+   server-side would therefore be three HTTP requests per poll per
+   object rather than one. This suite's events polling rate is already
+   a tracked load concern — `shakenfist/deploy/shakenfist_ci/load_budget.py`
+   excludes the harness's own events traffic from the database load
+   budget by hand, and says at length what that exclusion costs — so
+   tripling it to avoid a list comprehension in the harness is the
+   worse trade. The `limit` on the existing call goes from 1 to 10
+   instead, which is enough to see past a burst of periodic events,
+   and costs nothing extra on the wire.
 
    Which types count as progress is the implementing step's call
-   against `shakenfist/constants.py:93-113`, but the plan's position
-   is `status` and `mutate` renew, and `usage`, `resources`, `health`
-   and `prune` do not — the periodic channels are exactly the ones
-   that renew a dead wait forever. A test which needs an event type
-   outside that set to make progress is a test whose await is looking
-   at the wrong signal.
+   against `shakenfist/constants.py:93-113`. The plan's position was
+   that `status` and `mutate` renew and the periodic channels
+   (`usage`, `resources`, `health`, `prune`) do not. Step 7c verified
+   that against what is actually written during instance create,
+   agent readiness and network, artifact and blob readiness, and
+   **added `audit`** to the set: between a network reaching `initial`
+   and reaching `created` the only events on the network object are
+   `audit` (`network/bridged_vxlan_network.py`), so `status` and
+   `mutate` alone would cover a network create by its two bracketing
+   state changes and nothing in between. The plan's position held for
+   the other three — `mutate` on every phase boundary, `status` on
+   the image and blob fetch percentages. Excluding the other four
+   costs nothing: `resources` and `health` are written only against
+   nodes, and `prune` and `historic` are never written at all.
 
-   The `events-by-type` capability gate means an old server would make
-   the filtered call raise `IncapableException`. The suite always runs
-   against a cluster built from this repository, so this is not a
-   compatibility risk; the step should confirm the capability is
-   declared rather than add a fallback path for a case that cannot
-   arise.
+   The filter is not a proof, and the step's comment says so. Two
+   writers still emit a progress-typed event on a timer while nothing
+   progresses — `blob.py`'s "waiting for existing download to
+   complete" `audit` every ten seconds, and the network maintain
+   daemon re-emitting "network not ok" `status` every thirty. That is
+   an argument for the ceiling, not for a narrower set: no event
+   filter can tell a wait that is progressing from one that is only
+   being talked about.
+
+   Because the narrowing is client-side, the `events-by-type`
+   capability gate is not reached for the type filter. It is still
+   reached for `limit`, which the loops already passed before this
+   phase, so nothing about the capability requirement changes.
 
 4. **The functional tests go in the smoke suite, in a new file.** The
    four scenarios are server-behaviour tests, not guest-behaviour
@@ -418,10 +452,13 @@ Every item is checkable by running the command next to it.
       constant: read the three messages and check each against the
       constant it quotes. `_await_agent_state`'s "5 minutes" for 500
       seconds is the known instance.
-- [ ] Renewal is filtered server-side:
-      `grep -n "event_type=" shakenfist/deploy/shakenfist_ci/base.py`
-      shows the filter on every renewal call, and no renewal call
-      passes only `limit=1`.
+- [ ] Renewal only happens on progress events: every one of the three
+      loops renews through `_renew_progress()`, and
+      `grep -n "limit=1)" shakenfist/deploy/shakenfist_ci/base.py`
+      returns nothing — no renewal call reads a single event of any
+      type any more. `PROGRESS_EVENT_TYPES` on `BaseTestCase` names
+      the set, and excludes `usage`, `resources`, `health` and
+      `prune`.
 - [ ] `smoke_ci_tests/test_agentop_deadlines.py` exists and contains
       four tests, or fewer with each omission recorded in Future work
       and its reason given.

--- a/docs/plans/PLAN-agent-operation-deadlines-phase-07-docs-and-ci.md
+++ b/docs/plans/PLAN-agent-operation-deadlines-phase-07-docs-and-ci.md
@@ -1,0 +1,476 @@
+# Agent operation deadlines phase 7: documentation and CI coverage
+
+## Prompt
+
+Plan the next phase of `PLAN-agent-operation-deadlines.md` with the
+`next-phase` skill, after phase 6 merged as shakenfist#4005 and
+client-python#380. Phases 1 to 5 built and enforced the timing budgets
+server-side; phase 6 taught the client to propagate them and to fail
+fast on a terminal state. This phase is the one that tells a human
+what changed, proves the behaviour in functional CI, and pays off the
+audit finding that this repository's own test suite awaits agent
+operations with the very bug the plan exists to fix.
+
+## Planning effort
+
+High. The volume is modest but two of the four code changes turn on
+correctness questions the master plan gets wrong, and one of them
+would be a regression if the master plan's instruction were followed
+literally (see decision 1). The functional coverage also has to be
+designed against a dispatcher whose one-executor-per-instance rule is
+the thing being proven, which is easy to write as a test that passes
+for the wrong reason.
+
+## Scope
+
+**In scope.**
+
+- The three event-renewed await loops in
+  `shakenfist/deploy/shakenfist_ci/base.py` gain an absolute ceiling
+  as well as a progress window, and their renewal is restricted to
+  events which represent progress. This is #3770.
+- The ten agent-operation poll loops in the two `test_agentops.py`
+  files learn to fail fast on a terminal state, and stop sharing one
+  clock across sequential operations.
+- `base.AGENT_OPERATION_FAILURES` loses its `getattr()` compatibility
+  shim now that client-python#380 has merged, and the two
+  `test_get_missing_file` assertions narrow to the exception the new
+  client actually promises.
+- Functional coverage in `shakenfist_ci` for the four scenarios the
+  master plan enumerates.
+- A new `docs/operator_guide/agent_operations.md`, and an extension of
+  the existing `v07-v08.md` release-note section to cover phase 5's
+  retry and phase 6's client-visible changes.
+
+**Out of scope.**
+
+- `docs/developer_guide/state_machine.md`. It is a rendering of
+  `state_targets`, so phases 4 and 5 updated it as they changed that
+  dict rather than leaving the tree self-contradictory. The master
+  plan's phase 7 row already says so.
+- `docs/developer_guide/api_reference/instances.md` and the existing
+  release-note section on deadlines. Both were written by phase 3 and
+  corrected since; see survey finding F1. This phase adds what is
+  missing rather than rewriting what is there.
+- The push audit. That is phase 8, over the whole plan's accumulated
+  diff.
+- Any change to server-side enforcement. If the functional tests
+  written here find an enforcement bug, it is filed and recorded in
+  Future work, not fixed inline.
+
+## What the survey found
+
+The master plan's phase 7 row was written before phases 3 to 6
+executed and is wrong in four places. All four corrections are applied
+at source as part of the planning commit; a later step should not redo
+them.
+
+### F1 — the documentation is largely already written
+
+The row says docs were "deferred from phase 3 so it is written once,
+after enforcement exists". They were not. Phase 3's commit `cf094551b`
+("Document agent operation timing parameters"), corrected by
+`83a0d2d0e`, wrote both of the following:
+
+- `docs/developer_guide/api_reference/instances.md:657-710` — both
+  parameters, their units, the omitted-versus-zero distinction, the
+  defaults table, and why `agent/execute` refuses a progress timeout.
+- `docs/release_notes/v07-v08.md:731-782` — a full section, "Agent
+  operations are bounded by a deadline, not a fixed backstop",
+  covering the removal of the 900-second constant, both budgets, the
+  `expired` state, the three enforcement points, and an explicit
+  warning that the effective default is *tighter* than the behaviour
+  it replaces.
+
+What is genuinely missing:
+
+- **Phase 5's retry and reaper are undocumented outside the plan
+  files.** `AGENT_OPERATION_MAX_ATTEMPTS` appears in exactly one
+  published page, `docs/developer_guide/state_machine.md:45`. There is
+  no release-note text for the `EXECUTING -> QUEUED` edge, for attempt
+  counting, or for the node-local executor reaper, and no operator
+  guidance on what to do when an operation exhausts its attempts.
+- **There is no operator-guide page for agent operations at all.**
+  `docs/operator_guide/` has eighteen pages and none of them is about
+  agent operations; the only operator-facing mention of the two
+  defaults is a passing one in `docs/operator_guide/database.md:1141`,
+  in the context of what the schema columns mean.
+- **Phase 6's client-visible changes have no release note.** The new
+  `--deadline` and `--progress-timeout` flags on `instance execute`,
+  `upload` and `download`, and the behaviour change from
+  `AgentCommandError` to `AgentOperationFailed` on a terminal state,
+  are user-visible and unannounced.
+
+### F2 — `AGENT_OPERATION_FAILURES` must not become a plain reference
+
+The row instructs this phase to "narrow `base.AGENT_OPERATION_FAILURES`
+to a plain `AgentOperationFailed` reference now that both client
+generations no longer need tolerating". Half of that is right and half
+of it is a regression.
+
+The `getattr()` shim at
+`shakenfist/deploy/shakenfist_ci/base.py:46` genuinely can go:
+client-python#380 merged on 2026-09-03, so `AgentOperationFailed`
+always exists now. But the tuple has two kinds of consumer and they
+want different things.
+
+The two catch sites, `base.py:469` and `base.py:498`, are
+`_await_instance_ready`'s cloud-init retry loop and its debug-gathering
+loop. They mean "this attempt did not give us a usable answer, try
+again". On client-python's current `develop`, `await_agent_command()`
+raises **three** unrelated exception types, none of which shares a base
+class beyond `Exception`:
+
+- `AgentOperationFailed` — the operation reached a terminal failure
+  state (`apiclient.py:1301`, raised from `_await_agentop`).
+- `AgentAwaitTimeout` — the operation never completed within the
+  caller's own budget (`apiclient.py:1773`).
+- `AgentCommandError` — the operation completed but the result is
+  unusable: no results, unexpected stderr, no stdout blob
+  (`apiclient.py:1791`, `:1797`, `:1805`, `:1821`).
+
+Narrowing the tuple to `AgentOperationFailed` alone would stop the
+retry loop catching the other two. A cloud-init health check whose
+command writes to stderr would then escape the retry as an
+`AgentCommandError`, and the whole `_await_instance_ready` would fail
+on the first attempt instead of the third — a silent loss of retry
+coverage across every test in the suite that boots an instance.
+
+The assertion sites are the opposite case. `test_get_missing_file` in
+both suites (`smoke_ci_tests/test_agentops.py:306`,
+`guest_ci_tests/test_agentops.py:315`) asserts that fetching a
+non-existent file raises *something*. A three-member tuple there
+asserts almost nothing: it would pass if the operation timed out, or
+if it succeeded and returned garbage. Those two want the narrow
+reference.
+
+Decision 1 resolves this.
+
+### F3 — there is a third event-renewed loop, and the addresses drifted
+
+The master plan names two loops and gives addresses from before phase
+4 and 5 landed. Current addresses, and the one it misses:
+
+| Loop | Master plan says | Actually at | Window |
+|------|------------------|-------------|--------|
+| `_await_agent_state` | `base.py:436` | `base.py:522`, loop at `:531`, renewal at `:545` | 500s |
+| `_await_instance_create` | `base.py:471` | `base.py:557`, loop at `:561`, renewal at `:587` | 180s |
+| `_await_objects_ready` | not mentioned | `base.py:706`, renewal at `:724`, check at `:736` | 300s |
+
+`_await_objects_ready` is the same construction — `time.time() -
+time_since_last_progress > 300`, with `time_since_last_progress`
+reassigned from `last_event['timestamp']` for any event at all — and
+it backs `_await_networks_ready`, `_await_artifacts_ready` and
+`_await_blobs_ready`, so it is on the path of nearly every test in the
+suite. It has to be fixed with the other two or the class of bug
+survives.
+
+The mechanism is confirmed rather than assumed. `node_inst_op`
+(`shakenfist/operations/node_inst_op.py:169`) writes an
+`EVENT_TYPE_USAGE` event against every instance on a timer, with
+`suppress_event_logging=True`, so an instance which is going nowhere
+still produces events forever. `get_instance_events(..., limit=1)`
+returns the most recent event of any type, so that timer alone renews
+the window indefinitely. The client already supports the fix:
+`get_instance_events()` takes an `event_type` filter
+(`apiclient.py:570`), gated on the `events-by-type` capability, and
+the vocabulary is in `shakenfist/constants.py:93-113`.
+
+`_await_agent_state`'s timeout message also says "no progress in 5
+minutes" for a 500-second (8m20s) window. `_await_instance_create`'s
+says three minutes for 180s and is correct.
+
+### F4 — the fix for the merge-queue flake was never applied to smoke
+
+This one is not in the master plan at all and is the most valuable
+thing the survey turned up.
+
+Commit `a0cc243ad` ("Give each agent operation its own timeout in the
+put/get blob test", 2026-07-15) diagnosed an intermittent flake worth
+~9% of merge-queue runs: `test_instance_put_and_get_blob` set one
+`start_time` and then ran three sequential agent operations whose wait
+loops all measured against it, so `get-file` — the last and heaviest —
+was left only what the earlier two had not spent. The fix added
+`_await_agentop_complete()`, which polls one operation against its own
+fresh clock.
+
+That commit touched `guest_ci_tests/test_agentops.py` and nothing
+else. The identical test in `smoke_ci_tests/test_agentops.py:162` still
+has the bug: `start_time` is set once at `:201`, and the three loops at
+`:206` (30s), `:217` (60s) and `:235` (60s) all measure from it. The
+smoke suite is the one that runs on every pull request.
+
+The two files have identical test inventories — eight tests, same
+names, same order — and are near-exact copies of each other. Any fix
+applied to one and not the other is a fix that half-landed, which is
+precisely what happened here. That is the argument for hoisting the
+helper into `base.py` rather than copying it across (decision 2).
+
+### F5 — no functional coverage of the timing budgets exists
+
+Grepping `shakenfist/deploy/shakenfist_ci/` for `deadline`,
+`progress_timeout` or `expired` finds only unrelated local variables,
+the phase-4 hardening of `_await_command` (`base.py:772-828`), and the
+`AGENT_OPERATION_FAILURES` comment. Nothing exercises an explicit
+`deadline_seconds`, nothing asserts a `deadline` on `external_view()`,
+and nothing observes an operation reaching `expired`. Phase 4's
+`_await_command` work is the only CI-side change any phase of this
+plan has made.
+
+### F6 — everything else the row claims is accurate
+
+The audit finding that the suite's own loops "spin on `!= 'complete'`,
+one with no timeout at all" holds, with one correction: the one with no
+timeout at all was `_await_command`, and phase 4 already fixed it
+(`base.py:781`, now with `AGENT_OPERATION_TIMEOUT = 900` and
+`AGENT_OPERATION_FAILED_STATES`). The ten that remain all have a
+timeout and none has a terminal-state check.
+
+## Decisions
+
+1. **`AGENT_OPERATION_FAILURES` stays a tuple, and gains a member.**
+   It becomes `(AgentCommandError, AgentOperationFailed,
+   AgentAwaitTimeout)` — the honest set of "an agent operation did not
+   give us a usable answer" — with the `getattr()` shim and its
+   compatibility comment removed and replaced by a comment naming each
+   member and the call in `apiclient.py` that raises it. The two
+   `test_get_missing_file` assertions narrow to
+   `apiclient.AgentOperationFailed` on its own.
+
+   This is the decision a reviewer is most likely to argue with,
+   because it declines an explicit instruction in the master plan. The
+   reasoning is F2: the instruction conflates a *catch* site, which
+   wants breadth, with an *assert* site, which wants precision, and
+   following it literally silently disables the cloud-init retry for
+   the most common failure shape. `AgentAwaitTimeout` is added rather
+   than merely retained because it is new since the tuple was written
+   and belongs to the same category as the other two; the retry loop
+   should retry a timed-out health check.
+
+2. **The poll helper is hoisted to `base.BaseTestCase`, not copied.**
+   `_await_agentop_complete()` moves from
+   `guest_ci_tests/test_agentops.py:26` to `base.py`, gains a
+   terminal-state check that routes through the existing
+   `_raise_agent_operation_failure()` (`base.py:805`), and both
+   `test_agentops.py` files call it. F4 is what a copied fix looks like
+   a month later.
+
+   The helper keeps its per-operation clock and its explanatory
+   comment; the comment is the record of why the shared clock was
+   wrong, and deleting it while fixing the same bug in the other file
+   would lose that.
+
+3. **The three event-renewed loops keep the progress window and gain a
+   ceiling.** Both numbers are named constants on `BaseTestCase`, so
+   the ceiling is one place to change and the timeout message can
+   quote the real number. Renewal is restricted by passing
+   `event_type` to the events call rather than by filtering the
+   returned list, so the narrowing happens in SQL.
+
+   Which types count as progress is the implementing step's call
+   against `shakenfist/constants.py:93-113`, but the plan's position
+   is `status` and `mutate` renew, and `usage`, `resources`, `health`
+   and `prune` do not — the periodic channels are exactly the ones
+   that renew a dead wait forever. A test which needs an event type
+   outside that set to make progress is a test whose await is looking
+   at the wrong signal.
+
+   The `events-by-type` capability gate means an old server would make
+   the filtered call raise `IncapableException`. The suite always runs
+   against a cluster built from this repository, so this is not a
+   compatibility risk; the step should confirm the capability is
+   declared rather than add a fallback path for a case that cannot
+   arise.
+
+4. **The functional tests go in the smoke suite, in a new file.** The
+   four scenarios are server-behaviour tests, not guest-behaviour
+   tests: they need a working in-guest agent, which the smoke suite
+   already has (`smoke_ci_tests/test_agentops.py` executes commands
+   today), and they need to run on every pull request to be worth
+   having. A new `smoke_ci_tests/test_agentop_deadlines.py` keeps them
+   out of the file that is duplicated into the guest suite, so this
+   phase does not create a fifth F4.
+
+5. **The expiry tests assert the state, not the timing.** Each of the
+   four scenarios asserts on `state == 'expired'`, on the presence and
+   rough magnitude of `deadline`, or on a follow-up operation
+   *reaching* `executing` — never on how many seconds something took.
+   CI hardware is contended and a test that asserts an operation
+   expired "within 10 seconds" is a flake being written on purpose.
+   Waiting is bounded by the new `base.py` helpers, which fail with a
+   diagnosable dump rather than a bare timeout.
+
+6. **The operator guide gets one new page, not additions to five.**
+   `docs/operator_guide/agent_operations.md`, registered in
+   `mkdocs.yml` between "Scheduler" and "Threads", covering: what an
+   agent operation is and the one-executor-per-instance rule; the two
+   budgets and their three config defaults; the `expired` state and
+   how to tell it from `error`; retry, `AGENT_OPERATION_MAX_ATTEMPTS`
+   and the node-local reaper; and what to tune when long agent
+   commands are being killed. The existing passing mention in
+   `docs/operator_guide/database.md:1141` gains a link rather than
+   being duplicated.
+
+7. **The release note is extended, not restructured.** The existing
+   section at `docs/release_notes/v07-v08.md:731` stands as written.
+   Two subsections are appended to it — one on retry and the reaper,
+   one on the client — because they are the same story from a reader's
+   point of view and a second top-level section about agent operation
+   timing would invite the two to drift.
+
+## Step plan
+
+| Step | Effort | Model | Isolation | Brief for sub-agent |
+|------|--------|-------|-----------|---------------------|
+| 7a | medium | sonnet | none | **Hoist and harden the agent operation poll helper.** Move `_await_agentop_complete(self, instance_uuid, aop, timeout)` from `shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_agentops.py:26` onto `base.BaseTestCase` in `shakenfist/deploy/shakenfist_ci/base.py`, next to `_await_command` at `:781`. Keep its existing docstring-comment verbatim — it records why a shared clock was wrong. Add a terminal-state check at the top of each iteration, using the existing `AGENT_OPERATION_FAILED_STATES` at `:779` and calling the existing `_raise_agent_operation_failure()` at `:805` (its `command` argument is used only for the message; pass a short description of the operation). Then route every remaining poll loop in both test files through it: `smoke_ci_tests/test_agentops.py` lines 51, 95, 146, 206, 217 and 235, and `guest_ci_tests/test_agentops.py` lines 36 (the old helper body), 67, 111 and 162. Note that smoke's `test_instance_put_and_get_blob` (`:162`) sets one `start_time` at `:201` and shares it across the three loops at 206/217/235 — this is the bug commit `a0cc243ad` fixed in the guest copy only, so give those three the same independent budgets the guest copy uses (30/60/120, with the get-file operation getting 120). The two `while time.time() - start_time < 120` loops (smoke `:146`, guest `:162`) are the same pattern written inside out and also become helper calls. Do not change any assertion. Commit subject: "Poll agent operations against one clock each." |
+| 7b | low | sonnet | none | **Retire the client compatibility shim.** In `shakenfist/deploy/shakenfist_ci/base.py`, replace the `AGENT_OPERATION_FAILURES` definition at `:44-46` and the comment block above it at `:28-43`. The tuple becomes `(apiclient.AgentCommandError, apiclient.AgentOperationFailed, apiclient.AgentAwaitTimeout)` with no `getattr()`. Write a new comment which says these are the three unrelated exceptions `await_agent_command()` and `await_agent_fetch()` can raise — a terminal failure state, a caller-budget timeout, and an unusable result — that they share no base class, and that this tuple is for *catching* ("the attempt gave us no usable answer, retry"), which is why it is not narrowed to the one the two catch sites at `:469` and `:498` most often see. Separately, narrow the two assertion sites: `smoke_ci_tests/test_agentops.py:306` and `guest_ci_tests/test_agentops.py:315` become `apiclient.AgentOperationFailed` (import `apiclient` the way those files reach `base` today, or reference it via `base`). Do not otherwise touch those tests. Commit subject: "Name the agent failures the client can raise." |
+| 7c | high | opus | none | **Give the event-renewed awaits an absolute ceiling (#3770).** Three loops in `shakenfist/deploy/shakenfist_ci/base.py` renew their window from any event at all: `_await_agent_state` (`:522`, loop `:531`, renewal `:545`, 500s), `_await_instance_create` (`:557`, loop `:561`, renewal `:587`, 180s), and `_await_objects_ready` (`:706`, renewal `:724`, check `:736`, 300s). The renewal is unconditional because `get_instance_events(..., limit=1)` returns the most recent event of any type, and `node_inst_op` (`shakenfist/operations/node_inst_op.py:169`) writes a timer-driven `EVENT_TYPE_USAGE` event against every instance forever, so a stalled instance renews its own deadline indefinitely. Give each loop (a) a named absolute ceiling constant on `BaseTestCase` alongside the progress window, checked from a `start_time` taken before the loop; (b) renewal restricted to progress-representing events by passing `event_type` to the events call rather than filtering the returned list — `get_instance_events`/`get_network_events`/`get_artifact_events`/`get_blob_events` all take `event_type` (see `apiclient.py:570`), and the vocabulary is `shakenfist/constants.py:93-113`. Decision 3 in this plan says `status` and `mutate` renew and the periodic channels (`usage`, `resources`, `health`, `prune`) do not; confirm that against what actually gets written during instance create and object readiness before committing to it, and say in the commit message if you disagree. Note the client's `_get_events()` takes one `event_type`, not a list — check whether the server's `object_events_response()` accepts more than one before assuming two calls are needed. Ceilings should be generous relative to the existing windows (the point is to convert a silent budget fire into a diagnosable failure, not to tighten CI); the phase-4 precedent is `AGENT_OPERATION_TIMEOUT = 900` at `:772`. Correct `_await_agent_state`'s message, which says "no progress in 5 minutes" for a 500-second window, and make every message quote its constant rather than a hardcoded prose duration. There is a stray double space in `_await_objects_ready`'s message at `:744` (a trailing double space after "The last"); fix it while there. Commit subject: "Bound the CI awaits, not just their progress." |
+| 7d | high | opus | none | **Functional coverage for the timing budgets.** New file `shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentop_deadlines.py`, modelled on `smoke_ci_tests/test_agentops.py`'s class shape (`base.BaseNamespacedTestCase`, `namespace_prefix`, a network in `setUp`, `base.CLUSTER_CI_IMAGE`). Four tests, matching the four scenarios the master plan enumerates: (1) an explicit short `deadline_seconds` expiring an operation while it is still *queued* — enqueue a long `agent/execute` first so the instance's single executor is busy, then a second operation with a small deadline, and assert it reaches `expired` without ever executing; (2) the default deadline appears in `external_view()` — create an operation with no `deadline_seconds` and assert `deadline` is present and is roughly `now + AGENT_OPERATION_DEFAULT_DEADLINE` (600); (3) an `agent/execute` of a command that produces no output for well over the 30-second default progress timeout still completes, proving the progress timeout does not apply to commands that cannot report progress; (4) after an operation is expired, a follow-up operation on the same instance reaches `executing` promptly, proving the executor slot is freed. Assert on states and on the presence and rough magnitude of `deadline`, never on elapsed seconds (decision 5) — CI hardware is contended. Use the `base` helpers for all waiting, including `_await_agentop_complete` as hoisted by step 7a, so a failure prints the operation and the instance's recent events. The client parameters are `deadline_seconds` and `progress_timeout_seconds` on `instance_execute`/`instance_put_blob`/`instance_get` (`client-python:shakenfist_client/apiclient.py:1409-1455`); they are only sent when the server advertises the `agentoperation-deadlines` capability, which this repository's `shakenfist/external_api/app.py:364` does. Read `shakenfist/operations/agentoperation.py` and `shakenfist/daemons/sidechannel/main.py` for what actually sets `expired` before writing the assertions. If a test cannot be made non-flaky, say so and leave it out rather than landing a known flake — this plan's whole subject is CI reliability. Commit subject: "Test agent operation deadlines in CI." |
+| 7e | medium | sonnet | none | **Documentation.** Two files. First, new `docs/operator_guide/agent_operations.md` per decision 6, registered in `mkdocs.yml` in the operator guide nav (the list runs alphabetically at lines 494-509; insert "Agent Operations" after "Installation" to match the existing ordering, which puts Installation first and the rest alphabetically). Content: what an agent operation is and the one-executor-per-instance dispatch rule (`shakenfist/daemons/sidechannel/main.py`); the two budgets, `AGENT_OPERATION_DEFAULT_DEADLINE` (600) and `AGENT_OPERATION_DEFAULT_PROGRESS_TIMEOUT` (30), from `shakenfist/config.py:240` and `:259`; the `expired` state and how an operator tells it from `error` (the state row's message says which budget ran out, and `expire()` audits it against the instance); retry, `AGENT_OPERATION_MAX_ATTEMPTS` (`config.py:303`) and the per-command `retryable` flag; the node-local executor reaper from phase 5; and what to tune when long agent commands are being killed. Link to `docs/developer_guide/api_reference/instances.md` for the request parameters rather than restating them, and add a link from the passing mention at `docs/operator_guide/database.md:1141`. Second, append two subsections to the existing release-note section at `docs/release_notes/v07-v08.md:731` ("Agent operations are bounded by a deadline, not a fixed backstop") — do not restructure what is there. One subsection on phase 5: an operation which fails in `executing` for a retryable reason is now returned to the head of its instance's queue rather than abandoned, bounded by `AGENT_OPERATION_MAX_ATTEMPTS` (3), and a node-local reaper recovers operations whose executor died or never started. One on the client: `sf-client instance execute`, `upload` and `download` gained `--deadline`, and `upload` and `download` also `--progress-timeout`; and a terminal operation state now raises `AgentOperationFailed` immediately where the client previously polled to its full timeout and raised `AgentCommandError`, which is a behaviour change for anything catching that exception. Read the surrounding release-note prose and match its register — it explains consequences, not APIs. Commit subject: "Document agent operation timing for operators." |
+| 7f | low | sonnet | none | **Close the phase out.** Set phase 7 to `Complete` in the Execution table of `docs/plans/PLAN-agent-operation-deadlines.md` and link this file from the row (the row currently has an empty Plan cell). Update this plan's Definition of done checkboxes to reflect what actually happened, and record anything deferred in Future work. In `docs/plans/index.md`, move the plan's row from `7 of 9` to `8 of 9`, leaving the status at `In progress` — phase 8, the push audit, remains. Do not touch `docs/plans/order.yml`. Commit subject: "Close out agent operation deadlines phase 7." |
+
+## Corrections applied at source
+
+Made in the planning commit, so a later step does not repeat them:
+
+- `docs/plans/PLAN-agent-operation-deadlines.md`, phase 7 row: the
+  claim that documentation was deferred from phase 3 is corrected to
+  name what phase 3 actually wrote and what is left (F1); the
+  instruction to narrow `AGENT_OPERATION_FAILURES` to a plain
+  reference is corrected to say the shim goes and the tuple stays,
+  with a pointer to decision 1 (F2); `_await_objects_ready` is added
+  to the list of event-renewed loops and the two stale addresses are
+  refreshed (F3); the smoke-suite half of `a0cc243ad` is named as work
+  this phase picks up (F4).
+- `docs/plans/PLAN-agent-operation-deadlines.md`, the "#3770" section:
+  the two `base.py` line numbers are refreshed and
+  `_await_objects_ready` added; the note that `_await_command` was
+  pulled forward into phase 4 already stands and is left alone.
+- `docs/plans/index.md`: the plan's row keeps `7 of 9` and `In
+  progress` until step 7f, but its Intent cell is left as it is — it
+  describes the plan, not this phase, and is still accurate.
+
+## Risks and mitigations
+
+- **Step 7c tightens CI and turns a slow-but-passing test into a
+  failure.** The ceilings are new upper bounds on waits that
+  previously had none. Mitigation: the ceilings are set generously
+  relative to the existing progress windows, and the management
+  session reads the diff for any ceiling that is not comfortably above
+  the window it guards. The failure mode this converts *from* is a
+  killed 60-minute job with no named test, so a too-tight ceiling is
+  strictly easier to diagnose than the status quo.
+- **Step 7c's event-type filter starves a legitimate wait.** If an
+  object genuinely makes progress only through an event type the
+  filter excludes, that wait now fails at its progress window where it
+  previously renewed. Mitigation: the brief asks the implementer to
+  confirm the type set against what is actually written during
+  instance create and object readiness, rather than taking decision
+  3's list on faith, and to say so if they disagree. The ceiling is
+  the safety net either way.
+- **Step 7d writes a flaky test.** Expiry tests are timing tests
+  wearing a disguise. Mitigation: decision 5 forbids elapsed-time
+  assertions, and the brief explicitly authorises leaving a scenario
+  out rather than landing a known flake. The management session runs
+  the new file's tests against a real cluster before the phase closes,
+  and a scenario that cannot be made reliable is recorded in Future
+  work with its reason.
+- **Steps 7a and 7b both edit the two `test_agentops.py` files.** Run
+  them in order and re-read the second diff; they touch different
+  lines but the same files, and 7a renumbers everything below its
+  edits.
+- **The functional tests cannot run in the management session.** They
+  need a cluster. Mitigation: the phase is not marked complete on unit
+  tests alone — the Definition of done requires a CI run on the
+  branch, and a failure there is a phase-7 defect, not a flake to
+  re-queue.
+
+## Definition of done
+
+Every item is checkable by running the command next to it.
+
+- [ ] No `getattr(apiclient` remains in the CI suite:
+      `! grep -rn "getattr(apiclient" shakenfist/deploy/shakenfist_ci/`
+- [ ] `AGENT_OPERATION_FAILURES` names three exceptions and no shim:
+      `grep -A3 "^AGENT_OPERATION_FAILURES = (" shakenfist/deploy/shakenfist_ci/base.py`
+      shows `AgentCommandError`, `AgentOperationFailed` and
+      `AgentAwaitTimeout`.
+- [ ] Both `test_get_missing_file` assertions name the narrow
+      exception:
+      `grep -n "AgentOperationFailed" shakenfist/deploy/shakenfist_ci/*/test_agentops.py`
+      returns two lines, and
+      `grep -c "AGENT_OPERATION_FAILURES" shakenfist/deploy/shakenfist_ci/*_ci_tests/test_agentops.py`
+      returns zero for both.
+- [ ] No unguarded agent-operation poll loop remains in the suite:
+      `grep -rn "while aop\['state'\] != 'complete'" shakenfist/deploy/shakenfist_ci/`
+      returns nothing.
+- [ ] The helper is shared, not duplicated:
+      `grep -rn "def _await_agentop_complete" shakenfist/deploy/shakenfist_ci/`
+      returns exactly one line, in `base.py`.
+- [ ] The smoke put/get test no longer shares a clock: in
+      `smoke_ci_tests/test_agentops.py`, `test_instance_put_and_get_blob`
+      contains no `start_time` reused across two waits.
+- [ ] All three event-renewed loops have a ceiling: each of
+      `_await_agent_state`, `_await_instance_create` and
+      `_await_objects_ready` in `base.py` references a ceiling
+      constant distinct from its progress window.
+- [ ] No timeout message states a duration that disagrees with its
+      constant: read the three messages and check each against the
+      constant it quotes. `_await_agent_state`'s "5 minutes" for 500
+      seconds is the known instance.
+- [ ] Renewal is filtered server-side:
+      `grep -n "event_type=" shakenfist/deploy/shakenfist_ci/base.py`
+      shows the filter on every renewal call, and no renewal call
+      passes only `limit=1`.
+- [ ] `smoke_ci_tests/test_agentop_deadlines.py` exists and contains
+      four tests, or fewer with each omission recorded in Future work
+      and its reason given.
+- [ ] `docs/operator_guide/agent_operations.md` exists, is listed in
+      `mkdocs.yml`, and names all three of
+      `AGENT_OPERATION_DEFAULT_DEADLINE`,
+      `AGENT_OPERATION_DEFAULT_PROGRESS_TIMEOUT` and
+      `AGENT_OPERATION_MAX_ATTEMPTS`:
+      `grep -c "AGENT_OPERATION_" docs/operator_guide/agent_operations.md`
+      is at least 3.
+- [ ] The release note covers retry and the client:
+      `grep -n "AGENT_OPERATION_MAX_ATTEMPTS\|--progress-timeout\|AgentOperationFailed" docs/release_notes/v07-v08.md`
+      returns at least one line for each.
+- [ ] No fact about the timing budgets is stated differently on two
+      pages: the defaults quoted in
+      `docs/operator_guide/agent_operations.md`,
+      `docs/developer_guide/api_reference/instances.md:680` and
+      `docs/release_notes/v07-v08.md:744` agree.
+- [ ] `pre-commit run --all-files` exits zero.
+- [ ] CI has run green on the branch, including the smoke suite, and
+      the new deadline tests appear in its results rather than being
+      skipped.
+
+## Future work
+
+- The master plan's phase 7 row observes that `_await_instance_ready`
+  retries a cloud-init health check three times with a 30-second sleep
+  between attempts. If step 7c's event-type filter turns out to change
+  how often that path is entered, the retry count deserves a second
+  look — but not in this phase.
+- `docs/operator_guide/` has two pages that are not in `mkdocs.yml`'s
+  nav (`credential_rotation.md`, `vdi_console_tokens.md`). Noticed
+  while adding the new page; unrelated to this plan and not fixed
+  here.
+- The two `test_agentops.py` files are near-exact copies with
+  identical test inventories. F4 shows what that costs. Collapsing
+  them into one parameterised module is a larger change than this
+  phase should carry, and belongs to whoever next has a reason to
+  touch both.
+
+## Back brief
+
+Before executing any step of this plan, back brief the operator on
+your understanding of it and how the work you intend to do aligns
+with it.
+
+There is one gate. **Decision 1 declines an explicit instruction in
+the master plan**, on the grounds that following it literally would
+disable the cloud-init retry loop for the most common failure shape.
+Step 7b implements that decision. Confirm decision 1 before starting
+7b. Steps 7a, 7c, 7d and 7e do not depend on it and can proceed
+meanwhile.

--- a/docs/plans/PLAN-agent-operation-deadlines-phase-07-docs-and-ci.md
+++ b/docs/plans/PLAN-agent-operation-deadlines-phase-07-docs-and-ci.md
@@ -260,6 +260,16 @@ timeout and none has a terminal-state check.
    wrong, and deleting it while fixing the same bug in the other file
    would lose that.
 
+   **Correction (step 7a).** The helper landed on
+   `base.BaseNamespacedTestCase`, not `BaseTestCase` as decided above.
+   It polls as `self.test_client`, and only
+   `BaseNamespacedTestCase.setUp()` constructs that attribute
+   (`base.py:1072`); leaving it on `BaseTestCase` would have been a
+   latent `AttributeError` for any non-namespaced caller that ever
+   reached it. The management session read step 7a's diff, made this
+   move, and amended the commit before it landed — see Review
+   follow-ups.
+
 3. **The three event-renewed loops keep the progress window and gain a
    ceiling.** Both numbers are named constants on `BaseTestCase`, so
    the ceiling is one place to change and the timeout message can
@@ -421,66 +431,113 @@ Made in the planning commit, so a later step does not repeat them:
 
 ## Definition of done
 
-Every item is checkable by running the command next to it.
+Every item is checkable by running the command next to it. The final
+item is the one that gates the merge: it is unticked below, and until
+it is satisfied the four tests in
+`smoke_ci_tests/test_agentop_deadlines.py` are unverified — step 7d's
+own commit message says as much, and nothing a management session can
+read substitutes for a run against a real cluster.
 
-- [ ] No `getattr(apiclient` remains in the CI suite:
+- [x] No `getattr(apiclient` remains in the CI suite:
       `! grep -rn "getattr(apiclient" shakenfist/deploy/shakenfist_ci/`
-- [ ] `AGENT_OPERATION_FAILURES` names three exceptions and no shim:
+- [x] `AGENT_OPERATION_FAILURES` names three exceptions and no shim:
       `grep -A3 "^AGENT_OPERATION_FAILURES = (" shakenfist/deploy/shakenfist_ci/base.py`
       shows `AgentCommandError`, `AgentOperationFailed` and
       `AgentAwaitTimeout`.
-- [ ] Both `test_get_missing_file` assertions name the narrow
+- [x] Both `test_get_missing_file` assertions name the narrow
       exception:
       `grep -n "AgentOperationFailed" shakenfist/deploy/shakenfist_ci/*/test_agentops.py`
       returns two lines, and
       `grep -c "AGENT_OPERATION_FAILURES" shakenfist/deploy/shakenfist_ci/*_ci_tests/test_agentops.py`
       returns zero for both.
-- [ ] No unguarded agent-operation poll loop remains in the suite:
+- [x] No unguarded agent-operation poll loop remains in the suite:
       `grep -rn "while aop\['state'\] != 'complete'" shakenfist/deploy/shakenfist_ci/`
       returns nothing.
-- [ ] The helper is shared, not duplicated:
+
+      Correction: run as written, that command returns two lines, not
+      nothing — `_await_command` (`base.py:914`, phase 4's own
+      terminal-state check) and `_await_agentop_complete` itself
+      (`base.py:1159`). Both open with this exact condition and both
+      check `AGENT_OPERATION_FAILED_STATES` before looping again; the
+      grep cannot distinguish a guarded loop from an unguarded one when
+      both share the loop head's text. Read by hand, no loop that lacks
+      a terminal-state check remains, which is the substantive claim
+      this item is checking for.
+- [x] The helper is shared, not duplicated:
       `grep -rn "def _await_agentop_complete" shakenfist/deploy/shakenfist_ci/`
-      returns exactly one line, in `base.py`.
-- [ ] The smoke put/get test no longer shares a clock: in
+      returns exactly one line, in `base.py` (on
+      `BaseNamespacedTestCase`; see decision 2's correction).
+- [x] The smoke put/get test no longer shares a clock: in
       `smoke_ci_tests/test_agentops.py`, `test_instance_put_and_get_blob`
       contains no `start_time` reused across two waits.
-- [ ] All three event-renewed loops have a ceiling: each of
+- [x] All three event-renewed loops have a ceiling: each of
       `_await_agent_state`, `_await_instance_create` and
       `_await_objects_ready` in `base.py` references a ceiling
       constant distinct from its progress window.
-- [ ] No timeout message states a duration that disagrees with its
+- [x] No timeout message states a duration that disagrees with its
       constant: read the three messages and check each against the
       constant it quotes. `_await_agent_state`'s "5 minutes" for 500
-      seconds is the known instance.
-- [ ] Renewal only happens on progress events: every one of the three
+      seconds is the known instance. All three messages now build their
+      duration from `_await_expired()`'s f-strings, which quote the
+      real constant rather than hardcoded prose.
+- [x] Renewal only happens on progress events: every one of the three
       loops renews through `_renew_progress()`, and
       `grep -n "limit=1)" shakenfist/deploy/shakenfist_ci/base.py`
       returns nothing — no renewal call reads a single event of any
       type any more. `PROGRESS_EVENT_TYPES` on `BaseTestCase` names
       the set, and excludes `usage`, `resources`, `health` and
       `prune`.
-- [ ] `smoke_ci_tests/test_agentop_deadlines.py` exists and contains
+- [x] `smoke_ci_tests/test_agentop_deadlines.py` exists and contains
       four tests, or fewer with each omission recorded in Future work
-      and its reason given.
-- [ ] `docs/operator_guide/agent_operations.md` exists, is listed in
+      and its reason given. All four scenarios are present; none was
+      omitted.
+- [x] `docs/operator_guide/agent_operations.md` exists, is listed in
       `mkdocs.yml`, and names all three of
       `AGENT_OPERATION_DEFAULT_DEADLINE`,
       `AGENT_OPERATION_DEFAULT_PROGRESS_TIMEOUT` and
       `AGENT_OPERATION_MAX_ATTEMPTS`:
       `grep -c "AGENT_OPERATION_" docs/operator_guide/agent_operations.md`
       is at least 3.
-- [ ] The release note covers retry and the client:
+- [x] The release note covers retry and the client:
       `grep -n "AGENT_OPERATION_MAX_ATTEMPTS\|--progress-timeout\|AgentOperationFailed" docs/release_notes/v07-v08.md`
       returns at least one line for each.
-- [ ] No fact about the timing budgets is stated differently on two
+- [x] No fact about the timing budgets is stated differently on two
       pages: the defaults quoted in
       `docs/operator_guide/agent_operations.md`,
       `docs/developer_guide/api_reference/instances.md:680` and
-      `docs/release_notes/v07-v08.md:744` agree.
-- [ ] `pre-commit run --all-files` exits zero.
+      `docs/release_notes/v07-v08.md:744` agree (600 seconds and 30
+      seconds, in all three).
+- [x] `pre-commit run --all-files` exits zero.
 - [ ] CI has run green on the branch, including the smoke suite, and
       the new deadline tests appear in its results rather than being
-      skipped.
+      skipped. **Not satisfied.** The branch has not been pushed, and
+      the functional suite needs a real cluster that this closeout does
+      not have access to. This is what gates the merge; see What
+      remains.
+
+## Review follow-ups
+
+After step 7a landed, the management session read its diff and moved
+`_await_agentop_complete()` from `BaseTestCase` to
+`BaseNamespacedTestCase`, then amended the commit before continuing to
+7b. The reason is decision 2's correction above: the helper polls as
+`self.test_client`, which only `BaseNamespacedTestCase.setUp()`
+constructs, and leaving it on `BaseTestCase` would have been a latent
+`AttributeError` for the first non-namespaced caller to reach it.
+
+## What remains
+
+The code and documentation are done and reviewed: five commits, 7a
+through 7e, landed everything the step plan describes, and this
+closeout has independently re-run every Definition of done check that
+does not need a cluster. What is left is the one that does: a green CI
+run on this branch, including the smoke suite, with the four tests in
+`test_agentop_deadlines.py` appearing in the results rather than being
+skipped. The branch has not been pushed yet. Phase 7's status in
+`PLAN-agent-operation-deadlines.md`'s Execution table stays `In
+progress`, and the plan's row in `docs/plans/index.md` stays at `7 of
+9`, until that run happens; both flip to `Complete` and `8 of 9` once
+it does.
 
 ## Future work
 
@@ -498,6 +555,43 @@ Every item is checkable by running the command next to it.
   them into one parameterised module is a larger change than this
   phase should carry, and belongs to whoever next has a reason to
   touch both.
+- **A latent regression from phase 6, repaired here by accident.**
+  Phase 6 changed `await_agent_command()`'s timeout path in
+  client-python from raising `AgentCommandError` to raising the new
+  `AgentAwaitTimeout`. `base.AGENT_OPERATION_FAILURES` did not name the
+  new exception, so between phase 6 landing and step 7b,
+  `_await_instance_ready`'s cloud-init retry loop silently stopped
+  retrying a timed-out health check — it had retried them before, as
+  `AgentCommandError`. Step 7b restores that coverage by adding
+  `AgentAwaitTimeout` to the tuple. Worth naming because it is a
+  general hazard: changing which exception a client raises silently
+  narrows every `except` tuple downstream that was written against the
+  old one.
+- **The two `test_agentops.py` files diverged slightly rather than
+  converging**, which the entry above already names as a duplication
+  hazard. The specific new drift: step 7a gave the smoke suite's
+  `test_instance_put_and_get_blob` independent budgets of 30/60/120,
+  while the guest copy keeps 60/60/120, because each preserved its own
+  original first-operation budget. The shared-clock bug is gone from
+  both, but the files are still near-exact copies with one number
+  different.
+- **Decision 3 was corrected during execution**, by step 7c, and the
+  correction is written into the decision itself. Noted here only so a
+  reader does not go looking for an uncorrected copy elsewhere.
+- **Step 7d found no server-side enforcement bug**, which this plan's
+  out-of-scope section anticipated it might. Record the one thing it
+  did establish that the documentation now relies on: `agent/execute`
+  never goes through preflight — the endpoint sets the queued state
+  directly — so an expired execute was expired either at dequeue or
+  inside the executor, never at the preflight check that bounds other
+  operation types.
+- **Step 7e found and fixed two stale documentation facts** outside
+  this phase's stated scope, both licensed by the "no fact stated
+  differently on two pages" Definition-of-done criterion:
+  `docs/operator_guide/database.md` still said `attempts` and
+  `last_progress` were recorded but not yet consumed, and
+  `docs/developer_guide/api_reference/instances.md` still said nothing
+  is retried. Both were true before phase 5 and false after it.
 
 ## Back brief
 

--- a/docs/plans/PLAN-agent-operation-deadlines.md
+++ b/docs/plans/PLAN-agent-operation-deadlines.md
@@ -614,7 +614,7 @@ the slot at all.
 | 4 | [PLAN-agent-operation-deadlines-phase-04-enforcement.md](PLAN-agent-operation-deadlines-phase-04-enforcement.md) | Complete | Enforcement: dequeue expiry, preflight expiry, executor deadline + progress timeout, `observe_progress()` hooks; remove `AGENT_OPERATION_EXECUTION_TIMEOUT`; the `expired` state with its audit-enumerated obligations (`state_targets`, `FINAL_OBJECT_STATES`, guarded error writes, command-abort check). Survey corrections applied at source: every address in decision 1 was refreshed after phase 1's refactor, the reaper is phase 5's rather than this phase's, and preflight is a fourth enforcement point the design sketch never listed. The phase plan also decides that an expiry records its reason as a state message and an audit event rather than as `.error`, which the `error` setter refuses from a non-`error` state |
 | 5 | [PLAN-agent-operation-deadlines-phase-05-retry.md](PLAN-agent-operation-deadlines-phase-05-retry.md) | Complete | Retry: `EXECUTING -> QUEUED` edge, terminal-only lazy pop, attempt bound, partial-result cleanup; the node-local reaper, covering a dead executor thread, no executor at all after a daemon restart, and a live executor wedged in the pre-connection wait. Survey corrections applied at source: decision 5's address for `reap_instance_executors()`, that retryability is evaluated over the whole command list rather than the command in flight, and that partial-result cleanup has a registered-blob case the design sketch did not cover. The phase plan also decides that the terminal-only pop and the reaper must land in one commit, because the pop rule alone turns a daemon restart from a leak into a wedge |
 | 6 | `PLAN-agent-operation-deadlines-phase-06-client.md` (in shakenfist/client-python, branch `agent-operation-deadlines-phase-06-client`) | Complete | client-python: deadline from await timeout, CLI flags, terminal-state handling (includes fixing client-python#363: await loops poll to their full timeout on terminal failure states instead of failing fast). The plan file lives in the client repository because the code does, following the `PLAN-vdi-console-tokens.md` precedent; a relative link cannot cross repositories, so it is named here rather than linked. Survey corrections applied at source: the new parameters need a capability token before a client can send them safely, which phase 3 did not add and phase 6 does. The phase plan also decides to repair `await_agent_fetch()`'s three hardcoded timeout windows, which make its `timeout` argument a lie, because the phase rewrites those same loops |
-| 7 | | Not started | Docs (operator + developer guides, and the `v07-v08` release note for the deadline parameters and config options -- deferred from phase 3 so it is written once, after enforcement exists), functional CI coverage in `shakenfist_ci`; make the suite's agent-operation await loops fail fast on terminal states, and narrow `base.AGENT_OPERATION_FAILURES` to a plain `AgentOperationFailed` reference now that both client generations no longer need tolerating (audit finding: they spin on `!= 'complete'`, one with no timeout at all); and give the CI base class's instance and agent-state awaits an absolute ceiling as well as a progress window (#3770 — see below). Note `docs/developer_guide/state_machine.md` is **not** this phase's: it is a rendering of `state_targets`, so phase 4 updated it when it added `expired` rather than leaving the tree self-contradictory for three phases, and phase 5 adds its one further edge |
+| 7 | [PLAN-agent-operation-deadlines-phase-07-docs-and-ci.md](PLAN-agent-operation-deadlines-phase-07-docs-and-ci.md) | In progress | Documentation and CI coverage. Survey corrections applied at source, because this row was written before phases 3 to 6 executed and was wrong in four places. (a) The documentation was **not** deferred from phase 3: `cf094551b` wrote both the API reference at `docs/developer_guide/api_reference/instances.md:657-710` and the release note section at `docs/release_notes/v07-v08.md:731-782`. What is missing is phase 5 (retry, attempts and the reaper), phase 6 (the CLI flags and the `AgentCommandError` to `AgentOperationFailed` change), and an operator-guide page for agent operations, of which there is none. (b) `base.AGENT_OPERATION_FAILURES` must **not** narrow to a plain `AgentOperationFailed` reference: the `getattr()` shim goes, but the tuple stays and gains `AgentAwaitTimeout`, because `await_agent_command()` raises three unrelated exceptions and the two catch sites are `_await_instance_ready`'s retry loop, which wants all of them. Only the two `test_get_missing_file` assertions narrow. (c) There is a **third** event-renewed await, `_await_objects_ready`, which backs the network, artifact and blob readiness helpers and so sits on nearly every test in the suite; #3770 is not fixed without it. (d) Commit `a0cc243ad` fixed the shared-clock flake in `guest_ci_tests/test_agentops.py` only, and the identical `smoke_ci_tests` copy -- the suite that runs on every pull request -- still has it. Note `docs/developer_guide/state_machine.md` is **not** this phase's: it is a rendering of `state_targets`, so phase 4 updated it when it added `expired` rather than leaving the tree self-contradictory for three phases, and phase 5 added its one further edge |
 | 8 | | Not started | Push audit: runs `PUSH-AUDIT.md` over the accumulated diff of every phase in this plan against `develop`, not the last phase's diff alone. Findings land as their own pull request, and the plan is not complete until each is resolved or declined in writing here; if the audit finds nothing, that is recorded in one sentence |
 
 Each phase gets its own detailed plan file before implementation.
@@ -631,8 +631,8 @@ slot is actually freed).
 
 Found during merge CI triage of PR #3764 and verified against the
 tree. `_await_agent_state`
-(`shakenfist/deploy/shakenfist_ci/base.py:436`) looks like a
-500-second deadline and is not one:
+(`shakenfist/deploy/shakenfist_ci/base.py:522`, `:436` when this was
+written) looks like a 500-second deadline and is not one:
 
 ```python
 time_since_last_progress = time.time()
@@ -648,11 +648,22 @@ while time.time() - time_since_last_progress < 500:
 *any* type, so an instance going nowhere while still emitting events
 on any sub-500s cadence renews the window forever. The variable is
 named for progress; nothing in the query restricts it to progress.
-`_await_instance_create` (`base.py:471`) is the identical
-construction with a 180-second window. In run 31856630647 this cost
-the Guests job its entire 60-minute budget: two agent-awaiting tests
-never completed, and because the step was killed rather than failed,
-stestr wrote no results and the job named no failing test at all.
+`_await_instance_create` (`base.py:557`, `:471` when this was written)
+is the identical construction with a 180-second window. In run
+31856630647 this cost the Guests job its entire 60-minute budget: two
+agent-awaiting tests never completed, and because the step was killed
+rather than failed, stestr wrote no results and the job named no
+failing test at all.
+
+Phase 7's survey found a third loop the audit missed:
+`_await_objects_ready` (`base.py:706`) renews a 300-second window the
+same way, and backs `_await_networks_ready`, `_await_artifacts_ready`
+and `_await_blobs_ready`, so it sits on nearly every test in the
+suite. Fixing only the two named above would leave the bug class in
+place. The mechanism is also now confirmed rather than inferred:
+`node_inst_op` (`shakenfist/operations/node_inst_op.py:169`) writes an
+`EVENT_TYPE_USAGE` event against every instance on a timer, so a
+stalled instance renews its own deadline forever.
 
 This is the same two-knob confusion the plan resolves server-side --
 a progress window is not a deadline -- so phase 7 fixes it the same
@@ -697,6 +708,8 @@ client-python's `develop` and client-python's CI builds the server
 from this repository's `develop`. The deadlock is broken by
 `base.AGENT_OPERATION_FAILURES`, a tuple which accepts either
 exception and resolves the new one through `getattr()` so it still
-imports against an old client. Phase 7 narrows it to a plain
-reference once the client change has merged and the ordering
-constraint is gone.
+imports against an old client. Phase 7 removes the `getattr()` -- but
+not the tuple, which its survey found must instead grow to name all
+three exceptions `await_agent_command()` can raise, since the two
+catch sites want breadth and only the two `test_get_missing_file`
+assertions want the narrow reference.

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -776,3 +776,60 @@ previously only emitted an event and left the executor waiting, so the
 operation ended in whatever the 900 second backstop made of it. Clients
 which distinguish the two terminal states get a more useful answer, and
 get it sooner.
+
+### Retry and the executor reaper
+
+An operation that stalls in `executing` -- runs out of
+`progress_timeout_seconds` with nothing wrong except a lack of forward
+progress -- is no longer necessarily abandoned. If the operation is
+retryable (an `agent/get` or `agent/put`; an `agent/execute` never is,
+because re-running a command from the start would repeat a side effect
+the agent cannot take back), its deadline has not passed, and it has
+not already been dispatched `AGENT_OPERATION_MAX_ATTEMPTS` times
+(default 3, counting the first attempt), the operation goes back to the
+*head* of its instance's queue for another attempt instead of ending in
+`expired`. Each retry re-runs the operation's command list from the
+start, so partial results from an abandoned attempt are discarded
+before it runs again.
+
+What this looks like to an operator: a transfer that previously would
+have ended in `expired` after one stalled attempt may now recover on
+its own, at the cost of taking longer overall. Once the attempt cap is
+reached, or the operation's wall-clock deadline has passed, it still
+ends in `expired` exactly as before -- retry narrows the set of stalls
+that reach a terminal state, it does not remove the terminal states
+themselves.
+
+A related but separate change: a node-local reaper in the sidechannel
+daemon now recovers agent operations whose executor died or never
+started -- most visibly across a daemon restart, where an operation
+left `executing` with no process behind it would previously have
+blocked its instance's queue until something else noticed. The reaper
+also catches an executor that wedges before it ever reaches its own
+budget checks (before connecting to the agent), once that operation's
+wall-clock deadline has passed. It runs automatically; no operator
+action is required, but see
+[Agent Operations](../operator_guide/agent_operations.md) for what it
+recovers and what it deliberately cannot.
+
+### The client: `--deadline` and a faster failure on a terminal state
+
+`sf-client instance execute`, `upload` and `download` gained a
+`--deadline` option, and `upload` and `download` also gained
+`--progress-timeout` (`execute` did not, for the same reason the server
+refuses a `progress_timeout_seconds` on `agent/execute`: it could never
+fire). These map straight onto the request parameters described above.
+
+The client also changed how it reacts to a terminal operation state.
+Previously, if an agent operation reached `expired` or `error` while
+the client was polling for it to finish, the client kept polling until
+its own timeout and then raised `AgentCommandError`. It now recognises
+a terminal state immediately and raises `AgentOperationFailed` instead,
+without waiting out the rest of its timeout. Anything catching
+`AgentCommandError` to mean "the operation did not succeed" needs to
+catch `AgentOperationFailed` as well, or catch both.
+
+Both changes are gated on the server advertising the
+`agentoperation-deadlines` capability, so an old client against a new
+cluster and a new client against an old cluster both keep behaving as
+they did before this release.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -495,6 +495,7 @@ nav:
         - "Blob Storage Roadmap": plans/blob-storage-roadmap.md
     - Operator Guide:
        - "Installation": operator_guide/installation.md
+       - "Agent Operations": operator_guide/agent_operations.md
        - "Artifacts": operator_guide/artifacts.md
        - "Authentication": operator_guide/authentication.md
        - "Database": operator_guide/database.md

--- a/mkdocs.yml.tmpl
+++ b/mkdocs.yml.tmpl
@@ -126,6 +126,7 @@ nav:
         - "Blob Storage Roadmap": plans/blob-storage-roadmap.md
     - Operator Guide:
        - "Installation": operator_guide/installation.md
+       - "Agent Operations": operator_guide/agent_operations.md
        - "Artifacts": operator_guide/artifacts.md
        - "Authentication": operator_guide/authentication.md
        - "Database": operator_guide/database.md

--- a/shakenfist/deploy/shakenfist_ci/base.py
+++ b/shakenfist/deploy/shakenfist_ci/base.py
@@ -524,6 +524,104 @@ class BaseTestCase(testtools.TestCase):
             time.sleep(5)
         self.fail(f'Failed to delete instance after 5 minutes {instance_uuid}')
 
+    # The event types which mean an object actually moved forward, used to
+    # renew the progress windows in the awaits below.
+    #
+    # Issue 3770: those windows used to be renewed from the most recent event
+    # of *any* type, which makes them not a bound at all. node_inst_op
+    # (shakenfist/operations/node_inst_op.py) writes an EVENT_TYPE_USAGE event
+    # against every instance on a timer, so an instance going nowhere renewed
+    # its own window forever. In run 31856630647 that consumed the entire 60
+    # minute Guests job budget, and because the step was killed rather than
+    # failed stestr wrote no results and the job named no failing test.
+    #
+    # The set below was checked against what is actually written, rather than
+    # assumed from the vocabulary in shakenfist/constants.py:
+    #
+    # - mutate covers every phase boundary of everything waited on here.
+    #   _state_update() ends in _log_attribute_mutation() (baseobject.py), so
+    #   a state change is always a mutate, as is every attribute write --
+    #   including the agent_state transitions the sidechannel daemon makes.
+    # - status covers the slow parts: image and blob fetch percentages
+    #   (blob.py, images.py) and 'connected to agent'.
+    # - audit is in the set because networks need it. Between a network
+    #   reaching initial and reaching created, the only events on the network
+    #   object are audit ('creating network on hypervisor' and friends in
+    #   network/bridged_vxlan_network.py); with status and mutate alone a
+    #   network create is covered only by its two bracketing state changes.
+    # - usage is the timer channel that caused this bug. resources and health
+    #   are written only against nodes, and prune and historic are never
+    #   written at all, so excluding all four costs nothing.
+    #
+    # This is a filter, not a proof. Two known writers still emit a
+    # progress-typed event on a timer while nothing progresses: blob.py's
+    # 'waiting for existing download to complete' audit every 10 seconds
+    # while another node holds a partial, and the network maintain daemon
+    # re-emitting 'network not ok' status every 30 seconds. That is the
+    # argument for the ceilings below rather than an argument for a narrower
+    # set -- no event filter can distinguish a wait that is progressing from
+    # one that is only being talked about.
+    PROGRESS_EVENT_TYPES = ('audit', 'mutate', 'status')
+
+    # Read a handful of events per poll rather than exactly one, so that a
+    # burst of periodic events cannot hide the progress event behind it.
+    #
+    # Deliberately not a server side event_type filter, which would be the
+    # obvious way to do this: the client's event getters take a single
+    # event_type string, so narrowing to three types means three HTTP
+    # requests per poll per object, and this suite's events polling rate is
+    # already high enough that load_budget.py excludes it from the database
+    # load budget by hand. Tripling it to save a list comprehension is a bad
+    # trade.
+    PROGRESS_EVENT_LIMIT = 10
+
+    def _renew_progress(self, event_callback, reference, last_event,
+                        time_since_last_progress):
+        """Renew a progress window from an object's most recent events.
+
+        Returns the most recent event of any type -- which is what a timeout
+        message should report, because it is what tells a human what the
+        object was actually doing -- and the renewed progress timestamp.
+        """
+        events = event_callback(reference, limit=self.PROGRESS_EVENT_LIMIT)
+        if not events:
+            return last_event, time_since_last_progress
+
+        # Events arrive newest first, so the first match is the newest event
+        # which represents progress.
+        for event in events:
+            if event.get('event_type') in self.PROGRESS_EVENT_TYPES:
+                # Never move the window backwards. A progress event older
+                # than the last renewal is not new progress.
+                time_since_last_progress = max(
+                    time_since_last_progress, event['timestamp'])
+                break
+
+        return events[0], time_since_last_progress
+
+    def _await_expired(self, start_time, time_since_last_progress,
+                       progress_timeout, ceiling):
+        """Describe which bound on an await has been exceeded, if either.
+
+        A progress window is not a deadline. It is renewed by activity, so on
+        its own it bounds nothing; the ceiling is measured from the start of
+        the await, is renewed by nothing, and is what converts a stalled wait
+        from a silently consumed CI budget into a diagnosable test failure.
+        The two are reported distinctly so a reader of a CI log can tell which
+        one fired. Returns None while both bounds still hold.
+        """
+        now = time.time()
+        if now - time_since_last_progress > progress_timeout:
+            return f'has seen no progress in {progress_timeout} seconds'
+        if now - start_time > ceiling:
+            return f'did not finish within {ceiling} seconds overall'
+        return None
+
+    # An instance has to be created, boot, and have its in-guest agent report
+    # in, so the window here is generous and the ceiling more so.
+    AGENT_STATE_PROGRESS_TIMEOUT = 500
+    AGENT_STATE_CEILING = 1800
+
     def _await_agent_state(self, instance_uuid, ready=True):
         # Wait the instance to be created and enter the desired agent running state
         if ready:
@@ -532,8 +630,9 @@ class BaseTestCase(testtools.TestCase):
             desired = 'not ready'
 
         last_event = None
-        time_since_last_progress = time.time()
-        while time.time() - time_since_last_progress < 500:
+        start_time = time.time()
+        time_since_last_progress = start_time
+        while True:
             i = self.system_client.get_instance(instance_uuid)
             if i['state'] == 'error':
                 raise StartException(
@@ -543,27 +642,37 @@ class BaseTestCase(testtools.TestCase):
             if i['agent_state'] and i['agent_state'].startswith(desired):
                 return
 
-            events = self.system_client.get_instance_events(
-                instance_uuid, limit=1)
-            if events:
-                last_event = events[0]
-                time_since_last_progress = last_event['timestamp']
+            last_event, time_since_last_progress = self._renew_progress(
+                self.system_client.get_instance_events, instance_uuid,
+                last_event, time_since_last_progress)
 
             time.sleep(5)
+
+            expiry = self._await_expired(
+                start_time, time_since_last_progress,
+                self.AGENT_STATE_PROGRESS_TIMEOUT, self.AGENT_STATE_CEILING)
+            if expiry:
+                break
 
         cd = self.system_client.get_console_data(instance_uuid)
         cd = '\n'.join(cd.split('\n')[-10:])
         raise TimeoutException(
             f'Instance {instance_uuid} failed to start and enter the agent '
-            f'{desired} state and has seen no progress in 5 minutes. Agent '
-            f'state is {i["agent_state"]} and the last recorded event was '
+            f'{desired} state, and {expiry}. Agent state is '
+            f'{i["agent_state"]} and the last recorded event was '
             f'{last_event}. Last console lines were:\n\n{cd}\n...END...')
+
+    # Instance creation is the scheduler, the image fetch and libvirt define
+    # path only, not boot, so both bounds are tighter than the agent ones.
+    INSTANCE_CREATE_PROGRESS_TIMEOUT = 180
+    INSTANCE_CREATE_CEILING = 900
 
     def _await_instance_create(self, instance_uuid):
         # Wait for the instance to be created
         last_event = None
-        time_since_last_progress = time.time()
-        while time.time() - time_since_last_progress < 180:
+        start_time = time.time()
+        time_since_last_progress = start_time
+        while True:
             i = self.system_client.get_instance(instance_uuid)
             if i['state'] == 'error':
                 raise StartException(
@@ -585,19 +694,23 @@ class BaseTestCase(testtools.TestCase):
                     f'console ports: {ports}')
                 return
 
-            events = self.system_client.get_instance_events(
-                instance_uuid, limit=1)
-            if events:
-                last_event = events[0]
-                time_since_last_progress = last_event['timestamp']
+            last_event, time_since_last_progress = self._renew_progress(
+                self.system_client.get_instance_events, instance_uuid,
+                last_event, time_since_last_progress)
 
             time.sleep(5)
 
+            expiry = self._await_expired(
+                start_time, time_since_last_progress,
+                self.INSTANCE_CREATE_PROGRESS_TIMEOUT,
+                self.INSTANCE_CREATE_CEILING)
+            if expiry:
+                break
+
         raise TimeoutException(
             f'Instance {instance_uuid} failed to start and enter the created '
-            f'state and has seen no progress in 3 minutes. Instance '
-            f'state is {i["state"]} and the last recorded event was '
-            f'{last_event}.')
+            f'state, and {expiry}. Instance state is {i["state"]} and the '
+            f'last recorded event was {last_event}.')
 
     def _await_instance_event(
             self, instance_uuid, operation, message=None, after=None):
@@ -708,12 +821,19 @@ class BaseTestCase(testtools.TestCase):
             'After time %s, image %s had no event type "%s" (waited 5 mins)'
             % (after, image_uuid, operation))
 
+    # This backs the network, artifact and blob readiness helpers, so it is on
+    # the path of nearly every test in the suite. A blob can be replicating a
+    # large image, hence the generous ceiling.
+    OBJECTS_READY_PROGRESS_TIMEOUT = 300
+    OBJECTS_READY_CEILING = 1800
+
     def _await_objects_ready(self, get_callback, event_callback, items):
         waiting_for = list(enumerate(items))
         results = [None] * len(items)
 
         last_event = None
-        time_since_last_progress = time.time()
+        start_time = time.time()
+        time_since_last_progress = start_time
         while waiting_for:
             for idx, item in copy.copy(waiting_for):
                 try:
@@ -723,10 +843,10 @@ class BaseTestCase(testtools.TestCase):
                         results[idx] = n
                         time_since_last_progress = time.time()
                     else:
-                        events = event_callback(item, limit=1)
-                        if events:
-                            last_event = events[0]
-                            time_since_last_progress = last_event['timestamp']
+                        last_event, time_since_last_progress = (
+                            self._renew_progress(
+                                event_callback, item, last_event,
+                                time_since_last_progress))
 
                 except apiclient.ResourceNotFoundException:
                     # Its likely this exception can be removed once PR #1314 (or
@@ -738,16 +858,20 @@ class BaseTestCase(testtools.TestCase):
             if waiting_for:
                 time.sleep(5)
 
-            if waiting_for and time.time() - time_since_last_progress > 300:
-                remaining = []
-                for _, item in waiting_for:
-                    remaining.append(item)
-                remaining_string = ', '.join(remaining)
+                expiry = self._await_expired(
+                    start_time, time_since_last_progress,
+                    self.OBJECTS_READY_PROGRESS_TIMEOUT,
+                    self.OBJECTS_READY_CEILING)
+                if expiry:
+                    remaining = []
+                    for _, item in waiting_for:
+                        remaining.append(item)
+                    remaining_string = ', '.join(remaining)
 
-                raise TimeoutException(
-                    f'Items {remaining_string} never became ready, and no '
-                    f'progress has been made in at least five minutes. The last  '
-                    f'recorded event was {last_event}.')
+                    raise TimeoutException(
+                        f'Items {remaining_string} never became ready: the '
+                        f'wait {expiry}. The last recorded event was '
+                        f'{last_event}.')
 
         return results
 

--- a/shakenfist/deploy/shakenfist_ci/base.py
+++ b/shakenfist/deploy/shakenfist_ci/base.py
@@ -25,25 +25,30 @@ TRACE_PATH = '/srv/ci/traces'
 CLUSTER_CI_IMAGE = 'sf://upload/system/debian-12'
 
 
-# An agent operation which ends in a terminal state other than "complete"
-# reaches the caller as one of these. Historically the client had no way to
-# say "this operation definitively failed": every await loop spun out its
-# whole budget and then raised AgentCommandError, so that is what the suite
-# caught and asserted. client-python#380 (agent operation deadlines phase 6)
-# teaches those loops to recognise a terminal state on the first poll and
-# raise the new, more precise AgentOperationFailed instead.
+# await_agent_command() and await_agent_fetch() can raise three unrelated
+# exceptions, sharing no base class beyond Exception, so this tuple has to
+# enumerate them:
 #
-# Both client versions are in circulation while that lands: this repository's
-# CI builds the client from client-python's develop, and client-python's CI
-# builds the server from this repository's develop, so neither side can
-# switch first. Accepting either exception is what breaks that deadlock. The
-# getattr() is what makes an old client work -- AgentOperationFailed simply
-# does not exist there -- and can be narrowed to a plain reference once the
-# client change has merged. Phase 7 owns that cleanup, along with the rest of
-# this suite's await work.
+# - AgentOperationFailed -- the operation reached a terminal failure state.
+#   Raised from _await_agentop() in the client.
+# - AgentAwaitTimeout -- the operation never completed within the caller's
+#   own budget.
+# - AgentCommandError -- the operation completed but the result is unusable:
+#   no results, unexpected stderr, or no stdout/content blob.
+#
+# This tuple exists for catching, not asserting. Its two consumers, the
+# cloud-init retry loop and its debug-gathering loop in
+# _await_instance_ready() below, both mean "this attempt gave us no usable
+# answer, retry" -- so it is deliberately not narrowed to AgentOperationFailed
+# alone, even though client-python#380 has now merged and the getattr() shim
+# that used to accommodate an older client (which lacked AgentOperationFailed
+# entirely) is gone. Narrowing it would let a health check whose command
+# writes to stderr escape the retry on its first attempt. Assertion sites
+# want the opposite and use AgentOperationFailed directly.
 AGENT_OPERATION_FAILURES = (
     apiclient.AgentCommandError,
-    getattr(apiclient, 'AgentOperationFailed', apiclient.AgentCommandError))
+    apiclient.AgentOperationFailed,
+    apiclient.AgentAwaitTimeout)
 
 
 # Some functional assertions need to observe real host state (network

--- a/shakenfist/deploy/shakenfist_ci/base.py
+++ b/shakenfist/deploy/shakenfist_ci/base.py
@@ -999,6 +999,54 @@ class BaseNamespacedTestCase(BaseTestCase):
 
         self._remove_namespace(self.namespace)
 
+    def _await_agentop_complete(self, instance_uuid, aop, timeout,
+                                description='agent operation'):
+        # Poll a single agent operation to completion with its own independent
+        # timeout window. Previously test_instance_put_and_get_blob shared one
+        # start_time across three sequential operations, so the last and
+        # heaviest of them (get-file, which reads, hashes and uploads a blob
+        # back to the cluster) was left only whatever budget the earlier
+        # operations had not already consumed. Under under-cloud contention
+        # that remainder collapsed and get-file "timed out" while still
+        # legitimately executing -- the intermittent merge-queue flake.
+        #
+        # Hoisted here from guest_ci_tests/test_agentops.py in agent
+        # operation deadlines phase 7: a0cc243ad fixed this bug in that
+        # file's copy of test_instance_put_and_get_blob but never in the
+        # smoke suite's near-identical copy, which runs on every pull
+        # request and kept the flake alive. A shared implementation is what
+        # stops a fix from half-landing again. This is also where the
+        # terminal-state check lives -- an operation which reaches expired
+        # or error now fails immediately instead of burning the rest of its
+        # window and then reporting a bare timeout.
+        #
+        # It sits on BaseNamespacedTestCase rather than beside _await_command
+        # on BaseTestCase because it polls as self.test_client, which only
+        # the namespaced class creates. Polling as the system client instead
+        # would work -- it is admin -- but it would be a different assertion
+        # about what a namespaced caller can see, which is not this step's
+        # to make.
+        start_time = time.time()
+        while aop['state'] != 'complete':
+            if aop['state'] in self.AGENT_OPERATION_FAILED_STATES:
+                self._raise_agent_operation_failure(
+                    instance_uuid, description, aop,
+                    f"agent operation {aop['uuid']} for {description} "
+                    f"finished in state {aop['state']} instead of "
+                    'completing')
+
+            if time.time() - start_time > timeout:
+                self._raise_agent_operation_failure(
+                    instance_uuid, description, aop,
+                    f"agent operation {aop['uuid']} for {description} was "
+                    f"still in state {aop['state']} after {timeout} "
+                    'seconds')
+
+            time.sleep(5)
+            aop = self.test_client.get_agent_operation(aop['uuid'])
+
+        return aop
+
 
 class TestDistroBoots(BaseNamespacedTestCase):
     def setUp(self):

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_agentops.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_agentops.py
@@ -5,6 +5,7 @@ import time
 from testtools import content
 
 from shakenfist_ci import base
+from shakenfist_client import apiclient
 
 
 class TestAgentOperations(base.BaseNamespacedTestCase):
@@ -272,7 +273,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
 
         # Run a fetch command which should fail
         self.assertRaises(
-            base.AGENT_OPERATION_FAILURES, self.test_client.await_agent_fetch,
+            apiclient.AgentOperationFailed, self.test_client.await_agent_fetch,
             inst['uuid'], '/tmp/nosuch')
 
     def test_interface_plug_and_exec_dhcp(self):

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_agentops.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_agentops.py
@@ -23,25 +23,6 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
                                             sort_keys=True)))
         self._await_networks_ready([self.net_one['uuid']])
 
-    def _await_agentop_complete(self, instance_uuid, aop, timeout):
-        # Poll a single agent operation to completion with its own independent
-        # timeout window. Previously test_instance_put_and_get_blob shared one
-        # start_time across three sequential operations, so the last and
-        # heaviest of them (get-file, which reads, hashes and uploads a blob
-        # back to the cluster) was left only whatever budget the earlier
-        # operations had not already consumed. Under under-cloud contention
-        # that remainder collapsed and get-file "timed out" while still
-        # legitimately executing -- the intermittent merge-queue flake.
-        start_time = time.time()
-        while aop['state'] != 'complete':
-            if time.time() - start_time > timeout:
-                console_data = self.test_client.get_console_data(instance_uuid)
-                self.fail(
-                    f'Timeout for agentop: {aop}\n\nConsole: {console_data}')
-            time.sleep(5)
-            aop = self.test_client.get_agent_operation(aop['uuid'])
-        return aop
-
     def test_instance_execute_small(self):
         inst = self.test_client.create_instance(
             'test-instance-execute-small', 1, 1024,
@@ -62,15 +43,8 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
         self._await_instance_ready(inst['uuid'])
 
         # Execute a command
-        start_time = time.time()
         aop = self.test_client.instance_execute(inst['uuid'], 'whoami')
-        while aop['state'] != 'complete':
-            if time.time() - start_time > 30:
-                console_data = self.test_client.get_console_data(inst['uuid'])
-                self.fail(
-                    f'Timeout for agentop: {aop}\n\nConsole: {console_data}')
-            time.sleep(5)
-            aop = self.test_client.get_agent_operation(aop['uuid'])
+        aop = self._await_agentop_complete(inst['uuid'], aop, 30, 'whoami')
 
         self.assertTrue(
             '0' in aop['results'],
@@ -103,18 +77,12 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
         self._await_instance_ready(inst['uuid'])
 
         # Execute a command
-        start_time = time.time()
         aop = self.test_client.instance_execute(
             inst['uuid'], 'cat /var/log/syslog')
 
         # Wait for the operation to complete
-        while aop['state'] != 'complete':
-            if time.time() - start_time > 30:
-                console_data = self.test_client.get_console_data(inst['uuid'])
-                self.fail(
-                    f'Timeout for agentop: {aop}\n\nConsole: {console_data}')
-            time.sleep(5)
-            aop = self.test_client.get_agent_operation(aop['uuid'])
+        aop = self._await_agentop_complete(
+            inst['uuid'], aop, 30, 'cat /var/log/syslog')
 
         self.assertTrue(
             '0' in aop['results'],
@@ -157,17 +125,8 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
         # Request that the agent copy the file to the instance
         op = self.test_client.instance_put_blob(
             inst['uuid'], input_blob, '/tmp/fibonacci.py', 'ugo+rx')
-
-        start_time = time.time()
-        while time.time() - start_time < 120:
-            if op['state'] == 'complete':
-                break
-            time.sleep(5)
-            op = self.test_client.get_agent_operation(op['uuid'])
-
-        if op['state'] != 'complete':
-            self.fail('Agent put operation %s did not complete in 120 seconds (%s)'
-                      % (op['uuid'], op['state']))
+        op = self._await_agentop_complete(
+            inst['uuid'], op, 120, 'put fibonacci.py')
 
         # Request that the agent execute the file
         _, data = self.test_client.await_agent_command(
@@ -230,12 +189,13 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
 
         aop = self.test_client.instance_put_blob(
             inst['uuid'], blob_uuid, '/tmp/foo', 'ugo+r')
-        aop = self._await_agentop_complete(inst['uuid'], aop, 60)
+        aop = self._await_agentop_complete(inst['uuid'], aop, 60, 'put /tmp/foo')
 
         # Now ensure the data arrived correctly
         aop = self.test_client.instance_execute(
             inst['uuid'], 'sha512sum /tmp/foo')
-        aop = self._await_agentop_complete(inst['uuid'], aop, 60)
+        aop = self._await_agentop_complete(
+            inst['uuid'], aop, 60, 'sha512sum /tmp/foo')
 
         remote_hash = aop['results']['0']['stdout'].split(' ')[0]
         self.assertEqual(
@@ -247,7 +207,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
         # agent reads the file, hashes it and uploads it back as a new blob),
         # so it gets a more generous independent budget.
         aop = self.test_client.instance_get(inst['uuid'], '/tmp/foo')
-        aop = self._await_agentop_complete(inst['uuid'], aop, 120)
+        aop = self._await_agentop_complete(inst['uuid'], aop, 120, 'get /tmp/foo')
 
         self.assertTrue(
             '0' in aop['results'],

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentop_deadlines.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentop_deadlines.py
@@ -1,0 +1,331 @@
+"""Functional coverage of the agent operation timing budgets.
+
+Phases 1 to 5 of docs/plans/PLAN-agent-operation-deadlines.md replaced a
+hardcoded 900 second backstop in the sidechannel daemon with two budgets a
+caller can set per operation: a wall-clock deadline, and a progress timeout
+which only applies to commands which can actually report progress. Nothing
+in this suite exercised either of them, which is survey finding F5 of
+docs/plans/PLAN-agent-operation-deadlines-phase-07-docs-and-ci.md.
+
+Every assertion here is about a state, or about the presence and rough
+magnitude of an absolute timestamp. None of them is about how many seconds
+something took. CI hardware is contended and shared, so a test which asserts
+that an operation expired "within ten seconds" is a flake written on
+purpose; see decision 5 of that phase plan.
+"""
+
+import json
+import time
+
+from testtools import content
+
+from shakenfist_ci import base
+from shakenfist_client import apiclient
+
+
+# Mirrors of the two server side defaults, which live in
+# shakenfist/config.py as AGENT_OPERATION_DEFAULT_DEADLINE (:240) and
+# AGENT_OPERATION_DEFAULT_PROGRESS_TIMEOUT (:259). Neither is published
+# through the REST API, so the suite cannot read them from the cluster it is
+# talking to. If either default is retuned, this pair moves with it.
+AGENT_OPERATION_DEFAULT_DEADLINE = 600
+AGENT_OPERATION_DEFAULT_PROGRESS_TIMEOUT = 30
+
+# How far a freshly created operation's deadline may sit from where this
+# test's own clock says it should. The deadline is an absolute timestamp
+# stamped by whichever API node answered the request, so this window is
+# tolerance for clock skew between that node and the node running the suite,
+# plus however long the request spent on the wire. It is not a statement
+# about how precise the deadline is. Two minutes is far more skew than an
+# NTP synchronised cluster ever shows, and is still narrow enough that no
+# default at all, or the 900 second backstop this replaced, fails here.
+DEADLINE_CLOCK_SKEW_ALLOWANCE = 120
+
+# How long the blocking operation in the two queue tests occupies the
+# instance's single executor slot. It only has to outlast the deadline on
+# the operation queued behind it, which passes five seconds after that
+# operation is created, so this is six times what is strictly needed --
+# cheap insurance in a suite that runs on every pull request, where the
+# alternative is a test that occasionally proves nothing.
+BLOCKER_SECONDS = 30
+
+# The deadline given to the operation which is expected to expire. Small
+# enough that it has certainly passed by the time the executor slot frees,
+# and deliberately not zero: deadline_seconds=0 means "no wall-clock
+# deadline at all" to the API, not "expire immediately".
+SHORT_DEADLINE_SECONDS = 5
+
+# How long the silent command in the progress timeout test produces no
+# output for. Twice the default progress window, so a run which passes
+# cannot be explained by scheduling jitter around the boundary, and no
+# longer than that because the whole cost is paid on every pull request.
+NO_PROGRESS_SECONDS = 2 * AGENT_OPERATION_DEFAULT_PROGRESS_TIMEOUT
+
+# An absolute bound on every wait below. These exist only to turn a hung
+# test into a diagnosable failure -- an operation which expires in ten
+# seconds and one which expires in two minutes are both a pass -- so they
+# are deliberately generous, in the same spirit as base.py's
+# AGENT_OPERATION_TIMEOUT.
+AGENTOP_STATE_TIMEOUT = 300
+
+
+class TestAgentOperationDeadlines(base.BaseNamespacedTestCase):
+    def __init__(self, *args, **kwargs):
+        kwargs['namespace_prefix'] = 'aopdeadlines'
+        super().__init__(*args, **kwargs)
+
+    def setUp(self):
+        super().setUp()
+
+        # The client only sends deadline_seconds and
+        # progress_timeout_seconds to a server which advertises this
+        # capability (_add_agentop_timing() in client-python's apiclient).
+        # Against a server which does not, it silently sends neither and
+        # every operation below quietly gets the server default instead of
+        # the deadline it asked for -- which would make the expiry tests
+        # pass or fail for reasons that have nothing to do with what they
+        # claim to cover. Fail loudly here instead of subtly there.
+        self.assertTrue(
+            self.test_client.check_capability('agentoperation-deadlines'),
+            'The API server does not advertise the agentoperation-deadlines '
+            'capability, so the client will not send the timing parameters '
+            'these tests are about.')
+
+        # Creating an agent operation through self.test_client blocks.
+        # instance_execute(), instance_put_blob() and instance_get() all end
+        # in the client's _await_agentop(), which polls until the async
+        # strategy's deadline -- 60 seconds for the ASYNC_PAUSE client the
+        # base class builds -- and, worse for these tests, raises
+        # AgentOperationFailed the instant it polls a terminal failure
+        # state. An operation which is *expected* to expire would therefore
+        # arrive as an exception out of the create call rather than as
+        # something to inspect. An ASYNC_CONTINUE client returns the
+        # operation exactly as the POST response described it and never
+        # polls, which is what these tests want: they do their own waiting,
+        # explicitly and with a bound. The alternative -- catching
+        # AgentOperationFailed and reading e.op_view -- would work, but it
+        # makes an assertion about the operation contingent on an exception
+        # having been raised, which is a worse thing to have to read.
+        self.nonblocking_client = apiclient.Client(
+            base_url=self.system_client.base_url,
+            namespace=self.namespace, key=self.namespace_key,
+            async_strategy=apiclient.ASYNC_CONTINUE)
+
+        self.net_one = self.test_client.allocate_network(
+            '192.168.243.0/24', True, True, '%s-net-one' % self.namespace,
+            provide_dns=True)
+        self.addDetail(
+            'net_one',
+            content.text_content(json.dumps(self.net_one, indent=4,
+                                            sort_keys=True)))
+        self._await_networks_ready([self.net_one['uuid']])
+
+    def _create_ready_instance(self, name):
+        inst = self.test_client.create_instance(
+            name, 1, 1024,
+            [
+                {
+                    'network_uuid': self.net_one['uuid']
+                }
+            ],
+            [
+                {
+                    'size': 8,
+                    'base': base.CLUSTER_CI_IMAGE,
+                    'type': 'disk'
+                }
+            ], None, None)
+        self.addDetail(
+            'inst',
+            content.text_content(json.dumps(inst, indent=4, sort_keys=True)))
+
+        # Wait for the instance agent to report in
+        self._await_instance_ready(inst['uuid'])
+        return inst
+
+    def _await_agentop_state(self, instance_uuid, aop, states, timeout,
+                             description):
+        """Poll one agent operation until it reaches one of states.
+
+        base.BaseNamespacedTestCase._await_agentop_complete() only knows how
+        to wait for success. These tests wait for expired, and for
+        executing, so they need a version which is told which states it is
+        happy with. It lives here rather than in base.py because nothing
+        else in the suite waits for an agent operation to reach a state
+        other than complete, and base.py is where a helper with one caller
+        goes to be copied later.
+
+        Reaching some *other* terminal state fails immediately rather than
+        burning the rest of the window, and every failure routes through
+        _raise_agent_operation_failure() so it prints the operation and the
+        instance's recent events. That matters most for an expiry: the
+        reason an operation expired is on its state row's message, which is
+        not part of the external view, but expire() also audits it against
+        the instance, so the events are where "the operation deadline
+        passed while queued" is actually readable.
+        """
+        terminal = tuple(self.AGENT_OPERATION_FAILED_STATES) + ('complete',)
+        wanted = ', '.join(states)
+        start_time = time.time()
+
+        while aop['state'] not in states:
+            if aop['state'] in terminal:
+                self._raise_agent_operation_failure(
+                    instance_uuid, description, aop,
+                    f"agent operation {aop['uuid']} for {description} "
+                    f"finished in state {aop['state']}, but this test "
+                    f'expected it to reach one of {wanted}')
+
+            if time.time() - start_time > timeout:
+                self._raise_agent_operation_failure(
+                    instance_uuid, description, aop,
+                    f"agent operation {aop['uuid']} for {description} was "
+                    f"still in state {aop['state']} after {timeout} seconds "
+                    f'without reaching one of {wanted}')
+
+            time.sleep(5)
+            aop = self.test_client.get_agent_operation(aop['uuid'])
+
+        return aop
+
+    def test_queued_operation_expires_on_its_deadline(self):
+        inst = self._create_ready_instance('test-aop-deadline-queued')
+
+        # The sidechannel dispatcher runs at most one executor per instance
+        # and skips an instance which already has a live one, so this
+        # operation holds the instance's only executor slot for the whole
+        # sleep and anything enqueued behind it waits. It takes the server
+        # default deadline, which is twenty times longer than it needs.
+        blocker = self.nonblocking_client.instance_execute(
+            inst['uuid'], f'sleep {BLOCKER_SECONDS}')
+
+        # This one cannot possibly run until the blocker finishes, by which
+        # time its own deadline has long passed.
+        # Instance.agent_operation_next() is what notices: it is the
+        # dequeue enforcement point, and it expires and retires a queued
+        # head whose wall-clock deadline has passed rather than handing it
+        # to the executor.
+        victim = self.nonblocking_client.instance_execute(
+            inst['uuid'], 'whoami', deadline_seconds=SHORT_DEADLINE_SECONDS)
+
+        victim = self._await_agentop_state(
+            inst['uuid'], victim, ('expired',), AGENTOP_STATE_TIMEOUT,
+            'the operation expected to expire while queued')
+
+        # It never executed. attempts is incremented by the executor at the
+        # moment it moves an operation to executing (record_attempt(), from
+        # SideChannelExecutorJob's socket loop), so a zero here is the
+        # assertion that this operation expired without ever occupying the
+        # executor -- which is the entire point of enforcing the deadline at
+        # dequeue rather than only inside the executor.
+        self.assertEqual(
+            0, victim['attempts'],
+            f'Expired operation was dispatched to an executor anyway: {victim}')
+        self.assertEqual(
+            {}, victim['results'],
+            f'Expired operation produced results: {victim}')
+
+        # Leave the instance idle for the namespace teardown rather than
+        # racing it against a live agent operation. The blocker has
+        # necessarily already finished -- the expiry above cannot happen
+        # until it does -- so this returns on its first poll.
+        self._await_agentop_complete(
+            inst['uuid'], blocker, AGENTOP_STATE_TIMEOUT,
+            f'sleep {BLOCKER_SECONDS}')
+
+    def test_default_deadline_is_published(self):
+        inst = self._create_ready_instance('test-aop-deadline-default')
+
+        # No deadline_seconds, so the API server applies
+        # AGENT_OPERATION_DEFAULT_DEADLINE at request receipt and stores it
+        # as an absolute timestamp. The bracket is read around the call
+        # because the request itself takes time, and the deadline is
+        # stamped somewhere in the middle of it.
+        before = time.time()
+        aop = self.nonblocking_client.instance_execute(inst['uuid'], 'whoami')
+        after = time.time()
+
+        self.assertIsNotNone(
+            aop.get('deadline'),
+            f'Agent operation created with no deadline_seconds has no '
+            f'deadline: {aop}')
+
+        earliest = (before + AGENT_OPERATION_DEFAULT_DEADLINE
+                    - DEADLINE_CLOCK_SKEW_ALLOWANCE)
+        latest = (after + AGENT_OPERATION_DEFAULT_DEADLINE
+                  + DEADLINE_CLOCK_SKEW_ALLOWANCE)
+        self.assertTrue(
+            earliest <= aop['deadline'] <= latest,
+            f'Agent operation deadline {aop["deadline"]} is not roughly '
+            f'{AGENT_OPERATION_DEFAULT_DEADLINE} seconds from now: expected '
+            f'between {earliest} and {latest}. The operation was: {aop}')
+
+        self._await_agentop_complete(
+            inst['uuid'], aop, AGENTOP_STATE_TIMEOUT, 'whoami')
+
+    def test_silent_execute_survives_the_progress_timeout(self):
+        inst = self._create_ready_instance('test-aop-deadline-noprogress')
+
+        aop = self.nonblocking_client.instance_execute(
+            inst['uuid'], f'sleep {NO_PROGRESS_SECONDS}; echo done')
+
+        # The execute endpoint publishes no progress_timeout_seconds and
+        # records an explicit zero, because no command it builds can report
+        # progress -- and the executor independently declines to apply the
+        # window unless the in-flight handler says it reports progress
+        # (ExecuteCommand.reports_progress is False). Asserting the stored
+        # zero here means a regression which quietly started applying the
+        # default to execute is reported as itself, rather than as a
+        # mysterious expiry further down.
+        self.assertEqual(
+            0, aop['progress_timeout'],
+            f'Agent execute operation was given a progress timeout: {aop}')
+
+        aop = self._await_agentop_complete(
+            inst['uuid'], aop, AGENTOP_STATE_TIMEOUT,
+            f'sleep {NO_PROGRESS_SECONDS}; echo done')
+
+        self.assertEqual(
+            'done\n', aop['results']['0']['stdout'],
+            f'Agent operation result "0" stdout value lacks expected value '
+            f'"done\\n": {aop}')
+
+    def test_expiry_frees_the_executor_slot(self):
+        inst = self._create_ready_instance('test-aop-deadline-unblocks')
+
+        # Same shape as test_queued_operation_expires_on_its_deadline, plus
+        # a third operation behind the one which expires. The question this
+        # asks is whether an expired operation is retired from its
+        # instance's queue or left there as a corpse the dispatcher trips
+        # over -- before the queue learned about terminal states, a head
+        # which was never going to run blocked its instance forever.
+        blocker = self.nonblocking_client.instance_execute(
+            inst['uuid'], f'sleep {BLOCKER_SECONDS}')
+        victim = self.nonblocking_client.instance_execute(
+            inst['uuid'], 'whoami', deadline_seconds=SHORT_DEADLINE_SECONDS)
+        follower = self.nonblocking_client.instance_execute(
+            inst['uuid'], 'whoami')
+
+        victim = self._await_agentop_state(
+            inst['uuid'], victim, ('expired',), AGENTOP_STATE_TIMEOUT,
+            'the operation expected to expire while queued')
+
+        # complete is accepted alongside executing because whoami is fast
+        # enough to be finished before the next poll, and a completed
+        # operation is a strictly stronger demonstration that the slot
+        # freed than a dispatched one.
+        follower = self._await_agentop_state(
+            inst['uuid'], follower, ('executing', 'complete'),
+            AGENTOP_STATE_TIMEOUT, 'whoami queued behind an expired operation')
+        follower = self._await_agentop_complete(
+            inst['uuid'], follower, AGENTOP_STATE_TIMEOUT,
+            'whoami queued behind an expired operation')
+
+        self.assertEqual(
+            'root\n', follower['results']['0']['stdout'],
+            f'Agent operation result "0" stdout value lacks expected value '
+            f'"root\\n": {follower}')
+
+        self._await_agentop_complete(
+            inst['uuid'], blocker, AGENTOP_STATE_TIMEOUT,
+            f'sleep {BLOCKER_SECONDS}')

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
@@ -5,6 +5,7 @@ import time
 from testtools import content
 
 from shakenfist_ci import base
+from shakenfist_client import apiclient
 
 
 class TestAgentOperations(base.BaseNamespacedTestCase):
@@ -261,7 +262,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
 
         # Run a fetch command which should fail
         self.assertRaises(
-            base.AGENT_OPERATION_FAILURES, self.test_client.await_agent_fetch,
+            apiclient.AgentOperationFailed, self.test_client.await_agent_fetch,
             inst['uuid'], '/tmp/nosuch')
 
     def test_interface_plug_and_exec_dhcp(self):

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
@@ -46,15 +46,8 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
         self._await_instance_ready(inst['uuid'])
 
         # Execute a command
-        start_time = time.time()
         aop = self.test_client.instance_execute(inst['uuid'], 'whoami')
-        while aop['state'] != 'complete':
-            if time.time() - start_time > 30:
-                console_data = self.test_client.get_console_data(inst['uuid'])
-                self.fail(
-                    f'Timeout for agentop: {aop}\n\nConsole: {console_data}')
-            time.sleep(5)
-            aop = self.test_client.get_agent_operation(aop['uuid'])
+        aop = self._await_agentop_complete(inst['uuid'], aop, 30, 'whoami')
 
         self.assertTrue(
             '0' in aop['results'],
@@ -87,18 +80,12 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
         self._await_instance_ready(inst['uuid'])
 
         # Execute a command
-        start_time = time.time()
         aop = self.test_client.instance_execute(
             inst['uuid'], 'cat /var/log/syslog')
 
         # Wait for the operation to complete
-        while aop['state'] != 'complete':
-            if time.time() - start_time > 30:
-                console_data = self.test_client.get_console_data(inst['uuid'])
-                self.fail(
-                    f'Timeout for agentop: {aop}\n\nConsole: {console_data}')
-            time.sleep(5)
-            aop = self.test_client.get_agent_operation(aop['uuid'])
+        aop = self._await_agentop_complete(
+            inst['uuid'], aop, 30, 'cat /var/log/syslog')
 
         self.assertTrue(
             '0' in aop['results'],
@@ -141,17 +128,8 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
         # Request that the agent copy the file to the instance
         op = self.test_client.instance_put_blob(
             inst['uuid'], input_blob, '/tmp/fibonacci.py', 'ugo+rx')
-
-        start_time = time.time()
-        while time.time() - start_time < 120:
-            if op['state'] == 'complete':
-                break
-            time.sleep(5)
-            op = self.test_client.get_agent_operation(op['uuid'])
-
-        if op['state'] != 'complete':
-            self.fail('Agent put operation %s did not complete in 120 seconds (%s)'
-                      % (op['uuid'], op['state']))
+        op = self._await_agentop_complete(
+            inst['uuid'], op, 120, 'put fibonacci.py')
 
         # Request that the agent execute the file
         _, data = self.test_client.await_agent_command(
@@ -198,29 +176,15 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
         # Wait for the instance agent to report in
         self._await_instance_ready(inst['uuid'])
 
-        start_time = time.time()
         aop = self.test_client.instance_put_blob(
             inst['uuid'], blob_uuid, '/tmp/foo', 'ugo+r')
-
-        # Wait for the operation to complete
-        while aop['state'] != 'complete':
-            if time.time() - start_time > 30:
-                console_data = self.test_client.get_console_data(inst['uuid'])
-                self.fail(
-                    f'Timeout for agentop: {aop}\n\nConsole: {console_data}')
-            time.sleep(5)
-            aop = self.test_client.get_agent_operation(aop['uuid'])
+        aop = self._await_agentop_complete(inst['uuid'], aop, 30, 'put /tmp/foo')
 
         # Now ensure the data arrived correctly
         aop = self.test_client.instance_execute(
             inst['uuid'], 'sha512sum /tmp/foo')
-        while aop['state'] != 'complete':
-            if time.time() - start_time > 60:
-                console_data = self.test_client.get_console_data(inst['uuid'])
-                self.fail(
-                    f'Timeout for agentop: {aop}\n\nConsole: {console_data}')
-            time.sleep(5)
-            aop = self.test_client.get_agent_operation(aop['uuid'])
+        aop = self._await_agentop_complete(
+            inst['uuid'], aop, 60, 'sha512sum /tmp/foo')
 
         remote_hash = aop['results']['0']['stdout'].split(' ')[0]
         self.assertEqual(
@@ -228,17 +192,11 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             f'Cluster hash {cluster_hash} does not match remote hash'
             f'{remote_hash}')
 
-        # Now fetch the data back
+        # Now fetch the data back. get-file is the heaviest operation (the
+        # agent reads the file, hashes it and uploads it back as a new blob),
+        # so it gets a more generous independent budget.
         aop = self.test_client.instance_get(inst['uuid'], '/tmp/foo')
-
-        # Wait for the operation to complete
-        while aop['state'] != 'complete':
-            if time.time() - start_time > 60:
-                console_data = self.test_client.get_console_data(inst['uuid'])
-                self.fail(
-                    f'Timeout for agentop: {aop}\n\nConsole: {console_data}')
-            time.sleep(5)
-            aop = self.test_client.get_agent_operation(aop['uuid'])
+        aop = self._await_agentop_complete(inst['uuid'], aop, 120, 'get /tmp/foo')
 
         self.assertTrue(
             '0' in aop['results'],


### PR DESCRIPTION
Phase 7 of `docs/plans/PLAN-agent-operation-deadlines.md`: documentation
and CI coverage, and the last implementation phase before the push audit
(phase 8).

The phase plan is
`docs/plans/PLAN-agent-operation-deadlines-phase-07-docs-and-ci.md`,
committed as the first commit here.

## What the survey found

The master plan's row for phase 7 was written before phases 3 to 6
executed and was wrong in four places. All four are corrected at source
in the planning commit.

1. **The documentation was not deferred from phase 3.** Phase 3's
   `cf094551b` wrote both the API reference and the release-note section
   on the two parameters. What was actually missing: phase 5's retry and
   reaper (published in exactly one place, `state_machine.md`), phase 6's
   client changes, and an operator-guide page for agent operations, of
   which there was none.
2. **`AGENT_OPERATION_FAILURES` must not narrow to a plain reference.**
   The row said to. Following it literally is a regression -- see below.
3. **There is a third event-renewed await.** `_await_objects_ready`
   backs the network, artifact and blob readiness helpers, so #3770 is
   not fixed without it. The row's two addresses had also drifted ~86
   lines.
4. **Commit `a0cc243ad` half-landed.** It fixed the shared-clock flake
   (~9% of merge-queue runs at the time) in the guest copy of
   `test_agentops.py` and never in the near-identical smoke copy -- the
   suite that runs on every pull request. That is fixed here.

## The commits

| Step | Commit | What |
|---|---|---|
| plan | `69ecfe8fe` | The phase plan, plus the four corrections above |
| 7a | `ebbf5c0da` | One clock per agent operation, and fail fast on a terminal state |
| 7b | `e11869867` | The exception tuple the client can actually raise |
| 7c | `b4bc82551` | Absolute ceilings on the three event-renewed awaits (`Fixes #3770`) |
| 7d | `42d733a3a` | Four functional tests for the timing budgets |
| 7e | `55fee2ef6` | Operator guide page, and the release note extended |
| 7f | `ea7ffe4b2` | Close-out |

## Three things a reviewer should look at

**A latent regression from phase 6, repaired by 7b.** Phase 6 changed
`await_agent_command()`'s timeout path in client-python from raising
`AgentCommandError` to raising the new `AgentAwaitTimeout`.
`base.AGENT_OPERATION_FAILURES` did not name the new exception, so since
client-python#380 merged, `_await_instance_ready`'s cloud-init retry loop
has silently stopped retrying a timed-out health check -- it retried them
before. Adding `AgentAwaitTimeout` restores that coverage.

This is why 7b **declines the master plan's instruction** to narrow the
tuple to a plain `AgentOperationFailed` reference. The instruction
conflates a catch site, which wants breadth, with an assert site, which
wants precision: only the two `test_get_missing_file` assertions narrow.
The operator confirmed that decision during planning.

**Decision 3 was corrected during execution.** The plan said to filter
events server-side by `event_type`. It does not: every client event
getter funnels into `_get_events()`, which takes one type and not a set,
and the server is `Optional[str]` all the way down to
`mariadb.get_object_events`, so three types would be three HTTP requests
per poll per object -- against a suite whose events traffic
`load_budget.py` already excludes from the database load budget by hand
and explains at length. It reads ten events per poll and filters
client-side instead, at the same request count.

The progress-event set was verified rather than assumed, and gained
`audit`: between a network reaching `initial` and reaching `created`, the
only events on the network object are `audit`, so `status` and `mutate`
alone would have covered a network create by its two bracketing state
changes and nothing in between.

**The new functional tests are unverified.** They need a real cluster,
so this PR's own CI run is the first time they execute. If the smoke
suite goes red on `smoke_ci_tests/test_agentop_deadlines.py`, that is a
phase-7 defect rather than a flake to re-queue.

## Status is deliberately still `In progress`

Fourteen of the phase plan's fifteen Definition-of-done items tick. The
fifteenth is "CI has run green on the branch", which this PR is what
answers. The plan's own risk section says the phase is not marked
complete on unit tests alone, so the flip to `Complete` -- and the index
arithmetic to `8 of 9` -- is a follow-up commit once CI is green.

*(Pull request prepared with Claude Code)*
