### PR TITLE
Clean up the declared dependency set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,17 @@ dependencies = [
     "semver==3.0.4",                      # bsd
     "SQLAlchemy==2.0.52",                 # mit
 
+    # Imported directly, rather than reached through whichever package
+    # happens to require them today, so what keeps them installed is a
+    # declaration and not a transitive pin the reconciler could drop.
+    # logship.py imports pylogrus (which arrives via
+    # shakenfist-utilities), tools/render-review.py imports jsonschema
+    # (via flasgger) and tools/build-collection.py imports packaging
+    # (via the oslo stack).
+    "jsonschema==4.26.0",                 # mit
+    "packaging==26.3",                    # apache2
+    "pylogrus==0.4.0",                    # mit
+
     "greenlet==3.5.5",                    # mit
     "gevent==26.8.0",                     # mit
     "gunicorn[gevent]==26.2.0",           # mit
@@ -131,7 +142,6 @@ dependencies = [
     "iso8601==2.1.0",
     "itsdangerous==2.2.0",
     "jsonschema-specifications==2025.9.1",
-    "jsonschema==4.26.0",
     "MarkupSafe==3.0.3",
     "mistune==3.3.4",
     "netaddr==1.3.0",
@@ -139,9 +149,7 @@ dependencies = [
     "oslo.config==10.7.0",
     "oslo.i18n==6.9.0",
     "oslo.utils==10.2.0",
-    "packaging==26.3",
     "pycparser==3.0",
-    "pylogrus==0.4.0",
     "pyparsing==3.3.2",
     "python-dotenv==1.2.3",
     "pytz==2026.3.post1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,18 @@ dependencies = [
     # rather than as a reviewable PR. That is intended; pin them exactly
     # here if it ever stops being.
     "psutil>=5.9.4",                      # bsd
+    # not-imported: uv -- the node bootstrap runs "uv pip install" to
+    # install Shaken Fist into the node virtualenv.
     "uv>=0.8.0",                          # mit
 
     # Our requirements -- we specify exact versions here and let renovate update
     # them for the develop branch as required. Releases never update requirements.
     "shakenfist-utilities==0.8.6",        # apache2
-    "clingwrap==2.1",                  # apache2
+
+    # not-imported: clingwrap -- a CLI, installed into the node
+    # virtualenv so that debug bundles can be collected on a node with
+    # "clingwrap gather --target shakenfist".
+    "clingwrap==2.1",                     # apache2
 
     "fixtures==4.3.2",                    # apache2
     "PyYAML==6.0.3",                      # mit
@@ -54,7 +60,6 @@ dependencies = [
     "marshmallow==4.3.1",                 # mit
     "py-cpuinfo==9.0.0",                  # mit
     "distro==1.9.0",                      # apache2
-    "pbr==7.0.3",                         # apache2
     "symbolicmode==2.0.1",                # CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
     "pycdlib==1.20.0",                    # lgpl
     "validators==0.35.0",                 # mit
@@ -74,8 +79,6 @@ dependencies = [
     "packaging==26.3",                    # apache2
     "pylogrus==0.4.0",                    # mit
 
-    "greenlet==3.5.5",                    # mit
-    "gevent==26.8.0",                     # mit
     "gunicorn[gevent]==26.2.0",           # mit
 
     "flask==3.1.3",                       # bsd
@@ -103,14 +106,14 @@ dependencies = [
     "protobuf==7.36.1",                   # bsd
     "grpcio==1.83.1",                     # apache2
     "grpcio-health-checking==1.83.1",     # apache2
-    "grpcio-status==1.83.1",              # apache2
+
+    # not-imported: grpcio-tools -- protos/_make_stubs.sh runs it as
+    # "python3 -m grpc_tools.protoc", from the same environment, so
+    # that generated stubs match the runtime protobuf and grpcio pins.
     "grpcio-tools==1.83.1",               # apache2
     "googleapis-common-protos==1.75.2",   # apache2
 
     "requests==2.34.2",                   # apache2
-    "requests-toolbelt==1.0.0",           # apache2
-    "chardet==7.6.0",                     # lgpl
-    "urllib3==2.7.0",                     # mit
 
     # These must move as a set. pydantic-core is deliberately not pinned
     # here: pydantic pins it exactly (==), so the resolved version is fully
@@ -138,6 +141,8 @@ dependencies = [
     "charset-normalizer==3.5.1",
     "debtcollector==3.1.0",
     "fasteners==0.20",
+    "gevent==26.8.0",
+    "greenlet==3.5.5",
     "idna==3.19",
     "iso8601==2.1.0",
     "itsdangerous==2.2.0",
@@ -149,6 +154,7 @@ dependencies = [
     "oslo.config==10.7.0",
     "oslo.i18n==6.9.0",
     "oslo.utils==10.2.0",
+    "pbr==7.0.3",
     "pycparser==3.0",
     "pyparsing==3.3.2",
     "python-dotenv==1.2.3",
@@ -160,6 +166,7 @@ dependencies = [
     "stevedore==5.9.1",
     "typing-inspection==0.4.4",
     "typing_extensions==4.16.0",
+    "urllib3==2.7.0",
     "wrapt==2.4.0",
     "zope.event==6.2",
     "zope.interface==8.6",

--- a/shakenfist/tests/test_dnsmasq.py
+++ b/shakenfist/tests/test_dnsmasq.py
@@ -1,3 +1,4 @@
+import builtins
 import os
 import signal
 import tempfile
@@ -5,7 +6,6 @@ import time
 import uuid
 from unittest import mock
 
-import six
 import testtools
 from pydantic import AnyHttpUrl
 from pydantic import IPvAnyAddress
@@ -222,7 +222,7 @@ class DnsMasqTestCase(testtools.TestCase):
         d._read_templates()
 
         mock_open = mock.mock_open()
-        with mock.patch.object(six.moves.builtins, 'open', new=mock_open):
+        with mock.patch.object(builtins, 'open', new=mock_open):
             d._make_config(just_this_path='config')
 
         handle = mock_open()
@@ -276,7 +276,7 @@ class DnsMasqTestCase(testtools.TestCase):
         d._read_templates()
 
         mock_open = mock.mock_open()
-        with mock.patch.object(six.moves.builtins, 'open', new=mock_open):
+        with mock.patch.object(builtins, 'open', new=mock_open):
             d._make_config(just_this_path='config')
 
         handle = mock_open()
@@ -331,7 +331,7 @@ class DnsMasqTestCase(testtools.TestCase):
         d._read_templates()
 
         mock_open = mock.mock_open()
-        with mock.patch.object(six.moves.builtins, 'open', new=mock_open):
+        with mock.patch.object(builtins, 'open', new=mock_open):
             d._make_config(just_this_path='config')
 
         handle = mock_open()
@@ -405,7 +405,7 @@ class DnsMasqTestCase(testtools.TestCase):
         d._read_templates()
 
         mock_open = mock.mock_open()
-        with mock.patch.object(six.moves.builtins, 'open', new=mock_open):
+        with mock.patch.object(builtins, 'open', new=mock_open):
             d._make_config(just_this_path='config')
 
         handle = mock_open()
@@ -488,7 +488,7 @@ class DnsMasqTestCase(testtools.TestCase):
         d._read_templates()
 
         mock_open = mock.mock_open()
-        with mock.patch.object(six.moves.builtins, 'open', new=mock_open):
+        with mock.patch.object(builtins, 'open', new=mock_open):
             d._make_config(just_this_path='hosts')
 
         handle = mock_open()
@@ -539,7 +539,7 @@ class DnsMasqTestCase(testtools.TestCase):
         d._read_templates()
 
         mock_open = mock.mock_open()
-        with mock.patch.object(six.moves.builtins, 'open', new=mock_open):
+        with mock.patch.object(builtins, 'open', new=mock_open):
             d._make_config(just_this_path='dnshosts')
 
         handle = mock_open()
@@ -593,7 +593,7 @@ class DnsMasqTestCase(testtools.TestCase):
         d._read_templates()
 
         mock_open = mock.mock_open()
-        with mock.patch.object(six.moves.builtins, 'open', new=mock_open):
+        with mock.patch.object(builtins, 'open', new=mock_open):
             d._make_config(just_this_path='dnshosts')
 
         handle = mock_open()
@@ -638,7 +638,7 @@ class DnsMasqTestCase(testtools.TestCase):
         d = dnsmasq.DnsMasq.new(n)
 
         mock_open = mock.mock_open(read_data='424242')
-        with mock.patch.object(six.moves.builtins, 'open', new=mock_open):
+        with mock.patch.object(builtins, 'open', new=mock_open):
             self.assertEqual(True, d._send_signal(signal.SIGKILL))
 
         mock_pid_exists.assert_called()
@@ -661,7 +661,7 @@ class DnsMasqTestCase(testtools.TestCase):
         d = dnsmasq.DnsMasq.new(n)
 
         mock_open = mock.mock_open(read_data='424242')
-        with mock.patch.object(six.moves.builtins, 'open', new=mock_open):
+        with mock.patch.object(builtins, 'open', new=mock_open):
             self.assertEqual(False, d._send_signal(signal.SIGKILL))
 
         mock_pid_exists.assert_called()


### PR DESCRIPTION
Fixes the two dependency consistency audits, one commit each.

### Declare the dependencies we import directly (#4044)

Four packages were imported from a name that only appeared in the
generated indirect dependency block. That block is regenerated from
whatever the direct dependencies happen to resolve to, so an import of
one of its names works only until the intermediate library drops the
requirement.

Three are now declared above the `START_OF_INDIRECT_DEPS` marker at the
versions they already resolved to, and `tools/pin-indirect-dependencies.sh`
dropped the generated copies:

| Package | Imported by | Was arriving via |
| --- | --- | --- |
| `pylogrus` | `logship.py` (`JsonFormatter`) | `shakenfist-utilities` |
| `jsonschema` | `tools/render-review.py` | `flasgger` |
| `packaging` | `tools/build-collection.py` | the oslo stack |

The fourth needed no declaration, because the import should not have
been there: `test_dnsmasq.py` reached for `six.moves.builtins` to patch
`open()`, which on a project requiring Python 3.11 or later is spelled
`builtins`. `six` stays in the generated block, since other packages
still require it.

### Stop declaring dependencies we do not use (#4043)

Eleven dependencies were declared and imported nowhere, all of them
dating from the conversion of `requirements.txt` to `pyproject.toml`, so
none arrived with a reason recorded. Each was traced to how the package
is actually used before choosing between removing it and recording why
it is installed.

Three are genuinely used without being imported, and now carry the
`# not-imported:` annotation the audit asks for:

* `uv`, which the node bootstrap runs as `uv pip install`.
* `clingwrap`, a CLI installed into the node virtualenv, whose built-in
  targets include one for Shaken Fist.
* `grpcio-tools`, which `protos/_make_stubs.sh` runs as
  `python3 -m grpc_tools.protoc` from this same environment so that
  generated stubs match the runtime `protobuf` and `grpcio` pins.

Four are still required transitively, so dropping the direct declaration
moves them into the generated block rather than out of the install:
`gevent` and `greenlet` arrive with the `gunicorn[gevent]` extra, `pbr`
with the oslo stack, and `urllib3` with `requests`.

The remaining three leave the dependency closure entirely, taking it
from 87 packages to 84: `chardet` (`requests` resolves text encodings
through `charset-normalizer`), `requests-toolbelt` and `grpcio-status`.
Nothing in the tree imports `grpc_status`, `google.rpc` or
`status_pb2`.

### The one finding not fixed here

`flask-request-id-middleware` is left exactly as it is. It **is**
imported, by `external_api/app.py`, but the audit derives candidate
module names from the distribution name and cannot get from
`flask-request-id-middleware` to the `flask_request_id` the wheel
actually installs. Annotating it here would assert something untrue, so
the fix is an `IMPORT_NAME_ALIASES` entry in the development
repository, which is what `unused-declared-dependency.md` asks for:
shakenfist/development#99.

### Verification

* `pre-commit run --all-files` passes.
* `tools/pin-indirect-dependencies.sh` resolves and installs the full
  closure cleanly, and reports the block up to date afterwards.
* `scripts/audit-check.py` reports `unused-declared-dependency` and
  `undeclared-direct-dependency` as pass (the former with the
  development-repo alias applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cF33EswqGwZBR8QTRssfQ
