### PR TITLE
Triage failed merge queue runs automatically

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -645,9 +645,15 @@ jobs:
           # subscription credit is exhausted (HTTP 429). Every model being
           # out of credit exits 1 and produces no output, which the assess
           # step below sees as "no changes".
+          #
+          # The prompt goes in by file, not as an argument: Linux caps a single
+          # argv element at 128KiB and an issue with a long body and a long
+          # comment thread can reach that, where the exec fails outright rather
+          # than truncating and no model runs at all.
           ${{ runner.temp }}/claude-model-fallback.sh \
             --models "${MODELS}" \
-            -- "$(cat ${{ runner.temp }}/claude-prompt.txt)" \
+            --prompt-file ${{ runner.temp }}/claude-prompt.txt \
+            -- \
             --dangerously-skip-permissions \
             --max-turns "${MAX_TURNS}" \
             --output-format text \

--- a/.github/workflows/merge-failure-triage.yml
+++ b/.github/workflows/merge-failure-triage.yml
@@ -1,0 +1,137 @@
+# Triage a failed merge queue CI run with Claude Code
+#
+# When "Functional tests" fails on a merge_group event, GitHub ejects the pull
+# request from the merge queue and somebody has to work out whether the pull
+# request was at fault or whether the cluster fell over again. This automates
+# that first pass: it follows the merge-ci-triage skill, posts a verdict on the
+# pull request, and records a systemic failure against its tracking issue.
+#
+# WHY workflow_run AND NOT A JOB IN functional-tests.yml:
+# The obvious implementation is a job in the merge group run itself, gated on
+# "can_merge" having failed. It races the queue. Once can_merge reports its
+# failure the queue ejects the pull request and tears down the
+# gh-readonly-queue ref the run is on, and a triage job which takes minutes is
+# in exactly that window. Putting the triage in an earlier step of can_merge
+# avoids the race but holds the whole merge queue open while a model reads
+# logs. A job reachable on merge_group would also fall under the
+# merge-group-cancellation audit, whose correct behaviour -- be cancelled when
+# a newer merge group supersedes you -- is the opposite of what a triage job
+# wants. workflow_run runs afterwards, on the default branch, and cannot be
+# cancelled by any of that.
+#
+# The branches filter is doing real work: without it this workflow would be
+# invoked for every pull request run of the test suite as well, and every one
+# of those would show up in the Actions list as a skipped run. Merge group runs
+# are the only ones on a gh-readonly-queue ref.
+#
+# SECURITY CONSIDERATIONS:
+# - workflow_run runs in the base repository context with a writable token, and
+#   is deliberately never given the merge group's code. The checkout is the
+#   default branch; the failed run is read through gh, never executed.
+# - The model does read logs and a pull request diff, which are untrusted
+#   input. Its GitHub reach is bounded by the token permissions below: it can
+#   comment on issues and pull requests and nothing else. It cannot push, and
+#   the workflow does not check out or run any of the code it is triaging.
+# - The comment body is model output and goes through
+#   tools/neutralise-pr-body.sh before posting, so an @mention or an
+#   issue-closing keyword cannot fire on publication.
+#
+# NOTES:
+# - The verdict is uploaded as a build artifact and embedded in the pull
+#   request comment, both as tools/merge-triage-schema.json documents. The
+#   private-ci conductor consumes these to track which merge failures have been
+#   triaged and which of them blamed the pull request, so a document is written
+#   even when the model produces nothing usable -- see the header comment on
+#   tools/merge-ci-triage.sh.
+# - Scratch files live in runner.temp, never the workspace.
+
+name: Merge failure triage
+
+on:
+  workflow_run:
+    workflows: ["Functional tests"]
+    types: [completed]
+    branches:
+      - 'gh-readonly-queue/**'
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Workflow run id of the failed merge group run'
+        required: true
+        type: string
+      models:
+        description: 'Comma-separated models to try, in preference order'
+        required: false
+        default: 'claude-fable-5,claude-opus-5'
+        type: string
+      dry_run:
+        description: 'Dry run (classify only, no issue or PR comments)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+# One triage per failed run. Not cancel-in-progress: a second delivery for the
+# same run is rare, and cancelling a triage half way through leaves an issue
+# comment posted with no verdict published.
+concurrency:
+  group: merge-failure-triage-${{ github.event.workflow_run.id || inputs.run_id }}
+  cancel-in-progress: false
+
+env:
+  http_proxy: http://192.168.1.15:3128
+  https_proxy: http://192.168.1.15:3128
+  PIP_INDEX_URL: https://devpi.home.stillhq.com/root/pypi/+simple/
+
+jobs:
+  triage:
+    name: 'Triage the merge failure'
+    # workflow_run carries no conclusion filter, so the "did it fail?" half of
+    # the gate has to live here.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.event == 'merge_group' &&
+       github.event.workflow_run.conclusion == 'failure')
+    runs-on: [self-hosted, claude-code]
+    # Triage is minutes of log reading. The six hour GitHub default would let a
+    # wedged model hold a scarce claude-code runner for the rest of the day.
+    timeout-minutes: 45
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      MODELS: ${{ inputs.models || 'claude-fable-5,claude-opus-5' }}
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      FAILED_RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
+      TRIAGE_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    steps:
+      # The default branch, never the merge group's code. See the security
+      # note above.
+      - name: Checkout the default branch
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Triage the failure
+        # runner.temp is not available in a job-level env block, so this one
+        # lives here.
+        env:
+          OUTPUT_DIR: ${{ runner.temp }}/merge-triage
+        run: tools/merge-ci-triage.sh "${FAILED_RUN_ID}"
+
+      - name: Publish the verdict
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: merge-triage-${{ github.event.workflow_run.id || inputs.run_id }}
+          path: |
+            ${{ runner.temp }}/merge-triage/triage.json
+            ${{ runner.temp }}/merge-triage/response.txt
+            ${{ runner.temp }}/merge-triage/prompt.txt
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/merge-failure-triage.yml
+++ b/.github/workflows/merge-failure-triage.yml
@@ -42,7 +42,12 @@
 #   content has already passed review.
 # - The comment body is model output and goes through
 #   tools/neutralise-pr-body.sh before posting, so an @mention or an
-#   issue-closing keyword cannot fire on publication.
+#   issue-closing keyword cannot fire on publication. Publication is gated on
+#   that succeeding: the neutraliser rewrites the file in place and the driver
+#   does not run under "set -e", so an unchecked failure would leave the
+#   un-neutralised body exactly where the comment step reads it from. A triage
+#   nobody sees is the smaller problem, and the verdict is in the artifact
+#   either way.
 # - The model runs with --dangerously-skip-permissions and the checkout as its
 #   working directory, so everything this job executes is staged into
 #   runner.temp first: the triage driver, the verdict extractor, its schema,
@@ -169,5 +174,10 @@ jobs:
             ${{ runner.temp }}/merge-triage/triage.json
             ${{ runner.temp }}/merge-triage/response.txt
             ${{ runner.temp }}/merge-triage/prompt.txt
+            ${{ runner.temp }}/merge-triage/triage.invalid.json
+          # triage.invalid.json only exists when the document failed our own
+          # schema, which is a bug in this tooling rather than a triage
+          # outcome -- and the discarded document is the only evidence of it.
+          # Absent on every normal run, which "warn" tolerates.
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/merge-failure-triage.yml
+++ b/.github/workflows/merge-failure-triage.yml
@@ -43,6 +43,16 @@
 # - The comment body is model output and goes through
 #   tools/neutralise-pr-body.sh before posting, so an @mention or an
 #   issue-closing keyword cannot fire on publication.
+# - The model runs with --dangerously-skip-permissions and the checkout as its
+#   working directory, so everything this job executes is staged into
+#   runner.temp first: the triage driver, the verdict extractor, its schema,
+#   the neutraliser and the model wrapper. issue-fix.yml stages the same set
+#   for the same reason. Two hazards, one fix -- bash reads a script lazily as
+#   it executes, so an edit to the running driver mid-run corrupts it; and the
+#   extractor and neutraliser run *after* the model, so reading them from the
+#   workspace would mean parsing and defusing model output with a copy the
+#   model could have rewritten. The residual effect of a workspace write is
+#   then nil: the checkout is discarded with the runner and is never pushed.
 #
 # NOTES:
 # - The verdict is uploaded as a build artifact and embedded in the pull
@@ -129,12 +139,26 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Before the model runs, and out of its reach. See the security note.
+      - name: Stage the triage tools outside the workspace
+        env:
+          STAGE_DIR: ${{ runner.temp }}/merge-triage-tools
+        run: |
+          mkdir -p "${STAGE_DIR}"
+          cp tools/merge-ci-triage.sh tools/merge-triage.py \
+             tools/merge-triage-schema.json tools/claude-model-fallback.sh \
+             tools/neutralise-pr-body.sh "${STAGE_DIR}/"
+          chmod +x "${STAGE_DIR}"/*.sh "${STAGE_DIR}"/*.py
+
       - name: Triage the failure
         # runner.temp is not available in a job-level env block, so this one
         # lives here.
         env:
           OUTPUT_DIR: ${{ runner.temp }}/merge-triage
-        run: tools/merge-ci-triage.sh "${FAILED_RUN_ID}"
+        # From the staged copy, not from tools/: the script finds its helpers
+        # beside itself, so running it from the workspace would pull all of
+        # them back out of the tree the model can write to.
+        run: ${{ runner.temp }}/merge-triage-tools/merge-ci-triage.sh "${FAILED_RUN_ID}"
 
       - name: Publish the verdict
         if: always()

--- a/.github/workflows/merge-failure-triage.yml
+++ b/.github/workflows/merge-failure-triage.yml
@@ -3,8 +3,10 @@
 # When "Functional tests" fails on a merge_group event, GitHub ejects the pull
 # request from the merge queue and somebody has to work out whether the pull
 # request was at fault or whether the cluster fell over again. This automates
-# that first pass: it follows the merge-ci-triage skill, posts a verdict on the
-# pull request, and records a systemic failure against its tracking issue.
+# that first pass: it finds the first failing step, classifies the failure as
+# caused by the pull request or systemic, records a systemic failure against
+# its tracking issue, and posts a verdict on the pull request. The procedure it
+# follows is described in docs/developer_guide/ci.md.
 #
 # WHY workflow_run AND NOT A JOB IN functional-tests.yml:
 # The obvious implementation is a job in the merge group run itself, gated on
@@ -29,9 +31,15 @@
 #   is deliberately never given the merge group's code. The checkout is the
 #   default branch; the failed run is read through gh, never executed.
 # - The model does read logs and a pull request diff, which are untrusted
-#   input. Its GitHub reach is bounded by the token permissions below: it can
-#   comment on issues and pull requests and nothing else. It cannot push, and
-#   the workflow does not check out or run any of the code it is triaging.
+#   input, with GH_TOKEN in its environment. Be accurate about what that token
+#   allows: issues:write can close, reopen and label issues and edit or delete
+#   anybody's comment; pull-requests:write can close a pull request and rewrite
+#   its title and body. What it cannot do is push code, alter workflows, or
+#   read secrets, and this workflow never checks out or executes the code it is
+#   triaging. The prompt's "do not close anything" is a prompt-level
+#   constraint, not a token-level one; the bound that actually holds is the
+#   permissions block below. The residual risk is accepted because merge group
+#   content has already passed review.
 # - The comment body is model output and goes through
 #   tools/neutralise-pr-body.sh before posting, so an @mention or an
 #   issue-closing keyword cannot fire on publication.
@@ -70,7 +78,11 @@ on:
         default: false
         type: boolean
 
+# actions:read is not optional: naming any scope sets every unnamed one to
+# none, and every piece of evidence this workflow gathers -- the run, its jobs,
+# its failed step logs, the sibling merge group runs -- is an Actions API read.
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: write

--- a/.github/workflows/merge-failure-triage.yml
+++ b/.github/workflows/merge-failure-triage.yml
@@ -40,6 +40,19 @@
 #   constraint, not a token-level one; the bound that actually holds is the
 #   permissions block below. The residual risk is accepted because merge group
 #   content has already passed review.
+# - The larger bound, stated so that the acceptance is an informed one: the
+#   model runs with --dangerously-skip-permissions and no tool restrictions on
+#   a persistent [self-hosted, claude-code] runner, with untrusted input in its
+#   prompt. It can run arbitrary commands as the runner user, and anything it
+#   leaves outside the workspace -- ~/.claude state, caches, the runner's own
+#   tree, a cron entry or a shell profile -- survives this job and is there for
+#   whatever runs on that runner next. Narrowing the tool list does not bound
+#   that: triage reads GitHub through arbitrary gh sub-commands, so it needs
+#   Bash, and a model with Bash can write anything a --disallowed-tools list
+#   would have stopped. What actually bounds it is the same argument as for the
+#   token -- the model is fed content that has already passed review, and it is
+#   the same runner fleet issue-fix.yml already hands a model with the same
+#   flags. Anything stronger means a disposable runner, not a longer flag list.
 # - The comment body is model output and goes through
 #   tools/neutralise-pr-body.sh before posting, so an @mention or an
 #   issue-closing keyword cannot fire on publication. Publication is gated on

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -22,6 +22,7 @@ Every workflow in `.github/workflows/`:
 | `pr-fix-tests.yml` | Fix test failures on bot command | `@shakenfist-bot please attempt to fix` |
 | `test-drift-fix.yml` | Unit test fixer (called by `pr-fix-tests.yml`) | workflow_call, workflow_dispatch |
 | `issue-fix.yml` | Triage open issues, propose a fix as a draft PR | workflow_dispatch |
+| `merge-failure-triage.yml` | Triage a failed merge queue run: PR-caused or systemic, record the occurrence, post a verdict | workflow_run (a failed `Functional tests` merge group run), workflow_dispatch |
 | `scheduled-tests.yml` | Longer-running test sweep (schedule currently disabled) | workflow_dispatch |
 | `publish-website.yml` | Publish the mkdocs site | Push to `develop`, manual |
 | `refresh-website.yml` | Trigger a GitHub Pages rebuild | Daily schedule, manual |
@@ -399,6 +400,10 @@ The CI uses a two-stage merge queue pattern (see [this blog post](https://boinko
 in branch protection. `Can merge` is evaluated by the merge queue itself, not as
 a required check.
 
+A failed `Can merge` ejects the pull request from the queue, and
+[merge failure triage](#merge-failure-triage) then classifies the failure
+automatically.
+
 ### Superseded merge groups are cancelled
 
 Every job that can run in the queue and holds a scarce runner carries a
@@ -520,7 +525,8 @@ carries a comment.
 ## Automated CI Jobs
 
 `functional-tests.yml` carries three jobs which act on the pull request
-themselves rather than only reporting on it.
+themselves rather than only reporting on it. A fourth piece of automation,
+merge failure triage, is a separate workflow for the reasons given below.
 
 ### Automated Delinter
 
@@ -554,6 +560,85 @@ has already reviewed.
 
 The reviewer produces structured JSON reviews, creates GitHub issues for
 actionable items, and embeds the JSON in the PR comment for automation.
+
+### Merge failure triage
+
+When `Functional tests` fails on a `merge_group` event, GitHub ejects the pull
+request from the merge queue and somebody has to decide whether the pull
+request broke something or whether the test cloud fell over again.
+`merge-failure-triage.yml` does that first pass automatically, following the
+same steps a maintainer follows by hand with the `merge-ci-triage` skill: find
+the first failing step, classify the failure, record a systemic failure against
+its tracking issue, and recommend re-queueing or fixing first. The verdict is
+posted as a comment on the ejected pull request.
+
+Most of the work is in `tools/merge-ci-triage.sh`, which gathers the evidence,
+runs the model, and publishes the result; `tools/merge-triage.py` parses,
+validates and renders the verdict.
+
+#### Why it is a separate workflow
+
+The obvious implementation is another job in `functional-tests.yml`, gated on
+`can_merge` having failed. It races the queue: once `Can merge` reports its
+failure the queue ejects the pull request and tears down the
+`gh-readonly-queue` ref the run is on, and a triage job which takes minutes
+sits in exactly that window. Moving the triage into an earlier *step* of
+`can_merge` avoids the race but holds the merge queue open while a model reads
+logs. A job reachable on `merge_group` would also fall under the
+[merge-group-cancellation](/components/development/audits/merge-group-cancellation/)
+audit, whose correct behaviour — be cancelled when a newer merge group
+supersedes you — is the opposite of what a triage job wants.
+
+`workflow_run` runs after the merge group run has finished, on the default
+branch, in the base repository context, and none of that can cancel it. The
+trigger carries a `branches: ['gh-readonly-queue/**']` filter so the workflow is
+only invoked for merge group runs; without it every pull request run of the
+test suite would create a skipped run here. `workflow_run` has no conclusion
+filter, so the "did it actually fail?" half of the gate is the job's `if:`.
+
+The workflow never checks out or runs the code it is triaging. It reads the
+failed run through `gh` and checks out the default branch, which is what makes
+a writable token safe in a workflow that reads a pull request diff.
+
+#### The verdict document
+
+Each triage produces one JSON document matching
+`tools/merge-triage-schema.json`. It is published twice: as the
+`merge-triage-<run id>` build artifact, and embedded in a collapsed `<details>`
+section of the pull request comment, the same way the automated reviewer embeds
+its review. The private-ci conductor consumes these to track which merge
+failures have been triaged and which of them blamed the pull request, so the
+fields that matter to a consumer are:
+
+| Field | Meaning |
+|-------|---------|
+| `verdict` | `pr_caused`, `systemic`, `ambiguous`, or `unknown` |
+| `recommendation` | `requeue`, `fix_first`, or `investigate` |
+| `failure_signature` | Short stable string for grouping recurrences |
+| `tracking_issue` | Issue recording a systemic failure, or null |
+| `tracking_issue_action` | `commented`, `created`, or `none` |
+| `run_id`, `pull_request` | What was triaged |
+
+Three properties of that document are worth knowing before consuming it:
+
+- **A document is always written.** A model that answers in prose, or produces
+  no usable verdict, yields `verdict: unknown` with an `error` explaining why,
+  never a missing file. A missing document is indistinguishable from a triage
+  that never ran; an `unknown` one is not.
+- **The envelope is not model output.** The repository, run id and pull request
+  number are written from what GitHub said and overwrite whatever the model put
+  in those fields, so a verdict cannot be filed against the wrong failure. Only
+  the fields in `MODEL_FIELDS` are taken from the response at all.
+- **A cited tracking issue has been checked.** The issue has to exist and has to
+  carry a reference to the failed run; a citation that does not is dropped, with
+  the reason appended to `evidence`. A consumer can treat a non-null
+  `tracking_issue` as evidence the occurrence really was recorded — but only
+  when `tracking_issue_action` is `commented` or `created`. With an action of
+  `none` the number is a reference the triage found useful and nothing was
+  written to it, which is what a dry run produces.
+
+Re-triaging the same run does not double-post: the comment carries an invisible
+`<!-- merge-triage run:<id> -->` marker which a later run recognises.
 
 ### Developer Automation (Bot Commands)
 

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -567,10 +567,18 @@ When `Functional tests` fails on a `merge_group` event, GitHub ejects the pull
 request from the merge queue and somebody has to decide whether the pull
 request broke something or whether the test cloud fell over again.
 `merge-failure-triage.yml` does that first pass automatically, following the
-same steps a maintainer follows by hand with the `merge-ci-triage` skill: find
-the first failing step, classify the failure, record a systemic failure against
-its tracking issue, and recommend re-queueing or fixing first. The verdict is
-posted as a comment on the ejected pull request.
+same steps a maintainer follows by hand: find the first failing step (later
+failures are usually cascade), classify the failure as caused by the pull
+request or systemic, search for an existing tracking issue and record the
+occurrence on it — or file one — and recommend re-queueing or fixing first. The
+verdict is posted as a comment on the ejected pull request.
+
+Merge groups here launch several nested test clusters at once, so merge CI is
+far more sensitive to under-cloud capacity than pull request CI is, and
+historically most merge failures have been environmental rather than code
+regressions. That prior is in the prompt, which is why the evidence rules below
+matter: a model given no evidence and that prior will happily conclude
+"systemic, re-queue".
 
 Most of the work is in `tools/merge-ci-triage.sh`, which gathers the evidence,
 runs the model, and publishes the result; `tools/merge-triage.py` parses,
@@ -585,9 +593,13 @@ failure the queue ejects the pull request and tears down the
 sits in exactly that window. Moving the triage into an earlier *step* of
 `can_merge` avoids the race but holds the merge queue open while a model reads
 logs. A job reachable on `merge_group` would also fall under the
-[merge-group-cancellation](/components/development/audits/merge-group-cancellation/)
+[merge-group-cancellation](https://github.com/shakenfist/development/blob/main/audits/merge-group-cancellation.md)
 audit, whose correct behaviour — be cancelled when a newer merge group
 supersedes you — is the opposite of what a triage job wants.
+
+The workflow's `permissions:` block names `actions: read`, which is not
+optional: naming any scope at all sets every unnamed scope to `none`, and every
+piece of evidence the triage gathers is an Actions API read.
 
 `workflow_run` runs after the merge group run has finished, on the default
 branch, in the base repository context, and none of that can cancel it. The
@@ -621,10 +633,20 @@ fields that matter to a consumer are:
 
 Three properties of that document are worth knowing before consuming it:
 
-- **A document is always written.** A model that answers in prose, or produces
-  no usable verdict, yields `verdict: unknown` with an `error` explaining why,
-  never a missing file. A missing document is indistinguishable from a triage
-  that never ran; an `unknown` one is not.
+- **A document is always written.** A model that answers in prose, a run that
+  cannot be read, a document that fails its own schema — each yields
+  `verdict: unknown` with an `error` explaining why, never a missing file. The
+  guarantee is kept by an `EXIT` trap over an envelope written before anything
+  can fail, so it holds for the paths that fall over early too. A missing
+  document is indistinguishable from a triage that never ran; an `unknown` one
+  is not. The single exception is a run that was not a failed merge group run
+  at all: nothing was triaged, so there is nothing to publish a verdict about.
+- **No evidence means no verdict.** If neither the failed job list nor the
+  failed step logs can be read, no model is run: the document says so and the
+  verdict is `unknown`. Anything else that could not be gathered — the sibling
+  runs, the pull request diff — is named in `evidence`, so a verdict always
+  carries its own caveats rather than reading as though the model saw
+  everything.
 - **The envelope is not model output.** The repository, run id and pull request
   number are written from what GitHub said and overwrite whatever the model put
   in those fields, so a verdict cannot be filed against the wrong failure. Only
@@ -635,7 +657,8 @@ Three properties of that document are worth knowing before consuming it:
   `tracking_issue` as evidence the occurrence really was recorded — but only
   when `tracking_issue_action` is `commented` or `created`. With an action of
   `none` the number is a reference the triage found useful and nothing was
-  written to it, which is what a dry run produces.
+  written to it. A dry run forces `none` unconditionally, whatever the model
+  reports, because nothing was written to GitHub on that path.
 
 Re-triaging the same run does not double-post: the comment carries an invisible
 `<!-- merge-triage run:<id> -->` marker which a later run recognises.

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -641,6 +641,9 @@ Four properties of that document are worth knowing before consuming it:
   document is indistinguishable from a triage that never ran; an `unknown` one
   is not. The single exception is a run that was not a failed merge group run
   at all: nothing was triaged, so there is nothing to publish a verdict about.
+  A document that failed the schema is uploaded alongside the replacement as
+  `triage.invalid.json`, since that is a bug in the tooling rather than a
+  triage outcome and the discarded document is the only evidence of it.
 - **No evidence means no verdict.** If neither the failed job list nor the
   failed step logs can be read, no model is run: the document says so and the
   verdict is `unknown`. Anything else that could not be gathered — the sibling
@@ -665,6 +668,12 @@ Four properties of that document are worth knowing before consuming it:
   `none` unconditionally, whatever the model reports, because nothing was
   written to GitHub on that path; the verification still runs against what the
   model *claimed*, so that path is exercised outside production too.
+
+The comment is only posted if the body could be neutralised —
+`tools/neutralise-pr-body.sh` rewrites it in place, and a failure inside it
+would otherwise leave the un-neutralised model prose where `gh pr comment`
+reads it from. A triage nobody sees is a smaller problem than one that fires an
+@mention on publication, and the verdict is still in the artifact.
 
 An `unknown` verdict is posted on the pull request like any other. It is a thin
 comment, but the alternative is silence, and silence on an ejected pull request

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -631,7 +631,7 @@ fields that matter to a consumer are:
 | `tracking_issue_action` | `commented`, `created`, or `none` |
 | `run_id`, `pull_request` | What was triaged |
 
-Three properties of that document are worth knowing before consuming it:
+Four properties of that document are worth knowing before consuming it:
 
 - **A document is always written.** A model that answers in prose, a run that
   cannot be read, a document that fails its own schema — each yields
@@ -651,17 +651,50 @@ Three properties of that document are worth knowing before consuming it:
   number are written from what GitHub said and overwrite whatever the model put
   in those fields, so a verdict cannot be filed against the wrong failure. Only
   the fields in `MODEL_FIELDS` are taken from the response at all.
-- **A cited tracking issue has been checked.** The issue has to exist and has to
-  carry a reference to the failed run; a citation that does not is dropped, with
-  the reason appended to `evidence`. A consumer can treat a non-null
+- **A cited tracking issue has been checked.** A consumer can treat a non-null
   `tracking_issue` as evidence the occurrence really was recorded — but only
-  when `tracking_issue_action` is `commented` or `created`. With an action of
-  `none` the number is a reference the triage found useful and nothing was
-  written to it. A dry run forces `none` unconditionally, whatever the model
-  reports, because nothing was written to GitHub on that path.
+  when `tracking_issue_action` is `commented` or `created`, and those two are
+  the claims that get verified. The issue has to exist and the issue or one of
+  its comments has to carry the failed run's URL; a claim that does not check
+  out is downgraded to an action of `none`, keeping the number as a reference
+  and losing only the assertion, with the reason appended to `evidence`. An
+  issue that cannot be read at all is dropped outright, number and all. A
+  citation whose action is already `none` is not checked for the run URL —
+  nothing was written to it, so it will not reference this run, and checking
+  anyway would drop every reference-only citation ever made. A dry run forces
+  `none` unconditionally, whatever the model reports, because nothing was
+  written to GitHub on that path; the verification still runs against what the
+  model *claimed*, so that path is exercised outside production too.
+
+An `unknown` verdict is posted on the pull request like any other. It is a thin
+comment, but the alternative is silence, and silence on an ejected pull request
+reads as "triage never ran" — the same ambiguity the always-write-a-document
+rule exists to remove, moved from the artifact to the thread. The comment names
+why triage reached nothing, which is what tells a maintainer whether to look at
+the failed run or at this workflow.
 
 Re-triaging the same run does not double-post: the comment carries an invisible
 `<!-- merge-triage run:<id> -->` marker which a later run recognises.
+
+#### What the model can and cannot touch
+
+The model runs with `--dangerously-skip-permissions` and the checkout as its
+working directory, so the job stages everything it executes into `runner.temp`
+before the model starts: `merge-ci-triage.sh` itself, `merge-triage.py`, its
+schema, `neutralise-pr-body.sh` and `claude-model-fallback.sh`. `issue-fix.yml`
+stages the same set for the same two reasons. Bash reads a script lazily as it
+executes, so an edit to the running driver would corrupt it mid-run; and the
+extractor and the neutraliser run *after* the model has exited, so reading them
+from the workspace would mean parsing and defusing model output with a copy the
+model could have rewritten. With the staging in place a workspace write has no
+effect at all — the checkout is discarded with the runner and is never pushed.
+
+The failed step logs are cut to a byte budget before they reach the prompt, and
+both ends are kept with the tail given the larger share. Keeping only the head
+is the obvious implementation and it is wrong here: a single Ansible
+cluster-build step routinely exceeds the whole budget in progress output, and
+the message saying what actually broke is the last thing it emits. The elision
+is marked inline with the number of bytes dropped.
 
 ### Developer Automation (Bot Commands)
 

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -582,7 +582,10 @@ matter: a model given no evidence and that prior will happily conclude
 
 Most of the work is in `tools/merge-ci-triage.sh`, which gathers the evidence,
 runs the model, and publishes the result; `tools/merge-triage.py` parses,
-validates and renders the verdict.
+validates and renders the verdict. The evidence includes the other recent
+merge group runs *of the workflow that failed* — `--event merge_group` on its
+own is every workflow in the repository, and those twenty slots exist to answer
+"is this happening to everybody?" about this suite.
 
 #### Why it is a separate workflow
 
@@ -633,9 +636,13 @@ fields that matter to a consumer are:
 
 Four properties of that document are worth knowing before consuming it:
 
-- **A document is always written.** A model that answers in prose, a run that
-  cannot be read, a document that fails its own schema — each yields
-  `verdict: unknown` with an `error` explaining why, never a missing file. The
+- **A document is always written.** A model that answers in prose, a model
+  that could not be run at all, a run that cannot be read, a document that
+  fails its own schema — each yields `verdict: unknown` with an `error`
+  explaining why, never a missing file. Those are different failures and the
+  `error` names which one it was: the model wrapper's exit status is kept, so
+  "every model is out of subscription credit" does not reach a maintainer
+  disguised as "the response contained no JSON verdict object". The
   guarantee is kept by an `EXIT` trap over an envelope written before anything
   can fail, so it holds for the paths that fall over early too. A missing
   document is indistinguishable from a triage that never ran; an `unknown` one
@@ -661,13 +668,18 @@ Four properties of that document are worth knowing before consuming it:
   its comments has to carry the failed run's URL; a claim that does not check
   out is downgraded to an action of `none`, keeping the number as a reference
   and losing only the assertion, with the reason appended to `evidence`. An
-  issue that cannot be read at all is dropped outright, number and all. A
-  citation whose action is already `none` is not checked for the run URL —
+  issue that cannot be read at all is dropped outright, number and all — on a
+  dry run too, since an unreadable issue is not a useful pointer whichever mode
+  produced the citation. A citation whose action is already `none` is not
+  checked for the run URL —
   nothing was written to it, so it will not reference this run, and checking
   anyway would drop every reference-only citation ever made. A dry run forces
   `none` unconditionally, whatever the model reports, because nothing was
   written to GitHub on that path; the verification still runs against what the
-  model *claimed*, so that path is exercised outside production too.
+  model *claimed*, so that path is exercised outside production too. On a dry
+  run the missing reference is reported as such — nothing was written, so the
+  citation is unverified — rather than in the words used for a claim that did
+  not check out, which on that path would always read as a caught lie.
 
 The comment is only posted if the body could be neutralised —
 `tools/neutralise-pr-body.sh` rewrites it in place, and a failure inside it
@@ -684,6 +696,11 @@ the failed run or at this workflow.
 
 Re-triaging the same run does not double-post: the comment carries an invisible
 `<!-- merge-triage run:<id> -->` marker which a later run recognises.
+
+A comment that could not be posted fails the triage run. The verdict is in the
+artifact either way, but a green run with nothing on the pull request is
+indistinguishable from a triage that never ran, so the run itself carries the
+signal.
 
 #### What the model can and cannot touch
 
@@ -703,7 +720,32 @@ both ends are kept with the tail given the larger share. Keeping only the head
 is the obvious implementation and it is wrong here: a single Ansible
 cluster-build step routinely exceeds the whole budget in progress output, and
 the message saying what actually broke is the last thing it emits. The elision
-is marked inline with the number of bytes dropped.
+is marked inline with the number of bytes dropped, and each half is passed
+through `iconv -c` so a cut landing inside a multi-byte character cannot leave
+invalid UTF-8 at the join.
+
+The prompt reaches the model as a file, through
+`claude-model-fallback.sh --prompt-file`, which feeds it on stdin. Never as an
+argument: Linux caps a single argv element at 128KiB whatever `ulimit` says,
+this prompt is mostly log, and an argument over the cap does not truncate — the
+exec fails with `Argument list too long` and no model runs at all, on precisely
+the failures whose logs are largest. The byte budget above is therefore about
+what a model can usefully attend to and what the run costs, not about what can
+be passed to it. `issue-fix.yml` feeds its prompt the same way, for the same
+reason.
+
+What the staging does *not* bound is worth stating plainly: the model runs with
+`--dangerously-skip-permissions` and no tool restrictions on a persistent
+self-hosted runner, so it can run arbitrary commands as the runner user, and
+anything it leaves outside the workspace — `~/.claude` state, caches, the
+runner's own tree, a cron entry — survives the job and is there for whatever
+runs on that runner next. A narrower tool list does not help: triage reads
+GitHub through arbitrary `gh` sub-commands, so it needs `Bash`, and a model
+with `Bash` can write anything a `--disallowed-tools` list would have stopped.
+The risk is accepted on the same argument as the token — the content it is fed
+has already passed review, on the same runner fleet `issue-fix.yml` already
+hands a model with the same flags. Anything stronger means a disposable runner,
+not a longer flag list.
 
 ### Developer Automation (Bot Commands)
 
@@ -780,6 +822,17 @@ payload (`api_error_status`), which the claude CLI's own
 `--fallback-model` flag does not handle -- it only covers overloaded or
 unavailable models. A refused request is free, so the wrapper attempts
 the real job rather than paying for a pre-flight probe.
+
+Give it the prompt with `--prompt-file`, never as a claude argument.
+Linux caps a single argv element at 128KiB whatever `ulimit` says, and an
+argument over the cap does not truncate -- the exec fails with `Argument
+list too long`, so no model runs and the caller sees an empty answer it
+will blame on the model. `--prompt-file` feeds the prompt on stdin, which
+has no such limit. The option takes a path rather than reading the
+wrapper's own stdin because the wrapper may run claude more than once as
+it falls back through the model list, and one stream is drained by the
+first attempt. `shakenfist/tests/test_claude_model_fallback.py` covers
+both properties.
 
 ## CI Caching
 

--- a/shakenfist/tests/test_claude_model_fallback.py
+++ b/shakenfist/tests/test_claude_model_fallback.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Michael Still and contributors
+
+"""Tests for tools/claude-model-fallback.sh, the headless model wrapper.
+
+Only the prompt delivery is tested here, because that is the part with a
+failure mode that is silent in both directions. A prompt passed as a claude
+argument is capped by the kernel at MAX_ARG_STRLEN -- a hard 128KiB no ulimit
+raises -- and an argument over it does not truncate: the exec fails with
+E2BIG and no model runs at all. The caller sees an empty answer and blames
+the model. `--prompt-file` hands the prompt to claude on stdin instead, and
+the second silent failure lives there: this wrapper may run claude more than
+once as it falls back through the model list, and a prompt delivered as a
+stream rather than a path is drained by the first attempt, leaving the
+fallback model with nothing.
+
+The wrapper is run for real with `claude` replaced by a stub on PATH which
+records the arguments and the stdin it was given.
+
+Needs jq and bash, which both runner flavours install as base packages.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+
+from shakenfist.tests import base
+
+
+# A stub claude. Records how it was called, answers in the JSON shape the
+# wrapper parses, and reports the requested models as out of subscription
+# credit -- an HTTP 429 -- when OUT_OF_CREDIT names them.
+CLAUDE_STUB = '''#!/usr/bin/env python3
+import json
+import os
+import sys
+
+args = sys.argv[1:]
+model = args[args.index('--model') + 1]
+prompt = sys.stdin.read()
+
+with open(os.environ['STUB_RECORD'], 'a') as f:
+    f.write(json.dumps({'model': model, 'args': args, 'stdin': prompt}) + '\\n')
+
+if model in os.environ.get('OUT_OF_CREDIT', '').split(','):
+    print(json.dumps({
+        'is_error': True, 'total_cost_usd': 0, 'api_error_status': 429,
+        'result': "You've reached your %s limit." % model}))
+    sys.exit(0)
+
+print(json.dumps({
+    'is_error': False, 'api_error_status': None,
+    'result': 'the model saw %d bytes' % len(prompt)}))
+'''
+
+PROMPT = 'Triage this failure.\n' + ('x' * 200000)
+
+
+def _repo_root():
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.dirname(os.path.dirname(here))
+
+
+class ClaudeModelFallbackTestCase(base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+        self.assertIsNotNone(
+            shutil.which('jq'),
+            'these tests run the model wrapper, which needs jq; both runner '
+            'flavours install it as a base package')
+
+        self.tempdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tempdir, True)
+
+        self.wrapper = os.path.join(
+            _repo_root(), 'tools', 'claude-model-fallback.sh')
+        self.record = os.path.join(self.tempdir, 'calls.jsonl')
+        self.prompt_file = os.path.join(self.tempdir, 'prompt.txt')
+        with open(self.prompt_file, 'w') as f:
+            f.write(PROMPT)
+
+        self.bin = os.path.join(self.tempdir, 'bin')
+        os.makedirs(self.bin)
+        stub = os.path.join(self.bin, 'claude')
+        with open(stub, 'w') as f:
+            f.write(CLAUDE_STUB)
+        os.chmod(stub, 0o755)
+
+    def run_wrapper(self, args, out_of_credit=''):
+        environment = dict(os.environ)
+        environment.update({
+            'PATH': '%s:%s' % (self.bin, os.environ['PATH']),
+            'STUB_RECORD': self.record,
+            'OUT_OF_CREDIT': out_of_credit
+        })
+        return subprocess.run(
+            [self.wrapper] + args, capture_output=True, text=True,
+            env=environment, stdin=subprocess.DEVNULL)
+
+    def calls(self):
+        if not os.path.exists(self.record):
+            return []
+        with open(self.record) as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+    def test_a_prompt_file_reaches_the_model_on_stdin(self):
+        # And not in the argument vector, which is where the kernel's 128KiB
+        # cap on a single argument applies.
+        proc = self.run_wrapper([
+            '--models', 'model-a', '--prompt-file', self.prompt_file,
+            '--', '--output-format', 'text'])
+        self.assertEqual(0, proc.returncode, proc.stderr)
+        self.assertIn('the model saw %d bytes' % len(PROMPT), proc.stdout)
+
+        call = self.calls()[0]
+        self.assertEqual(PROMPT, call['stdin'])
+        for arg in call['args']:
+            self.assertNotIn('Triage this failure', arg)
+
+    def test_the_fallback_model_gets_the_prompt_too(self):
+        # The reason the option takes a path and the redirect is made again
+        # for each attempt: one stream shared by the whole loop is drained by
+        # the first model, and the fallback then runs against an empty prompt
+        # and answers confidently about nothing.
+        proc = self.run_wrapper(
+            ['--models', 'model-a,model-b', '--prompt-file', self.prompt_file,
+             '--quiet', '--', '--output-format', 'text'],
+            out_of_credit='model-a')
+        self.assertEqual(0, proc.returncode, proc.stderr)
+
+        calls = self.calls()
+        self.assertEqual(['model-a', 'model-b'], [c['model'] for c in calls])
+        for call in calls:
+            self.assertEqual(PROMPT, call['stdin'])
+
+    def test_an_unreadable_prompt_file_is_a_usage_error(self):
+        # Rather than a model run with an empty prompt, which is the failure
+        # this option exists to prevent.
+        proc = self.run_wrapper([
+            '--models', 'model-a', '--prompt-file',
+            os.path.join(self.tempdir, 'no-such-file'),
+            '--', '--output-format', 'text'])
+        self.assertEqual(2, proc.returncode)
+        self.assertIn('cannot be read', proc.stderr)
+        self.assertEqual([], self.calls())

--- a/shakenfist/tests/test_merge_ci_triage_shell.py
+++ b/shakenfist/tests/test_merge_ci_triage_shell.py
@@ -1,0 +1,452 @@
+# Copyright 2026 Michael Still and contributors
+
+"""Tests for tools/merge-ci-triage.sh, the merge failure triage driver.
+
+tools/merge-triage.py is what builds the verdict document, and it has its own
+unit tests. The driver is what makes the document *true*: it is the half that
+checks the model's claim to have recorded an occurrence, that forces the
+document to say nothing was written when nothing was written, that decides
+which part of a multi-megabyte log a model gets to see, and that decides
+whether the comment is posted at all. docs/developer_guide/ci.md tells a
+consumer to trust exactly those properties, so they are tested here rather
+than read off the source.
+
+The driver is run for real, with `gh` replaced by a stub on PATH and the
+model wrapper replaced by one that emits a canned response. That is the only
+arrangement in which the interesting cases can be reached at all: an issue
+which cannot be read, a run GitHub gave no URL for, a neutralisation which
+fails. Everything the script executes is staged into the temporary directory
+first, exactly as the workflow stages it, so a test can substitute one helper
+without touching the tree.
+
+Needs jq and bash, which both runner flavours install as base packages.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+
+from shakenfist.tests import base
+
+
+REPO = 'shakenfist/shakenfist'
+RUN_ID = '33952027147'
+PR_NUMBER = 4080
+RUN_URL = 'https://github.com/%s/actions/runs/%s' % (REPO, RUN_ID)
+
+# The tools the driver reaches for beside itself. The workflow stages the same
+# list; test_merge_triage_workflow_seams.py is what keeps the two in step.
+STAGED_TOOLS = [
+    'merge-ci-triage.sh',
+    'merge-triage.py',
+    'merge-triage-schema.json',
+    'neutralise-pr-body.sh',
+]
+
+RUN_JSON = {
+    'databaseId': int(RUN_ID),
+    'event': 'merge_group',
+    'conclusion': 'failure',
+    'headBranch': 'gh-readonly-queue/develop/pr-%d-abcdef0' % PR_NUMBER,
+    'headSha': 'abcdef0',
+    'url': RUN_URL,
+    'attempt': 1,
+    'workflowName': 'Functional tests',
+    'createdAt': '2026-09-05T00:00:00Z'
+}
+
+FAILED_JOBS = [{
+    'job': 'develop debian 12 cluster (collection)',
+    'url': '%s/job/1' % RUN_URL,
+    'failed_steps': ['Build the smoke cluster']
+}]
+
+VERDICT = {
+    'verdict': 'systemic',
+    'confidence': 'high',
+    'summary': 'The cluster build failed before any test ran.',
+    'failing_job': 'develop debian 12 cluster (collection)',
+    'failing_step': 'Build the smoke cluster',
+    'failure_signature': '507 sufficient_idle_cpu',
+    'recommendation': 'requeue',
+    'tracking_issue': 3772,
+    'tracking_issue_action': 'commented',
+    'evidence': ['Three sibling merge groups failed the same way.']
+}
+
+# A stub gh. Dispatches on the same argument shapes the driver uses and reads
+# its answers out of a fixture directory, so a test says what GitHub knows by
+# writing files. Every invocation is appended to gh.log, which is how the
+# tests that care about *which* API was called assert it.
+GH_STUB = '''#!/usr/bin/env python3
+import os
+import shutil
+import sys
+
+args = sys.argv[1:]
+fixtures = os.environ['GH_FIXTURES']
+
+with open(os.path.join(fixtures, 'gh.log'), 'a') as f:
+    f.write(' '.join(args) + '\\n')
+
+
+def emit(name, missing_is_failure=True):
+    path = os.path.join(fixtures, name)
+    if not os.path.exists(path):
+        if missing_is_failure:
+            # gh prints the error body of a 404 on stdout, not stderr, which
+            # is why the driver tests the exit status rather than the output.
+            sys.stdout.write('{"message": "Not Found"}\\n')
+            return 1
+        return 0
+    with open(path) as f:
+        sys.stdout.write(f.read())
+    return 0
+
+
+if args[:2] == ['run', 'view']:
+    if '--log-failed' in args:
+        sys.exit(emit('failed-logs.txt', missing_is_failure=False))
+    if 'jobs' in args:
+        sys.exit(emit('failed-jobs.json'))
+    sys.exit(emit('run.json'))
+
+if args[:2] == ['run', 'list']:
+    sys.exit(emit('sibling-runs.json'))
+
+if args[:2] == ['pr', 'view']:
+    sys.exit(emit('pr.json'))
+
+if args[:2] == ['pr', 'comment']:
+    body = args[args.index('--body-file') + 1]
+    shutil.copy(body, os.path.join(fixtures, 'posted-comment.md'))
+    sys.stdout.write('https://github.com/%s/pull/%s#issuecomment-1\\n'
+                     % (os.environ['REPO'], args[2]))
+    sys.exit(0)
+
+if args[:2] == ['issue', 'view']:
+    sys.exit(emit('issue-%s.body' % args[2]))
+
+if args[0] == 'api':
+    path = [a for a in args if '/issues/' in a][0]
+    number = path.split('/issues/')[1].split('/')[0]
+    sys.exit(emit('issue-%s.comments' % number, missing_is_failure=False))
+
+sys.stderr.write('stub gh: unexpected invocation: %s\\n' % ' '.join(args))
+sys.exit(3)
+'''
+
+# A stub model wrapper. The driver hands it the prompt and reads its stdout,
+# so a test says what the model answered by writing CLAUDE_RESPONSE.
+CLAUDE_STUB = '''#!/bin/bash
+cat "${CLAUDE_RESPONSE}"
+'''
+
+# A neutraliser which fails, for the test that publication is gated on it.
+BROKEN_NEUTRALISER = '''#!/bin/bash
+echo "stub neutraliser: could not rewrite $1" >&2
+exit 1
+'''
+
+
+def _repo_root():
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.dirname(os.path.dirname(here))
+
+
+class MergeCiTriageShellTestCase(base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+        self.root = _repo_root()
+        # A missing jq means every jq read in the driver returns nothing and
+        # the assertions below fail in a way that says nothing useful, so say
+        # it here instead.
+        self.assertIsNotNone(
+            shutil.which('jq'),
+            'these tests run the triage driver, which needs jq; both runner '
+            'flavours install it as a base package')
+
+        self.tempdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tempdir, True)
+
+        self.tools = os.path.join(self.tempdir, 'tools')
+        self.bin = os.path.join(self.tempdir, 'bin')
+        self.fixtures = os.path.join(self.tempdir, 'fixtures')
+        self.output = os.path.join(self.tempdir, 'output')
+        for path in [self.tools, self.bin, self.fixtures, self.output]:
+            os.makedirs(path)
+
+        for tool in STAGED_TOOLS:
+            shutil.copy(os.path.join(self.root, 'tools', tool), self.tools)
+        self._write_executable(
+            os.path.join(self.tools, 'claude-model-fallback.sh'), CLAUDE_STUB)
+        self._write_executable(os.path.join(self.bin, 'gh'), GH_STUB)
+
+        # The defaults, which individual tests overwrite. A run that can be
+        # read, one failed job, a short log and a pull request.
+        self.write_fixture('run.json', json.dumps(RUN_JSON))
+        self.write_fixture('failed-jobs.json', json.dumps(FAILED_JOBS))
+        self.write_fixture('failed-logs.txt', 'TASK [build the cluster]\nfatal: 507\n')
+        self.write_fixture('sibling-runs.json', json.dumps([]))
+        self.write_fixture('pr.json', json.dumps(
+            {'number': PR_NUMBER, 'title': 'A pull request', 'files': [], 'body': ''}))
+        self.response = VERDICT
+
+    def _write_executable(self, path, content):
+        with open(path, 'w') as f:
+            f.write(content)
+        os.chmod(path, 0o755)
+
+    def write_fixture(self, name, content):
+        with open(os.path.join(self.fixtures, name), 'w') as f:
+            f.write(content)
+
+    def read_fixture(self, name):
+        path = os.path.join(self.fixtures, name)
+        if not os.path.exists(path):
+            return None
+        with open(path) as f:
+            return f.read()
+
+    def run_triage(self, dry_run=False, env=None, response=None):
+        """Run the driver, returning (exit code, document or None, stderr)."""
+        response_path = os.path.join(self.tempdir, 'response.txt')
+        with open(response_path, 'w') as f:
+            if response is None:
+                f.write('```json\n%s\n```\n' % json.dumps(self.response))
+            else:
+                f.write(response)
+
+        environment = dict(os.environ)
+        environment.update({
+            'PATH': '%s:%s' % (self.bin, os.environ['PATH']),
+            'REPO': REPO,
+            'OUTPUT_DIR': self.output,
+            'DRY_RUN': 'true' if dry_run else 'false',
+            'GH_FIXTURES': self.fixtures,
+            'CLAUDE_RESPONSE': response_path,
+            'TRIAGE_RUN_URL': 'https://github.com/%s/actions/runs/1' % REPO
+        })
+        environment.update(env or {})
+
+        proc = subprocess.run(
+            [os.path.join(self.tools, 'merge-ci-triage.sh'), RUN_ID],
+            capture_output=True, text=True, env=environment)
+
+        document = None
+        path = os.path.join(self.output, 'triage.json')
+        if os.path.exists(path):
+            with open(path) as f:
+                document = json.load(f)
+        return proc.returncode, document, proc.stderr
+
+    def gh_log(self):
+        return self.read_fixture('gh.log') or ''
+
+    # -- the citation check ------------------------------------------------
+
+    def test_a_citation_the_issue_references_survives(self):
+        self.write_fixture('issue-3772.body', 'The 507 flake.\n')
+        self.write_fixture('issue-3772.comments', 'Seen again in %s\n' % RUN_URL)
+
+        code, document, _ = self.run_triage()
+        self.assertEqual(0, code)
+        self.assertEqual(3772, document['tracking_issue'])
+        self.assertEqual('commented', document['tracking_issue_action'])
+        self.assertIsNotNone(self.read_fixture('posted-comment.md'))
+
+    def test_an_issue_that_does_not_mention_the_run_loses_the_claim(self):
+        # The issue exists, so the number is still a useful pointer for a
+        # reader. What fails is the assertion that the occurrence was recorded
+        # there, and that is what the conductor reads, so that is what goes.
+        self.write_fixture('issue-3772.body', 'The 507 flake.\n')
+        self.write_fixture('issue-3772.comments', 'Seen in some other run.\n')
+
+        code, document, _ = self.run_triage()
+        self.assertEqual(0, code)
+        self.assertEqual(3772, document['tracking_issue'])
+        self.assertEqual('none', document['tracking_issue_action'])
+        self.assertIn('kept as a reference only', ' '.join(document['evidence']))
+
+    def test_an_unreadable_issue_loses_the_citation_entirely(self):
+        # No fixture, so the stub 404s. An issue which cannot be read is not
+        # even a pointer.
+        code, document, _ = self.run_triage()
+        self.assertEqual(0, code)
+        self.assertIsNone(document['tracking_issue'])
+        self.assertEqual('none', document['tracking_issue_action'])
+        self.assertIn('could not be read', ' '.join(document['evidence']))
+
+    def test_a_run_with_no_url_does_not_verify_a_citation_vacuously(self):
+        # "grep -qF ''" matches every non-empty input, so a run GitHub gave no
+        # URL for would turn the check into a rubber stamp: any issue at all
+        # would appear to carry the reference. The driver falls back to the
+        # URL the run must have, and the prompt gets the same value.
+        run = dict(RUN_JSON)
+        del run['url']
+        self.write_fixture('run.json', json.dumps(run))
+        self.write_fixture('issue-3772.body', 'The 507 flake.\n')
+        self.write_fixture('issue-3772.comments', 'Nothing about this run.\n')
+
+        code, document, _ = self.run_triage()
+        self.assertEqual(0, code)
+        self.assertEqual('none', document['tracking_issue_action'])
+        self.assertIn(RUN_URL, ' '.join(document['evidence']))
+
+        with open(os.path.join(self.output, 'prompt.txt')) as f:
+            self.assertIn(RUN_URL, f.read())
+
+    def test_a_citation_already_claiming_nothing_is_not_checked(self):
+        # An action of "none" says nothing was written, so nothing will
+        # reference this run and checking anyway would drop every
+        # reference-only citation ever made.
+        self.response = dict(VERDICT, tracking_issue_action='none')
+        self.write_fixture('issue-3772.body', 'The 507 flake.\n')
+
+        code, document, _ = self.run_triage()
+        self.assertEqual(0, code)
+        self.assertEqual(3772, document['tracking_issue'])
+        self.assertEqual('none', document['tracking_issue_action'])
+        self.assertNotIn('/issues/3772/comments', self.gh_log())
+
+    # -- dry runs ----------------------------------------------------------
+
+    def test_a_dry_run_records_nothing_and_says_so(self):
+        self.write_fixture('issue-3772.body', 'The 507 flake.\n')
+        self.write_fixture('issue-3772.comments', 'Seen again in %s\n' % RUN_URL)
+
+        code, document, _ = self.run_triage(dry_run=True)
+        self.assertEqual(0, code)
+        self.assertEqual('none', document['tracking_issue_action'])
+        self.assertIn('This was a dry run', ' '.join(document['evidence']))
+        self.assertIsNone(self.read_fixture('posted-comment.md'))
+
+    def test_a_dry_run_still_checks_the_claim_it_overwrote(self):
+        # The claimed action is read before the dry run forces it to "none",
+        # because gating the check on the value left in the document would
+        # mean a dry run never exercises this path at all -- and a dry run is
+        # how the driver is tested by hand.
+        self.write_fixture('issue-3772.body', 'The 507 flake.\n')
+        self.write_fixture('issue-3772.comments', 'Nothing about this run.\n')
+
+        code, document, _ = self.run_triage(dry_run=True)
+        self.assertEqual(0, code)
+        self.assertIn('kept as a reference only', ' '.join(document['evidence']))
+        # The citation itself survives a dry run: the issue triage would have
+        # used is the useful half of a dry run's output.
+        self.assertEqual(3772, document['tracking_issue'])
+
+    # -- what the model is shown -------------------------------------------
+
+    def test_long_logs_are_cut_from_the_middle(self):
+        # Both ends are kept, and the marker says how much went, because a
+        # head-only cut elides the last thing a failed step emits -- which is
+        # the message that says what broke.
+        self.write_fixture(
+            'failed-logs.txt', 'HEADMARK' + ('x' * 1000) + 'TAILMARK')
+        code, _, _ = self.run_triage(
+            env={'LOG_HEAD_BYTES': '100', 'LOG_TAIL_BYTES': '200'})
+        self.assertEqual(0, code)
+
+        with open(os.path.join(self.output, 'failed-logs.txt')) as f:
+            logs = f.read()
+        self.assertTrue(logs.startswith('HEADMARK'))
+        self.assertTrue(logs.endswith('TAILMARK'))
+        # 1016 bytes in, 300 of them kept.
+        self.assertIn('[... 716 bytes elided by triage: this is the first 100 '
+                      'and the last 200 bytes of the failed step logs ...]', logs)
+
+    def test_evidence_that_could_not_be_gathered_travels_with_the_verdict(self):
+        # A model handed an empty log still produces a verdict, and the
+        # prompt's own heuristics push an evidence-free run towards "systemic,
+        # re-queue". A reader has to be told which pieces were missing.
+        os.unlink(os.path.join(self.fixtures, 'sibling-runs.json'))
+        self.write_fixture('issue-3772.body', 'The 507 flake.\n')
+        self.write_fixture('issue-3772.comments', 'Seen again in %s\n' % RUN_URL)
+
+        code, document, _ = self.run_triage()
+        self.assertEqual(0, code)
+        self.assertIn('no correlation was possible', ' '.join(document['evidence']))
+
+    def test_nothing_readable_at_all_does_not_reach_a_model(self):
+        self.write_fixture('failed-jobs.json', json.dumps([]))
+        self.write_fixture('failed-logs.txt', '')
+
+        code, document, _ = self.run_triage()
+        self.assertEqual(0, code)
+        self.assertEqual('unknown', document['verdict'])
+        self.assertFalse(os.path.exists(os.path.join(self.output, 'prompt.txt')))
+
+    # -- publication -------------------------------------------------------
+
+    def test_the_comment_is_not_posted_if_it_cannot_be_neutralised(self):
+        # The neutralisation rewrites the file in place, so a failure inside
+        # it leaves the original, un-neutralised body exactly where "gh pr
+        # comment" would read it from -- and this script does not run under
+        # "set -e". A triage nobody sees beats one that fires an @mention.
+        self._write_executable(
+            os.path.join(self.tools, 'neutralise-pr-body.sh'), BROKEN_NEUTRALISER)
+        self.write_fixture('issue-3772.body', 'The 507 flake.\n')
+        self.write_fixture('issue-3772.comments', 'Seen again in %s\n' % RUN_URL)
+
+        code, _, stderr = self.run_triage()
+        self.assertEqual(1, code)
+        self.assertIn('could not be neutralised', stderr)
+        self.assertIsNone(self.read_fixture('posted-comment.md'))
+
+    def test_the_posted_comment_is_neutralised(self):
+        self.response = dict(
+            VERDICT, summary='Reported by @mikal, fixes #1234, in run 33952027147.')
+        self.write_fixture('issue-3772.body', 'The 507 flake.\n')
+        self.write_fixture('issue-3772.comments', 'Seen again in %s\n' % RUN_URL)
+
+        code, _, _ = self.run_triage()
+        self.assertEqual(0, code)
+        # The prose half. The embedded JSON keeps what the model said
+        # verbatim, which is the point of embedding it: the neutraliser leaves
+        # fenced regions alone because GitHub does not linkify inside one.
+        prose = self.read_fixture('posted-comment.md').split('```json')[0]
+        self.assertIn('mikal', prose)
+        self.assertNotIn('@mikal', prose)
+        self.assertNotIn('fixes #1234', prose)
+
+    def test_an_already_triaged_run_is_not_commented_on_twice(self):
+        # The dedup search reads the pull request's comments through the
+        # paginated issues API rather than "gh pr view --json comments", whose
+        # GraphQL layer stops at a hundred: on a long-lived pull request the
+        # marker would fall off the end and a re-delivered workflow_run would
+        # post the same verdict again.
+        self.write_fixture('issue-3772.body', 'The 507 flake.\n')
+        self.write_fixture('issue-3772.comments', 'Seen again in %s\n' % RUN_URL)
+        self.write_fixture(
+            'issue-%d.comments' % PR_NUMBER,
+            '<!-- merge-triage run:%s -->\nAn earlier verdict.\n' % RUN_ID)
+
+        code, _, _ = self.run_triage()
+        self.assertEqual(0, code)
+        self.assertIsNone(self.read_fixture('posted-comment.md'))
+        self.assertIn('--paginate repos/%s/issues/%d/comments' % (REPO, PR_NUMBER),
+                      self.gh_log())
+
+    # -- the document is always written ------------------------------------
+
+    def test_a_run_that_cannot_be_read_still_publishes_a_document(self):
+        # A missing document is indistinguishable from a triage that never
+        # ran, which is the ambiguity the whole design exists to remove.
+        os.unlink(os.path.join(self.fixtures, 'run.json'))
+
+        code, document, _ = self.run_triage()
+        self.assertEqual(1, code)
+        self.assertEqual('unknown', document['verdict'])
+        self.assertIn('could not be read', document['error'])
+
+    def test_a_run_that_is_not_a_failed_merge_group_publishes_nothing(self):
+        # The one exception: nothing was triaged, so there is no verdict to
+        # file about it.
+        self.write_fixture('run.json', json.dumps(dict(RUN_JSON, event='pull_request')))
+
+        code, document, _ = self.run_triage()
+        self.assertEqual(0, code)
+        self.assertIsNone(document)

--- a/shakenfist/tests/test_merge_ci_triage_shell.py
+++ b/shakenfist/tests/test_merge_ci_triage_shell.py
@@ -120,6 +120,9 @@ if args[:2] == ['pr', 'view']:
     sys.exit(emit('pr.json'))
 
 if args[:2] == ['pr', 'comment']:
+    if os.path.exists(os.path.join(fixtures, 'comment-fails')):
+        sys.stderr.write('stub gh: could not post the comment\\n')
+        sys.exit(1)
     body = args[args.index('--body-file') + 1]
     shutil.copy(body, os.path.join(fixtures, 'posted-comment.md'))
     sys.stdout.write('https://github.com/%s/pull/%s#issuecomment-1\\n'
@@ -139,9 +142,20 @@ sys.exit(3)
 '''
 
 # A stub model wrapper. The driver hands it the prompt and reads its stdout,
-# so a test says what the model answered by writing CLAUDE_RESPONSE.
+# so a test says what the model answered by writing CLAUDE_RESPONSE. Its
+# argument vector is recorded, because how the prompt gets to the model is
+# itself a property under test: as a file, never as an argument.
 CLAUDE_STUB = '''#!/bin/bash
+printf '%s\n' "$@" > "${GH_FIXTURES}/claude-args"
 cat "${CLAUDE_RESPONSE}"
+'''
+
+# A model wrapper that could not run a model at all -- every model out of
+# subscription credit is its documented exit 1, and an exec that never
+# happened looks the same from here.
+BROKEN_CLAUDE_STUB = '''#!/bin/bash
+echo "claude-model-fallback: every model in 'claude-fable-5' is out of credit" >&2
+exit 1
 '''
 
 # A neutraliser which fails, for the test that publication is gated on it.
@@ -245,6 +259,17 @@ class MergeCiTriageShellTestCase(base.ShakenFistTestCase):
     def gh_log(self):
         return self.read_fixture('gh.log') or ''
 
+    def claude_args(self):
+        """The argument vector the model wrapper was called with."""
+        recorded = self.read_fixture('claude-args')
+        if recorded is None:
+            return None
+        return recorded.split('\n')[:-1]
+
+    def prompt(self):
+        with open(os.path.join(self.output, 'prompt.txt')) as f:
+            return f.read()
+
     # -- the citation check ------------------------------------------------
 
     def test_a_citation_the_issue_references_survives(self):
@@ -333,10 +358,31 @@ class MergeCiTriageShellTestCase(base.ShakenFistTestCase):
 
         code, document, _ = self.run_triage(dry_run=True)
         self.assertEqual(0, code)
-        self.assertIn('kept as a reference only', ' '.join(document['evidence']))
+        # In the words of a dry run, not those of a claim that did not check
+        # out: on this path nothing was written, so the missing reference is
+        # certain and says nothing about the model. Reporting it as a caught
+        # lie is how a maintainer stops trusting the tool that does the
+        # catching.
+        evidence = ' '.join(document['evidence'])
+        self.assertIn('Nothing was written, so the citation is unverified',
+                      evidence)
+        self.assertNotIn('kept as a reference only', evidence)
         # The citation itself survives a dry run: the issue triage would have
         # used is the useful half of a dry run's output.
         self.assertEqual(3772, document['tracking_issue'])
+
+    def test_a_dry_run_drops_an_unreadable_citation_too(self):
+        # The two failures are not interchangeable and the order of the
+        # branches decides which one wins. An issue that cannot be read is not
+        # a useful pointer whichever mode produced the citation, and testing
+        # the dry run first would keep the number here -- inverting the
+        # documented contract on exactly the path a maintainer uses to inspect
+        # this behaviour by hand.
+        code, document, _ = self.run_triage(dry_run=True)
+        self.assertEqual(0, code)
+        self.assertIsNone(document['tracking_issue'])
+        self.assertEqual('none', document['tracking_issue_action'])
+        self.assertIn('could not be read', ' '.join(document['evidence']))
 
     # -- what the model is shown -------------------------------------------
 
@@ -357,6 +403,100 @@ class MergeCiTriageShellTestCase(base.ShakenFistTestCase):
         # 1016 bytes in, 300 of them kept.
         self.assertIn('[... 716 bytes elided by triage: this is the first 100 '
                       'and the last 200 bytes of the failed step logs ...]', logs)
+
+    def test_the_prompt_reaches_the_model_as_a_file(self):
+        # Never as an argument. Linux caps a single argv element at
+        # MAX_ARG_STRLEN, a hard 128KiB no ulimit raises, and an argument over
+        # it does not truncate -- the exec fails with E2BIG and no model runs.
+        code, _, _ = self.run_triage()
+        self.assertEqual(0, code)
+
+        args = self.claude_args()
+        self.assertIn('--prompt-file', args)
+        self.assertEqual(os.path.join(self.output, 'prompt.txt'),
+                         args[args.index('--prompt-file') + 1])
+        for arg in args:
+            self.assertNotIn(
+                'You are triaging a failed merge queue CI run', arg,
+                'the prompt is being passed as an argument again')
+
+    def test_a_prompt_over_the_argv_limit_still_reaches_the_model(self):
+        # The regression test for the bug above, at the size that produces it:
+        # a failed Ansible cluster build emits megabytes, the budget keeps
+        # 160KB of it here, and an argv element cannot exceed 131072 bytes.
+        # Passed as an argument this run reaches no model at all and publishes
+        # "unknown" -- on precisely the failure class the triage exists for.
+        self.write_fixture('failed-logs.txt', 'HEADMARK' + ('x' * 4000000) + 'TAILMARK')
+        self.write_fixture('issue-3772.body', 'The 507 flake.\n')
+        self.write_fixture('issue-3772.comments', 'Seen again in %s\n' % RUN_URL)
+
+        code, document, _ = self.run_triage(
+            env={'LOG_HEAD_BYTES': '60000', 'LOG_TAIL_BYTES': '100000'})
+        self.assertEqual(0, code)
+        self.assertGreater(
+            os.path.getsize(os.path.join(self.output, 'prompt.txt')), 131072,
+            'this test no longer builds a prompt over the argv limit, so it '
+            'no longer tests anything')
+        self.assertEqual('systemic', document['verdict'])
+
+    def test_a_model_that_could_not_be_run_is_not_a_model_that_rambled(self):
+        # Every model out of subscription credit, a crashed CLI, an exec that
+        # never happened: all of them exit non-zero and produce no verdict.
+        # Reporting them as "the response contained no JSON verdict object"
+        # sends a maintainer to read a response file that explains nothing,
+        # and the whole point of always publishing a document is that it says
+        # what happened.
+        self._write_executable(
+            os.path.join(self.tools, 'claude-model-fallback.sh'),
+            BROKEN_CLAUDE_STUB)
+
+        code, document, _ = self.run_triage()
+        self.assertEqual(0, code)
+        self.assertEqual('unknown', document['verdict'])
+        self.assertIn('the model wrapper exited 1', document['error'])
+        self.assertIn('the model wrapper exited 1', ' '.join(document['evidence']))
+
+    def test_the_sibling_runs_are_scoped_to_the_workflow_that_failed(self):
+        # "--event merge_group" on its own is every workflow in the
+        # repository, and these twenty slots exist to answer "is this
+        # happening to everybody?" about this suite. The run being triaged is
+        # not its own sibling either.
+        self.write_fixture('sibling-runs.json', json.dumps([
+            {'databaseId': int(RUN_ID), 'conclusion': 'failure',
+             'headBranch': 'gh-readonly-queue/develop/pr-4080-abcdef0',
+             'createdAt': '2026-09-05T00:00:00Z', 'url': RUN_URL},
+            {'databaseId': 33952027000, 'conclusion': 'failure',
+             'headBranch': 'gh-readonly-queue/develop/pr-4079-abcdef1',
+             'createdAt': '2026-09-04T00:00:00Z',
+             'url': 'https://github.com/%s/actions/runs/33952027000' % REPO}]))
+
+        code, _, _ = self.run_triage()
+        self.assertEqual(0, code)
+        self.assertIn("--workflow Functional tests", self.gh_log())
+
+        siblings = self.prompt().split('# Other recent merge_group runs')[1]
+        siblings = siblings.split('# The pull request')[0]
+        self.assertIn('33952027000', siblings)
+        self.assertNotIn(RUN_ID, siblings)
+
+    def test_a_log_cut_inside_a_character_leaves_valid_utf8(self):
+        # The budget is in bytes, which is the right unit -- one wrapped
+        # ansible line can be thousands of characters -- but a byte offset can
+        # land in the middle of one. What is left over is invalid UTF-8 at the
+        # join, and it travels into the prompt and into the run's artifact.
+        with open(os.path.join(self.fixtures, 'failed-logs.txt'), 'wb') as f:
+            # The cuts at 101 and 201 bytes both land inside a three-byte
+            # character.
+            f.write(b'x' * 100 + '\u4e2d'.encode('utf-8') * 40 + b'y' * 100)
+
+        code, _, _ = self.run_triage(
+            env={'LOG_HEAD_BYTES': '101', 'LOG_TAIL_BYTES': '101'})
+        self.assertEqual(0, code)
+
+        with open(os.path.join(self.output, 'failed-logs.txt'), 'rb') as f:
+            logs = f.read()
+        # Decodes, rather than raising UnicodeDecodeError on the join.
+        logs.decode('utf-8')
 
     def test_evidence_that_could_not_be_gathered_travels_with_the_verdict(self):
         # A model handed an empty log still produces a verdict, and the
@@ -411,6 +551,37 @@ class MergeCiTriageShellTestCase(base.ShakenFistTestCase):
         self.assertIn('mikal', prose)
         self.assertNotIn('@mikal', prose)
         self.assertNotIn('fixes #1234', prose)
+
+    def test_the_dedup_marker_survives_neutralisation(self):
+        # The marker is prepended to the comment body and the body is then
+        # rewritten by neutralise-pr-body.sh, so the marker a later run greps
+        # for is whatever came out of that pass. It has to be byte identical
+        # to the one written, or a re-delivered workflow_run posts the same
+        # verdict a second time.
+        self.write_fixture('issue-3772.body', 'The 507 flake.\n')
+        self.write_fixture('issue-3772.comments', 'Seen again in %s\n' % RUN_URL)
+
+        code, _, _ = self.run_triage()
+        self.assertEqual(0, code)
+        self.assertTrue(
+            self.read_fixture('posted-comment.md').startswith(
+                '<!-- merge-triage run:%s -->' % RUN_ID),
+            'the dedup marker did not survive the neutralisation pass')
+
+    def test_a_comment_that_cannot_be_posted_fails_the_run(self):
+        # A green run with nothing on the pull request is indistinguishable
+        # from a triage that never ran, which is the ambiguity this design
+        # exists to remove. The verdict is in the artifact either way, so what
+        # is missing is the signal, and the run itself has to carry it.
+        self.write_fixture('comment-fails', '')
+        self.write_fixture('issue-3772.body', 'The 507 flake.\n')
+        self.write_fixture('issue-3772.comments', 'Seen again in %s\n' % RUN_URL)
+
+        code, document, stderr = self.run_triage()
+        self.assertEqual(1, code)
+        self.assertIn('could not comment on #%d' % PR_NUMBER, stderr)
+        # The verdict itself is unharmed: it is the publication that failed.
+        self.assertEqual('systemic', document['verdict'])
 
     def test_an_already_triaged_run_is_not_commented_on_twice(self):
         # The dedup search reads the pull request's comments through the

--- a/shakenfist/tests/test_merge_triage.py
+++ b/shakenfist/tests/test_merge_triage.py
@@ -1,0 +1,222 @@
+# Copyright 2026 Michael Still and contributors
+
+"""Tests for tools/merge-triage.py.
+
+The merge failure triage job produces one small JSON document per failed merge
+group run, and two consumers depend on it being right. A human reads the
+rendered comment on the ejected pull request, and the private-ci conductor
+reads the document itself to track which merge failures have been triaged and
+which of them blamed the pull request. Both are worse off with a confidently
+wrong document than with no document, which is what these tests pin.
+
+The cases below are the ones where a naive implementation gets it wrong: a
+model which illustrates the format before filling it in (so the last object
+wins, not the first), a model which puts its own idea of the run id in the
+document (so the envelope wins, always), a model which answers in prose (so a
+fallback verdict is written rather than nothing at all), and the several ways
+a field arrives in nearly but not quite the right shape.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+from shakenfist.tests import base
+
+
+def _script_path():
+    here = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.dirname(os.path.dirname(here))
+    return os.path.join(root, 'tools', 'merge-triage.py')
+
+
+SCRIPT = _script_path()
+
+ENVELOPE = {
+    'repository': 'shakenfist/shakenfist',
+    'run_id': 12345,
+    'run_url': 'https://github.com/shakenfist/shakenfist/actions/runs/12345',
+    'run_attempt': 1,
+    'head_branch': 'gh-readonly-queue/develop/pr-4067-abcdef0',
+    'head_sha': 'abcdef0',
+    'base_branch': 'develop',
+    'pull_request': 4067,
+    'triage_run_url': 'https://github.com/shakenfist/shakenfist/actions/runs/12346'
+}
+
+VERDICT = {
+    'verdict': 'systemic',
+    'confidence': 'high',
+    'summary': 'The cluster build failed before any test ran.',
+    'failing_job': 'develop debian 12 cluster (collection)',
+    'failing_step': 'Build the smoke cluster',
+    'failure_signature': 'no SSH prompt from sf2',
+    'recommendation': 'requeue',
+    'tracking_issue': 3813,
+    'tracking_issue_action': 'commented',
+    'evidence': ['The pull request touches only docs/.']
+}
+
+
+class MergeTriageTestCase(base.ShakenFistTestCase):
+    def _extract(self, response, envelope=None):
+        """Run the extractor over a response, returning (exit code, document)."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            response_path = os.path.join(tempdir, 'response.txt')
+            envelope_path = os.path.join(tempdir, 'envelope.json')
+            output_path = os.path.join(tempdir, 'triage.json')
+
+            with open(response_path, 'w') as f:
+                f.write(response)
+            with open(envelope_path, 'w') as f:
+                json.dump(envelope if envelope is not None else ENVELOPE, f)
+
+            proc = subprocess.run(
+                [sys.executable, SCRIPT, 'extract', response_path, envelope_path, output_path],
+                capture_output=True, text=True)
+
+            # The document is always written, because a triage which reached
+            # nothing still has to be distinguishable from a triage which never
+            # ran.
+            self.assertTrue(os.path.exists(output_path), 'no document was written')
+            with open(output_path) as f:
+                return proc.returncode, json.load(f)
+
+    def _validate(self, document):
+        with tempfile.TemporaryDirectory() as tempdir:
+            path = os.path.join(tempdir, 'triage.json')
+            with open(path, 'w') as f:
+                json.dump(document, f)
+            return subprocess.run(
+                [sys.executable, SCRIPT, 'validate', path],
+                capture_output=True, text=True).returncode
+
+    def _render(self, document):
+        with tempfile.TemporaryDirectory() as tempdir:
+            source = os.path.join(tempdir, 'triage.json')
+            rendered = os.path.join(tempdir, 'comment.md')
+            with open(source, 'w') as f:
+                json.dump(document, f)
+            proc = subprocess.run(
+                [sys.executable, SCRIPT, 'render', source, rendered],
+                capture_output=True, text=True)
+            self.assertEqual(0, proc.returncode, proc.stderr)
+            with open(rendered) as f:
+                return f.read()
+
+    def test_script_is_executable(self):
+        self.assertTrue(os.access(SCRIPT, os.X_OK))
+
+    def test_fenced_verdict_is_extracted(self):
+        code, document = self._extract(
+            'Here is what I found.\n\n```json\n%s\n```\n' % json.dumps(VERDICT))
+        self.assertEqual(0, code)
+        self.assertEqual('systemic', document['verdict'])
+        self.assertEqual(3813, document['tracking_issue'])
+        self.assertEqual(0, self._validate(document))
+
+    def test_unfenced_verdict_is_extracted(self):
+        # Models drop the fence often enough that requiring it would throw
+        # away good verdicts.
+        code, document = self._extract('My verdict:\n\n%s\n' % json.dumps(VERDICT))
+        self.assertEqual(0, code)
+        self.assertEqual('systemic', document['verdict'])
+
+    def test_last_object_wins(self):
+        # The prompt shows the format before asking for it, and a model which
+        # echoes the illustration puts the real answer last.
+        illustration = dict(VERDICT, verdict='pr_caused', summary='illustration')
+        code, document = self._extract(
+            'Format:\n```json\n%s\n```\nAnswer:\n```json\n%s\n```\n'
+            % (json.dumps(illustration), json.dumps(VERDICT)))
+        self.assertEqual(0, code)
+        self.assertEqual('systemic', document['verdict'])
+        self.assertEqual('The cluster build failed before any test ran.', document['summary'])
+
+    def test_envelope_always_wins(self):
+        # A model which misremembers the run id or the pull request number must
+        # not be able to file a verdict against somebody else's failure.
+        lying = dict(VERDICT, repository='someone/else', run_id=1, pull_request=1,
+                     run_url='https://example.com/', schema_version=99,
+                     invented_field='this should not survive')
+        code, document = self._extract('```json\n%s\n```' % json.dumps(lying))
+        self.assertEqual(0, code)
+        self.assertEqual('shakenfist/shakenfist', document['repository'])
+        self.assertEqual(12345, document['run_id'])
+        self.assertEqual(4067, document['pull_request'])
+        self.assertEqual(ENVELOPE['run_url'], document['run_url'])
+
+        # Two separate mechanisms defend that, and this pins the other one:
+        # only the fields in MODEL_FIELDS are taken from the response at all,
+        # so a key the schema has never heard of cannot ride along into a
+        # document the conductor parses.
+        self.assertEqual(1, document['schema_version'])
+        self.assertNotIn('invented_field', document)
+
+    def test_prose_answer_becomes_an_unknown_verdict(self):
+        code, document = self._extract(
+            'I think the cluster fell over, but I could not read the logs.')
+        self.assertEqual(1, code)
+        self.assertEqual('unknown', document['verdict'])
+        self.assertEqual('investigate', document['recommendation'])
+        self.assertIsNotNone(document['error'])
+        self.assertEqual(12345, document['run_id'])
+        self.assertEqual(0, self._validate(document))
+
+    def test_unusable_verdict_value_becomes_unknown(self):
+        # "maybe" is not one of the verdicts, and guessing which one it meant
+        # is how a wrong verdict gets published with confidence.
+        code, document = self._extract(
+            '```json\n%s\n```' % json.dumps(dict(VERDICT, verdict='maybe')))
+        self.assertEqual(1, code)
+        self.assertEqual('unknown', document['verdict'])
+        self.assertIn('no usable verdict', document['error'])
+
+    def test_self_declared_unknown_is_a_fallback_not_a_verdict(self):
+        code, document = self._extract(
+            '```json\n%s\n```' % json.dumps(dict(VERDICT, verdict='unknown')))
+        self.assertEqual(1, code)
+        self.assertEqual('unknown', document['verdict'])
+        self.assertIsNotNone(document['error'])
+
+    def test_missing_recommendation_is_derived(self):
+        verdict = dict(VERDICT, verdict='pr_caused')
+        del verdict['recommendation']
+        code, document = self._extract('```json\n%s\n```' % json.dumps(verdict))
+        self.assertEqual(0, code)
+        self.assertEqual('fix_first', document['recommendation'])
+
+    def test_field_shapes_are_coerced(self):
+        # Each of these has turned up in real model output for the reviewer:
+        # an issue reference written the way a human writes it, a single
+        # evidence string rather than a list, and a capitalised enum.
+        code, document = self._extract('```json\n%s\n```' % json.dumps(dict(
+            VERDICT, tracking_issue='#3813', evidence='One observation.',
+            confidence='High')))
+        self.assertEqual(0, code)
+        self.assertEqual(3813, document['tracking_issue'])
+        self.assertEqual(['One observation.'], document['evidence'])
+        self.assertEqual('high', document['confidence'])
+
+    def test_rendered_comment_embeds_the_document(self):
+        code, document = self._extract('```json\n%s\n```' % json.dumps(VERDICT))
+        self.assertEqual(0, code)
+
+        rendered = self._render(document)
+        self.assertIn('Systemic failure', rendered)
+        self.assertIn('Re-queue as-is.', rendered)
+        self.assertIn('#3813', rendered)
+
+        # The conductor can read the verdict back out of the posted comment,
+        # not only out of the run artifact, so the embedded copy has to be the
+        # whole document and has to parse.
+        embedded = rendered.split('```json\n')[-1].split('```')[0]
+        self.assertEqual(document, json.loads(embedded))
+
+    def test_validate_rejects_a_broken_document(self):
+        self.assertNotEqual(0, self._validate(dict(ENVELOPE, verdict='nonsense',
+                                                   recommendation='requeue',
+                                                   schema_version=1,
+                                                   triaged_at='2026-09-05T00:00:00+00:00')))

--- a/shakenfist/tests/test_merge_triage.py
+++ b/shakenfist/tests/test_merge_triage.py
@@ -19,6 +19,7 @@ a field arrives in nearly but not quite the right shape.
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -341,20 +342,75 @@ class MergeTriageTestCase(base.ShakenFistTestCase):
         # or a </details> ends the block early -- and it also stops
         # neutralise-pr-body.sh defusing mentions, because that tracks fenced
         # regions, so this is a security control as well as a formatting one.
+        #
+        # Every spelling of both delimiters, because the narrow forms were not
+        # enough: ~~~ is a GitHub fence too, and a details tag may carry
+        # attributes or whitespace. An unmatched <details open> is as damaging
+        # as an unmatched close -- the real section's closing tag closes the
+        # injected one and the machine-readable section is left hanging open.
         code, document = self._extract('```json\n%s\n```' % json.dumps(dict(
             VERDICT,
             summary='It failed ``` here </details> and again ```json',
-            evidence=['</DETAILS> in the evidence too'])))
+            failing_job='<details open> and ~~~ and <DETAILS >',
+            evidence=['</DETAILS > in the evidence too', '~~~ and a tilde fence'])))
         self.assertEqual(0, code)
         self.assertNotIn('```', document['summary'])
         self.assertNotIn('</details>', document['summary'].lower())
-        self.assertNotIn('</details>', document['evidence'][0].lower())
+        for value in [document['failing_job']] + document['evidence']:
+            self.assertNotIn('~~~', value)
+            self.assertNotIn('<details', value.lower())
+            self.assertNotIn('</details', value.lower())
 
         rendered = self._render(document)
         embedded = rendered.split('```json\n')[-1].split('```')[0]
         self.assertEqual(document, json.loads(embedded))
-        # And the details section still closes exactly once.
+        # And the details section opens and closes exactly once. Counting only
+        # the closes would miss an injected open.
+        self.assertEqual(1, rendered.lower().count('<details>'))
         self.assertEqual(1, rendered.lower().count('</details>'))
+        self.assertEqual(1, rendered.lower().count('<details'))
+
+    def test_a_field_with_a_newline_or_a_pipe_does_not_break_the_table(self):
+        # failing_job, failing_step, failure_signature and confidence are
+        # rendered as single cells of the facts table, three of them inside an
+        # inline code span. A newline splits the row, a pipe adds a column and
+        # a backtick ends the span. The embedded JSON is unaffected either way
+        # -- json.dumps escapes all three -- so this is about the half of the
+        # comment a human reads.
+        code, document = self._extract('```json\n%s\n```' % json.dumps(dict(
+            VERDICT,
+            failing_job='job\nname | with pipe',
+            failing_step='step with a `backtick`',
+            failure_signature='sig | with | pipes')))
+        self.assertEqual(0, code)
+
+        rendered = self._render(document)
+        table = [line for line in rendered.split('\n') if line.startswith('| ')]
+        for row in table:
+            # Two columns, so three pipes: the pair of delimiters plus the one
+            # in the middle. Any unescaped pipe from the model shows up here.
+            self.assertEqual(
+                3, len(re.findall(r'(?<!\\)\|', row)),
+                'row has come apart: %r' % row)
+        self.assertIn('job name \\| with pipe', rendered)
+        # The document itself keeps what the model said.
+        self.assertEqual('job\nname | with pipe', document['failing_job'])
+        embedded = rendered.split('```json\n')[-1].split('```')[0]
+        self.assertEqual(document, json.loads(embedded))
+
+    def test_a_trailing_appendix_does_not_beat_the_verdict(self):
+        # Both searches run newest first, so a model which emits the verdict
+        # and then a trailing block of one field -- an evidence list, a
+        # signature it thought of afterwards -- would have the appendix chosen,
+        # rejected for having no verdict, and the whole triage published as
+        # "unknown" despite a perfectly good verdict being right there.
+        code, document = self._extract(
+            'Here is my verdict:\n\n```json\n%s\n```\n\n'
+            'And the evidence again:\n\n```json\n%s\n```\n'
+            % (json.dumps(VERDICT), json.dumps({'evidence': ['an afterthought']})))
+        self.assertEqual(0, code)
+        self.assertEqual('systemic', document['verdict'])
+        self.assertEqual(['The pull request touches only docs/.'], document['evidence'])
 
     def test_a_fenced_verdict_beats_a_bare_object_in_the_prose(self):
         # The prompt asks for a fenced block, so a fenced one is the answer

--- a/shakenfist/tests/test_merge_triage.py
+++ b/shakenfist/tests/test_merge_triage.py
@@ -290,6 +290,20 @@ class MergeTriageTestCase(base.ShakenFistTestCase):
         self.assertIsNone(envelope['pull_request'])
         self.assertIsNone(envelope['base_branch'])
 
+    def test_a_run_with_no_url_gets_the_url_it_must_have(self):
+        # run_url is a required field, so an absent one would cost the whole
+        # document -- and it is the string the driver looks for in a tracking
+        # issue to check that the occurrence was recorded there, where an
+        # empty value matches every issue rather than none of them. The URL is
+        # a function of the repository and the run id, so it can be rebuilt.
+        run = dict(RUN)
+        del run['url']
+        code, envelope = self._envelope(run)
+        self.assertEqual(0, code)
+        self.assertEqual(
+            'https://github.com/shakenfist/shakenfist/actions/runs/12345',
+            envelope['run_url'])
+
     def test_a_run_with_no_numeric_id_is_refused(self):
         code, _ = self._envelope(dict(RUN, databaseId='not a number'))
         self.assertEqual(1, code)
@@ -421,3 +435,91 @@ class MergeTriageTestCase(base.ShakenFistTestCase):
             % (json.dumps(bare), json.dumps(VERDICT)))
         self.assertEqual(0, code)
         self.assertEqual('systemic', document['verdict'])
+
+    def test_an_unfenced_verdict_beats_a_fenced_appendix(self):
+        # The mirror image of the test above, and the one the preference for a
+        # fence got wrong on its own: a model which reasons in prose, writes
+        # the verdict object there, and then fences a one-field appendix. The
+        # appendix is the only fenced block, so choosing it purely because it
+        # is fenced rejects it for having no verdict and publishes "unknown"
+        # over a verdict which is right there in the response.
+        code, document = self._extract(
+            'Thinking out loud: %s\n\nAppendix:\n\n```json\n%s\n```\n'
+            % (json.dumps(VERDICT), json.dumps({'evidence': ['an afterthought']})))
+        self.assertEqual(0, code)
+        self.assertEqual('systemic', document['verdict'])
+        self.assertEqual(['The pull request touches only docs/.'], document['evidence'])
+
+    def test_html_comments_are_stripped(self):
+        # An HTML comment renders as nothing, so an unterminated one hides
+        # everything after it -- the recommendation included -- from the human
+        # reading the comment, while the machine-readable extraction below it
+        # still succeeds. A human and the conductor then disagree about a
+        # verdict neither of them can see is truncated. The same construct is
+        # also the driver's dedup marker, which a model must not be able to
+        # write for itself.
+        code, document = self._extract('```json\n%s\n```' % json.dumps(dict(
+            VERDICT,
+            summary='It failed <!-- and the rest of this comment is invisible',
+            evidence=['<!-- merge-triage run:99999 -->'])))
+        self.assertEqual(0, code)
+        self.assertNotIn('<!--', document['summary'])
+        for value in document['evidence']:
+            self.assertNotIn('<!--', value)
+            self.assertNotIn('-->', value)
+
+        rendered = self._render(document)
+        self.assertNotIn('<!--', rendered)
+        self.assertIn('Re-queue as-is.', rendered)
+
+    def test_evidence_appended_after_extraction_cannot_break_the_comment(self):
+        # merge-ci-triage.sh appends to evidence three times after extraction
+        # -- the gather notes, the dry run note and the citation drop reason,
+        # the last two of which interpolate values from GitHub -- and writes
+        # the error field on its fallback paths. None of that goes back
+        # through the extractor, so stripping the markup only there defends
+        # the fields nothing subsequently touches. Rendering is the last thing
+        # to see the document, so the defence has to be there too.
+        document = dict(VERDICT, **ENVELOPE)
+        document.update({
+            'evidence': ['No pull request number could be parsed out of '
+                         '```json\n{"verdict": "pr_caused"}\n```'],
+            'error': 'Something </details> went wrong'
+        })
+
+        rendered = self._render(document)
+        embedded = rendered.split('```json\n')[-1].split('```')[0]
+        recovered = json.loads(embedded)
+        self.assertEqual('systemic', recovered['verdict'])
+        self.assertEqual(1, rendered.lower().count('<details>'))
+        self.assertEqual(1, rendered.lower().count('</details>'))
+        # Three fences in the rendered comment and no more: the one that opens
+        # the embedded block, the one that closes it, and nothing smuggled in
+        # between them.
+        self.assertEqual(2, rendered.count('```'))
+
+    def test_a_multi_line_evidence_item_stays_one_bullet(self):
+        # An evidence string carrying a newline otherwise renders its
+        # continuation lines as loose prose which has visibly fallen out of
+        # the list.
+        document = dict(VERDICT, **ENVELOPE)
+        document['evidence'] = ['first line\nsecond line', 'another item']
+        rendered = self._render(document)
+        bullets = [line for line in rendered.split('\n') if line.startswith('- ')]
+        self.assertEqual(['- first line second line', '- another item'], bullets)
+
+    def test_a_float_issue_number_is_still_an_issue_number(self):
+        # A model which emits the tracking issue as a JSON number with a
+        # decimal point should not cost the reader the pointer to the issue
+        # the occurrence was recorded on: int('3813.0') raises, and the
+        # citation would be dropped for its spelling. A fractional number is
+        # not an issue number and is still dropped.
+        code, document = self._extract(
+            '```json\n%s\n```' % json.dumps(dict(VERDICT, tracking_issue=3813.0)))
+        self.assertEqual(0, code)
+        self.assertEqual(3813, document['tracking_issue'])
+
+        code, document = self._extract(
+            '```json\n%s\n```' % json.dumps(dict(VERDICT, tracking_issue=38.13)))
+        self.assertEqual(0, code)
+        self.assertIsNone(document['tracking_issue'])

--- a/shakenfist/tests/test_merge_triage.py
+++ b/shakenfist/tests/test_merge_triage.py
@@ -46,6 +46,17 @@ ENVELOPE = {
     'triage_run_url': 'https://github.com/shakenfist/shakenfist/actions/runs/12346'
 }
 
+# What "gh run view --json ..." returns for the failed merge group run.
+RUN = {
+    'databaseId': 12345,
+    'event': 'merge_group',
+    'conclusion': 'failure',
+    'headBranch': 'gh-readonly-queue/develop/pr-4067-abcdef0',
+    'headSha': 'abcdef0',
+    'url': 'https://github.com/shakenfist/shakenfist/actions/runs/12345',
+    'attempt': 1,
+}
+
 VERDICT = {
     'verdict': 'systemic',
     'confidence': 'high',
@@ -105,6 +116,36 @@ class MergeTriageTestCase(base.ShakenFistTestCase):
             self.assertEqual(0, proc.returncode, proc.stderr)
             with open(rendered) as f:
                 return f.read()
+
+    def _envelope(self, run, repository='shakenfist/shakenfist', triage_run_url=''):
+        """Run the envelope builder over a gh run view document."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            run_path = os.path.join(tempdir, 'run.json')
+            output_path = os.path.join(tempdir, 'envelope.json')
+            with open(run_path, 'w') as f:
+                json.dump(run, f)
+
+            proc = subprocess.run(
+                [sys.executable, SCRIPT, 'envelope', repository, run_path,
+                 output_path, triage_run_url],
+                capture_output=True, text=True)
+            if not os.path.exists(output_path):
+                return proc.returncode, None
+            with open(output_path) as f:
+                return proc.returncode, json.load(f)
+
+    def _fallback(self, envelope, error):
+        with tempfile.TemporaryDirectory() as tempdir:
+            envelope_path = os.path.join(tempdir, 'envelope.json')
+            output_path = os.path.join(tempdir, 'triage.json')
+            with open(envelope_path, 'w') as f:
+                json.dump(envelope, f)
+            proc = subprocess.run(
+                [sys.executable, SCRIPT, 'fallback', envelope_path, output_path, error],
+                capture_output=True, text=True)
+            self.assertEqual(0, proc.returncode, proc.stderr)
+            with open(output_path) as f:
+                return json.load(f)
 
     def test_script_is_executable(self):
         self.assertTrue(os.access(SCRIPT, os.X_OK))
@@ -220,3 +261,107 @@ class MergeTriageTestCase(base.ShakenFistTestCase):
                                                    recommendation='requeue',
                                                    schema_version=1,
                                                    triaged_at='2026-09-05T00:00:00+00:00')))
+
+    def test_envelope_is_built_from_the_run(self):
+        code, envelope = self._envelope(RUN, triage_run_url='https://example.com/t')
+        self.assertEqual(0, code)
+        self.assertEqual('shakenfist/shakenfist', envelope['repository'])
+        self.assertEqual(12345, envelope['run_id'])
+        self.assertEqual('develop', envelope['base_branch'])
+        self.assertEqual(4067, envelope['pull_request'])
+        self.assertEqual(1, envelope['schema_version'])
+        self.assertEqual('https://example.com/t', envelope['triage_run_url'])
+
+    def test_a_base_branch_containing_a_slash_is_parsed(self):
+        # release/1.0 is a legal base branch, and the ref then has three
+        # slashes before the pr- segment rather than two.
+        code, envelope = self._envelope(dict(
+            RUN, headBranch='gh-readonly-queue/release/1.0/pr-12-9f8e7d6'))
+        self.assertEqual(0, code)
+        self.assertEqual('release/1.0', envelope['base_branch'])
+        self.assertEqual(12, envelope['pull_request'])
+
+    def test_an_unparseable_ref_still_yields_an_envelope(self):
+        # Survivable: triage runs, the verdict simply has no pull request to
+        # attach itself to, and the conductor sees a document either way.
+        code, envelope = self._envelope(dict(RUN, headBranch='refs/heads/develop'))
+        self.assertEqual(0, code)
+        self.assertIsNone(envelope['pull_request'])
+        self.assertIsNone(envelope['base_branch'])
+
+    def test_a_run_with_no_numeric_id_is_refused(self):
+        code, _ = self._envelope(dict(RUN, databaseId='not a number'))
+        self.assertEqual(1, code)
+
+    def test_the_fallback_document_validates(self):
+        # The path taken when a run cannot be read at all, which is exactly
+        # when a consumer most needs to see that triage ran and failed.
+        code, envelope = self._envelope(RUN)
+        self.assertEqual(0, code)
+        document = self._fallback(envelope, 'The run could not be read.')
+        self.assertEqual('unknown', document['verdict'])
+        self.assertEqual('investigate', document['recommendation'])
+        self.assertEqual('The run could not be read.', document['error'])
+        self.assertEqual(4067, document['pull_request'])
+        self.assertEqual(0, self._validate(document))
+
+    def test_a_verdict_without_a_summary_still_validates(self):
+        # A model that gives a verdict and no prose has still given a verdict.
+        # Discarding it at the validation gate would throw away a successful
+        # triage over a missing sentence.
+        verdict = dict(VERDICT)
+        del verdict['summary']
+        code, document = self._extract('```json\n%s\n```' % json.dumps(verdict))
+        self.assertEqual(0, code)
+        self.assertEqual('systemic', document['verdict'])
+        self.assertIsNone(document['summary'])
+        self.assertEqual(0, self._validate(document))
+
+    def test_a_verdict_without_a_confidence_still_validates(self):
+        verdict = dict(VERDICT)
+        del verdict['confidence']
+        code, document = self._extract('```json\n%s\n```' % json.dumps(verdict))
+        self.assertEqual(0, code)
+        self.assertNotIn('confidence', document)
+        self.assertEqual(0, self._validate(document))
+
+    def test_an_unstated_issue_action_is_not_assumed_to_be_a_comment(self):
+        # The consumer is told that "commented" means the occurrence really
+        # was recorded. Guessing that a write happened is the wrong direction
+        # to guess in: verification downstream can only take the claim away.
+        verdict = dict(VERDICT)
+        del verdict['tracking_issue_action']
+        code, document = self._extract('```json\n%s\n```' % json.dumps(verdict))
+        self.assertEqual(0, code)
+        self.assertEqual('none', document['tracking_issue_action'])
+
+    def test_markup_that_would_break_the_comment_is_stripped(self):
+        # The published contract is that a consumer can read the document back
+        # out of the last json block in the comment. A summary carrying a fence
+        # or a </details> ends the block early -- and it also stops
+        # neutralise-pr-body.sh defusing mentions, because that tracks fenced
+        # regions, so this is a security control as well as a formatting one.
+        code, document = self._extract('```json\n%s\n```' % json.dumps(dict(
+            VERDICT,
+            summary='It failed ``` here </details> and again ```json',
+            evidence=['</DETAILS> in the evidence too'])))
+        self.assertEqual(0, code)
+        self.assertNotIn('```', document['summary'])
+        self.assertNotIn('</details>', document['summary'].lower())
+        self.assertNotIn('</details>', document['evidence'][0].lower())
+
+        rendered = self._render(document)
+        embedded = rendered.split('```json\n')[-1].split('```')[0]
+        self.assertEqual(document, json.loads(embedded))
+        # And the details section still closes exactly once.
+        self.assertEqual(1, rendered.lower().count('</details>'))
+
+    def test_a_fenced_verdict_beats_a_bare_object_in_the_prose(self):
+        # The prompt asks for a fenced block, so a fenced one is the answer
+        # even when the model also wrote an object into its prose above.
+        bare = dict(VERDICT, verdict='pr_caused', summary='thinking aloud')
+        code, document = self._extract(
+            'Maybe %s\n\nFinal answer:\n```json\n%s\n```\n'
+            % (json.dumps(bare), json.dumps(VERDICT)))
+        self.assertEqual(0, code)
+        self.assertEqual('systemic', document['verdict'])

--- a/shakenfist/tests/test_merge_triage.py
+++ b/shakenfist/tests/test_merge_triage.py
@@ -472,6 +472,26 @@ class MergeTriageTestCase(base.ShakenFistTestCase):
         self.assertNotIn('<!--', rendered)
         self.assertIn('Re-queue as-is.', rendered)
 
+    def test_the_other_spelling_of_a_comment_end_is_stripped_too(self):
+        # An HTML comment ends at --!> as well as at -->: the parser's comment
+        # end bang state accepts both, so a filter which knows only the common
+        # spelling can be walked straight past -- the model closes its comment
+        # with --!> and everything the human reader was meant to lose reappears
+        # while the marker it forged stays intact. CodeQL reports the narrow
+        # pattern as py/bad-tag-filter for exactly this reason.
+        code, document = self._extract('```json\n%s\n```' % json.dumps(dict(
+            VERDICT,
+            summary='It failed --!> and the comment ended here',
+            evidence=['<!-- merge-triage run:99999 --!>'])))
+        self.assertEqual(0, code)
+        self.assertNotIn('--!>', document['summary'])
+        for value in document['evidence']:
+            self.assertNotIn('<!--', value)
+            self.assertNotIn('--!>', value)
+
+        rendered = self._render(document)
+        self.assertNotIn('--!>', rendered)
+
     def test_evidence_appended_after_extraction_cannot_break_the_comment(self):
         # merge-ci-triage.sh appends to evidence three times after extraction
         # -- the gather notes, the dry run note and the citation drop reason,

--- a/shakenfist/tests/test_merge_triage_workflow_seams.py
+++ b/shakenfist/tests/test_merge_triage_workflow_seams.py
@@ -1,0 +1,147 @@
+# Copyright 2026 Michael Still and contributors
+
+"""Tests for how merge-failure-triage.yml wires up its helper scripts.
+
+`tools/merge-triage.py` has its own unit tests, but a tested script the
+workflow does not call is not an extraction and not a defence -- the same
+argument test_issue_fix_workflow_seams.py makes. These pin the seams between
+the workflow and the shell.
+
+The one worth explaining is the staging. The model runs with
+`--dangerously-skip-permissions` and the checkout as its working directory,
+and the checkout holds a copy of every script this job executes. So the whole
+set is copied into `runner.temp` before the model starts and run from there,
+which closes two different holes at once: bash reads a script lazily as it
+executes, so an edit to the running driver would corrupt it mid-run, and the
+extractor and the neutraliser run *after* the model exits, so reading them
+from the workspace would mean parsing and defusing model output with a copy
+the model could have rewritten. `issue-fix.yml` stages the same set for the
+same two reasons.
+
+The other seams are cheap to get wrong and silent when wrong: an OUTPUT_DIR
+which no longer matches the artifact paths uploads nothing (`if-no-files-found:
+warn`, not `error`), and a permissions block which stops naming `actions: read`
+403s on every piece of evidence the triage gathers, because naming any scope
+sets every unnamed one to `none`.
+"""
+
+import os
+import re
+
+import yaml
+
+from shakenfist.tests import base
+
+
+# Everything tools/merge-ci-triage.sh reaches for through TOOLS_DIR, plus the
+# script itself. Kept here rather than derived, so that adding a helper to the
+# shell without staging it fails this test rather than failing in production
+# with the workspace copy.
+STAGED_TOOLS = [
+    'merge-ci-triage.sh',
+    'merge-triage.py',
+    'merge-triage-schema.json',
+    'claude-model-fallback.sh',
+    'neutralise-pr-body.sh',
+]
+
+STAGE_DIR = '${{ runner.temp }}/merge-triage-tools'
+OUTPUT_DIR = '${{ runner.temp }}/merge-triage'
+
+
+def _repo_root():
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.dirname(os.path.dirname(here))
+
+
+class MergeTriageWorkflowSeamsTestCase(base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+        self.root = _repo_root()
+        path = os.path.join(self.root, '.github', 'workflows',
+                            'merge-failure-triage.yml')
+        with open(path) as f:
+            self.text = f.read()
+        self.workflow = yaml.safe_load(self.text)
+        self.steps = self.workflow['jobs']['triage']['steps']
+
+    def _step(self, name):
+        for step in self.steps:
+            if step.get('name') == name:
+                return step
+        self.fail('no step named %r in the triage job' % name)
+
+    def test_every_tool_the_shell_uses_is_staged(self):
+        stage = self._step('Stage the triage tools outside the workspace')
+        self.assertEqual(STAGE_DIR, stage['env']['STAGE_DIR'])
+        for tool in STAGED_TOOLS:
+            self.assertTrue(
+                os.path.exists(os.path.join(self.root, 'tools', tool)),
+                'tools/%s does not exist, so staging it will fail the job' % tool)
+            self.assertIn(
+                'tools/%s' % tool, stage['run'],
+                'tools/%s is used by the triage but is not staged out of the '
+                'workspace, so the model could rewrite the copy that runs.'
+                % tool)
+
+    def test_the_staging_happens_before_the_model_runs(self):
+        names = [step.get('name') for step in self.steps]
+        self.assertLess(
+            names.index('Stage the triage tools outside the workspace'),
+            names.index('Triage the failure'),
+            'staging after the triage step stages nothing useful: the model '
+            'has already run by then.')
+
+    def test_the_triage_runs_the_staged_driver_not_the_workspace_one(self):
+        triage = self._step('Triage the failure')
+        self.assertIn('%s/merge-ci-triage.sh' % STAGE_DIR, triage['run'])
+        # The script finds its helpers beside itself, so running the workspace
+        # copy would pull every one of them back out of the tree the model can
+        # write to -- which is the whole point of the staging step.
+        self.assertFalse(
+            re.search(r'(^|\s)tools/merge-ci-triage\.sh', triage['run']),
+            'the triage runs the workspace copy of the driver')
+
+    def test_the_output_directory_is_what_the_artifact_uploads(self):
+        triage = self._step('Triage the failure')
+        self.assertEqual(OUTPUT_DIR, triage['env']['OUTPUT_DIR'])
+
+        publish = self._step('Publish the verdict')
+        paths = [p for p in publish['with']['path'].split('\n') if p.strip()]
+        self.assertIn('%s/triage.json' % OUTPUT_DIR, paths,
+                      'the verdict document is not uploaded, and '
+                      'if-no-files-found is warn, so this fails silently.')
+        for path in paths:
+            self.assertTrue(
+                path.startswith(OUTPUT_DIR + '/'),
+                '%s is not under OUTPUT_DIR, so nothing writes it' % path)
+
+    def test_scratch_files_never_land_in_the_workspace(self):
+        # runner.temp, not the checkout: the workspace is what the model is
+        # pointed at, and the evidence and the prompt are inputs to the
+        # verdict.
+        self.assertTrue(OUTPUT_DIR.startswith('${{ runner.temp }}/'))
+        self.assertTrue(STAGE_DIR.startswith('${{ runner.temp }}/'))
+
+    def test_actions_read_is_declared(self):
+        # Naming any scope in a permissions block sets every unnamed scope to
+        # none, and every piece of evidence this workflow gathers -- the run,
+        # its jobs, its failed step logs, the sibling merge group runs -- is an
+        # Actions API read. Without this the job reads nothing and triages an
+        # empty run.
+        self.assertEqual('read', self.workflow['permissions'].get('actions'))
+        self.assertEqual('write', self.workflow['permissions'].get('issues'))
+        self.assertEqual('write', self.workflow['permissions'].get('pull-requests'))
+
+    def test_the_comment_body_is_neutralised_by_the_shell(self):
+        # The workflow does not post the comment itself, so the seam that
+        # matters is in the driver: model prose reaches "gh pr comment" only
+        # through neutralise-pr-body.sh.
+        with open(os.path.join(self.root, 'tools', 'merge-ci-triage.sh')) as f:
+            script = f.read()
+        neutralise = script.index('neutralise-pr-body.sh')
+        comment = script.index('gh pr comment')
+        self.assertLess(
+            neutralise, comment,
+            'the comment body is posted before it is neutralised, so an '
+            '@mention or an issue-closing keyword fires on publication.')

--- a/shakenfist/tests/test_merge_triage_workflow_seams.py
+++ b/shakenfist/tests/test_merge_triage_workflow_seams.py
@@ -111,6 +111,12 @@ class MergeTriageWorkflowSeamsTestCase(base.ShakenFistTestCase):
         self.assertIn('%s/triage.json' % OUTPUT_DIR, paths,
                       'the verdict document is not uploaded, and '
                       'if-no-files-found is warn, so this fails silently.')
+        # Only written when the document failed our own schema, which is a
+        # bug in this tooling rather than a triage outcome. Leaving it behind
+        # on the runner discards the only evidence of that bug.
+        self.assertIn('%s/triage.invalid.json' % OUTPUT_DIR, paths,
+                      'a document which failed its own schema is not '
+                      'uploaded, so the bug that produced it is unreadable.')
         for path in paths:
             self.assertTrue(
                 path.startswith(OUTPUT_DIR + '/'),
@@ -136,12 +142,25 @@ class MergeTriageWorkflowSeamsTestCase(base.ShakenFistTestCase):
     def test_the_comment_body_is_neutralised_by_the_shell(self):
         # The workflow does not post the comment itself, so the seam that
         # matters is in the driver: model prose reaches "gh pr comment" only
-        # through neutralise-pr-body.sh.
+        # through neutralise-pr-body.sh, and only if that succeeded. The
+        # driver runs without "set -e", so an unchecked call here fails open
+        # -- it leaves the un-neutralised body exactly where the comment step
+        # reads it from. test_merge_ci_triage_shell.py tests the behaviour by
+        # running the driver with a neutraliser that fails; this pins the
+        # ordering, which that test cannot see.
         with open(os.path.join(self.root, 'tools', 'merge-ci-triage.sh')) as f:
             script = f.read()
-        neutralise = script.index('neutralise-pr-body.sh')
-        comment = script.index('gh pr comment')
+        # The invocations, not the prose about them: both are named in
+        # comments above the code that runs them.
+        neutralise = re.search(
+            r'(?m)^if ! "\$\{TOOLS_DIR\}/neutralise-pr-body\.sh"', script)
+        comment = re.search(r'(?m)^gh pr comment ', script)
+        self.assertIsNotNone(
+            neutralise,
+            'the neutralisation result is discarded, so a failure inside it '
+            'publishes the un-neutralised body.')
+        self.assertIsNotNone(comment, 'the driver no longer posts a comment')
         self.assertLess(
-            neutralise, comment,
+            neutralise.start(), comment.start(),
             'the comment body is posted before it is neutralised, so an '
             '@mention or an issue-closing keyword fires on publication.')

--- a/shakenfist/tests/test_merge_triage_workflow_seams.py
+++ b/shakenfist/tests/test_merge_triage_workflow_seams.py
@@ -33,6 +33,12 @@ import yaml
 from shakenfist.tests import base
 
 
+# The workflow whose merge group failures this triages. Matched by workflow
+# *name*, which is the seam test_the_trigger_names_the_functional_test_workflow
+# exists for.
+TRIGGERED_BY = os.path.join('.github', 'workflows', 'functional-tests.yml')
+
+
 # Everything tools/merge-ci-triage.sh reaches for through TOOLS_DIR, plus the
 # script itself. Kept here rather than derived, so that adding a helper to the
 # shell without staging it fails this test rather than failing in production
@@ -64,6 +70,11 @@ class MergeTriageWorkflowSeamsTestCase(base.ShakenFistTestCase):
             self.text = f.read()
         self.workflow = yaml.safe_load(self.text)
         self.steps = self.workflow['jobs']['triage']['steps']
+
+    def _triggers(self):
+        # YAML 1.1 reads a bare "on" as the boolean true, which is what
+        # yaml.safe_load implements and what GitHub's own parser does not.
+        return self.workflow.get('on', self.workflow.get(True))
 
     def _step(self, name):
         for step in self.steps:
@@ -129,6 +140,35 @@ class MergeTriageWorkflowSeamsTestCase(base.ShakenFistTestCase):
         self.assertTrue(OUTPUT_DIR.startswith('${{ runner.temp }}/'))
         self.assertTrue(STAGE_DIR.startswith('${{ runner.temp }}/'))
 
+    def test_the_trigger_names_the_functional_test_workflow(self):
+        # workflow_run matches by the workflow's name, not its filename, so
+        # renaming the "name:" in functional-tests.yml disables this triage
+        # silently and forever: no failing check, no skipped run, no comment
+        # on an ejected pull request. It is the only seam here whose breakage
+        # produces total silence rather than a failure.
+        with open(os.path.join(self.root, TRIGGERED_BY)) as f:
+            triggering = yaml.safe_load(f)
+
+        self.assertIn(
+            triggering['name'], self._triggers()['workflow_run']['workflows'],
+            '%s is named %r, which this workflow does not listen for'
+            % (TRIGGERED_BY, triggering['name']))
+
+    def test_the_trigger_only_fires_for_failed_merge_group_runs(self):
+        # Two halves of one gate. The branches filter is what stops a skipped
+        # run appearing for every pull request run of the test suite, and
+        # workflow_run carries no conclusion filter at all, so "did it fail?"
+        # can only live in the job's if:.
+        self.assertEqual(
+            ['gh-readonly-queue/**'],
+            self._triggers()['workflow_run']['branches'],
+            'without the branches filter this is invoked for every pull '
+            'request run of the test suite as well')
+
+        gate = self.workflow['jobs']['triage']['if']
+        self.assertIn("github.event.workflow_run.event == 'merge_group'", gate)
+        self.assertIn("github.event.workflow_run.conclusion == 'failure'", gate)
+
     def test_actions_read_is_declared(self):
         # Naming any scope in a permissions block sets every unnamed scope to
         # none, and every piece of evidence this workflow gathers -- the run,
@@ -154,7 +194,7 @@ class MergeTriageWorkflowSeamsTestCase(base.ShakenFistTestCase):
         # comments above the code that runs them.
         neutralise = re.search(
             r'(?m)^if ! "\$\{TOOLS_DIR\}/neutralise-pr-body\.sh"', script)
-        comment = re.search(r'(?m)^gh pr comment ', script)
+        comment = re.search(r'(?m)^if ! gh pr comment ', script)
         self.assertIsNotNone(
             neutralise,
             'the neutralisation result is discarded, so a failure inside it '

--- a/tools/claude-model-fallback.sh
+++ b/tools/claude-model-fallback.sh
@@ -19,6 +19,18 @@
 # running a separate pre-flight probe, which would cost real money on every
 # run in which the preferred model *is* available.
 #
+# PASS A LARGE PROMPT WITH --prompt-file, NOT AS A CLAUDE ARGUMENT. Linux caps
+# a single argv element at MAX_ARG_STRLEN, a hard 128KiB which no ulimit
+# raises, and an exec over it fails outright with "Argument list too long" --
+# so the model never runs and the caller sees an empty answer rather than an
+# error it can name. A prompt carrying CI logs reaches that size easily.
+# --prompt-file hands the prompt to claude on stdin, which has no such limit.
+# It takes a path, and the redirect is made again for each attempt, because
+# this wrapper may run claude more than once: a stream -- the wrapper's own
+# stdin, or one descriptor opened before the loop -- is drained by the first
+# model, and the fallback would run against an empty prompt and answer
+# confidently about nothing.
+#
 # Usage:
 #   tools/claude-model-fallback.sh [options] -- <claude args...>
 #   tools/claude-model-fallback.sh --check MODEL
@@ -26,6 +38,9 @@
 # Options:
 #   --models LIST  Comma-separated models to try in order
 #                  (default: claude-fable-5,claude-opus-5)
+#   --prompt-file FILE
+#                  Read the prompt from FILE, on stdin, rather than passing it
+#                  as a claude argument. Required for a prompt of any size.
 #   --quiet        Suppress the "falling back" notice on stderr
 #   --check MODEL  Probe MODEL only and exit; 0 = available, 1 = out of
 #                  credit. Note that a successful probe costs a small
@@ -50,6 +65,7 @@ set -uo pipefail
 models='claude-fable-5,claude-opus-5'
 quiet=0
 check_model=''
+prompt_file=''
 output_format='text'
 claude_args=()
 
@@ -62,6 +78,10 @@ Usage:
 Options:
   --models LIST  Comma-separated models to try in order
                  (default: claude-fable-5,claude-opus-5)
+  --prompt-file FILE
+                 Read the prompt from FILE, on stdin, rather than passing it
+                 as a claude argument. Required for a prompt of any size: a
+                 single argument is capped at 128KiB by the kernel.
   --quiet        Suppress the "falling back" notice on stderr
   --check MODEL  Probe MODEL only and exit; 0 = available, 1 = out of credit
   --help         Show this help message
@@ -88,6 +108,15 @@ while [ $# -gt 0 ]; do
             models="${1#*=}"
             shift
             ;;
+        --prompt-file)
+            [ $# -ge 2 ] || { echo 'claude-model-fallback: --prompt-file needs a value' >&2; exit 2; }
+            prompt_file="$2"
+            shift 2
+            ;;
+        --prompt-file=*)
+            prompt_file="${1#*=}"
+            shift
+            ;;
         --quiet)
             quiet=1
             shift
@@ -112,6 +141,11 @@ while [ $# -gt 0 ]; do
 done
 
 command -v jq > /dev/null || { echo 'claude-model-fallback: jq is required' >&2; exit 2; }
+
+if [ -n "${prompt_file}" ] && [ ! -r "${prompt_file}" ]; then
+    echo "claude-model-fallback: prompt file '${prompt_file}' cannot be read" >&2
+    exit 2
+fi
 
 # --check: probe a single model with a throwaway prompt.
 if [ -n "${check_model}" ]; then
@@ -161,15 +195,23 @@ case "${output_format}" in
         ;;
 esac
 
-[ "${#claude_args[@]}" -gt 0 ] || {
+if [ "${#claude_args[@]}" -eq 0 ] && [ -z "${prompt_file}" ]; then
     echo 'claude-model-fallback: no claude arguments given' >&2
     exit 2
-}
+fi
 
 rc=0
 IFS=',' read -ra model_list <<< "${models}"
 for model in "${model_list[@]}"; do
-    out=$(claude -p --output-format json --model "${model}" "${claude_args[@]}")
+    if [ -n "${prompt_file}" ]; then
+        # Reopened for each attempt rather than being one stream shared by
+        # all of them: a stream is drained by the first model and the fallback
+        # would see an empty prompt. See the note at the top of this script.
+        out=$(claude -p --output-format json --model "${model}" \
+            "${claude_args[@]}" < "${prompt_file}")
+    else
+        out=$(claude -p --output-format json --model "${model}" "${claude_args[@]}")
+    fi
     rc=$?
 
     status=$(jq -r '.api_error_status // empty' <<< "${out}" 2>/dev/null)

--- a/tools/merge-ci-triage.sh
+++ b/tools/merge-ci-triage.sh
@@ -164,7 +164,6 @@ fi
 run_event=$(jq -r '.event // ""' "${OUTPUT_DIR}/run.json")
 run_conclusion=$(jq -r '.conclusion // ""' "${OUTPUT_DIR}/run.json")
 head_branch=$(jq -r '.headBranch // ""' "${OUTPUT_DIR}/run.json")
-run_url=$(jq -r '.url // ""' "${OUTPUT_DIR}/run.json")
 run_attempt=$(jq -r '.attempt // 1' "${OUTPUT_DIR}/run.json")
 
 echo "merge-ci-triage: ${REPO} run ${RUN_ID} (${run_event}, ${run_conclusion}) on ${head_branch}"
@@ -187,6 +186,14 @@ fi
 
 base_branch=$(jq -r '.base_branch // ""' "${ENVELOPE_JSON}")
 pr_number=$(jq -r '.pull_request // ""' "${ENVELOPE_JSON}")
+
+# From the envelope rather than from run.json, so that the URL in the prompt
+# and the URL the citation check greps for are the one the document publishes.
+# The envelope builder substitutes the URL the run must have when GitHub gave
+# none, which matters here more than it looks: "grep -qF ''" matches every
+# non-empty input, so an empty pattern below would not fail the citation
+# check, it would pass it against any issue in the repository.
+run_url=$(jq -r '.run_url // ""' "${ENVELOPE_JSON}")
 
 # ---------------------------------------------------------------------------
 # Gather the evidence
@@ -234,9 +241,10 @@ if [ "${log_bytes}" -le $((LOG_HEAD_BYTES + LOG_TAIL_BYTES)) ]; then
 else
     {
         head -c "${LOG_HEAD_BYTES}" "${OUTPUT_DIR}/failed-logs.full.txt"
-        printf '\n\n[... %s bytes elided by triage: this is the first %s and the last %s bytes of the failed step logs ...]\n\n' \
-            "$((log_bytes - LOG_HEAD_BYTES - LOG_TAIL_BYTES))" \
-            "${LOG_HEAD_BYTES}" "${LOG_TAIL_BYTES}"
+        printf '\n\n[... %s bytes elided by triage: this is the first %s ' \
+            "$((log_bytes - LOG_HEAD_BYTES - LOG_TAIL_BYTES))" "${LOG_HEAD_BYTES}"
+        printf 'and the last %s bytes of the failed step logs ...]\n\n' \
+            "${LOG_TAIL_BYTES}"
         tail -c "${LOG_TAIL_BYTES}" "${OUTPUT_DIR}/failed-logs.full.txt"
     } > "${OUTPUT_DIR}/failed-logs.txt"
 fi
@@ -512,9 +520,18 @@ if [ -n "${tracking_issue}" ]; then
 
         # The run URL rather than the bare id: the digits of a run id turn up
         # in unrelated URLs on a long issue, and the prompt asks for the URL.
-        if ! printf '%s\n%s\n' "${issue_body}" "${issue_comments}" \
+        if [ -z "${run_url}" ]; then
+            # Unreachable while the envelope builder substitutes a URL, and
+            # the document would not have validated without one either. Kept
+            # because the alternative to failing closed here is a grep for the
+            # empty string, which reports every issue as carrying the
+            # reference rather than none of them.
+            drop_reason="Triage cited issue #${tracking_issue}, but this run's URL is unknown"
+            drop_reason="${drop_reason}, so the claim that the occurrence was recorded there could not be checked."
+        elif ! printf '%s\n%s\n' "${issue_body}" "${issue_comments}" \
                 | grep -qF "${run_url}"; then
-            drop_reason="Triage said it recorded this occurrence on issue #${tracking_issue}, but nothing there references ${run_url}. The issue is kept as a reference only."
+            drop_reason="Triage said it recorded this occurrence on issue #${tracking_issue}, but nothing"
+            drop_reason="${drop_reason} there references ${run_url}. The issue is kept as a reference only."
         fi
     fi
 
@@ -579,7 +596,17 @@ mv "${OUTPUT_DIR}/comment.body.md" "${OUTPUT_DIR}/comment.md"
 # taken back should not rest on the model having complied. The markup which
 # would break the comment's own structure is already gone, stripped by
 # merge-triage.py before the document was written.
-"${TOOLS_DIR}/neutralise-pr-body.sh" "${OUTPUT_DIR}/comment.md"
+#
+# Nothing is posted if this fails. It rewrites the file in place through a
+# temporary copy, so a failure anywhere inside it leaves the original,
+# un-neutralised body exactly where "gh pr comment" would read it from -- and
+# this script runs without "set -e". A triage nobody sees is a smaller problem
+# than a triage which fires an @mention or an issue-closing keyword on
+# publication, which is the whole reason the neutralisation is here.
+if ! "${TOOLS_DIR}/neutralise-pr-body.sh" "${OUTPUT_DIR}/comment.md"; then
+    echo "merge-ci-triage: the comment body could not be neutralised, not posting it" >&2
+    exit 1
+fi
 
 if [ "${DRY_RUN}" = "true" ]; then
     echo "merge-ci-triage: dry run, not commenting on the pull request"
@@ -591,8 +618,13 @@ if [ -z "${pr_number}" ]; then
     exit "${exit_status}"
 fi
 
-if gh pr view "${pr_number}" --repo "${REPO}" --json comments \
-        --jq '[.comments[].body] | join("\n")' 2>/dev/null \
+# Paged, and through the issues API rather than "gh pr view --json comments":
+# the GraphQL layer behind that caps a pull request at its first hundred
+# comments, so on a long-lived pull request the earlier marker falls off the
+# end and a re-delivered workflow_run posts a second copy of the same verdict.
+# The citation check above pages for the same reason.
+if gh api --paginate "repos/${REPO}/issues/${pr_number}/comments" \
+        --jq '.[].body' 2>/dev/null \
         | grep -qF "${marker}"; then
     echo "merge-ci-triage: run ${RUN_ID} has already been triaged on #${pr_number}"
     exit "${exit_status}"

--- a/tools/merge-ci-triage.sh
+++ b/tools/merge-ci-triage.sh
@@ -5,11 +5,11 @@
 #
 #   merge-ci-triage.sh <run id>
 #
-# Reproduces, unattended, what a maintainer does by hand with the
-# merge-ci-triage skill: work out whether a merge_group failure was caused by
-# the pull request in the merge group or by something systemic, record a
-# systemic failure against its tracking issue, and say whether the pull
-# request should be re-queued as-is or fixed first.
+# Reproduces, unattended, what a maintainer does by hand after a merge queue
+# ejection: work out whether the failure was caused by the pull request in the
+# merge group or by something systemic, record a systemic failure against its
+# tracking issue, and say whether the pull request should be re-queued as-is or
+# fixed first. docs/developer_guide/ci.md describes the procedure.
 #
 # Environment:
 #   REPO            owner/repo to triage in (default: GITHUB_REPOSITORY)
@@ -19,26 +19,43 @@
 #   MAX_TURNS       turn cap for the triage run
 #   DRY_RUN         "true" to classify without writing anything to GitHub
 #   TRIAGE_RUN_URL  URL of the run doing the triage, recorded in the verdict
-#   GH_TOKEN        token for gh, as usual
+#   GH_TOKEN        token for gh, as usual. Needs actions:read to read the
+#                   failed run at all, plus issues:write and
+#                   pull-requests:write to publish anything.
 #
 # The deliverable is $OUTPUT_DIR/triage.json, a document matching
 # tools/merge-triage-schema.json. It is written whatever happens -- a model
-# which produces nothing usable yields a verdict of "unknown" rather than no
-# file -- because the private-ci conductor consumes these to track which merge
-# failures have been triaged and which of them blamed the pull request. A
-# missing document is indistinguishable from a triage that never ran; an
-# "unknown" one is not.
+# which produces nothing usable, or a run which cannot be read at all, yields
+# a verdict of "unknown" rather than no file -- because the private-ci
+# conductor consumes these to track which merge failures have been triaged and
+# which of them blamed the pull request. A missing document is
+# indistinguishable from a triage that never ran; an "unknown" one is not.
+# That promise is kept by an EXIT trap over an envelope written before
+# anything can fail, so it holds for the paths which fall over early rather
+# than only for the ones which reach a model.
 #
-# Two things the model reports are checked rather than believed, on the same
+# The one exception is a run which is not a failed merge_group run at all.
+# Nothing was triaged, so there is nothing to publish a verdict about.
+#
+# Three things the model reports are checked rather than believed, on the same
 # argument the issue-fix workflow makes when it re-runs the test suite the
 # model claims to have run:
 #
-# - The envelope (repository, run id, pull request number) is written here from
-#   what GitHub said, and overwrites whatever the model put in those fields.
-# - A tracking issue the model says it commented on has to exist, and has to
-#   carry a reference to this run. A verdict which cites an issue that does not
-#   mention the failure is downgraded to "no issue", because the conductor
-#   treats a cited issue as evidence the occurrence was recorded.
+# - The envelope (repository, run id, pull request number) is built by
+#   tools/merge-triage.py from what GitHub said, and overwrites whatever the
+#   model put in those fields.
+# - A tracking issue the model says it commented on has to exist, and the
+#   issue or one of its comments has to carry this run's URL. A verdict which
+#   cites an issue that does not mention the failure is downgraded to "no
+#   issue", because the conductor treats a cited issue as evidence the
+#   occurrence was recorded. The comments are paged through in full: a
+#   long-lived flake issue accumulates one comment per occurrence, and reading
+#   only the first page would false-drop the comment just written.
+# - Evidence that could not be gathered is recorded as such. A model handed an
+#   empty log and asked for a verdict will still produce one, and the prompt's
+#   own heuristics push an evidence-free run towards "systemic, re-queue" --
+#   which is precisely the confidently wrong document the rest of this design
+#   works to prevent. With nothing readable at all, no model is run.
 #
 # The pull request comment carries the same JSON in a collapsed details
 # section, mirroring the automated reviewer, so the verdict can be recovered
@@ -49,6 +66,14 @@ set -uo pipefail
 RUN_ID="${1:-}"
 if [ -z "${RUN_ID}" ]; then
     echo "usage: merge-ci-triage.sh <run id>" >&2
+    exit 2
+fi
+
+# Before anything else, because this value ends up in the envelope -- the part
+# of the document the design says nothing untrusted can influence -- and the
+# workflow accepts it as a string from workflow_dispatch.
+if ! [[ "${RUN_ID}" =~ ^[0-9]+$ ]]; then
+    echo "merge-ci-triage: run id must be numeric, got '${RUN_ID}'" >&2
     exit 2
 fi
 
@@ -68,21 +93,53 @@ TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mkdir -p "${OUTPUT_DIR}"
 echo "merge-ci-triage: working in ${OUTPUT_DIR}"
 
+TRIAGE_JSON="${OUTPUT_DIR}/triage.json"
+ENVELOPE_JSON="${OUTPUT_DIR}/envelope.json"
+
+# The minimum envelope, written before the first thing that can fail. It is
+# replaced with the full one as soon as GitHub has been asked about the run;
+# until then it is what lets a failure still publish a document.
+cat > "${ENVELOPE_JSON}" <<ENVELOPE_EOF
+{
+  "repository": "${REPO}",
+  "run_id": ${RUN_ID},
+  "run_url": "https://github.com/${REPO}/actions/runs/${RUN_ID}",
+  "triage_run_url": $([ -n "${TRIAGE_RUN_URL}" ] && echo "\"${TRIAGE_RUN_URL}\"" || echo null)
+}
+ENVELOPE_EOF
+
+publish_document=true
+failure_reason='Triage exited before it reached a verdict.'
+
+publish_fallback_on_exit() {
+    if [ "${publish_document}" != "true" ]; then
+        return
+    fi
+    if [ -f "${TRIAGE_JSON}" ]; then
+        return
+    fi
+    python3 "${TOOLS_DIR}/merge-triage.py" fallback \
+        "${ENVELOPE_JSON}" "${TRIAGE_JSON}" "${failure_reason}" \
+        || echo "merge-ci-triage: could not write a fallback document" >&2
+    echo "merge-ci-triage: no verdict was reached: ${failure_reason}" >&2
+}
+trap publish_fallback_on_exit EXIT
+
 # ---------------------------------------------------------------------------
 # What are we looking at?
 # ---------------------------------------------------------------------------
 
 if ! gh run view "${RUN_ID}" --repo "${REPO}" \
-        --json event,conclusion,headBranch,headSha,url,attempt,workflowName,createdAt \
+        --json databaseId,event,conclusion,headBranch,headSha,url,attempt,workflowName,createdAt \
         > "${OUTPUT_DIR}/run.json"; then
-    echo "merge-ci-triage: could not read run ${RUN_ID} in ${REPO}" >&2
+    failure_reason="The failed run ${RUN_ID} could not be read from ${REPO}. The token needs actions:read."
+    echo "merge-ci-triage: ${failure_reason}" >&2
     exit 1
 fi
 
 run_event=$(jq -r '.event // ""' "${OUTPUT_DIR}/run.json")
 run_conclusion=$(jq -r '.conclusion // ""' "${OUTPUT_DIR}/run.json")
 head_branch=$(jq -r '.headBranch // ""' "${OUTPUT_DIR}/run.json")
-head_sha=$(jq -r '.headSha // ""' "${OUTPUT_DIR}/run.json")
 run_url=$(jq -r '.url // ""' "${OUTPUT_DIR}/run.json")
 run_attempt=$(jq -r '.attempt // 1' "${OUTPUT_DIR}/run.json")
 
@@ -90,68 +147,101 @@ echo "merge-ci-triage: ${REPO} run ${RUN_ID} (${run_event}, ${run_conclusion}) o
 
 # The workflow filters on these too, but this script is also run by hand
 # against a run id, and triaging a green run or a pull request run would
-# produce a confident verdict about nothing.
+# produce a confident verdict about nothing. Nothing was triaged, so this is
+# the one exit which publishes no document.
 if [ "${run_event}" != "merge_group" ] || [ "${run_conclusion}" != "failure" ]; then
     echo "merge-ci-triage: not a failed merge_group run, nothing to triage" >&2
+    publish_document=false
     exit 0
 fi
 
-# gh-readonly-queue/<base>/pr-<number>-<sha>. The queue on the branches this
-# runs against is serial, so a merge group holds exactly one pull request and
-# the number in the ref is it. A parse failure is survivable: triage still runs
-# and the verdict simply has no pull request to attach itself to.
-base_branch=$(echo "${head_branch}" | sed -n 's|^gh-readonly-queue/\(.*\)/pr-[0-9][0-9]*-[0-9a-f]*$|\1|p')
-pr_number=$(echo "${head_branch}" | sed -n 's|^gh-readonly-queue/.*/pr-\([0-9][0-9]*\)-[0-9a-f]*$|\1|p')
-if [ -z "${pr_number}" ]; then
-    echo "merge-ci-triage: could not parse a pull request number out of '${head_branch}'" >&2
+if ! python3 "${TOOLS_DIR}/merge-triage.py" envelope \
+        "${REPO}" "${OUTPUT_DIR}/run.json" "${ENVELOPE_JSON}" "${TRIAGE_RUN_URL}"; then
+    failure_reason='The run metadata could not be turned into a verdict envelope.'
+    exit 1
 fi
 
+base_branch=$(jq -r '.base_branch // ""' "${ENVELOPE_JSON}")
+pr_number=$(jq -r '.pull_request // ""' "${ENVELOPE_JSON}")
+
 # ---------------------------------------------------------------------------
-# Gather the evidence the skill's step 1 asks for
+# Gather the evidence
 # ---------------------------------------------------------------------------
 
-gh run view "${RUN_ID}" --repo "${REPO}" --json jobs \
-    --jq '[.jobs[] | select(.conclusion == "failure") |
-           {job: .name, url: .url,
-            failed_steps: [.steps[] | select(.conclusion == "failure") | .name]}]' \
-    > "${OUTPUT_DIR}/failed-jobs.json" 2>/dev/null || echo '[]' > "${OUTPUT_DIR}/failed-jobs.json"
+# Anything that could not be read is recorded and travels with the verdict.
+# Silence here is how a model ends up classifying a failure it was never shown.
+gather_notes=()
+
+if ! gh run view "${RUN_ID}" --repo "${REPO}" --json jobs \
+        --jq '[.jobs[] | select(.conclusion == "failure") |
+               {job: .name, url: .url,
+                failed_steps: [.steps[] | select(.conclusion == "failure") | .name]}]' \
+        > "${OUTPUT_DIR}/failed-jobs.json" 2>/dev/null; then
+    echo '[]' > "${OUTPUT_DIR}/failed-jobs.json"
+    gather_notes+=('Triage could not read the list of failed jobs for this run.')
+fi
 
 # --log-failed is only the failed steps, which is the part worth reading, but
 # a cluster build can still emit megabytes of it. The cap is on bytes rather
 # than lines because one wrapped ansible line can be thousands of characters.
+# The exit status of this pipeline is deliberately ignored: head closes the
+# pipe once it has its bytes, which kills gh with SIGPIPE on any log longer
+# than the cap -- that is the successful case, not a failure. Whether anything
+# arrived is the question that matters, and the file answers it.
 gh run view "${RUN_ID}" --repo "${REPO}" --log-failed 2>/dev/null \
     | head -c 120000 > "${OUTPUT_DIR}/failed-logs.txt" || true
+if [ ! -s "${OUTPUT_DIR}/failed-logs.txt" ]; then
+    gather_notes+=('Triage could not read the logs of the failed steps; they may have aged out of retention.')
+fi
 
 # Sibling merge groups, for the "is this happening to everybody?" question
 # which is what separates systemic from PR-caused more reliably than the log
 # does.
-gh run list --repo "${REPO}" --event merge_group --limit 20 \
-    --json databaseId,conclusion,headBranch,createdAt,url \
-    > "${OUTPUT_DIR}/sibling-runs.json" 2>/dev/null || echo '[]' > "${OUTPUT_DIR}/sibling-runs.json"
-
-if [ -n "${pr_number}" ]; then
-    gh pr view "${pr_number}" --repo "${REPO}" --json number,title,author,files,body \
-        > "${OUTPUT_DIR}/pr.json" 2>/dev/null || echo '{}' > "${OUTPUT_DIR}/pr.json"
-else
-    echo '{}' > "${OUTPUT_DIR}/pr.json"
+if ! gh run list --repo "${REPO}" --event merge_group --limit 20 \
+        --json databaseId,conclusion,headBranch,createdAt,url \
+        > "${OUTPUT_DIR}/sibling-runs.json" 2>/dev/null; then
+    echo '[]' > "${OUTPUT_DIR}/sibling-runs.json"
+    gather_notes+=('Triage could not read other recent merge group runs, so no correlation was possible.')
 fi
 
+echo '{}' > "${OUTPUT_DIR}/pr.json"
+if [ -n "${pr_number}" ]; then
+    if ! gh pr view "${pr_number}" --repo "${REPO}" --json number,title,author,files,body \
+            > "${OUTPUT_DIR}/pr.json" 2>/dev/null; then
+        echo '{}' > "${OUTPUT_DIR}/pr.json"
+        gather_notes+=("Triage could not read pull request #${pr_number}, so the diff was not considered.")
+    fi
+else
+    gather_notes+=("No pull request number could be parsed out of '${head_branch}'.")
+fi
+
+failed_job_count=$(jq 'length' "${OUTPUT_DIR}/failed-jobs.json" 2>/dev/null || echo 0)
+
 # ---------------------------------------------------------------------------
-# Build the prompt
+# Classify
 # ---------------------------------------------------------------------------
 
-if [ "${DRY_RUN}" = "true" ]; then
-    github_writes="DRY RUN: do not write anything to GitHub. Do not comment on
+if [ "${failed_job_count}" -eq 0 ] && [ ! -s "${OUTPUT_DIR}/failed-logs.txt" ]; then
+    # No jobs and no logs is not a hard case for a model, it is an absent one.
+    # Asking anyway buys a confident verdict drawn entirely from the prompt's
+    # own heuristics.
+    echo "merge-ci-triage: nothing about the failure could be read, not running a model" >&2
+    python3 "${TOOLS_DIR}/merge-triage.py" fallback \
+        "${ENVELOPE_JSON}" "${TRIAGE_JSON}" \
+        'Neither the failed jobs nor their logs could be read, so there was nothing to classify.'
+else
+    if [ "${DRY_RUN}" = "true" ]; then
+        github_writes="DRY RUN: do not write anything to GitHub. Do not comment on
           or create any issue. Report in the JSON what you would have done,
           with tracking_issue_action set to \"none\"."
-else
-    github_writes="You may comment on an existing issue, or create a new one,
+    else
+        github_writes="You may comment on an existing issue, or create a new one,
           using gh. Do not comment on the pull request -- this workflow posts
           the verdict there itself. Do not push code, do not modify the pull
           request, and do not close anything."
-fi
+    fi
 
-cat > "${OUTPUT_DIR}/prompt.txt" <<PROMPT_EOF
+    cat > "${OUTPUT_DIR}/prompt.txt" <<PROMPT_EOF
 You are triaging a failed merge queue CI run for ${REPO}. This is a
 non-interactive, single-shot run: everything you need to do must happen in this
 turn, and nothing is waiting to ask you a question afterwards.
@@ -160,7 +250,6 @@ The failure:
 
 - Run: ${run_url} (id ${RUN_ID}, attempt ${run_attempt})
 - Merge group ref: ${head_branch}
-- Merge commit: ${head_sha}
 - Pull request in the merge group: ${pr_number:-unknown}
 - Base branch: ${base_branch:-unknown}
 
@@ -173,6 +262,10 @@ Your job, in order:
      gh run view ${RUN_ID} --repo ${REPO} --log-failed
      gh pr diff ${pr_number:-N} --repo ${REPO}
      gh run list --repo ${REPO} --event merge_group --limit 20
+
+   Anything listed under "What could not be read" below is missing, not
+   uninteresting. Say so in your evidence and lower your confidence
+   accordingly rather than filling the gap with a plausible story.
 
 2. Classify the failure as pr_caused, systemic, or ambiguous.
 
@@ -216,8 +309,10 @@ Your job, in order:
    already in flight or the issue needs human design work rather than a
    same-day patch, since the issue-fix workflow skips labelled issues.
 
-   Your comment or issue body MUST contain the run URL. It is what a later
-   triage matches on to avoid recording the same occurrence twice.
+   Your comment or issue body MUST contain the run URL ${run_url} verbatim. It
+   is checked: a cited issue which does not reference this run is dropped from
+   the verdict, because a consumer reads a cited issue as proof the occurrence
+   was recorded.
 
    ${github_writes}
 
@@ -239,15 +334,23 @@ Your job, in order:
 }
 \`\`\`
 
-  - tracking_issue is the issue number you commented on or created, or null.
-    It is checked: an issue which does not exist, or which carries no
-    reference to this run, is dropped from the verdict.
+  - tracking_issue is the issue number you commented on or created, or null,
+    and tracking_issue_action says which. Report "none" if you wrote nothing:
+    an unbacked claim is dropped, so it buys you nothing.
   - recommendation is requeue for a systemic failure the pull request cannot
     fix, fix_first when the pull request needs a change, investigate when a
     human has to decide.
   - Do not put an @ in front of any username anywhere in your output, and do
     not write "fixes", "closes" or "resolves" before an issue number. Both do
     something irreversible when this is posted.
+
+# What could not be read
+
+$(if [ ${#gather_notes[@]} -eq 0 ]; then
+    echo 'Everything listed below was gathered successfully.'
+else
+    printf -- '- %s\n' "${gather_notes[@]}"
+fi)
 
 # Failed jobs and steps
 
@@ -269,84 +372,105 @@ $(jq -r 'if .number then "#\(.number) \(.title) by \(.author.login // "unknown")
 $(cat "${OUTPUT_DIR}/failed-logs.txt")
 PROMPT_EOF
 
-# ---------------------------------------------------------------------------
-# Run the triage
-# ---------------------------------------------------------------------------
+    echo "merge-ci-triage: running triage with models ${MODELS}"
+    "${TOOLS_DIR}/claude-model-fallback.sh" \
+        --models "${MODELS}" \
+        -- "$(cat "${OUTPUT_DIR}/prompt.txt")" \
+        --dangerously-skip-permissions \
+        --max-turns "${MAX_TURNS}" \
+        --output-format text \
+        2>&1 | tee "${OUTPUT_DIR}/response.txt" \
+        || true
 
-echo "merge-ci-triage: running triage with models ${MODELS}"
-"${TOOLS_DIR}/claude-model-fallback.sh" \
-    --models "${MODELS}" \
-    -- "$(cat "${OUTPUT_DIR}/prompt.txt")" \
-    --dangerously-skip-permissions \
-    --max-turns "${MAX_TURNS}" \
-    --output-format text \
-    2>&1 | tee "${OUTPUT_DIR}/response.txt" \
-    || true
+    if ! python3 "${TOOLS_DIR}/merge-triage.py" extract \
+            "${OUTPUT_DIR}/response.txt" "${ENVELOPE_JSON}" "${TRIAGE_JSON}"; then
+        echo "merge-ci-triage: triage produced no verdict, publishing the fallback document"
+    fi
 
-# ---------------------------------------------------------------------------
-# Turn the response into a verdict document
-# ---------------------------------------------------------------------------
-
-jq -n \
-    --arg repository "${REPO}" \
-    --arg run_url "${run_url}" \
-    --arg head_branch "${head_branch}" \
-    --arg head_sha "${head_sha}" \
-    --arg base_branch "${base_branch}" \
-    --arg triage_run_url "${TRIAGE_RUN_URL}" \
-    --argjson run_id "${RUN_ID}" \
-    --argjson run_attempt "${run_attempt}" \
-    --argjson pull_request "${pr_number:-null}" \
-    '{repository: $repository, run_id: $run_id, run_url: $run_url,
-      run_attempt: $run_attempt, head_branch: $head_branch, head_sha: $head_sha,
-      base_branch: (if $base_branch == "" then null else $base_branch end),
-      pull_request: $pull_request,
-      triage_run_url: (if $triage_run_url == "" then null else $triage_run_url end)}' \
-    > "${OUTPUT_DIR}/envelope.json"
-
-python3 "${TOOLS_DIR}/merge-triage.py" extract \
-    "${OUTPUT_DIR}/response.txt" "${OUTPUT_DIR}/envelope.json" "${OUTPUT_DIR}/triage.json"
-extract_status=$?
-if [ "${extract_status}" -ne 0 ]; then
-    echo "merge-ci-triage: triage produced no verdict, publishing the fallback document"
+    # Whatever could not be gathered travels with the verdict, so a reader is
+    # never left to assume the model saw everything.
+    if [ ${#gather_notes[@]} -gt 0 ]; then
+        printf '%s\n' "${gather_notes[@]}" | jq -R . | jq -s . \
+            > "${OUTPUT_DIR}/gather-notes.json"
+        jq --slurpfile notes "${OUTPUT_DIR}/gather-notes.json" \
+            '.evidence += $notes[0]' "${TRIAGE_JSON}" \
+            > "${TRIAGE_JSON}.notes" && mv "${TRIAGE_JSON}.notes" "${TRIAGE_JSON}"
+    fi
 fi
 
-# Check the tracking issue rather than believing it. A cited issue is how the
-# conductor knows an occurrence was recorded, so a citation which is not backed
-# by a comment naming this run is worse than no citation at all.
-tracking_issue=$(jq -r '.tracking_issue // empty' "${OUTPUT_DIR}/triage.json")
+# ---------------------------------------------------------------------------
+# Check what the model said it did
+# ---------------------------------------------------------------------------
+
+if [ "${DRY_RUN}" = "true" ]; then
+    # Nothing was written to GitHub, whatever the model believes, and the
+    # document must not claim an occurrence was recorded. Forced here rather
+    # than left to the prompt: this is the field a consumer is told to trust.
+    jq '.tracking_issue_action = "none" |
+        .evidence += ["This was a dry run: nothing was written to GitHub."]' \
+        "${TRIAGE_JSON}" > "${TRIAGE_JSON}.dry" \
+        && mv "${TRIAGE_JSON}.dry" "${TRIAGE_JSON}"
+fi
+
+# Run whenever an issue is cited, not only when the document claims a write:
+# a dry run has already been forced to "none" above, and gating the check on
+# the action would mean the verification path was never exercised except in
+# production. What differs in a dry run is the consequence -- the note is
+# recorded, but the citation is left in place, because "the issue it would
+# have used" is the useful half of a dry run's output.
+tracking_issue=$(jq -r '.tracking_issue // empty' "${TRIAGE_JSON}")
 if [ -n "${tracking_issue}" ]; then
-    issue_text=""
-    if gh issue view "${tracking_issue}" --repo "${REPO}" \
-            --json body,comments > "${OUTPUT_DIR}/tracking-issue.json" 2>/dev/null; then
-        issue_text=$(jq -r '.body + "\n" + ([.comments[]?.body] | join("\n"))' \
-            "${OUTPUT_DIR}/tracking-issue.json")
-    fi
+    # The issue body plus every comment, paged in full. A tracking issue for a
+    # recurring flake carries one comment per occurrence, and a single page of
+    # them would stop short of the comment just written.
+    issue_text=$(
+        {
+            gh issue view "${tracking_issue}" --repo "${REPO}" --json body --jq '.body'
+            gh api --paginate "repos/${REPO}/issues/${tracking_issue}/comments" \
+                --jq '.[].body'
+        } 2>/dev/null)
 
     drop_reason=""
     if [ -z "${issue_text}" ]; then
         drop_reason="Triage cited issue #${tracking_issue}, which could not be read in ${REPO}."
-    elif ! echo "${issue_text}" | grep -qF "${RUN_ID}"; then
-        drop_reason="Triage cited issue #${tracking_issue}, but nothing on that issue references run ${RUN_ID}."
+    elif ! echo "${issue_text}" | grep -qF "${run_url}"; then
+        # The run URL rather than the bare id: the digits of a run id turn up
+        # in unrelated URLs on a long issue, and the prompt asks for the URL.
+        drop_reason="Triage cited issue #${tracking_issue}, but nothing there references ${run_url}."
     fi
 
-    if [ -n "${drop_reason}" ] && [ "${DRY_RUN}" != "true" ]; then
+    if [ -n "${drop_reason}" ]; then
         echo "merge-ci-triage: ${drop_reason}"
-        jq --arg reason "${drop_reason}" \
-            '.tracking_issue = null | .tracking_issue_action = "none" |
-             .evidence += [$reason]' \
-            "${OUTPUT_DIR}/triage.json" > "${OUTPUT_DIR}/triage.checked.json" \
-            && mv "${OUTPUT_DIR}/triage.checked.json" "${OUTPUT_DIR}/triage.json"
+        if [ "${DRY_RUN}" = "true" ]; then
+            jq --arg reason "${drop_reason}" '.evidence += [$reason]' \
+                "${TRIAGE_JSON}" > "${TRIAGE_JSON}.checked" \
+                && mv "${TRIAGE_JSON}.checked" "${TRIAGE_JSON}"
+        else
+            jq --arg reason "${drop_reason}" \
+                '.tracking_issue = null | .tracking_issue_action = "none" |
+                 .evidence += [$reason]' \
+                "${TRIAGE_JSON}" > "${TRIAGE_JSON}.checked" \
+                && mv "${TRIAGE_JSON}.checked" "${TRIAGE_JSON}"
+        fi
     fi
 fi
 
-if ! python3 "${TOOLS_DIR}/merge-triage.py" validate "${OUTPUT_DIR}/triage.json"; then
+exit_status=0
+if ! python3 "${TOOLS_DIR}/merge-triage.py" validate "${TRIAGE_JSON}"; then
+    # A document that fails our own schema is a bug here, not a triage
+    # outcome. It is replaced rather than published, because a consumer
+    # reading a malformed document is worse off than one reading an honest
+    # "no verdict" -- but the exit status still reports the bug.
     echo "merge-ci-triage: the verdict document does not validate, which is a bug here" >&2
-    exit 1
+    cp "${TRIAGE_JSON}" "${OUTPUT_DIR}/triage.invalid.json"
+    python3 "${TOOLS_DIR}/merge-triage.py" fallback \
+        "${ENVELOPE_JSON}" "${TRIAGE_JSON}" \
+        'The verdict document did not match the published schema and was discarded.'
+    exit_status=1
 fi
 
-verdict=$(jq -r '.verdict' "${OUTPUT_DIR}/triage.json")
-recommendation=$(jq -r '.recommendation' "${OUTPUT_DIR}/triage.json")
+verdict=$(jq -r '.verdict' "${TRIAGE_JSON}")
+recommendation=$(jq -r '.recommendation' "${TRIAGE_JSON}")
 echo "merge-ci-triage: verdict ${verdict}, recommendation ${recommendation}"
 
 # ---------------------------------------------------------------------------
@@ -354,7 +478,7 @@ echo "merge-ci-triage: verdict ${verdict}, recommendation ${recommendation}"
 # ---------------------------------------------------------------------------
 
 python3 "${TOOLS_DIR}/merge-triage.py" render \
-    "${OUTPUT_DIR}/triage.json" "${OUTPUT_DIR}/comment.md" || exit 1
+    "${TRIAGE_JSON}" "${OUTPUT_DIR}/comment.md" || exit 1
 
 # The marker is how a re-run of triage over the same failure recognises its own
 # earlier comment. It is invisible in the rendered comment.
@@ -365,32 +489,29 @@ mv "${OUTPUT_DIR}/comment.body.md" "${OUTPUT_DIR}/comment.md"
 # The body is model output. Neutralise the two constructs GitHub acts on
 # rather than renders, for the same reason the issue-fix workflow does: the
 # prompt forbids both, and a side effect which fires on posting and cannot be
-# taken back should not rest on the model having complied.
+# taken back should not rest on the model having complied. The markup which
+# would break the comment's own structure is already gone, stripped by
+# merge-triage.py before the document was written.
 "${TOOLS_DIR}/neutralise-pr-body.sh" "${OUTPUT_DIR}/comment.md"
 
 if [ "${DRY_RUN}" = "true" ]; then
     echo "merge-ci-triage: dry run, not commenting on the pull request"
-    exit 0
+    exit "${exit_status}"
 fi
 
 if [ -z "${pr_number}" ]; then
     echo "merge-ci-triage: no pull request to comment on"
-    exit 0
+    exit "${exit_status}"
 fi
 
-already_posted=false
 if gh pr view "${pr_number}" --repo "${REPO}" --json comments \
         --jq '[.comments[].body] | join("\n")' 2>/dev/null \
         | grep -qF "${marker}"; then
-    already_posted=true
-fi
-
-if [ "${already_posted}" = "true" ]; then
     echo "merge-ci-triage: run ${RUN_ID} has already been triaged on #${pr_number}"
-    exit 0
+    exit "${exit_status}"
 fi
 
 gh pr comment "${pr_number}" --repo "${REPO}" --body-file "${OUTPUT_DIR}/comment.md" \
     || echo "merge-ci-triage: could not comment on #${pr_number}" >&2
 
-exit 0
+exit "${exit_status}"

--- a/tools/merge-ci-triage.sh
+++ b/tools/merge-ci-triage.sh
@@ -14,9 +14,11 @@
 # Environment:
 #   REPO            owner/repo to triage in (default: GITHUB_REPOSITORY)
 #   OUTPUT_DIR      where evidence, the prompt and triage.json are written
-#                   (default: a mktemp directory, printed on exit)
+#                   (default: a mktemp directory, printed at startup)
 #   MODELS          comma separated models to try, in preference order
 #   MAX_TURNS       turn cap for the triage run
+#   LOG_HEAD_BYTES  bytes of the failed step logs kept from the start
+#   LOG_TAIL_BYTES  bytes kept from the end, where the error message is
 #   DRY_RUN         "true" to classify without writing anything to GitHub
 #   TRIAGE_RUN_URL  URL of the run doing the triage, recorded in the verdict
 #   GH_TOKEN        token for gh, as usual. Needs actions:read to read the
@@ -45,12 +47,14 @@
 #   tools/merge-triage.py from what GitHub said, and overwrites whatever the
 #   model put in those fields.
 # - A tracking issue the model says it commented on has to exist, and the
-#   issue or one of its comments has to carry this run's URL. A verdict which
-#   cites an issue that does not mention the failure is downgraded to "no
-#   issue", because the conductor treats a cited issue as evidence the
-#   occurrence was recorded. The comments are paged through in full: a
-#   long-lived flake issue accumulates one comment per occurrence, and reading
-#   only the first page would false-drop the comment just written.
+#   issue or one of its comments has to carry this run's URL. A claim which
+#   does not check out is downgraded to an action of "none" -- the number
+#   survives as a reference, the assertion that the occurrence was recorded
+#   does not -- because the conductor reads "commented" or "created" as proof
+#   the occurrence was filed. An issue which cannot be read at all is dropped
+#   outright. The comments are paged through in full: a long-lived flake issue
+#   accumulates one comment per occurrence, and reading only the first page
+#   would false-drop the comment just written.
 # - Evidence that could not be gathered is recorded as such. A model handed an
 #   empty log and asked for a verdict will still produce one, and the prompt's
 #   own heuristics push an evidence-free run towards "systemic, re-queue" --
@@ -60,6 +64,16 @@
 # The pull request comment carries the same JSON in a collapsed details
 # section, mirroring the automated reviewer, so the verdict can be recovered
 # from the thread as well as from the run's artifact.
+#
+# WHERE THIS SCRIPT IS RUN FROM MATTERS. Everything it invokes -- the model
+# wrapper, merge-triage.py, its schema, neutralise-pr-body.sh -- is found
+# beside it, and the model runs with --dangerously-skip-permissions in a
+# checkout which contains a copy of every one of them. The workflow therefore
+# copies the whole set into runner.temp and runs this script from there, so a
+# model which edits tools/ edits nothing that will subsequently be executed --
+# including this script, which bash reads lazily as it goes. Run by hand from
+# a checkout the copies are the checkout's, which is fine because by hand
+# there is no untrusted step in between.
 
 set -uo pipefail
 
@@ -80,6 +94,16 @@ fi
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 if [ -z "${REPO}" ]; then
     echo "merge-ci-triage: REPO or GITHUB_REPOSITORY must be set" >&2
+    exit 2
+fi
+
+# For the same reason as the run id above: REPO is interpolated into the
+# bootstrap envelope, and a value carrying a quote or a backslash would make
+# that JSON unparseable -- which breaks the one path whose whole job is to
+# still produce a document when everything else has failed. github.repository
+# cannot do that, but this script documents itself as runnable by hand.
+if ! [[ "${REPO}" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+    echo "merge-ci-triage: REPO must be owner/repo, got '${REPO}'" >&2
     exit 2
 fi
 
@@ -182,14 +206,40 @@ if ! gh run view "${RUN_ID}" --repo "${REPO}" --json jobs \
 fi
 
 # --log-failed is only the failed steps, which is the part worth reading, but
-# a cluster build can still emit megabytes of it. The cap is on bytes rather
-# than lines because one wrapped ansible line can be thousands of characters.
-# The exit status of this pipeline is deliberately ignored: head closes the
-# pipe once it has its bytes, which kills gh with SIGPIPE on any log longer
-# than the cap -- that is the successful case, not a failure. Whether anything
-# arrived is the question that matters, and the file answers it.
-gh run view "${RUN_ID}" --repo "${REPO}" --log-failed 2>/dev/null \
-    | head -c 120000 > "${OUTPUT_DIR}/failed-logs.txt" || true
+# a cluster build can still emit megabytes of it, so it is cut down to a
+# budget. The budget is in bytes rather than lines because one wrapped ansible
+# line can be thousands of characters.
+#
+# Both ends are kept, and the tail is the larger share. Keeping only the head
+# is the obvious implementation and it is wrong here: within a failed step the
+# message that says what actually broke is the last thing emitted, and a
+# single ansible cluster-build step routinely exceeds the whole budget in
+# progress output on its own. That is exactly the failure class this triage
+# sees most, so a head-only cut would hand the model the noise and elide the
+# diagnosis. The head is kept as well because the first failing task is what
+# says where in the build it got to.
+#
+# The full log is fetched to a file rather than piped through head, so that
+# the elision marker can state how much was dropped. gh's exit status is
+# ignored: whether anything arrived is the question that matters, and the file
+# answers it.
+LOG_HEAD_BYTES="${LOG_HEAD_BYTES:-40000}"
+LOG_TAIL_BYTES="${LOG_TAIL_BYTES:-80000}"
+
+gh run view "${RUN_ID}" --repo "${REPO}" --log-failed \
+    > "${OUTPUT_DIR}/failed-logs.full.txt" 2>/dev/null || true
+log_bytes=$(wc -c < "${OUTPUT_DIR}/failed-logs.full.txt")
+if [ "${log_bytes}" -le $((LOG_HEAD_BYTES + LOG_TAIL_BYTES)) ]; then
+    cp "${OUTPUT_DIR}/failed-logs.full.txt" "${OUTPUT_DIR}/failed-logs.txt"
+else
+    {
+        head -c "${LOG_HEAD_BYTES}" "${OUTPUT_DIR}/failed-logs.full.txt"
+        printf '\n\n[... %s bytes elided by triage: this is the first %s and the last %s bytes of the failed step logs ...]\n\n' \
+            "$((log_bytes - LOG_HEAD_BYTES - LOG_TAIL_BYTES))" \
+            "${LOG_HEAD_BYTES}" "${LOG_TAIL_BYTES}"
+        tail -c "${LOG_TAIL_BYTES}" "${OUTPUT_DIR}/failed-logs.full.txt"
+    } > "${OUTPUT_DIR}/failed-logs.txt"
+fi
 if [ ! -s "${OUTPUT_DIR}/failed-logs.txt" ]; then
     gather_notes+=('Triage could not read the logs of the failed steps; they may have aged out of retention.')
 fi
@@ -386,21 +436,30 @@ PROMPT_EOF
             "${OUTPUT_DIR}/response.txt" "${ENVELOPE_JSON}" "${TRIAGE_JSON}"; then
         echo "merge-ci-triage: triage produced no verdict, publishing the fallback document"
     fi
+fi
 
-    # Whatever could not be gathered travels with the verdict, so a reader is
-    # never left to assume the model saw everything.
-    if [ ${#gather_notes[@]} -gt 0 ]; then
-        printf '%s\n' "${gather_notes[@]}" | jq -R . | jq -s . \
-            > "${OUTPUT_DIR}/gather-notes.json"
-        jq --slurpfile notes "${OUTPUT_DIR}/gather-notes.json" \
-            '.evidence += $notes[0]' "${TRIAGE_JSON}" \
-            > "${TRIAGE_JSON}.notes" && mv "${TRIAGE_JSON}.notes" "${TRIAGE_JSON}"
-    fi
+# Whatever could not be gathered travels with the verdict, so a reader is never
+# left to assume the model saw everything. Outside the branch above, not inside
+# it: the run where nothing at all could be read is the run where a consumer
+# most needs to be told which pieces were missing, and that is precisely the
+# branch which does not run a model.
+if [ ${#gather_notes[@]} -gt 0 ]; then
+    printf '%s\n' "${gather_notes[@]}" | jq -R . | jq -s . \
+        > "${OUTPUT_DIR}/gather-notes.json"
+    jq --slurpfile notes "${OUTPUT_DIR}/gather-notes.json" \
+        '.evidence += $notes[0]' "${TRIAGE_JSON}" \
+        > "${TRIAGE_JSON}.notes" && mv "${TRIAGE_JSON}.notes" "${TRIAGE_JSON}"
 fi
 
 # ---------------------------------------------------------------------------
 # Check what the model said it did
 # ---------------------------------------------------------------------------
+
+# What the model said it did, read before a dry run overwrites it below. The
+# verification is about the claim, so it has to be the claim that is checked:
+# gating on the value left in the document would mean a dry run, which forces
+# "none", never exercised this path.
+claimed_action=$(jq -r '.tracking_issue_action // "none"' "${TRIAGE_JSON}")
 
 if [ "${DRY_RUN}" = "true" ]; then
     # Nothing was written to GitHub, whatever the model believes, and the
@@ -412,43 +471,71 @@ if [ "${DRY_RUN}" = "true" ]; then
         && mv "${TRIAGE_JSON}.dry" "${TRIAGE_JSON}"
 fi
 
-# Run whenever an issue is cited, not only when the document claims a write:
-# a dry run has already been forced to "none" above, and gating the check on
-# the action would mean the verification path was never exercised except in
-# production. What differs in a dry run is the consequence -- the note is
-# recorded, but the citation is left in place, because "the issue it would
-# have used" is the useful half of a dry run's output.
+# Two different things can be wrong with a citation, and they are not
+# interchangeable:
+#
+# - The issue cannot be read at all. Then the number is not even a useful
+#   pointer, and it goes.
+# - The issue exists but does not mention this run, and the model claimed to
+#   have written the occurrence there. The claim is what fails, not the
+#   citation: the action drops to "none" and the number stays, which is what
+#   "referenced only, nothing recorded" means and is strictly more useful to a
+#   reader than no number at all.
+#
+# A citation whose claimed action is already "none" is *not* checked for the
+# run URL. By definition nothing was written to it, so it will not reference
+# this run, and checking anyway would drop every reference-only citation ever
+# made -- making that documented state unreachable in production.
 tracking_issue=$(jq -r '.tracking_issue // empty' "${TRIAGE_JSON}")
 if [ -n "${tracking_issue}" ]; then
-    # The issue body plus every comment, paged in full. A tracking issue for a
-    # recurring flake carries one comment per occurrence, and a single page of
-    # them would stop short of the comment just written.
-    issue_text=$(
-        {
-            gh issue view "${tracking_issue}" --repo "${REPO}" --json body --jq '.body'
-            gh api --paginate "repos/${REPO}/issues/${tracking_issue}/comments" \
-                --jq '.[].body'
-        } 2>/dev/null)
-
+    drop_citation=false
     drop_reason=""
-    if [ -z "${issue_text}" ]; then
+
+    # Readability is the exit status, not the emptiness of the output. "gh api"
+    # prints the error body of a 404 on stdout, so an issue which does not
+    # exist yields plenty of text -- and a real issue may legitimately have an
+    # empty body. Testing the text would confuse the two in both directions.
+    if ! issue_body=$(gh issue view "${tracking_issue}" --repo "${REPO}" \
+            --json body --jq '.body' 2>/dev/null); then
+        drop_citation=true
         drop_reason="Triage cited issue #${tracking_issue}, which could not be read in ${REPO}."
-    elif ! echo "${issue_text}" | grep -qF "${run_url}"; then
+    elif [ "${claimed_action}" != "none" ]; then
+        # Every comment, paged in full, and only on the path that needs them: a
+        # tracking issue for a recurring flake carries one comment per
+        # occurrence, and a single page of them would stop short of the comment
+        # just written.
+        if ! issue_comments=$(gh api --paginate \
+                "repos/${REPO}/issues/${tracking_issue}/comments" \
+                --jq '.[].body' 2>/dev/null); then
+            issue_comments=""
+        fi
+
         # The run URL rather than the bare id: the digits of a run id turn up
         # in unrelated URLs on a long issue, and the prompt asks for the URL.
-        drop_reason="Triage cited issue #${tracking_issue}, but nothing there references ${run_url}."
+        if ! printf '%s\n%s\n' "${issue_body}" "${issue_comments}" \
+                | grep -qF "${run_url}"; then
+            drop_reason="Triage said it recorded this occurrence on issue #${tracking_issue}, but nothing there references ${run_url}. The issue is kept as a reference only."
+        fi
     fi
 
     if [ -n "${drop_reason}" ]; then
         echo "merge-ci-triage: ${drop_reason}"
         if [ "${DRY_RUN}" = "true" ]; then
+            # A dry run wrote nothing, so there is no claim to take away. The
+            # finding is still recorded: "the issue it would have used" is the
+            # useful half of a dry run's output.
             jq --arg reason "${drop_reason}" '.evidence += [$reason]' \
+                "${TRIAGE_JSON}" > "${TRIAGE_JSON}.checked" \
+                && mv "${TRIAGE_JSON}.checked" "${TRIAGE_JSON}"
+        elif [ "${drop_citation}" = "true" ]; then
+            jq --arg reason "${drop_reason}" \
+                '.tracking_issue = null | .tracking_issue_action = "none" |
+                 .evidence += [$reason]' \
                 "${TRIAGE_JSON}" > "${TRIAGE_JSON}.checked" \
                 && mv "${TRIAGE_JSON}.checked" "${TRIAGE_JSON}"
         else
             jq --arg reason "${drop_reason}" \
-                '.tracking_issue = null | .tracking_issue_action = "none" |
-                 .evidence += [$reason]' \
+                '.tracking_issue_action = "none" | .evidence += [$reason]' \
                 "${TRIAGE_JSON}" > "${TRIAGE_JSON}.checked" \
                 && mv "${TRIAGE_JSON}.checked" "${TRIAGE_JSON}"
         fi
@@ -511,6 +598,12 @@ if gh pr view "${pr_number}" --repo "${REPO}" --json comments \
     exit "${exit_status}"
 fi
 
+# An "unknown" verdict is posted like any other, deliberately. It is a thin
+# comment, but the alternative is silence, and silence on an ejected pull
+# request reads as "triage did not run" -- which is the same ambiguity the
+# always-write-a-document rule exists to remove, just moved from the artifact
+# to the thread. The comment names why triage reached nothing, which is what
+# tells a maintainer whether to look at the run or at this workflow.
 gh pr comment "${pr_number}" --repo "${REPO}" --body-file "${OUTPUT_DIR}/comment.md" \
     || echo "merge-ci-triage: could not comment on #${pr_number}" >&2
 

--- a/tools/merge-ci-triage.sh
+++ b/tools/merge-ci-triage.sh
@@ -1,0 +1,396 @@
+#!/bin/bash
+# Copyright 2026 Michael Still and contributors
+#
+# Triage a failed merge queue CI run with Claude Code.
+#
+#   merge-ci-triage.sh <run id>
+#
+# Reproduces, unattended, what a maintainer does by hand with the
+# merge-ci-triage skill: work out whether a merge_group failure was caused by
+# the pull request in the merge group or by something systemic, record a
+# systemic failure against its tracking issue, and say whether the pull
+# request should be re-queued as-is or fixed first.
+#
+# Environment:
+#   REPO            owner/repo to triage in (default: GITHUB_REPOSITORY)
+#   OUTPUT_DIR      where evidence, the prompt and triage.json are written
+#                   (default: a mktemp directory, printed on exit)
+#   MODELS          comma separated models to try, in preference order
+#   MAX_TURNS       turn cap for the triage run
+#   DRY_RUN         "true" to classify without writing anything to GitHub
+#   TRIAGE_RUN_URL  URL of the run doing the triage, recorded in the verdict
+#   GH_TOKEN        token for gh, as usual
+#
+# The deliverable is $OUTPUT_DIR/triage.json, a document matching
+# tools/merge-triage-schema.json. It is written whatever happens -- a model
+# which produces nothing usable yields a verdict of "unknown" rather than no
+# file -- because the private-ci conductor consumes these to track which merge
+# failures have been triaged and which of them blamed the pull request. A
+# missing document is indistinguishable from a triage that never ran; an
+# "unknown" one is not.
+#
+# Two things the model reports are checked rather than believed, on the same
+# argument the issue-fix workflow makes when it re-runs the test suite the
+# model claims to have run:
+#
+# - The envelope (repository, run id, pull request number) is written here from
+#   what GitHub said, and overwrites whatever the model put in those fields.
+# - A tracking issue the model says it commented on has to exist, and has to
+#   carry a reference to this run. A verdict which cites an issue that does not
+#   mention the failure is downgraded to "no issue", because the conductor
+#   treats a cited issue as evidence the occurrence was recorded.
+#
+# The pull request comment carries the same JSON in a collapsed details
+# section, mirroring the automated reviewer, so the verdict can be recovered
+# from the thread as well as from the run's artifact.
+
+set -uo pipefail
+
+RUN_ID="${1:-}"
+if [ -z "${RUN_ID}" ]; then
+    echo "usage: merge-ci-triage.sh <run id>" >&2
+    exit 2
+fi
+
+REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
+if [ -z "${REPO}" ]; then
+    echo "merge-ci-triage: REPO or GITHUB_REPOSITORY must be set" >&2
+    exit 2
+fi
+
+OUTPUT_DIR="${OUTPUT_DIR:-$(mktemp -d)}"
+MODELS="${MODELS:-claude-fable-5,claude-opus-5}"
+MAX_TURNS="${MAX_TURNS:-60}"
+DRY_RUN="${DRY_RUN:-false}"
+TRIAGE_RUN_URL="${TRIAGE_RUN_URL:-}"
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+mkdir -p "${OUTPUT_DIR}"
+echo "merge-ci-triage: working in ${OUTPUT_DIR}"
+
+# ---------------------------------------------------------------------------
+# What are we looking at?
+# ---------------------------------------------------------------------------
+
+if ! gh run view "${RUN_ID}" --repo "${REPO}" \
+        --json event,conclusion,headBranch,headSha,url,attempt,workflowName,createdAt \
+        > "${OUTPUT_DIR}/run.json"; then
+    echo "merge-ci-triage: could not read run ${RUN_ID} in ${REPO}" >&2
+    exit 1
+fi
+
+run_event=$(jq -r '.event // ""' "${OUTPUT_DIR}/run.json")
+run_conclusion=$(jq -r '.conclusion // ""' "${OUTPUT_DIR}/run.json")
+head_branch=$(jq -r '.headBranch // ""' "${OUTPUT_DIR}/run.json")
+head_sha=$(jq -r '.headSha // ""' "${OUTPUT_DIR}/run.json")
+run_url=$(jq -r '.url // ""' "${OUTPUT_DIR}/run.json")
+run_attempt=$(jq -r '.attempt // 1' "${OUTPUT_DIR}/run.json")
+
+echo "merge-ci-triage: ${REPO} run ${RUN_ID} (${run_event}, ${run_conclusion}) on ${head_branch}"
+
+# The workflow filters on these too, but this script is also run by hand
+# against a run id, and triaging a green run or a pull request run would
+# produce a confident verdict about nothing.
+if [ "${run_event}" != "merge_group" ] || [ "${run_conclusion}" != "failure" ]; then
+    echo "merge-ci-triage: not a failed merge_group run, nothing to triage" >&2
+    exit 0
+fi
+
+# gh-readonly-queue/<base>/pr-<number>-<sha>. The queue on the branches this
+# runs against is serial, so a merge group holds exactly one pull request and
+# the number in the ref is it. A parse failure is survivable: triage still runs
+# and the verdict simply has no pull request to attach itself to.
+base_branch=$(echo "${head_branch}" | sed -n 's|^gh-readonly-queue/\(.*\)/pr-[0-9][0-9]*-[0-9a-f]*$|\1|p')
+pr_number=$(echo "${head_branch}" | sed -n 's|^gh-readonly-queue/.*/pr-\([0-9][0-9]*\)-[0-9a-f]*$|\1|p')
+if [ -z "${pr_number}" ]; then
+    echo "merge-ci-triage: could not parse a pull request number out of '${head_branch}'" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Gather the evidence the skill's step 1 asks for
+# ---------------------------------------------------------------------------
+
+gh run view "${RUN_ID}" --repo "${REPO}" --json jobs \
+    --jq '[.jobs[] | select(.conclusion == "failure") |
+           {job: .name, url: .url,
+            failed_steps: [.steps[] | select(.conclusion == "failure") | .name]}]' \
+    > "${OUTPUT_DIR}/failed-jobs.json" 2>/dev/null || echo '[]' > "${OUTPUT_DIR}/failed-jobs.json"
+
+# --log-failed is only the failed steps, which is the part worth reading, but
+# a cluster build can still emit megabytes of it. The cap is on bytes rather
+# than lines because one wrapped ansible line can be thousands of characters.
+gh run view "${RUN_ID}" --repo "${REPO}" --log-failed 2>/dev/null \
+    | head -c 120000 > "${OUTPUT_DIR}/failed-logs.txt" || true
+
+# Sibling merge groups, for the "is this happening to everybody?" question
+# which is what separates systemic from PR-caused more reliably than the log
+# does.
+gh run list --repo "${REPO}" --event merge_group --limit 20 \
+    --json databaseId,conclusion,headBranch,createdAt,url \
+    > "${OUTPUT_DIR}/sibling-runs.json" 2>/dev/null || echo '[]' > "${OUTPUT_DIR}/sibling-runs.json"
+
+if [ -n "${pr_number}" ]; then
+    gh pr view "${pr_number}" --repo "${REPO}" --json number,title,author,files,body \
+        > "${OUTPUT_DIR}/pr.json" 2>/dev/null || echo '{}' > "${OUTPUT_DIR}/pr.json"
+else
+    echo '{}' > "${OUTPUT_DIR}/pr.json"
+fi
+
+# ---------------------------------------------------------------------------
+# Build the prompt
+# ---------------------------------------------------------------------------
+
+if [ "${DRY_RUN}" = "true" ]; then
+    github_writes="DRY RUN: do not write anything to GitHub. Do not comment on
+          or create any issue. Report in the JSON what you would have done,
+          with tracking_issue_action set to \"none\"."
+else
+    github_writes="You may comment on an existing issue, or create a new one,
+          using gh. Do not comment on the pull request -- this workflow posts
+          the verdict there itself. Do not push code, do not modify the pull
+          request, and do not close anything."
+fi
+
+cat > "${OUTPUT_DIR}/prompt.txt" <<PROMPT_EOF
+You are triaging a failed merge queue CI run for ${REPO}. This is a
+non-interactive, single-shot run: everything you need to do must happen in this
+turn, and nothing is waiting to ask you a question afterwards.
+
+The failure:
+
+- Run: ${run_url} (id ${RUN_ID}, attempt ${run_attempt})
+- Merge group ref: ${head_branch}
+- Merge commit: ${head_sha}
+- Pull request in the merge group: ${pr_number:-unknown}
+- Base branch: ${base_branch:-unknown}
+
+Your job, in order:
+
+1. Work out what actually failed. The first failing step is the diagnosis;
+   later failures are usually cascade. The failed jobs and steps, and the logs
+   of the failed steps, are given below. You have gh and a checkout of the
+   default branch, so you can read more with:
+     gh run view ${RUN_ID} --repo ${REPO} --log-failed
+     gh pr diff ${pr_number:-N} --repo ${REPO}
+     gh run list --repo ${REPO} --event merge_group --limit 20
+
+2. Classify the failure as pr_caused, systemic, or ambiguous.
+
+   Signals the pull request caused it: the failing test exercises code the
+   diff changed; the failure looks deterministic (an assertion about behaviour
+   the diff altered, a lint or schema error in a changed file); the same job
+   passes on recent runs without this pull request.
+
+   Signals it is systemic: the failure is in code or infrastructure the diff
+   did not touch; infrastructure symptoms such as timeouts, connection
+   refused, no SSH prompt, capacity errors, or cluster provisioning failing
+   before tests run; the same signature in other recent merge_group runs; the
+   pull request already passed the identical suite in its pull_request run.
+
+   In this repository specifically: merge groups launch several nested test
+   clusters at once, so merge CI is far more sensitive to under-cloud capacity
+   than pull request CI, and historically most merge failures have been
+   environmental rather than code regressions. A first failing step in cluster
+   provisioning is almost always infrastructure. If it is a functional test,
+   check the known flake issues before concluding it is a new bug.
+
+   If it is genuinely ambiguous, say so. Do not manufacture confidence.
+
+3. For a systemic failure, record the occurrence. Search open issues for the
+   failure signature first, trying several phrasings, and check recently
+   closed ones too -- most merge CI failures here are recurrences, not novel:
+     gh issue list --repo ${REPO} --search 'TEST_NAME' --state open
+     gh issue list --repo ${REPO} --search '"key error phrase"' --state all --limit 10
+
+   If a tracking issue exists, comment on it recording this occurrence: the
+   date, the run URL ${run_url}, which pull request hit it, the failing job and
+   step, a few lines of log showing it is the same signature, and anything new
+   this occurrence adds. Read the recent comments first and do not double-post
+   an occurrence which is already recorded.
+
+   If nothing tracks it, create an issue. The title must be the failure
+   signature, specific enough that the search above finds it next time. The
+   body needs the run URL, the pull request, the first failing step, a log
+   excerpt, and why you believe it is systemic. Note that it was found during
+   automated merge CI triage. Add the label automated-fix-attempted if a fix is
+   already in flight or the issue needs human design work rather than a
+   same-day patch, since the issue-fix workflow skips labelled issues.
+
+   Your comment or issue body MUST contain the run URL. It is what a later
+   triage matches on to avoid recording the same occurrence twice.
+
+   ${github_writes}
+
+4. Emit your verdict as a single JSON object in a fenced json block, as the
+   last thing you output. Nothing after it. The fields:
+
+\`\`\`json
+{
+  "verdict": "pr_caused | systemic | ambiguous",
+  "confidence": "high | medium | low",
+  "summary": "One paragraph: what failed, and why the verdict is what it is.",
+  "failing_job": "name of the first failing job",
+  "failing_step": "name of the first failing step",
+  "failure_signature": "short stable string for grouping recurrences, e.g. a test name or key error phrase",
+  "recommendation": "requeue | fix_first | investigate",
+  "tracking_issue": 1234,
+  "tracking_issue_action": "commented | created | none",
+  "evidence": ["short factual observations the verdict rests on"]
+}
+\`\`\`
+
+  - tracking_issue is the issue number you commented on or created, or null.
+    It is checked: an issue which does not exist, or which carries no
+    reference to this run, is dropped from the verdict.
+  - recommendation is requeue for a systemic failure the pull request cannot
+    fix, fix_first when the pull request needs a change, investigate when a
+    human has to decide.
+  - Do not put an @ in front of any username anywhere in your output, and do
+    not write "fixes", "closes" or "resolves" before an issue number. Both do
+    something irreversible when this is posted.
+
+# Failed jobs and steps
+
+$(cat "${OUTPUT_DIR}/failed-jobs.json")
+
+# Recent merge_group runs on this repository
+
+$(jq -r '.[] | "- \(.createdAt) \(.conclusion // "in progress") \(.headBranch) \(.url)"' \
+    "${OUTPUT_DIR}/sibling-runs.json" 2>/dev/null || true)
+
+# The pull request in the merge group
+
+$(jq -r 'if .number then "#\(.number) \(.title) by \(.author.login // "unknown")\n\nFiles changed:\n" +
+         ([.files[]? | "- \(.path) (+\(.additions)/-\(.deletions))"] | join("\n")) else "unknown" end' \
+    "${OUTPUT_DIR}/pr.json" 2>/dev/null || true)
+
+# Logs of the failed steps (truncated)
+
+$(cat "${OUTPUT_DIR}/failed-logs.txt")
+PROMPT_EOF
+
+# ---------------------------------------------------------------------------
+# Run the triage
+# ---------------------------------------------------------------------------
+
+echo "merge-ci-triage: running triage with models ${MODELS}"
+"${TOOLS_DIR}/claude-model-fallback.sh" \
+    --models "${MODELS}" \
+    -- "$(cat "${OUTPUT_DIR}/prompt.txt")" \
+    --dangerously-skip-permissions \
+    --max-turns "${MAX_TURNS}" \
+    --output-format text \
+    2>&1 | tee "${OUTPUT_DIR}/response.txt" \
+    || true
+
+# ---------------------------------------------------------------------------
+# Turn the response into a verdict document
+# ---------------------------------------------------------------------------
+
+jq -n \
+    --arg repository "${REPO}" \
+    --arg run_url "${run_url}" \
+    --arg head_branch "${head_branch}" \
+    --arg head_sha "${head_sha}" \
+    --arg base_branch "${base_branch}" \
+    --arg triage_run_url "${TRIAGE_RUN_URL}" \
+    --argjson run_id "${RUN_ID}" \
+    --argjson run_attempt "${run_attempt}" \
+    --argjson pull_request "${pr_number:-null}" \
+    '{repository: $repository, run_id: $run_id, run_url: $run_url,
+      run_attempt: $run_attempt, head_branch: $head_branch, head_sha: $head_sha,
+      base_branch: (if $base_branch == "" then null else $base_branch end),
+      pull_request: $pull_request,
+      triage_run_url: (if $triage_run_url == "" then null else $triage_run_url end)}' \
+    > "${OUTPUT_DIR}/envelope.json"
+
+python3 "${TOOLS_DIR}/merge-triage.py" extract \
+    "${OUTPUT_DIR}/response.txt" "${OUTPUT_DIR}/envelope.json" "${OUTPUT_DIR}/triage.json"
+extract_status=$?
+if [ "${extract_status}" -ne 0 ]; then
+    echo "merge-ci-triage: triage produced no verdict, publishing the fallback document"
+fi
+
+# Check the tracking issue rather than believing it. A cited issue is how the
+# conductor knows an occurrence was recorded, so a citation which is not backed
+# by a comment naming this run is worse than no citation at all.
+tracking_issue=$(jq -r '.tracking_issue // empty' "${OUTPUT_DIR}/triage.json")
+if [ -n "${tracking_issue}" ]; then
+    issue_text=""
+    if gh issue view "${tracking_issue}" --repo "${REPO}" \
+            --json body,comments > "${OUTPUT_DIR}/tracking-issue.json" 2>/dev/null; then
+        issue_text=$(jq -r '.body + "\n" + ([.comments[]?.body] | join("\n"))' \
+            "${OUTPUT_DIR}/tracking-issue.json")
+    fi
+
+    drop_reason=""
+    if [ -z "${issue_text}" ]; then
+        drop_reason="Triage cited issue #${tracking_issue}, which could not be read in ${REPO}."
+    elif ! echo "${issue_text}" | grep -qF "${RUN_ID}"; then
+        drop_reason="Triage cited issue #${tracking_issue}, but nothing on that issue references run ${RUN_ID}."
+    fi
+
+    if [ -n "${drop_reason}" ] && [ "${DRY_RUN}" != "true" ]; then
+        echo "merge-ci-triage: ${drop_reason}"
+        jq --arg reason "${drop_reason}" \
+            '.tracking_issue = null | .tracking_issue_action = "none" |
+             .evidence += [$reason]' \
+            "${OUTPUT_DIR}/triage.json" > "${OUTPUT_DIR}/triage.checked.json" \
+            && mv "${OUTPUT_DIR}/triage.checked.json" "${OUTPUT_DIR}/triage.json"
+    fi
+fi
+
+if ! python3 "${TOOLS_DIR}/merge-triage.py" validate "${OUTPUT_DIR}/triage.json"; then
+    echo "merge-ci-triage: the verdict document does not validate, which is a bug here" >&2
+    exit 1
+fi
+
+verdict=$(jq -r '.verdict' "${OUTPUT_DIR}/triage.json")
+recommendation=$(jq -r '.recommendation' "${OUTPUT_DIR}/triage.json")
+echo "merge-ci-triage: verdict ${verdict}, recommendation ${recommendation}"
+
+# ---------------------------------------------------------------------------
+# Publish
+# ---------------------------------------------------------------------------
+
+python3 "${TOOLS_DIR}/merge-triage.py" render \
+    "${OUTPUT_DIR}/triage.json" "${OUTPUT_DIR}/comment.md" || exit 1
+
+# The marker is how a re-run of triage over the same failure recognises its own
+# earlier comment. It is invisible in the rendered comment.
+marker="<!-- merge-triage run:${RUN_ID} -->"
+{ echo "${marker}"; echo; cat "${OUTPUT_DIR}/comment.md"; } > "${OUTPUT_DIR}/comment.body.md"
+mv "${OUTPUT_DIR}/comment.body.md" "${OUTPUT_DIR}/comment.md"
+
+# The body is model output. Neutralise the two constructs GitHub acts on
+# rather than renders, for the same reason the issue-fix workflow does: the
+# prompt forbids both, and a side effect which fires on posting and cannot be
+# taken back should not rest on the model having complied.
+"${TOOLS_DIR}/neutralise-pr-body.sh" "${OUTPUT_DIR}/comment.md"
+
+if [ "${DRY_RUN}" = "true" ]; then
+    echo "merge-ci-triage: dry run, not commenting on the pull request"
+    exit 0
+fi
+
+if [ -z "${pr_number}" ]; then
+    echo "merge-ci-triage: no pull request to comment on"
+    exit 0
+fi
+
+already_posted=false
+if gh pr view "${pr_number}" --repo "${REPO}" --json comments \
+        --jq '[.comments[].body] | join("\n")' 2>/dev/null \
+        | grep -qF "${marker}"; then
+    already_posted=true
+fi
+
+if [ "${already_posted}" = "true" ]; then
+    echo "merge-ci-triage: run ${RUN_ID} has already been triaged on #${pr_number}"
+    exit 0
+fi
+
+gh pr comment "${pr_number}" --repo "${REPO}" --body-file "${OUTPUT_DIR}/comment.md" \
+    || echo "merge-ci-triage: could not comment on #${pr_number}" >&2
+
+exit 0

--- a/tools/merge-ci-triage.sh
+++ b/tools/merge-ci-triage.sh
@@ -165,6 +165,7 @@ run_event=$(jq -r '.event // ""' "${OUTPUT_DIR}/run.json")
 run_conclusion=$(jq -r '.conclusion // ""' "${OUTPUT_DIR}/run.json")
 head_branch=$(jq -r '.headBranch // ""' "${OUTPUT_DIR}/run.json")
 run_attempt=$(jq -r '.attempt // 1' "${OUTPUT_DIR}/run.json")
+workflow_name=$(jq -r '.workflowName // ""' "${OUTPUT_DIR}/run.json")
 
 echo "merge-ci-triage: ${REPO} run ${RUN_ID} (${run_event}, ${run_conclusion}) on ${head_branch}"
 
@@ -230,8 +231,26 @@ fi
 # the elision marker can state how much was dropped. gh's exit status is
 # ignored: whether anything arrived is the question that matters, and the file
 # answers it.
+#
+# The budget is about what a model can usefully attend to and what the run
+# costs, not about what can be passed to it: the prompt reaches the model as a
+# file on stdin, so the 128KiB kernel limit on a single argument does not
+# apply. See the --prompt-file note in tools/claude-model-fallback.sh.
 LOG_HEAD_BYTES="${LOG_HEAD_BYTES:-40000}"
 LOG_TAIL_BYTES="${LOG_TAIL_BYTES:-80000}"
+
+# head -c and tail -c cut at a byte offset, which is the right unit here, but
+# the cut can land in the middle of a multi-byte character and leave invalid
+# UTF-8 at the join -- which then travels into the prompt and into prompt.txt
+# in the run's artifact. iconv -c drops the partial sequence. Without iconv the
+# cut is used as it is: a byte of mojibake is a smaller problem than no logs.
+valid_utf8() {
+    if command -v iconv > /dev/null; then
+        iconv -f UTF-8 -t UTF-8 -c
+    else
+        cat
+    fi
+}
 
 gh run view "${RUN_ID}" --repo "${REPO}" --log-failed \
     > "${OUTPUT_DIR}/failed-logs.full.txt" 2>/dev/null || true
@@ -240,12 +259,12 @@ if [ "${log_bytes}" -le $((LOG_HEAD_BYTES + LOG_TAIL_BYTES)) ]; then
     cp "${OUTPUT_DIR}/failed-logs.full.txt" "${OUTPUT_DIR}/failed-logs.txt"
 else
     {
-        head -c "${LOG_HEAD_BYTES}" "${OUTPUT_DIR}/failed-logs.full.txt"
+        head -c "${LOG_HEAD_BYTES}" "${OUTPUT_DIR}/failed-logs.full.txt" | valid_utf8
         printf '\n\n[... %s bytes elided by triage: this is the first %s ' \
             "$((log_bytes - LOG_HEAD_BYTES - LOG_TAIL_BYTES))" "${LOG_HEAD_BYTES}"
         printf 'and the last %s bytes of the failed step logs ...]\n\n' \
             "${LOG_TAIL_BYTES}"
-        tail -c "${LOG_TAIL_BYTES}" "${OUTPUT_DIR}/failed-logs.full.txt"
+        tail -c "${LOG_TAIL_BYTES}" "${OUTPUT_DIR}/failed-logs.full.txt" | valid_utf8
     } > "${OUTPUT_DIR}/failed-logs.txt"
 fi
 if [ ! -s "${OUTPUT_DIR}/failed-logs.txt" ]; then
@@ -255,7 +274,21 @@ fi
 # Sibling merge groups, for the "is this happening to everybody?" question
 # which is what separates systemic from PR-caused more reliably than the log
 # does.
-if ! gh run list --repo "${REPO}" --event merge_group --limit 20 \
+#
+# Scoped to the workflow that failed, because "--event merge_group" on its own
+# is every workflow in the repository: the twenty slots would be shared with
+# runs of unrelated workflows, diluting the one signal this list exists to
+# carry. The name comes from the failed run itself rather than being hardcoded,
+# so triaging some other workflow's merge group failure correlates against that
+# workflow.
+sibling_args=(--repo "${REPO}" --event merge_group --limit 20)
+sibling_command="gh run list --repo ${REPO} --event merge_group --limit 20"
+if [ -n "${workflow_name}" ]; then
+    sibling_args+=(--workflow "${workflow_name}")
+    sibling_command="${sibling_command} --workflow '${workflow_name}'"
+fi
+
+if ! gh run list "${sibling_args[@]}" \
         --json databaseId,conclusion,headBranch,createdAt,url \
         > "${OUTPUT_DIR}/sibling-runs.json" 2>/dev/null; then
     echo '[]' > "${OUTPUT_DIR}/sibling-runs.json"
@@ -319,7 +352,7 @@ Your job, in order:
    default branch, so you can read more with:
      gh run view ${RUN_ID} --repo ${REPO} --log-failed
      gh pr diff ${pr_number:-N} --repo ${REPO}
-     gh run list --repo ${REPO} --event merge_group --limit 20
+     ${sibling_command}
 
    Anything listed under "What could not be read" below is missing, not
    uninteresting. Say so in your evidence and lower your confidence
@@ -414,9 +447,11 @@ fi)
 
 $(cat "${OUTPUT_DIR}/failed-jobs.json")
 
-# Recent merge_group runs on this repository
+# Other recent merge_group runs of ${workflow_name:-this workflow}
 
-$(jq -r '.[] | "- \(.createdAt) \(.conclusion // "in progress") \(.headBranch) \(.url)"' \
+$(jq -r --argjson this "${RUN_ID}" \
+    '.[] | select(.databaseId != $this) |
+     "- \(.createdAt) \(.conclusion // "in progress") \(.headBranch) \(.url)"' \
     "${OUTPUT_DIR}/sibling-runs.json" 2>/dev/null || true)
 
 # The pull request in the merge group
@@ -431,17 +466,42 @@ $(cat "${OUTPUT_DIR}/failed-logs.txt")
 PROMPT_EOF
 
     echo "merge-ci-triage: running triage with models ${MODELS}"
+
+    # The prompt goes to the model in a file, never as an argument. Linux caps
+    # a single argv element at 128KiB whatever ulimit says, and this prompt is
+    # mostly log: the default budget alone lands within a few kilobytes of that
+    # ceiling before a single failed job, sibling run or changed file is added.
+    # An argument over the cap does not truncate, it fails the exec with
+    # "Argument list too long" -- so the model never runs, and it never runs on
+    # exactly the failures this triage exists for, the ones whose failed step
+    # emitted megabytes. claude-model-fallback.sh feeds the file on stdin.
     "${TOOLS_DIR}/claude-model-fallback.sh" \
         --models "${MODELS}" \
-        -- "$(cat "${OUTPUT_DIR}/prompt.txt")" \
+        --prompt-file "${OUTPUT_DIR}/prompt.txt" \
+        -- \
         --dangerously-skip-permissions \
         --max-turns "${MAX_TURNS}" \
         --output-format text \
-        2>&1 | tee "${OUTPUT_DIR}/response.txt" \
-        || true
+        2>&1 | tee "${OUTPUT_DIR}/response.txt"
+    model_status=${PIPESTATUS[0]}
+
+    # "The model answered in prose" and "the model could not be run at all"
+    # are different failures with different remedies, and only the first is
+    # about the model. Every model in the list being out of subscription
+    # credit, a crashed CLI, an exec that never happened: all of those exit
+    # non-zero here, and reporting them as an unparseable answer sends a
+    # maintainer to read a response file which explains nothing. The status is
+    # the only thing that separates them, so it is not thrown away.
+    model_error='The triage response contained no JSON verdict object.'
+    if [ "${model_status}" -ne 0 ]; then
+        gather_notes+=("The triage model could not be run: the model wrapper exited ${model_status}.")
+        model_error="The triage model could not be run: the model wrapper exited ${model_status}."
+        model_error="${model_error} See response.txt in this run's artifact."
+    fi
 
     if ! python3 "${TOOLS_DIR}/merge-triage.py" extract \
-            "${OUTPUT_DIR}/response.txt" "${ENVELOPE_JSON}" "${TRIAGE_JSON}"; then
+            "${OUTPUT_DIR}/response.txt" "${ENVELOPE_JSON}" "${TRIAGE_JSON}" \
+            "${model_error}"; then
         echo "merge-ci-triage: triage produced no verdict, publishing the fallback document"
     fi
 fi
@@ -530,24 +590,40 @@ if [ -n "${tracking_issue}" ]; then
             drop_reason="${drop_reason}, so the claim that the occurrence was recorded there could not be checked."
         elif ! printf '%s\n%s\n' "${issue_body}" "${issue_comments}" \
                 | grep -qF "${run_url}"; then
-            drop_reason="Triage said it recorded this occurrence on issue #${tracking_issue}, but nothing"
-            drop_reason="${drop_reason} there references ${run_url}. The issue is kept as a reference only."
+            if [ "${DRY_RUN}" = "true" ]; then
+                # A dry run wrote nothing, so the absence of a reference is
+                # guaranteed and says nothing about whether the model would
+                # have written one. Reporting it in the words used for a claim
+                # that did not check out reads as a caught lie on the one path
+                # where the failure is certain and meaningless -- and dry runs
+                # are how a maintainer builds trust in this tooling.
+                drop_reason="Dry run: triage would have recorded this occurrence on issue"
+                drop_reason="${drop_reason} #${tracking_issue}. Nothing was written, so the citation is unverified."
+            else
+                drop_reason="Triage said it recorded this occurrence on issue #${tracking_issue}, but nothing"
+                drop_reason="${drop_reason} there references ${run_url}. The issue is kept as a reference only."
+            fi
         fi
     fi
 
     if [ -n "${drop_reason}" ]; then
         echo "merge-ci-triage: ${drop_reason}"
-        if [ "${DRY_RUN}" = "true" ]; then
+        if [ "${drop_citation}" = "true" ]; then
+            # Before the dry run branch, not after it: an issue which cannot be
+            # read is not a useful pointer whichever mode produced the
+            # citation, and testing the mode first would keep the number on a
+            # dry run -- inverting the documented contract on precisely the
+            # path a maintainer uses to inspect this behaviour by hand.
+            jq --arg reason "${drop_reason}" \
+                '.tracking_issue = null | .tracking_issue_action = "none" |
+                 .evidence += [$reason]' \
+                "${TRIAGE_JSON}" > "${TRIAGE_JSON}.checked" \
+                && mv "${TRIAGE_JSON}.checked" "${TRIAGE_JSON}"
+        elif [ "${DRY_RUN}" = "true" ]; then
             # A dry run wrote nothing, so there is no claim to take away. The
             # finding is still recorded: "the issue it would have used" is the
             # useful half of a dry run's output.
             jq --arg reason "${drop_reason}" '.evidence += [$reason]' \
-                "${TRIAGE_JSON}" > "${TRIAGE_JSON}.checked" \
-                && mv "${TRIAGE_JSON}.checked" "${TRIAGE_JSON}"
-        elif [ "${drop_citation}" = "true" ]; then
-            jq --arg reason "${drop_reason}" \
-                '.tracking_issue = null | .tracking_issue_action = "none" |
-                 .evidence += [$reason]' \
                 "${TRIAGE_JSON}" > "${TRIAGE_JSON}.checked" \
                 && mv "${TRIAGE_JSON}.checked" "${TRIAGE_JSON}"
         else
@@ -636,7 +712,14 @@ fi
 # always-write-a-document rule exists to remove, just moved from the artifact
 # to the thread. The comment names why triage reached nothing, which is what
 # tells a maintainer whether to look at the run or at this workflow.
-gh pr comment "${pr_number}" --repo "${REPO}" --body-file "${OUTPUT_DIR}/comment.md" \
-    || echo "merge-ci-triage: could not comment on #${pr_number}" >&2
+if ! gh pr comment "${pr_number}" --repo "${REPO}" \
+        --body-file "${OUTPUT_DIR}/comment.md"; then
+    # Red, rather than a green run with nothing on the pull request. The
+    # verdict survives in the artifact either way, but a missing comment is
+    # indistinguishable from a triage that never ran -- the ambiguity this
+    # design exists to remove -- so the run itself has to carry the signal.
+    echo "merge-ci-triage: could not comment on #${pr_number}" >&2
+    exit_status=1
+fi
 
 exit "${exit_status}"

--- a/tools/merge-triage-schema.json
+++ b/tools/merge-triage-schema.json
@@ -70,8 +70,8 @@
       "description": "How firmly the evidence supports the verdict"
     },
     "summary": {
-      "type": "string",
-      "description": "One paragraph statement of what failed and why the verdict is what it is"
+      "type": ["string", "null"],
+      "description": "One paragraph statement of what failed and why the verdict is what it is. Null when the model gave a verdict without one, which is not a reason to discard the verdict."
     },
     "failing_job": {
       "type": ["string", "null"],

--- a/tools/merge-triage-schema.json
+++ b/tools/merge-triage-schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shakenfist.com/merge-triage-schema.json",
+  "title": "Merge queue failure triage",
+  "description": "Structured verdict from the automated merge CI triage job. The envelope fields are written by the workflow from GitHub's own data; the remainder is the model's verdict.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "repository",
+    "run_id",
+    "run_url",
+    "verdict",
+    "recommendation",
+    "triaged_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "description": "Version of this document format. Consumers should ignore documents with a version they do not know."
+    },
+    "repository": {
+      "type": "string",
+      "description": "owner/repo the failure happened in"
+    },
+    "run_id": {
+      "type": "integer",
+      "description": "Workflow run id of the failed merge group run"
+    },
+    "run_url": {
+      "type": "string",
+      "description": "URL of the failed merge group run"
+    },
+    "run_attempt": {
+      "type": "integer",
+      "description": "Attempt number of the failed run"
+    },
+    "head_branch": {
+      "type": "string",
+      "description": "The gh-readonly-queue/<base>/pr-<N>-<sha> ref the merge group ran on"
+    },
+    "head_sha": {
+      "type": "string",
+      "description": "Merge group commit the run tested"
+    },
+    "base_branch": {
+      "type": ["string", "null"],
+      "description": "Branch the merge group was queued against, parsed from head_branch"
+    },
+    "pull_request": {
+      "type": ["integer", "null"],
+      "description": "Pull request in the merge group, parsed from head_branch. Null when the ref could not be parsed."
+    },
+    "triaged_at": {
+      "type": "string",
+      "description": "RFC 3339 timestamp of when triage ran"
+    },
+    "triage_run_url": {
+      "type": ["string", "null"],
+      "description": "URL of the triage run which produced this document"
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["pr_caused", "systemic", "ambiguous", "unknown"],
+      "description": "Whether the pull request is to blame. 'unknown' means triage itself failed and nothing was classified."
+    },
+    "confidence": {
+      "type": "string",
+      "enum": ["high", "medium", "low"],
+      "description": "How firmly the evidence supports the verdict"
+    },
+    "summary": {
+      "type": "string",
+      "description": "One paragraph statement of what failed and why the verdict is what it is"
+    },
+    "failing_job": {
+      "type": ["string", "null"],
+      "description": "Name of the first failing job"
+    },
+    "failing_step": {
+      "type": ["string", "null"],
+      "description": "Name of the first failing step in that job, which is the diagnosis"
+    },
+    "failure_signature": {
+      "type": ["string", "null"],
+      "description": "Short stable string identifying this failure mode, suitable for grouping recurrences (a test name, or a key error phrase)"
+    },
+    "recommendation": {
+      "type": "string",
+      "enum": ["requeue", "fix_first", "investigate"],
+      "description": "What should happen to the pull request next"
+    },
+    "tracking_issue": {
+      "type": ["integer", "null"],
+      "description": "Issue tracking a systemic failure. Verified to exist, and to reference this run, when tracking_issue_action is commented or created; with an action of none it is a reference only and nothing was recorded there."
+    },
+    "tracking_issue_action": {
+      "type": "string",
+      "enum": ["commented", "created", "none"],
+      "description": "What triage did with the tracking issue. Downgraded to 'none' by the workflow if the issue could not be verified."
+    },
+    "evidence": {
+      "type": "array",
+      "description": "Short factual observations the verdict rests on",
+      "items": {"type": "string"}
+    },
+    "error": {
+      "type": ["string", "null"],
+      "description": "Why no verdict was reached. Set only when verdict is 'unknown'."
+    }
+  }
+}

--- a/tools/merge-triage.py
+++ b/tools/merge-triage.py
@@ -95,7 +95,14 @@ QUEUE_REF_RE = re.compile(
 # enough: ~~~ is a GitHub fence too, and a details tag may carry attributes
 # (<details open>) or whitespace before the close. Match the tag by name and
 # swallow to the closing angle bracket.
-UNSAFE_MARKUP_RE = re.compile(r'```+|~~~+|</?details\b[^>]*>', re.IGNORECASE)
+#
+# An HTML comment delimiter is in here for a third reason. It renders as
+# nothing, so an unterminated <!-- in a summary hides the rest of the comment
+# -- the recommendation included -- from a human while the machine-readable
+# extraction still succeeds, which is the worst shape a disagreement between
+# those two readers can take. It is also the dedup marker the driver writes,
+# and a marker that can be forged is not a marker.
+UNSAFE_MARKUP_RE = re.compile(r'```+|~~~+|</?details\b[^>]*>|<!--|-->', re.IGNORECASE)
 
 # Characters that break a markdown table cell. The facts table puts model
 # prose in single cells, several of them inside an inline code span, so an
@@ -183,9 +190,17 @@ def _find_json_object(text):
     away good verdicts. raw_decode() stops at the end of the first complete
     value, so trailing prose after the object is tolerated.
 
-    The unfenced scan is only reached when no fenced block held a candidate,
+    The unfenced scan is skipped when a fenced block already held a verdict,
     because it is the expensive half: a decode attempt from every brace in the
-    tail of a response which may quote a hundred kilobytes of log.
+    tail of a response which may quote a hundred kilobytes of log. It is not
+    enough for a fenced block to be merely schema-shaped, though. A model
+    which writes the verdict as bare prose and then a fenced appendix --
+    {"evidence": [...]} -- would otherwise have the appendix chosen, rejected
+    by the cleaning step for having no verdict, and a triage which actually
+    succeeded published as "unknown". That is the same failure
+    _pick_verdict() exists to prevent, with the two objects in different
+    formats, so the preference for a verdict has to outrank the preference
+    for a fence.
     """
     fenced = []
     for block in reversed(FENCED_BLOCK_RE.findall(text)):
@@ -197,7 +212,7 @@ def _find_json_object(text):
             fenced.append(value)
 
     chosen = _pick_verdict(fenced)
-    if chosen is not None:
+    if chosen is not None and 'verdict' in chosen:
         return chosen
 
     decoder = json.JSONDecoder()
@@ -211,7 +226,15 @@ def _find_json_object(text):
             continue
         if _looks_like_verdict(value):
             unfenced.append(value)
-    return _pick_verdict(unfenced)
+
+    scanned = _pick_verdict(unfenced)
+    if scanned is not None and 'verdict' in scanned:
+        return scanned
+    # Neither format held a verdict. The fenced candidate is still the better
+    # guess -- it is the format the prompt asked for -- and letting it through
+    # keeps the "no usable verdict field" error, which names what went wrong,
+    # rather than the "no JSON verdict object" one, which does not.
+    return chosen if chosen is not None else scanned
 
 
 def _coerce_int(value):
@@ -219,6 +242,13 @@ def _coerce_int(value):
         return None
     if isinstance(value, int):
         return value
+    # A whole number written with a decimal point is still an issue number.
+    # int('3813.0') raises, and dropping the citation over the spelling loses
+    # the reader the pointer to the issue the occurrence was recorded on --
+    # the one thing the verification downstream cannot reconstruct. A
+    # fractional value is not an issue number and is dropped.
+    if isinstance(value, float):
+        return int(value) if value.is_integer() else None
     try:
         return int(str(value).lstrip('#'))
     except (TypeError, ValueError):
@@ -258,6 +288,38 @@ def _table_cell(value):
     """
     return TABLE_WHITESPACE_RE.sub(' ', str(value)).strip().replace(
         '|', r'\|').replace('`', "'")
+
+
+# The prose fields, as opposed to the envelope. These are what the model wrote
+# and what the driver appends to, so they are the fields _safe_document()
+# re-sanitises. The envelope fields are deliberately not in here: a consumer
+# compares repository, run id and pull request against the failure it is
+# reading, and rewriting one of those to make a comment render better would
+# break the one promise the envelope makes.
+PROSE_FIELDS = ['summary', 'failing_job', 'failing_step', 'failure_signature', 'error']
+
+
+def _safe_document(document):
+    """A copy of document with the prose re-run through _safe_prose().
+
+    _clean_model_fields() already did this to everything the model wrote, but
+    the document is mutated afterwards: merge-ci-triage.sh appends to
+    `evidence` three times -- the gather notes, the dry run note and the
+    citation drop reason -- and writes the `error` field on the fallback
+    paths, none of which goes back through extraction. A fence appended there
+    would end the ```json block the machine-readable half lives in, so the
+    defence belongs at the point of rendering, which is the last thing to
+    touch the document, rather than only at the point of extraction, which is
+    not.
+    """
+    safe = dict(document)
+    for field in PROSE_FIELDS:
+        if safe.get(field) is not None:
+            safe[field] = _safe_prose(safe[field])
+    evidence = safe.get('evidence')
+    if isinstance(evidence, list):
+        safe['evidence'] = [item for item in (_safe_prose(i) for i in evidence) if item]
+    return safe
 
 
 def _clean_model_fields(raw):
@@ -366,10 +428,18 @@ def do_envelope(repository, run_path, output_path, triage_run_url=''):
             'merge-triage: no pull request number in ref %r\n' % head_branch)
 
     attempt = run.get('attempt')
+
+    # The URL GitHub gave us, or the one it would have given us. It is a
+    # required field of the schema, so an absent one costs the whole document
+    # -- and it is also the string the driver looks for in a tracking issue
+    # to check that the occurrence really was recorded there, where an empty
+    # value would match everything rather than nothing.
+    run_url = run.get('url') or 'https://github.com/%s/actions/runs/%d' % (repository, run_id)
+
     envelope = {
         'repository': repository,
         'run_id': run_id,
-        'run_url': run.get('url') or '',
+        'run_url': run_url,
         'run_attempt': attempt if isinstance(attempt, int) else 1,
         'head_branch': head_branch,
         'head_sha': run.get('headSha') or '',
@@ -470,6 +540,11 @@ def do_validate(path):
 
 
 def render_markdown(document):
+    # Both halves of the comment are rendered from the sanitised copy, because
+    # the embedded JSON is as breakable as the prose above it: json.dumps()
+    # escapes a newline and a quote but not a backtick, so an unsanitised
+    # fence in a string value ends the block a consumer parses.
+    document = _safe_document(document)
     verdict = document.get('verdict', 'unknown')
     lines = ['## Automated merge CI triage', '']
     lines.append('**%s**' % VERDICT_HEADLINE.get(verdict, VERDICT_HEADLINE['unknown']))
@@ -507,7 +582,10 @@ def render_markdown(document):
         lines.append('### Evidence')
         lines.append('')
         for item in evidence:
-            lines.append('- %s' % item)
+            # One bullet per item, whatever the item does with newlines: a
+            # multi-line evidence string otherwise renders its continuation
+            # lines as loose prose that has visibly fallen out of the list.
+            lines.append('- %s' % TABLE_WHITESPACE_RE.sub(' ', str(item)).strip())
         lines.append('')
 
     lines.append('### Recommendation')

--- a/tools/merge-triage.py
+++ b/tools/merge-triage.py
@@ -8,9 +8,17 @@ describing whether a merge queue failure was the pull request's fault. Three
 things then need doing to it, and each is here rather than in
 tools/merge-ci-triage.sh because each has edge cases worth testing:
 
+    merge-triage.py envelope <repository> <run json> <output> [triage run url]
     merge-triage.py extract <response> <envelope> <output>
+    merge-triage.py fallback <envelope> <output> <error>
     merge-triage.py render <triage> <output>
     merge-triage.py validate <triage>
+
+**envelope** builds the facts half of the document out of what GitHub said
+about the run, including picking the pull request number out of the merge
+group ref. It is here rather than in the shell because the ref shapes worth
+getting right -- a base branch with a slash in it, a ref that is not a queue
+ref at all -- are worth a test each, and jq is a poor place to keep them.
 
 **extract** pulls the object out of the model's captured stdout and merges it
 into an envelope the workflow built from GitHub's own data. The envelope always
@@ -33,12 +41,19 @@ markdown with the JSON embedded in a collapsed details section, exactly as the
 automated reviewer does it, so the verdict can be read back out of the comment
 by machine as well as fetched from the run's artifact.
 
+**fallback** writes the no-verdict document directly, for the paths in
+tools/merge-ci-triage.sh which fail before a model is ever run. The promise
+made to consumers is that a triage which happened is always visible as a
+document, and a triage that fell over reading the run is exactly the case
+where that matters.
+
 **validate** checks a document against tools/merge-triage-schema.json.
 """
 
 import datetime
 import json
 import os
+import re
 import sys
 
 
@@ -62,6 +77,19 @@ MODEL_FIELDS = [
     'failure_signature', 'recommendation', 'tracking_issue',
     'tracking_issue_action', 'evidence'
 ]
+
+# gh-readonly-queue/<base>/pr-<number>-<sha>. The base branch is greedy
+# because it may itself contain slashes (release/1.0), and the pull request
+# number is the last "pr-<digits>-" before the merge commit sha.
+QUEUE_REF_RE = re.compile(
+    r'^gh-readonly-queue/(?P<base>.+)/pr-(?P<number>\d+)-(?P<sha>[0-9a-fA-F]+)$')
+
+# Markup that would break the comment the document is embedded in: a fence
+# ends the ```json block a consumer reads the verdict out of, and a stray
+# </details> ends the collapsed section early. Both also stop
+# neutralise-pr-body.sh defusing mentions on every line after them, because it
+# tracks fenced regions. Model text is not trusted to avoid either.
+UNSAFE_MARKUP_RE = re.compile(r'```+|</?details\s*>', re.IGNORECASE)
 
 VERDICTS = ['pr_caused', 'systemic', 'ambiguous', 'unknown']
 RECOMMENDATIONS = ['requeue', 'fix_first', 'investigate']
@@ -101,22 +129,47 @@ RECOMMENDATION_TEXT = {
 }
 
 
-def _find_json_object(text):
-    """Return the last complete JSON object in text, or None.
+# How far back from the end of the response the unfenced scan looks. The
+# prompt asks for the verdict as the last thing emitted, and a response can
+# quote a hundred kilobytes of log above it; trying a decode from every brace
+# in all of that is quadratic work to find something the prompt says is at the
+# bottom.
+UNFENCED_SCAN_BYTES = 65536
 
-    Candidate start positions are tried newest first because a model which
-    illustrates the format before filling it in emits the real answer last.
-    raw_decode() stops at the end of the first complete value, so trailing
-    prose after the object, and a closing code fence, are both tolerated.
+FENCED_BLOCK_RE = re.compile(r'```(?:json)?\s*\n(.*?)\n\s*```', re.DOTALL)
+
+
+def _looks_like_verdict(value):
+    return isinstance(value, dict) and any(field in value for field in MODEL_FIELDS)
+
+
+def _find_json_object(text):
+    """Return the last usable JSON object in text, or None.
+
+    Fenced blocks are tried first, and both searches run newest first: a model
+    which illustrates the format before filling it in emits the real answer
+    last. Failing that the tail of the response is scanned for a bare object,
+    because models drop the fence often enough that requiring it would throw
+    away good verdicts. raw_decode() stops at the end of the first complete
+    value, so trailing prose after the object is tolerated.
     """
-    decoder = json.JSONDecoder()
-    starts = [i for i, char in enumerate(text) if char == '{']
-    for start in reversed(starts):
+    for block in reversed(FENCED_BLOCK_RE.findall(text)):
         try:
-            value, _ = decoder.raw_decode(text[start:])
+            value = json.loads(block)
         except ValueError:
             continue
-        if isinstance(value, dict) and any(field in value for field in MODEL_FIELDS):
+        if _looks_like_verdict(value):
+            return value
+
+    decoder = json.JSONDecoder()
+    tail = text[-UNFENCED_SCAN_BYTES:]
+    starts = [i for i, char in enumerate(tail) if char == '{']
+    for start in reversed(starts):
+        try:
+            value, _ = decoder.raw_decode(tail[start:])
+        except ValueError:
+            continue
+        if _looks_like_verdict(value):
             return value
     return None
 
@@ -138,6 +191,20 @@ def _coerce_str(value):
     if isinstance(value, str):
         return value.strip() or None
     return str(value)
+
+
+def _safe_prose(value):
+    """Model prose with the markup that would break its own container removed.
+
+    The document is published inside a fenced block inside a <details> section
+    of a pull request comment, and the promise that a consumer can read the
+    verdict back out of that comment rests on both surviving. A summary
+    carrying a fence or a </details> ends them early. See UNSAFE_MARKUP_RE.
+    """
+    text = _coerce_str(value)
+    if text is None:
+        return None
+    return _coerce_str(UNSAFE_MARKUP_RE.sub(' ', text))
 
 
 def _clean_model_fields(raw):
@@ -167,7 +234,7 @@ def _clean_model_fields(raw):
     cleaned['recommendation'] = recommendation
 
     for field in ['summary', 'failing_job', 'failing_step', 'failure_signature']:
-        cleaned[field] = _coerce_str(raw.get(field))
+        cleaned[field] = _safe_prose(raw.get(field))
 
     cleaned['tracking_issue'] = _coerce_int(raw.get('tracking_issue'))
 
@@ -175,14 +242,18 @@ def _clean_model_fields(raw):
     if action is not None:
         action = action.lower()
     if action not in ISSUE_ACTIONS:
-        action = 'commented' if cleaned['tracking_issue'] else 'none'
+        # 'none' rather than a guess of 'commented': the consumer is told that
+        # an action of commented means the occurrence really was recorded, and
+        # the verification step downstream can only take that claim away, not
+        # discover one. Guessing a write happened is the wrong direction.
+        action = 'none'
     cleaned['tracking_issue_action'] = action
 
     evidence = raw.get('evidence')
     if isinstance(evidence, list):
-        cleaned['evidence'] = [_coerce_str(item) for item in evidence if _coerce_str(item)]
-    elif _coerce_str(evidence):
-        cleaned['evidence'] = [_coerce_str(evidence)]
+        cleaned['evidence'] = [_safe_prose(item) for item in evidence if _safe_prose(item)]
+    elif _safe_prose(evidence):
+        cleaned['evidence'] = [_safe_prose(evidence)]
     else:
         cleaned['evidence'] = []
 
@@ -213,6 +284,65 @@ def _envelope_defaults(envelope):
     envelope.setdefault('triaged_at',
                         datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat())
     return envelope
+
+
+def parse_queue_ref(ref):
+    """Merge group ref -> (base branch, pull request number).
+
+    Returns (None, None) for anything that is not a merge queue ref, which is
+    survivable: triage still runs and the verdict simply has no pull request
+    to attach itself to.
+    """
+    match = QUEUE_REF_RE.match(ref or '')
+    if not match:
+        return None, None
+    return match.group('base'), int(match.group('number'))
+
+
+def do_envelope(repository, run_path, output_path, triage_run_url=''):
+    """Build the facts half of the document from what GitHub said."""
+    with open(run_path) as f:
+        run = json.load(f)
+
+    run_id = run.get('databaseId')
+    if not isinstance(run_id, int) or isinstance(run_id, bool):
+        sys.stderr.write('merge-triage: run json carries no numeric databaseId\n')
+        return 1
+
+    head_branch = run.get('headBranch') or ''
+    base_branch, pull_request = parse_queue_ref(head_branch)
+    if pull_request is None:
+        sys.stderr.write(
+            'merge-triage: no pull request number in ref %r\n' % head_branch)
+
+    attempt = run.get('attempt')
+    envelope = {
+        'repository': repository,
+        'run_id': run_id,
+        'run_url': run.get('url') or '',
+        'run_attempt': attempt if isinstance(attempt, int) else 1,
+        'head_branch': head_branch,
+        'head_sha': run.get('headSha') or '',
+        'base_branch': base_branch,
+        'pull_request': pull_request,
+        'triage_run_url': triage_run_url or None
+    }
+
+    with open(output_path, 'w') as f:
+        json.dump(_envelope_defaults(envelope), f, indent=2, sort_keys=True)
+        f.write('\n')
+    return 0
+
+
+def do_fallback(envelope_path, output_path, error):
+    """Write the no-verdict document for a triage that never reached a model."""
+    with open(envelope_path) as f:
+        envelope = _envelope_defaults(json.load(f))
+
+    with open(output_path, 'w') as f:
+        json.dump(_fallback(envelope, error), f, indent=2, sort_keys=True)
+        f.write('\n')
+    return 0
 
 
 def do_extract(response_path, envelope_path, output_path):
@@ -340,7 +470,7 @@ def render_markdown(document):
         lines.append('')
 
     lines.append('This verdict is automated and is not a substitute for reading the run. '
-                 'The triage skill it follows is documented in `docs/developer_guide/ci.md`.')
+                 'The procedure it follows is described in `docs/developer_guide/ci.md`.')
     lines.append('')
     lines.append('<details>')
     lines.append('<summary>Machine-readable triage data (for automation)</summary>')
@@ -370,8 +500,12 @@ def main(argv):
     command = argv[1]
     args = argv[2:]
 
+    if command == 'envelope' and len(args) in (3, 4):
+        return do_envelope(*args)
     if command == 'extract' and len(args) == 3:
         return do_extract(*args)
+    if command == 'fallback' and len(args) == 3:
+        return do_fallback(*args)
     if command == 'render' and len(args) == 2:
         return do_render(*args)
     if command == 'validate' and len(args) == 1:

--- a/tools/merge-triage.py
+++ b/tools/merge-triage.py
@@ -86,10 +86,24 @@ QUEUE_REF_RE = re.compile(
 
 # Markup that would break the comment the document is embedded in: a fence
 # ends the ```json block a consumer reads the verdict out of, and a stray
-# </details> ends the collapsed section early. Both also stop
+# details tag ends the collapsed section early -- or opens a second one the
+# real closing tag then closes, leaving the section unclosed. Both also stop
 # neutralise-pr-body.sh defusing mentions on every line after them, because it
 # tracks fenced regions. Model text is not trusted to avoid either.
-UNSAFE_MARKUP_RE = re.compile(r'```+|</?details\s*>', re.IGNORECASE)
+#
+# Both delimiters have more than one spelling and the narrow forms were not
+# enough: ~~~ is a GitHub fence too, and a details tag may carry attributes
+# (<details open>) or whitespace before the close. Match the tag by name and
+# swallow to the closing angle bracket.
+UNSAFE_MARKUP_RE = re.compile(r'```+|~~~+|</?details\b[^>]*>', re.IGNORECASE)
+
+# Characters that break a markdown table cell. The facts table puts model
+# prose in single cells, several of them inside an inline code span, so an
+# embedded newline splits the row, a pipe adds a column, and a backtick ends
+# the span. Only the human-readable half is affected -- json.dumps escapes all
+# three for the embedded document -- but a table which has come apart is how a
+# reader decides the whole comment is untrustworthy.
+TABLE_WHITESPACE_RE = re.compile(r'\s+')
 
 VERDICTS = ['pr_caused', 'systemic', 'ambiguous', 'unknown']
 RECOMMENDATIONS = ['requeue', 'fix_first', 'investigate']
@@ -143,6 +157,22 @@ def _looks_like_verdict(value):
     return isinstance(value, dict) and any(field in value for field in MODEL_FIELDS)
 
 
+def _pick_verdict(candidates):
+    """The best of several candidate objects, in newest-first order.
+
+    An object carrying a `verdict` key beats one that merely has some other
+    field of the schema in it. Without that preference a model which emits the
+    verdict and then a trailing appendix -- {"evidence": [...]}, or a bare
+    {"failure_signature": "..."} -- has the appendix chosen, the cleaning step
+    then rejects it for having no verdict, and a triage which actually
+    succeeded is published as "unknown".
+    """
+    for value in candidates:
+        if 'verdict' in value:
+            return value
+    return candidates[0] if candidates else None
+
+
 def _find_json_object(text):
     """Return the last usable JSON object in text, or None.
 
@@ -152,26 +182,36 @@ def _find_json_object(text):
     because models drop the fence often enough that requiring it would throw
     away good verdicts. raw_decode() stops at the end of the first complete
     value, so trailing prose after the object is tolerated.
+
+    The unfenced scan is only reached when no fenced block held a candidate,
+    because it is the expensive half: a decode attempt from every brace in the
+    tail of a response which may quote a hundred kilobytes of log.
     """
+    fenced = []
     for block in reversed(FENCED_BLOCK_RE.findall(text)):
         try:
             value = json.loads(block)
         except ValueError:
             continue
         if _looks_like_verdict(value):
-            return value
+            fenced.append(value)
+
+    chosen = _pick_verdict(fenced)
+    if chosen is not None:
+        return chosen
 
     decoder = json.JSONDecoder()
     tail = text[-UNFENCED_SCAN_BYTES:]
     starts = [i for i, char in enumerate(tail) if char == '{']
+    unfenced = []
     for start in reversed(starts):
         try:
             value, _ = decoder.raw_decode(tail[start:])
         except ValueError:
             continue
         if _looks_like_verdict(value):
-            return value
-    return None
+            unfenced.append(value)
+    return _pick_verdict(unfenced)
 
 
 def _coerce_int(value):
@@ -205,6 +245,19 @@ def _safe_prose(value):
     if text is None:
         return None
     return _coerce_str(UNSAFE_MARKUP_RE.sub(' ', text))
+
+
+def _table_cell(value):
+    """Model prose flattened into something a markdown table cell survives.
+
+    Applied at render time rather than in _safe_prose, because the escaping is
+    a property of where the text is being put rather than of the text: the
+    same value goes into the embedded JSON unmangled, and the summary
+    paragraph above the table needs its pipes and backticks left alone. See
+    TABLE_WHITESPACE_RE.
+    """
+    return TABLE_WHITESPACE_RE.sub(' ', str(value)).strip().replace(
+        '|', r'\|').replace('`', "'")
 
 
 def _clean_model_fields(raw):
@@ -250,12 +303,9 @@ def _clean_model_fields(raw):
     cleaned['tracking_issue_action'] = action
 
     evidence = raw.get('evidence')
-    if isinstance(evidence, list):
-        cleaned['evidence'] = [_safe_prose(item) for item in evidence if _safe_prose(item)]
-    elif _safe_prose(evidence):
-        cleaned['evidence'] = [_safe_prose(evidence)]
-    else:
-        cleaned['evidence'] = []
+    if not isinstance(evidence, list):
+        evidence = [evidence]
+    cleaned['evidence'] = [item for item in (_safe_prose(i) for i in evidence) if item]
 
     return cleaned
 
@@ -433,13 +483,13 @@ def render_markdown(document):
     if document.get('run_url'):
         facts.append('| Failed run | %s |' % document['run_url'])
     if document.get('failing_job'):
-        facts.append('| First failing job | `%s` |' % document['failing_job'])
+        facts.append('| First failing job | `%s` |' % _table_cell(document['failing_job']))
     if document.get('failing_step'):
-        facts.append('| First failing step | `%s` |' % document['failing_step'])
+        facts.append('| First failing step | `%s` |' % _table_cell(document['failing_step']))
     if document.get('failure_signature'):
-        facts.append('| Signature | `%s` |' % document['failure_signature'])
+        facts.append('| Signature | `%s` |' % _table_cell(document['failure_signature']))
     if document.get('confidence'):
-        facts.append('| Confidence | %s |' % document['confidence'])
+        facts.append('| Confidence | %s |' % _table_cell(document['confidence']))
     if document.get('tracking_issue'):
         facts.append('| Tracking issue | #%d (%s) |' % (
             document['tracking_issue'],

--- a/tools/merge-triage.py
+++ b/tools/merge-triage.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+# Copyright 2026 Michael Still and contributors
+
+"""Read, validate and render the automated merge CI triage verdict.
+
+The merge failure triage job asks Claude Code for one small JSON object
+describing whether a merge queue failure was the pull request's fault. Three
+things then need doing to it, and each is here rather than in
+tools/merge-ci-triage.sh because each has edge cases worth testing:
+
+    merge-triage.py extract <response> <envelope> <output>
+    merge-triage.py render <triage> <output>
+    merge-triage.py validate <triage>
+
+**extract** pulls the object out of the model's captured stdout and merges it
+into an envelope the workflow built from GitHub's own data. The envelope always
+wins: the run id, the pull request number and the repository are facts we
+already hold, and a model which misremembers one of them must not be able to
+mislabel somebody else's failure. Only the fields in MODEL_FIELDS are taken
+from the response at all.
+
+A response which holds no usable object is not an error condition to be
+retried. It becomes a document with a verdict of `unknown` and an `error`
+saying why, because the conductor tracking these needs a record that triage
+ran and reached nothing far more than it needs a missing file. That is also
+why there is no truncation salvage here of the sort
+`review-pr-with-claude/extract-review-json.py` carries: a review is hundreds of
+lines and worth rescuing halfway, a triage verdict is fifteen and a half one
+is not a verdict.
+
+**render** produces the comment posted on the pull request: human readable
+markdown with the JSON embedded in a collapsed details section, exactly as the
+automated reviewer does it, so the verdict can be read back out of the comment
+by machine as well as fetched from the run's artifact.
+
+**validate** checks a document against tools/merge-triage-schema.json.
+"""
+
+import datetime
+import json
+import os
+import sys
+
+
+# jsonschema is not in the runtime dependencies, and this script runs on a CI
+# runner where it may or may not be installed. Validation degrades to the
+# structural checks in _validate_basic() rather than failing, which follows
+# what review-pr-with-claude/render-review.py does with the review schema.
+try:
+    import jsonschema
+except ImportError:
+    jsonschema = None
+
+
+SCHEMA_VERSION = 1
+SCHEMA_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'merge-triage-schema.json')
+
+# The only keys taken from the model's response. Everything else in the
+# document is envelope, written from what GitHub told us.
+MODEL_FIELDS = [
+    'verdict', 'confidence', 'summary', 'failing_job', 'failing_step',
+    'failure_signature', 'recommendation', 'tracking_issue',
+    'tracking_issue_action', 'evidence'
+]
+
+VERDICTS = ['pr_caused', 'systemic', 'ambiguous', 'unknown']
+RECOMMENDATIONS = ['requeue', 'fix_first', 'investigate']
+CONFIDENCES = ['high', 'medium', 'low']
+ISSUE_ACTIONS = ['commented', 'created', 'none']
+
+# What to do about a pull request, when the model gave a verdict but no usable
+# recommendation. These are the only sensible pairings, so deriving one is
+# better than discarding an otherwise good verdict.
+DEFAULT_RECOMMENDATION = {
+    'pr_caused': 'fix_first',
+    'systemic': 'requeue',
+    'ambiguous': 'investigate',
+    'unknown': 'investigate'
+}
+
+VERDICT_HEADLINE = {
+    'pr_caused': 'This pull request caused the failure',
+    'systemic': 'Systemic failure, not caused by this pull request',
+    'ambiguous': 'Ambiguous -- the evidence points both ways',
+    'unknown': 'Triage did not reach a verdict'
+}
+
+# How a cited tracking issue is described in the comment. A cited issue with
+# an action of "none" is a reference the reader may find useful, not a record
+# that the occurrence was filed anywhere -- and the two must not read alike.
+ISSUE_ACTION_TEXT = {
+    'commented': 'occurrence recorded',
+    'created': 'issue created',
+    'none': 'referenced only, nothing recorded'
+}
+
+RECOMMENDATION_TEXT = {
+    'requeue': 'Re-queue as-is.',
+    'fix_first': 'Fix the pull request before re-queueing.',
+    'investigate': 'Needs a human look before re-queueing.'
+}
+
+
+def _find_json_object(text):
+    """Return the last complete JSON object in text, or None.
+
+    Candidate start positions are tried newest first because a model which
+    illustrates the format before filling it in emits the real answer last.
+    raw_decode() stops at the end of the first complete value, so trailing
+    prose after the object, and a closing code fence, are both tolerated.
+    """
+    decoder = json.JSONDecoder()
+    starts = [i for i, char in enumerate(text) if char == '{']
+    for start in reversed(starts):
+        try:
+            value, _ = decoder.raw_decode(text[start:])
+        except ValueError:
+            continue
+        if isinstance(value, dict) and any(field in value for field in MODEL_FIELDS):
+            return value
+    return None
+
+
+def _coerce_int(value):
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        return int(str(value).lstrip('#'))
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_str(value):
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value.strip() or None
+    return str(value)
+
+
+def _clean_model_fields(raw):
+    """Normalise the model's object into the fields the schema allows."""
+    cleaned = {}
+
+    verdict = _coerce_str(raw.get('verdict'))
+    if verdict is not None:
+        verdict = verdict.lower().replace('-', '_').replace(' ', '_')
+    if verdict not in VERDICTS or verdict == 'unknown':
+        # An absent, misspelled or self-declared-unknown verdict is not a
+        # verdict. The caller turns this into the fallback document, so that
+        # the reason lands in the error field rather than being silently
+        # rendered as a confident "unknown".
+        return None
+    cleaned['verdict'] = verdict
+
+    confidence = _coerce_str(raw.get('confidence'))
+    if confidence is not None and confidence.lower() in CONFIDENCES:
+        cleaned['confidence'] = confidence.lower()
+
+    recommendation = _coerce_str(raw.get('recommendation'))
+    if recommendation is not None:
+        recommendation = recommendation.lower().replace('-', '_').replace(' ', '_')
+    if recommendation not in RECOMMENDATIONS:
+        recommendation = DEFAULT_RECOMMENDATION[verdict]
+    cleaned['recommendation'] = recommendation
+
+    for field in ['summary', 'failing_job', 'failing_step', 'failure_signature']:
+        cleaned[field] = _coerce_str(raw.get(field))
+
+    cleaned['tracking_issue'] = _coerce_int(raw.get('tracking_issue'))
+
+    action = _coerce_str(raw.get('tracking_issue_action'))
+    if action is not None:
+        action = action.lower()
+    if action not in ISSUE_ACTIONS:
+        action = 'commented' if cleaned['tracking_issue'] else 'none'
+    cleaned['tracking_issue_action'] = action
+
+    evidence = raw.get('evidence')
+    if isinstance(evidence, list):
+        cleaned['evidence'] = [_coerce_str(item) for item in evidence if _coerce_str(item)]
+    elif _coerce_str(evidence):
+        cleaned['evidence'] = [_coerce_str(evidence)]
+    else:
+        cleaned['evidence'] = []
+
+    return cleaned
+
+
+def _fallback(envelope, error):
+    document = dict(envelope)
+    document.update({
+        'verdict': 'unknown',
+        'confidence': 'low',
+        'recommendation': 'investigate',
+        'summary': 'Automated triage ran but did not produce a usable verdict.',
+        'failing_job': None,
+        'failing_step': None,
+        'failure_signature': None,
+        'tracking_issue': None,
+        'tracking_issue_action': 'none',
+        'evidence': [],
+        'error': error
+    })
+    return document
+
+
+def _envelope_defaults(envelope):
+    envelope = dict(envelope)
+    envelope['schema_version'] = SCHEMA_VERSION
+    envelope.setdefault('triaged_at',
+                        datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat())
+    return envelope
+
+
+def do_extract(response_path, envelope_path, output_path):
+    with open(envelope_path) as f:
+        envelope = _envelope_defaults(json.load(f))
+
+    with open(response_path) as f:
+        response = f.read()
+
+    raw = _find_json_object(response)
+    if raw is None:
+        document = _fallback(envelope, 'The triage response contained no JSON verdict object.')
+        used_model = False
+    else:
+        cleaned = _clean_model_fields(raw)
+        if cleaned is None:
+            document = _fallback(
+                envelope, 'The triage response held a JSON object with no usable verdict field.')
+            used_model = False
+        else:
+            document = dict(cleaned)
+            document['error'] = None
+            # The envelope is applied last and wins every collision.
+            document.update(envelope)
+            used_model = True
+
+    with open(output_path, 'w') as f:
+        json.dump(document, f, indent=2, sort_keys=True)
+        f.write('\n')
+
+    if not used_model:
+        sys.stderr.write('merge-triage: no verdict in the model response, wrote a fallback document\n')
+        return 1
+    return 0
+
+
+def _validate_basic(document):
+    """Structural validation for when jsonschema is not installed."""
+    errors = []
+    for field in ['schema_version', 'repository', 'run_id', 'run_url', 'verdict',
+                  'recommendation', 'triaged_at']:
+        if document.get(field) in (None, ''):
+            errors.append('missing required field: %s' % field)
+    if document.get('verdict') not in VERDICTS:
+        errors.append('verdict is not one of %s' % VERDICTS)
+    if document.get('recommendation') not in RECOMMENDATIONS:
+        errors.append('recommendation is not one of %s' % RECOMMENDATIONS)
+    if document.get('tracking_issue_action') not in ISSUE_ACTIONS:
+        errors.append('tracking_issue_action is not one of %s' % ISSUE_ACTIONS)
+    return errors
+
+
+def do_validate(path):
+    with open(path) as f:
+        document = json.load(f)
+
+    errors = _validate_basic(document)
+    if errors:
+        for error in errors:
+            sys.stderr.write('merge-triage: %s\n' % error)
+        return 1
+
+    if jsonschema is None:
+        sys.stderr.write('merge-triage: jsonschema not installed, basic validation only\n')
+        return 0
+
+    with open(SCHEMA_PATH) as f:
+        schema = json.load(f)
+    try:
+        jsonschema.validate(document, schema)
+    except jsonschema.ValidationError as e:
+        sys.stderr.write('merge-triage: schema validation failed: %s\n' % e.message)
+        return 1
+    return 0
+
+
+def render_markdown(document):
+    verdict = document.get('verdict', 'unknown')
+    lines = ['## Automated merge CI triage', '']
+    lines.append('**%s**' % VERDICT_HEADLINE.get(verdict, VERDICT_HEADLINE['unknown']))
+    lines.append('')
+
+    if document.get('summary'):
+        lines.append(document['summary'])
+        lines.append('')
+
+    facts = []
+    if document.get('run_url'):
+        facts.append('| Failed run | %s |' % document['run_url'])
+    if document.get('failing_job'):
+        facts.append('| First failing job | `%s` |' % document['failing_job'])
+    if document.get('failing_step'):
+        facts.append('| First failing step | `%s` |' % document['failing_step'])
+    if document.get('failure_signature'):
+        facts.append('| Signature | `%s` |' % document['failure_signature'])
+    if document.get('confidence'):
+        facts.append('| Confidence | %s |' % document['confidence'])
+    if document.get('tracking_issue'):
+        facts.append('| Tracking issue | #%d (%s) |' % (
+            document['tracking_issue'],
+            ISSUE_ACTION_TEXT.get(document.get('tracking_issue_action'), ISSUE_ACTION_TEXT['none'])))
+    if document.get('triage_run_url'):
+        facts.append('| Triaged by | %s |' % document['triage_run_url'])
+    if facts:
+        lines.append('| | |')
+        lines.append('|---|---|')
+        lines.extend(facts)
+        lines.append('')
+
+    evidence = document.get('evidence') or []
+    if evidence:
+        lines.append('### Evidence')
+        lines.append('')
+        for item in evidence:
+            lines.append('- %s' % item)
+        lines.append('')
+
+    lines.append('### Recommendation')
+    lines.append('')
+    lines.append(RECOMMENDATION_TEXT.get(document.get('recommendation'), RECOMMENDATION_TEXT['investigate']))
+    lines.append('')
+
+    if document.get('error'):
+        lines.append('> Triage did not complete: %s' % document['error'])
+        lines.append('')
+
+    lines.append('This verdict is automated and is not a substitute for reading the run. '
+                 'The triage skill it follows is documented in `docs/developer_guide/ci.md`.')
+    lines.append('')
+    lines.append('<details>')
+    lines.append('<summary>Machine-readable triage data (for automation)</summary>')
+    lines.append('')
+    lines.append('```json')
+    lines.append(json.dumps(document, indent=2, sort_keys=True))
+    lines.append('```')
+    lines.append('')
+    lines.append('</details>')
+
+    return '\n'.join(lines) + '\n'
+
+
+def do_render(input_path, output_path):
+    with open(input_path) as f:
+        document = json.load(f)
+    with open(output_path, 'w') as f:
+        f.write(render_markdown(document))
+    return 0
+
+
+def main(argv):
+    if len(argv) < 2:
+        sys.stderr.write(__doc__)
+        return 2
+
+    command = argv[1]
+    args = argv[2:]
+
+    if command == 'extract' and len(args) == 3:
+        return do_extract(*args)
+    if command == 'render' and len(args) == 2:
+        return do_render(*args)
+    if command == 'validate' and len(args) == 1:
+        return do_validate(*args)
+
+    sys.stderr.write(__doc__)
+    return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tools/merge-triage.py
+++ b/tools/merge-triage.py
@@ -9,7 +9,7 @@ things then need doing to it, and each is here rather than in
 tools/merge-ci-triage.sh because each has edge cases worth testing:
 
     merge-triage.py envelope <repository> <run json> <output> [triage run url]
-    merge-triage.py extract <response> <envelope> <output>
+    merge-triage.py extract <response> <envelope> <output> [no verdict error]
     merge-triage.py fallback <envelope> <output> <error>
     merge-triage.py render <triage> <output>
     merge-triage.py validate <triage>
@@ -30,7 +30,10 @@ from the response at all.
 A response which holds no usable object is not an error condition to be
 retried. It becomes a document with a verdict of `unknown` and an `error`
 saying why, because the conductor tracking these needs a record that triage
-ran and reached nothing far more than it needs a missing file. That is also
+ran and reached nothing far more than it needs a missing file. The caller may
+supply that `error` itself: an empty response because no model could be run at
+all is a tooling failure rather than an unreadable answer, and only the caller
+knows which of the two it is holding. That is also
 why there is no truncation salvage here of the sort
 `review-pr-with-claude/extract-review-json.py` carries: a review is hundreds of
 lines and worth rescuing halfway, a triage verdict is fifteen and a half one
@@ -102,7 +105,13 @@ QUEUE_REF_RE = re.compile(
 # extraction still succeeds, which is the worst shape a disagreement between
 # those two readers can take. It is also the dedup marker the driver writes,
 # and a marker that can be forged is not a marker.
-UNSAFE_MARKUP_RE = re.compile(r'```+|~~~+|</?details\b[^>]*>|<!--|-->', re.IGNORECASE)
+#
+# A comment ends at --!> as well as at -->; the HTML parser's comment end bang
+# state accepts both, so a pattern which knows only the common spelling can be
+# walked straight past. CodeQL's py/bad-tag-filter reports exactly that as a
+# security finding, and it is right to: every alternative here has to cover
+# every spelling of the construct it defuses, or it defuses nothing.
+UNSAFE_MARKUP_RE = re.compile(r'```+|~~~+|</?details\b[^>]*>|<!--|--!?>', re.IGNORECASE)
 
 # Characters that break a markdown table cell. The facts table puts model
 # prose in single cells, several of them inside an inline code span, so an
@@ -465,7 +474,7 @@ def do_fallback(envelope_path, output_path, error):
     return 0
 
 
-def do_extract(response_path, envelope_path, output_path):
+def do_extract(response_path, envelope_path, output_path, no_verdict_error=None):
     with open(envelope_path) as f:
         envelope = _envelope_defaults(json.load(f))
 
@@ -474,7 +483,12 @@ def do_extract(response_path, envelope_path, output_path):
 
     raw = _find_json_object(response)
     if raw is None:
-        document = _fallback(envelope, 'The triage response contained no JSON verdict object.')
+        # The caller's reason if it has one. "No JSON verdict object" is true
+        # of a model which answered in prose and misleading about a model that
+        # never ran, and the driver is the half that can tell them apart.
+        document = _fallback(
+            envelope,
+            no_verdict_error or 'The triage response contained no JSON verdict object.')
         used_model = False
     else:
         cleaned = _clean_model_fields(raw)
@@ -630,7 +644,7 @@ def main(argv):
 
     if command == 'envelope' and len(args) in (3, 4):
         return do_envelope(*args)
-    if command == 'extract' and len(args) == 3:
+    if command == 'extract' and len(args) in (3, 4):
         return do_extract(*args)
     if command == 'fallback' and len(args) == 3:
         return do_fallback(*args)


### PR DESCRIPTION
When `Functional tests` fails on a `merge_group` event, GitHub ejects the pull
request from the merge queue and somebody has to work out whether the pull
request broke something or whether the test cloud fell over again. This
automates that first pass, following the same steps the `merge-ci-triage` skill
describes: find the first failing step, classify the failure as PR-caused or
systemic, record a systemic failure against its tracking issue, and recommend
re-queueing or fixing first. The verdict is posted as a comment on the ejected
pull request.

## Why `workflow_run` and not a job in `functional-tests.yml`

The obvious implementation is another job gated on `can_merge` having failed.
It races the queue: once `Can merge` reports its failure the queue ejects the
pull request and tears down the `gh-readonly-queue` ref the run is on, and a
triage which takes minutes sits in exactly that window. Moving the triage into
an earlier *step* of `can_merge` avoids the race but holds the merge queue open
while a model reads logs. A job reachable on `merge_group` would also fall
under the `merge-group-cancellation` audit, whose correct behaviour -- be
cancelled when a newer merge group supersedes you -- is the opposite of what a
triage job wants.

`workflow_run` runs afterwards, on the default branch, in the base repository
context, and none of that can cancel it. The `branches: ['gh-readonly-queue/**']`
filter keeps the workflow from being invoked for every pull request run of the
suite as well; without it each of those leaves a skipped run in the Actions
list.

The workflow never checks out or runs the code it is triaging. It reads the
failed run through `gh` and checks out the default branch, which is what makes
a writable token safe in a workflow that reads a pull request diff.

## The verdict document

Each triage produces one JSON document matching `tools/merge-triage-schema.json`,
published both as the `merge-triage-<run id>` build artifact and embedded in a
collapsed `<details>` section of the pull request comment, the way the automated
reviewer embeds its review. The private-ci conductor will consume these to track
which merge failures have been triaged and which of them blamed the pull
request, so three properties exist for that consumer:

- **A document is always written.** A model which answers in prose, or produces
  nothing, yields `verdict: unknown` with an `error` rather than a missing file.
  A missing document is indistinguishable from a triage that never ran.
- **The envelope is not model output.** Repository, run id and pull request
  number are written from what GitHub said and overwrite whatever the model put
  in those fields, so a verdict cannot be filed against the wrong failure. Only
  the fields in `MODEL_FIELDS` are taken from the response at all.
- **A cited tracking issue has been checked.** It has to exist and to carry a
  reference to the failed run, or it is dropped with the reason appended to
  `evidence`.

## Verification

Dry-run against a real failure -- run 33952027147, the merge group for #4080 --
classified it systemic against #4021 (the `(FindNetworks, api)` unbudgeted-poll
signature) and #3772 (the `507 sufficient_idle_cpu` family), with a re-queue
recommendation. That is the verdict manual triage reached, and it took about
two minutes.

`tools/merge-triage.py` has 12 unit tests covering the extraction and rendering
edge cases; both mechanisms that keep model output out of the envelope were
mutation tested. `pre-commit run --all-files` passes.

Note that `workflow_dispatch` only appears once this is on `develop`, so the
first test of the trigger itself happens after it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2iPhBZTSqq2fKt7ovFipv
