### PR TITLE
API input validation phase 4: declaration fixes ahead of enforcement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -362,8 +362,10 @@ does not start**. The rules, in full in
 3. A `path` parameter must be `required=True`.
 4. A raw request body is declared as `api_base.RAW_BODY_PARAMETER`, and
    cannot be combined with named body parameters.
-5. Every kwarg the handler accepts is declared; decorator-injected
-   `*_from_db` objects are not parameters.
+5. Every kwarg the handler accepts is declared, including one a
+   decorator pops out of `kwargs` before the handler runs (the ref
+   decorators' `namespace`); decorator-injected `*_from_db` objects
+   are not parameters.
 6. The type is a token from `api_base.ARGTYPES`. Objects and arrays of
    objects can only be declared in the body, since outside one there is
    no schema object to nest a structure in.

--- a/docs/developer_guide/writing_an_endpoint.md
+++ b/docs/developer_guide/writing_an_endpoint.md
@@ -313,7 +313,7 @@ strings, because semantic validation of them is not built yet. Only
 ## What is not checked yet
 
 Enforcement is off, so a correct declaration still does not stop a
-caller sending something else. Three known gaps in the derivation
+caller sending something else. Five known gaps in the derivation
 itself:
 
 (The published specification itself *is* checked:
@@ -347,3 +347,28 @@ the type vocabulary landed.)
   every unfound name would report the whole API and mean nothing.
   Within a decorator this *can* resolve, an unreadable pop key or an
   unfollowable delegation is reported rather than skipped.
+* A decorator that *reads* a parameter without removing it stays
+  invisible. The derivation recognises `kwargs.pop` and
+  `del kwargs[...]` because those are what make a kwarg the handler
+  cannot receive; a decorator that acts on `kwargs.get('x')`,
+  `'x' in kwargs` or `kwargs['x']` and leaves the key in place is not
+  seen, so nothing requires `x` to be declared. There is no example in
+  the tree: `_resolve_artifact_ref` had the only one, an
+  `if 'artifact_uuid' in kwargs:` branch which resolved an artifact
+  from a body key that no handler accepts — so the call after it
+  raised `TypeError` and answered 400 with interpreter text. It was
+  deleted rather than declared, since declaring it would have
+  published a parameter that never worked, and
+  `test_artifact_uuid_is_not_a_parameter` pins the property that made
+  it dead. A new one would have to be added deliberately.
+* A handler cannot both take a raw request body and sit behind a ref
+  resolving decorator. `swagger_helper()` refuses
+  `RAW_BODY_PARAMETER` combined with any named body parameter, while
+  the audit requires a decorator-consumed kwarg such as `namespace` to
+  be declared in the body — so such a handler could satisfy neither
+  rule: declaring the parameter aborts sf-api at import, omitting it
+  fails CI. No handler in the tree has both, and nothing detects the
+  combination; it is recorded here so the first author to hit the
+  contradiction does not have to derive it. The fix, if it is ever
+  needed, is a rendering for "a raw body plus these named
+  parameters", not an exemption from either rule.

--- a/docs/developer_guide/writing_an_endpoint.md
+++ b/docs/developer_guide/writing_an_endpoint.md
@@ -168,11 +168,20 @@ are listed in `UNDOCUMENTED_BY_DESIGN` in
 | a segment of the mounted route in `app.py` | `path` |
 | in a schema bound with `@use_kwargs(..., location='query')` | `query` |
 | read from `flask.request.args` | `query` |
+| popped out of kwargs by one of the handler's decorators | `body` |
 | anything else | `body` |
 
-That last row is the default because `log_request` merges the JSON
-request body into the handler's kwargs, and the official client sends
-a JSON body for every method including `GET`.
+The last two rows are the same default, because `log_request` merges
+the JSON request body into the handler's kwargs and the official client
+sends a JSON body for every method including `GET`. The decorator row
+is called out because it is the one source that reaches neither the
+signature nor any of the rows above: `arg_is_instance_ref`,
+`arg_is_network_ref` and the two artifact ref decorators each do
+`kwargs.pop('namespace', None)` and resolve the lookup with it, so
+`namespace` is a functional parameter of all 55 routes behind them
+while being invisible to a derivation that reads only signatures. It
+went undeclared for years on that account
+([#3739](https://github.com/shakenfist/shakenfist/issues/3739)).
 
 **3. A `path` parameter must be `required=True`.** The route cannot
 match without it, and an optional path parameter makes the published
@@ -202,13 +211,23 @@ collection and item endpoints into two classes, which is what the
 tree does everywhere (`Readyz`, the only class mounted twice, has two
 parameter-free routes).
 
-**5. Every kwarg the handler accepts is declared.** An accepted-but-
-undeclared parameter is invisible to anyone reading the API, which is
-how `sshkey` and `userdata` sat in the published specification for
-years while the handler read `ssh_key` and `user_data`. If a kwarg
-genuinely must not be published, add it to `UNDECLARED_BY_DESIGN` with
-a reason. Objects the decorators inject — anything ending in
-`_from_db` — are not parameters and must not be declared.
+**5. Every kwarg the handler accepts is declared**, including the ones
+a decorator consumes on its behalf. An accepted-but-undeclared
+parameter is invisible to anyone reading the API, which is how `sshkey`
+and `userdata` sat in the published specification for years while the
+handler read `ssh_key` and `user_data`. If a kwarg genuinely must not
+be published, add it to `UNDECLARED_BY_DESIGN` with a reason. Objects
+the decorators inject — anything ending in `_from_db` — are not
+parameters and must not be declared.
+
+"Accepts" means what a caller can send, not what the signature names.
+`declarations.decorator_kwargs()` resolves each of a handler's
+decorators to its definition in `shakenfist/external_api/` and collects
+the literal keys it removes from kwargs, following one `return
+other_decorator(func, ...)` delegation — which is how
+`arg_is_artifact_ref` and `arg_is_visible_artifact_ref` are written.
+If you add a decorator that consumes a request parameter, the audit
+will require every handler wearing it to declare that parameter.
 
 A handler must therefore name its parameters: `*args` or `**kwargs` in
 the signature accepts body keys nothing can enumerate (`log_request`
@@ -294,7 +313,7 @@ strings, because semantic validation of them is not built yet. Only
 ## What is not checked yet
 
 Enforcement is off, so a correct declaration still does not stop a
-caller sending something else. Two known gaps in the derivation
+caller sending something else. Three known gaps in the derivation
 itself:
 
 (The published specification itself *is* checked:
@@ -318,3 +337,13 @@ the type vocabulary landed.)
   know which parameters arrive in the query string, so an opt-out
   entry would have to restate the schema's keys by hand — exactly the
   second source of truth this machinery exists to remove.
+* A decorator that consumes a request parameter must be a module level
+  function of `shakenfist/external_api/`, and must consume it with a
+  literal `kwargs.pop('name', ...)` or `del kwargs['name']` reached
+  either directly or through a single `return other(func, ...)`
+  delegation. A decorator imported from outside the package is skipped
+  in silence — deliberately, because most of the decorators on any
+  handler are third-party (`swag_from`, `use_kwargs`) and reporting
+  every unfound name would report the whole API and mean nothing.
+  Within a decorator this *can* resolve, an unreadable pop key or an
+  unfollowable delegation is reported rather than skipped.

--- a/docs/developer_guide/writing_an_endpoint.md
+++ b/docs/developer_guide/writing_an_endpoint.md
@@ -53,9 +53,25 @@ string whose published format is Swagger 2.0's standard `byte` token),
 stays the single source of truth for what parses, and a published
 IPv4 pattern would describe the API as narrower than it is), and real
 array types for `arrayofstring`/`arrayofdict` and a real object type
-for `dict`. Objects, and arrays of objects, can only be declared in
-the body: outside one there is no schema object to nest a structure
-in, so they are rejected at import time.
+for `dict`.
+
+`any` is the one token that deliberately constrains nothing: it
+renders with no `type` at all, only a `format` annotation saying what
+the parameter is. It exists for the object metadata `value`
+parameters, where `add_metadata_key()` serialises whatever it is
+given and real callers store strings, dictionaries and lists under
+the same key — so no single token is wide enough, and declaring one
+of them would make enforcement refuse working callers. Reach for it
+only when that is genuinely true of the parameter; the fourteen
+declarations using it today are pinned by name in
+`ANY_TOKEN_DECLARATIONS`
+(`shakenfist/tests/external_api/test_parameter_declarations.py`), so
+a fifteenth is a visible, reviewable edit rather than a quiet
+widening.
+
+Objects, arrays of objects, and `any` can only be declared in the
+body: outside one there is no schema object to nest a structure in,
+so they are rejected at import time.
 
 Declare the token that matches what the handler accepts, and **publish
 what the server backs**: a bound tighter than the server's own
@@ -229,6 +245,13 @@ other_decorator(func, ...)` delegation — which is how
 If you add a decorator that consumes a request parameter, the audit
 will require every handler wearing it to declare that parameter.
 
+`UNDECLARED_BY_DESIGN` does not reach these. It exists for a kwarg
+the signature names and the handler ignores; a kwarg a decorator pops
+is one a caller can send and which changes what happens, so there is
+no reading of it that is not part of the API. Both guards say so —
+`declarations.audit()`, which backs the pre-commit fixer, has no
+exemption path for one at all — so declare it or stop consuming it.
+
 A handler must therefore name its parameters: `*args` or `**kwargs` in
 the signature accepts body keys nothing can enumerate (`log_request`
 merges the whole JSON body into the handler's kwargs), so the audit
@@ -313,7 +336,7 @@ strings, because semantic validation of them is not built yet. Only
 ## What is not checked yet
 
 Enforcement is off, so a correct declaration still does not stop a
-caller sending something else. Five known gaps in the derivation
+caller sending something else. Six known gaps in the derivation
 itself:
 
 (The published specification itself *is* checked:
@@ -346,7 +369,27 @@ the type vocabulary landed.)
   handler are third-party (`swag_from`, `use_kwargs`) and reporting
   every unfound name would report the whole API and mean nothing.
   Within a decorator this *can* resolve, an unreadable pop key or an
-  unfollowable delegation is reported rather than skipped.
+  unfollowable delegation is reported rather than skipped. That report
+  fires on *any* top level `return <call>` whose callee is not a single
+  package function, including a decorator which consumes nothing and
+  merely happens to be written as `return functools.wraps(func)(wrapper)`
+  or `return _make_wrapper(func)` against a helper living elsewhere. No
+  decorator in the tree is written either way, and the report is
+  deliberately fail-closed — an unfollowable delegation and a decorator
+  that consumes nothing produce the same empty set, so guessing between
+  them is the confident wrong answer this module exists to refuse. The
+  remedy, which the message now names, is to return the wrapper directly
+  or move the helper to module level in `external_api/`.
+* Decoration sites and delegation targets are matched on their bare
+  name, because that is all the site carries: `@api_base.arg_is_instance_ref`
+  in one module and `@arg_is_artifact_ref` in another name the same kind
+  of thing, and nothing here resolves module aliases through the
+  decorating file's imports. Two package functions sharing a name are
+  reported as ambiguous, but a package function sharing a name with an
+  *imported* one is not detectable, and the derivation will confidently
+  attribute the package function's pops to the import. No such collision
+  exists today; if you import something into `external_api/` under a name
+  a module level function there already has, rename one of them.
 * A decorator that *reads* a parameter without removing it stays
   invisible. The derivation recognises `kwargs.pop` and
   `del kwargs[...]` because those are what make a kwarg the handler
@@ -360,7 +403,9 @@ the type vocabulary landed.)
   deleted rather than declared, since declaring it would have
   published a parameter that never worked, and
   `test_artifact_uuid_is_not_a_parameter` pins the property that made
-  it dead. A new one would have to be added deliberately.
+  it dead, while `test_arg_is_ref_namespace_scoping.py` covers the
+  control flow that replaced it. A new one would have to be added
+  deliberately.
 * A handler cannot both take a raw request body and sit behind a ref
   resolving decorator. `swagger_helper()` refuses
   `RAW_BODY_PARAMETER` combined with any named body parameter, while

--- a/docs/plans/PLAN-api-input-validation-phase-04-enforce.md
+++ b/docs/plans/PLAN-api-input-validation-phase-04-enforce.md
@@ -82,8 +82,12 @@ kwargs before the handler sees it:
 `_resolve_artifact_ref` (`artifact.py:57`, reached through both
 `arg_is_artifact_ref` and `arg_is_visible_artifact_ref`). An AST walk
 of `shakenfist/external_api/` finds **55 handler methods** behind one
-of those four decorators, and **not one of them declares a body
-`namespace`**. The warn log saw nine findings because CI exercised one
+of those four decorators, and **51 of them declare no body
+`namespace`**. (The survey's first draft said none of them did. Four already had one — `InstanceEndpoint.get`/`delete` and
+`NetworkEndpoint.get`/`delete` — passing the audit only because those
+four handlers carry a vestigial `namespace=None` in their signature
+which the decorator's pop guarantees is always `None`. Corrected here
+during implementation.) The warn log saw nine findings because CI exercised one
 route family; the exposure is all 55.
 
 This is not a theoretical caller. `shakenfist_client/apiclient.py`
@@ -302,6 +306,99 @@ arrives.
 | 5 | medium | sonnet | none | Documentation and release note. In `docs/developer_guide/writing_an_endpoint.md`, rewrite "What validation does with them" (line 262) and "What is not checked yet" (294): enforcement is on, `enforce` is the default, and the sections currently state the opposite in four places. Add the `any` token wherever the type vocabulary is listed. In `docs/release_notes/v07-v08.md`, add an entry under `## REST API` (line 30) covering: malformed input is now refused with `{"error": "<parameter>: <reason>", "status": 400}`; validation runs ahead of the per-method decorators, **so a request that is both malformed and refers to a missing or unauthorised object now answers 400 where it previously answered 404 or 403** — this is the contract change and it must be stated plainly rather than implied; `required` is still not enforced; and `API_VALIDATION_MODE=warn` or `off` is the rollback for an operator whose callers break. Check `docs/developer_guide/coding_rules.md` and `CLAUDE.md`'s "Parameter declarations are enforced" section for statements that enforcement is off. Commit subject: `Document API input validation enforcement.` |
 | 6 | medium | sonnet | none | Functional CI coverage in `shakenfist/deploy/shakenfist_ci`. Add tests that a request carrying an undeclared body key is refused with a 400 whose error names the parameter and contains no Python interpreter text, and that a cross-namespace lookup passing `namespace` in the body — the exact `shakenfist_client` call pattern from `get_instance`/`get_artifact`/`get_network` — still works after step 1. The second is the regression test for #3739 and is the more important of the two: it is the thing that would have caught this before the warn window did. Follow the existing patterns in the CI suite; find a test that already asserts on an API error body rather than inventing a helper. Commit subject: `Test that malformed API input is refused.` |
 
+## Progress
+
+### Steps 1 and 2 were merged, because they cannot be separated
+
+`test_declared_names_are_real_parameters`
+(`shakenfist/tests/external_api/test_parameter_declarations.py:254`)
+asserts that every declared parameter name appears in the handler's
+own signature. The whole point of #3739 is that `namespace` never
+does — the decorator popped it. So the 55 declarations of step 1 fail
+that assertion 55 times until step 2's derivation term exists to
+explain them, and step 2's term turns 51 handlers red until step 1's
+declarations exist to satisfy it. Neither is green alone, and this
+repository requires each commit to build and pass its tests.
+
+They landed as one commit, `Declare the namespace parameter decorators
+consume.` The alternative — 55 entries in `UNDECLARED_BY_DESIGN` for
+one commit and their removal in the next — would have written the
+exact exemption list this phase exists to shrink.
+
+**The audit term was proven to fire, not assumed to.** With the
+derivation in place and the declarations reverted, `audit()` reports
+51 problems naming class, method and parameter, and no others; with
+the declarations applied it reports none. Three mutations were added
+to `tools/check-api-declaration-guards.sh` and all three are caught.
+
+### Found while implementing, recorded rather than fixed
+
+* **Mutation 4 of the guard harness had been silently defanged.** It
+  deleted a handler's `swag_from` by pasting the decorator's full
+  text; adding a parameter made the paste stop matching, so the
+  mutation became a no-op while still reporting success. Rewritten to
+  bound the deletion by line number. The harness has this fragility
+  wherever a mutation matches source text it does not own, and the
+  failure mode is the one this plan keeps meeting: a check that
+  reports success because it could not find what it was looking for.
+* **`requires_namespace_exist_if_specified` is dead on two routes.**
+  `InstanceEndpoint.delete` and `NetworkEndpoint.delete` carry it
+  *after* the ref decorator, which has already popped `namespace`, so
+  its `kwargs.get('namespace')` is always `None`. The other ten uses
+  are on creation and collection routes and work. Pre-existing, out of
+  scope, untouched.
+* **Four now-redundant `namespace=None` signature parameters** on the
+  same four handlers that already declared the key. Harmless and never
+  populated. Removing them is safe now that the derivation sees the
+  decorator, and is not worth its own risk in this phase.
+* **The `any` token needed the specification test's completeness
+  derivation widened.** That derivation asked whether a published
+  schema was an object or an array. A typeless schema is neither, so
+  the widest token in the vocabulary would have been the one type
+  change the table could never catch. It now also fires on a schema
+  with no `type`, verified by removing a registered entry and watching
+  the test fail.
+
+### Two comments in the tree blamed this phase wrongly
+
+Both are corrected, and both now point at issues instead.
+
+* **`InstanceSnapshotEndpoint.post` and `thin`** (`snapshot.py:66` and
+  the note above `UNDECLARED_BY_DESIGN`). Both said the
+  absent-versus-false distinction waits on phase 4. It does not: the
+  compiled path is check-only, so the handler receives `thin=False`
+  from `log_request`'s body merge whatever the validation mode, and
+  `'thin' in flask.request.json` draws the distinction today without
+  any schema layer. The real blocker is that every shipped client
+  sends the key unconditionally (`apiclient.py:706`), so honouring
+  `false` needs a client release plus a capability token to detect it.
+  Filed as
+  [#4100](https://github.com/shakenfist/shakenfist/issues/4100).
+* **The `get_args` fold** is
+  [#4098](https://github.com/shakenfist/shakenfist/issues/4098), per
+  D19, satisfying definition of done item 12.
+
+### Added to step 4's scope: empty `UNDECLARED_BY_DESIGN`
+
+The five `(*MetadataEndpoint, 'delete', 'value')` entries carry a
+comment saying they are deferred to phase 4 and that "once the schema
+layer rejects unknown parameters cleanly, this list should be empty".
+That is correct, and this phase should finish it: the five handlers
+accept a `value` kwarg on DELETE that none of them reads.
+
+It belongs in **step 4 and not earlier**. Removing the kwarg while
+validation is still in `warn` reintroduces exactly the leak the
+comment warns about — a caller sending `value` on a metadata delete
+gets `delete() got an unexpected keyword argument` as a 400. After the
+D16 flip, D14's RAISE answers `value: not declared by this endpoint`
+before the handler either way, so the signature cleanup becomes
+correct rather than dangerous.
+
+Checked before committing to it: the official client's
+`_delete_metadata` (`apiclient.py:514`) sends no body at all, so no
+shipped caller is affected. Two of the seven metadata delete handlers
+were cleaned up already, so the pattern is proven.
+
 ## Risks and mitigations
 
 **A caller nobody measured sends an undeclared key.** One sfcbr
@@ -369,7 +466,10 @@ run, so absence is evidence rather than silence.
     `docs/release_notes/v07-v08.md` and `CLAUDE.md`.
 11. `pre-commit run --all-files` is clean.
 12. An issue exists for the deferred `get_args` fold (D19), linked
-    from the master plan's Future work.
+    from the master plan. **Done: #4098.**
+13. `UNDECLARED_BY_DESIGN` in `test_parameter_declarations.py` is
+    empty, and the five metadata delete handlers no longer accept a
+    `value` kwarg they never read.
 
 ## Back brief
 

--- a/docs/plans/PLAN-api-input-validation-phase-04-enforce.md
+++ b/docs/plans/PLAN-api-input-validation-phase-04-enforce.md
@@ -399,6 +399,79 @@ Checked before committing to it: the official client's
 shipped caller is affected. Two of the seven metadata delete handlers
 were cleaned up already, so the pattern is proven.
 
+### Review round 1 on [#4101](https://github.com/shakenfist/shakenfist/pull/4101)
+
+Ten items: 2 `fix`, 1 `document`, 4 `consider`, 3 `none`. All seven
+actionable items were taken, which is more than the exit rule asks
+for. The reasoning, since taking every `consider` is normally the
+wrong move: three of the four were one edit each, and the fourth
+shrank the diff.
+
+**Both `fix` items were the same fault this phase keeps finding: a
+check that reports success without meaning it.**
+
+* **Mutation 32 deleted a whole handler.** It searched for the
+  namespace tuple by its nine-space indentation, which is a substring
+  of the twelve-space declaration in `InstanceSnapshotEndpoint.post`
+  above it. The search matched `post`, the terminator search ran on,
+  and the splice removed the rest of `post`'s parameters, its
+  responses, all five decorators, its body, and the head of `get`'s
+  declaration. The result still parsed, so the harness reported a
+  catch — of "a handler vanished", not of the defect the mutation
+  names. Rewritten to anchor on `get`'s summary and bound every later
+  index to the region after it, with three assertions which refuse
+  the write rather than corrupting the tree; the old escaping splice
+  now trips assertion B. Verified by diffing the mutation applied to
+  a copy: one tuple, nothing else.
+* **`any` compiled through the unrecognised-type fallback.**
+  `_field()` reads `spec.get('type')`, and `any` deliberately has
+  none, so every one of the fourteen sites took the branch whose only
+  output is a warning saying the published specification contains a
+  type the compiler does not know. Fourteen of those at every sf-api
+  start, measured; a genuinely unrecognised token would have been
+  indistinguishable from the expected noise. The rendering moved to
+  `validation.ANY_VALUE_FORMAT` and `ARGTYPES['any']` is built from
+  it, so recognition and rendering are the same string by
+  construction. Measured after: **zero** warnings across 139 compiled
+  schemas.
+
+**One `consider` was stronger than reported.**
+`_resolve_artifact_ref` carried an `if 'artifact_uuid' in kwargs:`
+branch. The reviewer suggested declaring it, since the new derivation
+cannot see a *read* the way it sees a pop. It is worse than
+undeclared: no handler anywhere in `shakenfist/external_api/` accepts
+an `artifact_uuid` kwarg and no route mounts one, verified by AST
+walk, so the branch resolved the artifact and then called a handler
+which raised `TypeError` — a 400 carrying interpreter text. Declaring
+it would have published a parameter that never worked. Deleted, with
+`test_artifact_uuid_is_not_a_parameter` pinning the property that
+made it dead rather than the branch's absence.
+
+The other three: the four namespace descriptions were pasted inline
+at 55 sites, so a wording fix was 55 edits and drift between copies
+was invisible — hoisted into `api_base` with
+`test_namespace_descriptions_match_their_decorator` asserting the
+pairing per handler and pinning the count at 55, which took ~145
+lines *out* of the endpoint modules. The widened artifact description
+omitted that `from_db_by_ref_visible_to` searches the caller's own
+namespace first and wins, including answering 400 on an ambiguous
+name there rather than widening. And the gap list in
+`writing_an_endpoint.md` went from three entries to five.
+
+**Recorded, not fixed.** Eight `sed` mutations in the guard harness
+(1, 6, 7, 8, 10, 11, 15, 22) match several `blob.py` lines and mutate
+all of them identically, so the intended defect is created at four to
+eight sites instead of one. Fragile rather than wrong — a multiplied
+identical defect still proves the guard fires for the reason claimed,
+which is exactly what mutation 32 did not do.
+
+**For step 5.** The release note must say that the specification now
+documents a body on GET and DELETE read routes. That is not new
+behaviour — the ref decorators have always popped `namespace` there —
+but it is newly *visible*, and a reader who takes the published
+specification as the contract will see a body appear on fifty-five
+routes that had none.
+
 ## Risks and mitigations
 
 **A caller nobody measured sends an undeclared key.** One sfcbr

--- a/docs/plans/PLAN-api-input-validation-phase-04-enforce.md
+++ b/docs/plans/PLAN-api-input-validation-phase-04-enforce.md
@@ -1,0 +1,389 @@
+# Phase 4: Enforce
+
+Phase 4 of [`PLAN-api-input-validation.md`](PLAN-api-input-validation.md),
+following [phase 3](PLAN-api-input-validation-phase-03-compile-and-warn.md).
+
+Phase 3 built the layer and rejected nothing. This phase makes it
+reject, which is the first request-visible change in the plan. Three
+declaration defects the warn window found are fixed first, the
+derivation is taught to see the class of defect that produced the
+larger of them, and the switch is thrown only after the log has been
+watched going quiet.
+
+**Planning effort:** high. The phase turns on the plan's one
+irreversible-feeling decision (D10), changes status codes on paths no
+test covers, and touches 55 endpoint declarations.
+
+## Context
+
+The measurement window opened 2026-08-13 and closed 2026-08-21. Its
+result, in one line: **the layer is correct and the declarations are
+not quite**. Across one full functional CI run and eight daily sfcbr
+readings, every finding was explained, and exactly two of the five
+signatures were declaration bugs rather than intended rejections.
+
+| Population | n | Verdict |
+|---|---|---|
+| Intended rejections (negative tests) | 33 | Enforcement is the point |
+| `unknown-parameter` `namespace` on ref lookups | 9 | Declaration bug, [#3739](https://github.com/shakenfist/shakenfist/issues/3739) |
+| `type-mismatch` on metadata `value` | 22 | Declaration bug, found on the last day of the window |
+| `body-path-collision` | 0 | Nothing observed |
+| `unknown-parameter` reaching its handler | 0 | The population D10 turns on |
+
+Both declaration bugs have the same shape — a declaration narrower
+than the behaviour it describes — and both would become a 400 for a
+working caller the moment enforcement is on. Neither was visible to
+phase 1's audit, and one of them is invisible to it *by construction*.
+
+## Scope
+
+**In:**
+
+* Declare the `namespace` body parameter on every handler behind a
+  ref-resolving decorator (#3739).
+* Teach `declarations.py` to see kwargs consumed by decorators, so
+  that class of defect fails CI instead of being found by a warn log.
+* A vocabulary token for a caller-opaque JSON value, applied to the
+  fourteen metadata `value` declarations.
+* A confirmatory warn reading on sfcbr with those fixes deployed.
+* Flip `API_VALIDATION_MODE` to `enforce` by default.
+* Documentation and a release note for the contract change.
+* Functional CI coverage of the refusal shape.
+
+**Out:**
+
+* Enforcing `required` (D17). Phase 6 owns it.
+* Semantic validation of the prose formats (`netblock`, `uuidorname`,
+  `url`, `ipv4`, `node`, `namespace`). Phase 6.
+* Narrowing `except TypeError` to JWT errors. Phase 5, gated on this.
+* Folding the four hand-authored `get_args` schemas into the compiled
+  path — the master plan's phase 4 line asks for this and the survey
+  found the line is wrong about what it would mean. See D19.
+* Response validation. Ruled out in phase 0 (D7).
+
+## What the survey found
+
+Every claim below was checked against the tree at `45debf843`.
+
+**The enforcement code already exists and is tested.**
+`validate_request` in `shakenfist/external_api/base.py:1570` already
+has the `enforce` branch (`base.py:1644`), already filters
+`missing-required` out of it, and already stashes findings *before*
+the enforce decision so a refused request still emits its telemetry.
+`API_VALIDATION_MODE` is a `Literal['off', 'warn', 'enforce']` at
+`shakenfist/config.py:226`. Phase 4 is therefore mostly a
+declaration-correctness phase with a one-word default change at the
+end, which is not what the master plan's phase 4 line implies.
+
+**#3739 is larger than the warn log showed, and it is precisely
+countable.** Three decorators pop an undeclared `namespace` from
+kwargs before the handler sees it:
+`arg_is_instance_ref` (`base.py:901`), `arg_is_network_ref`, and
+`_resolve_artifact_ref` (`artifact.py:57`, reached through both
+`arg_is_artifact_ref` and `arg_is_visible_artifact_ref`). An AST walk
+of `shakenfist/external_api/` finds **55 handler methods** behind one
+of those four decorators, and **not one of them declares a body
+`namespace`**. The warn log saw nine findings because CI exercised one
+route family; the exposure is all 55.
+
+This is not a theoretical caller. `shakenfist_client/apiclient.py`
+sends `{'namespace': ...}` in the body from `get_instance` (line 608),
+`delete_instance` (812), `get_artifact` (873), `get_network` (995) and
+`delete_network` (1007), gated on the `get-instance-namespace` /
+`get-network-namespace` capability tokens. **Enforcing today would 400
+the official client's own cross-namespace lookups.**
+
+**Phase 1's audit cannot see this, and that is structural.**
+`declarations.py` derives a handler's parameters from its signature
+(`handler_kwargs`, line 408), its `@use_kwargs` schema
+(`query_parameters`, 235) and its `flask.request.args` reads
+(`request_args_parameters`, 348). A kwarg a *decorator* removes never
+appears in any of the three. Nothing in the audit is wrong; the
+derivation simply has no term for it. Fixing the 55 declarations
+without fixing the derivation leaves the next `kwargs.pop` in a
+decorator as the next enforcement outage.
+
+**The metadata `value` finding is fourteen sites, not one.**
+`grep -rn "'value', 'body'" shakenfist/external_api/` returns fifteen.
+Fourteen are the metadata `value` parameter, every one declared
+`string`: `auth.py:664,690`, `instance.py:1387,1536`,
+`network.py:473,499`, `artifact.py:927,953`, `blob.py:402,427`,
+`node.py:224,252`, `interface.py:153,180`. The fifteenth,
+`network.py:712`, is an unrelated `value` declared `ipv4` and is
+correct. The handlers pass the value straight to
+`add_metadata_key()` (`baseobject.py:669`), which stores whatever it
+is given, so every one of the fourteen declarations is narrower than
+its handler.
+
+**`ARGTYPES` has no token for "any JSON value."**
+`shakenfist/external_api/base.py:359` carries eighteen tokens; the
+widest structured ones are `dict` (`{'type': 'object'}`) and
+`arrayofdict`. sfcbr's k3s orchestration traffic stored both a dict
+and a list under the same parameter, so neither is wide enough. This
+is the one genuinely new piece of vocabulary the phase needs.
+
+**The master plan's phase 4 line is wrong about the `get_args` fold,
+and this plan corrects it at source.** See D19. The master plan's
+phase 4 row and the `docs/plans/index.md` row were both edited in the
+same commit as this plan; a later step should not redo it.
+
+**Phase 3's status was Complete in substance and `In progress` in
+both tables.** The window closed in `b452b5761` (2026-08-21), the
+D10 recommendation and the classified list are both written up, the
+`test_every_documented_handler_compiles` criterion is enforced by
+`shakenfist/tests/external_api/test_validation_compiler.py:35`, and
+the kasm cron watcher and its state directory are gone. Only the
+status columns were never flipped, and this plan's commit flips them.
+
+**Nothing else in the master plan's phase 4 section was stale.** The
+error shape (D4), the chain position (D3) and the warn-only exit
+criterion (D5) all describe the code as it stands.
+
+## Decisions
+
+### D14. `unknown=RAISE`. Undeclared body keys are refused.
+
+Phase 3 recommended this provisionally and said phase 4 would settle
+it with counts in hand. The counts:
+
+* **Reaches-handler population: 0.** No observed request carried an
+  undeclared key *and* would have reached its handler. RAISE and
+  today's behaviour never disagreed in the window.
+* **Answered-first population: 9,** every one of them the `namespace`
+  key of #3739 — a declaration bug this phase fixes in step 1. After
+  step 1 that population is empty too.
+
+So RAISE refuses nothing any observed caller sends. What it changes is
+the *message*: today an undeclared key that reaches its handler is a
+400 carrying `AuthEndpoint.post() got an unexpected keyword argument
+'zzz'`, which is #3612 in its purest form. RAISE makes it
+`{"error": "zzz: not declared by this endpoint", "status": 400}`.
+
+`EXCLUDE` was the alternative and is rejected: silently dropping
+`{"nmae": "x"}` would create an unnamed instance rather than telling
+the caller they typed the parameter wrong, which is the defect class
+this plan exists to close, arriving by a different door.
+
+### D15. A new `any` token for caller-opaque values.
+
+Body-only, like `dict` and the array tokens, because outside a body
+there is no schema object to hold it. It renders as
+`{'format': 'any JSON value'}` — a `format` annotation with no `type`,
+so the published schema constrains nothing while still telling a
+reader what the parameter is. If `openapi_spec_validator` objects to a
+schema with no `type`, fall back to a bare `{}`; **the specification
+validation test is the arbiter, not this paragraph.**
+
+It compiles to `marshmallow.fields.Raw`, which the compiler already
+falls back to for unrecognised tokens (phase 3's third review round
+made that path drop published bounds, so `any` carrying no bounds is
+already the supported case).
+
+Applied to exactly the fourteen metadata `value` declarations named
+in the survey. Not applied to `network.py:712`, and not applied to
+anything else: the metadata family is the only place the API stores a
+caller-supplied value it never interprets, and widening a declaration
+is the one edit in this phase that *loses* validation.
+
+### D16. The default flips to `enforce`.
+
+Not an operator opt-in. The warn window was the price of earning the
+switch, and leaving the default at `warn` would mean the defect class
+stays open in every deployment while the machinery to close it sits
+there unused. `off` and `warn` remain as the operator's valve, and the
+release note names them as the rollback.
+
+### D17. `missing-required` stays out of the enforcement decision.
+
+This is already the code's behaviour (`base.py:1650`) and it is one
+line away from being tidied into consistency by someone who has not
+read why. Several parameters are declared `required` while omitting
+them has always worked; enforcing that is phase 6's decision and
+would break working callers. The request-level test that `enforce`
+plus an omitted required parameter still reaches the handler is a
+**required** deliverable of step 4, not an optional one.
+
+### D18. `body-path-collision` is enforced.
+
+Decision D8 said a body key overwriting a path parameter is rejected.
+The window observed zero, so enforcing it costs nothing measured and
+closes a real overwrite hazard. Recorded because it is the one reason
+code being switched on without a population behind it.
+
+### D19. The `get_args` fold is deferred, and the master plan's
+description of it is corrected.
+
+The master plan's phase 4 line reads "fold the hand-authored
+`get_args` schemas into the compiled path". Read literally — delete
+the four `@use_kwargs` decorators and let the compiled path take over
+— **it is a bug, not a refactor.** The compiled path is check-only:
+`validation.check()` returns findings and `validate_request` calls
+through, never coercing or injecting. `log_request` merges the JSON
+body into kwargs and nothing merges `flask.request.args`. So
+`@use_kwargs` is the *only* mechanism by which a query-string
+parameter reaches a handler at all. Deleting it from
+`blob.py:196` would silently revert `offset` and `limit` to their
+signature defaults on `GET /blobs/<uuid>/data` — reading a whole blob
+where the caller asked for a range.
+
+The defensible reading is the other one: keep `@use_kwargs` and
+*generate* its schema from the same declaration list `swagger_helper`
+receives, removing the second source of truth that phase 0's D2
+called out. That is achievable — hoist the parameter list to a module
+name, pass it to both, and build the marshmallow schema from the
+shared token mapping — but it needs signature defaults at runtime and
+it moves `blob.py`'s hand-rolled negative-offset check into a field,
+which changes an error message. Two request-visible changes in the
+phase that flips enforcement is exactly the shape that gave phase 3
+four review rounds.
+
+So: deferred, with an issue filed, and the master plan's phase 4 row
+edited to say what folding actually means. Enforcement does not need
+it — the compiled check runs first and answers 400 before the
+hand-authored schema is consulted, so the duplication is inert, not
+dangerous.
+
+### D20. The derivation learns to see decorator-consumed kwargs.
+
+Without this, step 1 is a sweep that nothing keeps true. `audit()`
+gains a term: for each handler, walk the decorators applied to it,
+resolve each to its definition in the same tree, and collect literal
+`kwargs.pop('<name>', ...)` keys as parameters that must be declared
+in the `body`. A decorator this cannot resolve is *reported*, not
+skipped — the same "absence must not be indistinguishable from
+success" rule the audit was rewritten around in phase 1.
+
+This is what turns step 1's 55 edits from a one-off into an
+invariant, and it is why step 2 exists as its own step rather than as
+a line in step 1's brief.
+
+### D21. No capability token for enforcement.
+
+`API_CAPABILITIES` (`app.py:309`) exists and the client uses
+`check_capability` for feature detection. Declined here: enforcement
+is not a feature a client can use differently. A well-formed request
+is unaffected, and a malformed one has no fallback path to take. The
+release note is the right surface. Recorded so it is not re-proposed
+in review.
+
+### D22. The switch is thrown only after a confirmatory reading.
+
+Steps 1 to 3 fix exactly the two signatures the window found. Landing
+them and flipping the default in the same pull request means nothing
+ever verifies they worked — the measurement would go dark at the
+moment it stops being cheap to run.
+
+So steps 1 to 3 merge, sfcbr redeploys in `warn`, and step 4 does not
+merge until:
+
+* one full functional CI run produces **zero** `unknown-parameter
+  namespace` findings (that run is what produced the nine), and
+* the `type-mismatch` on metadata `value` is absent across at least
+  72 hours **during which the k3s orchestration traffic that produced
+  it has actually run**. An absent signature whose generator did not
+  run is not evidence, and phase 3's log records three separate
+  occasions where a quiet channel was mistaken for a quiet system.
+
+Whatever watches this window is exercised by hand before it is
+trusted — phase 3's notifier failed silently for its last three runs
+because cron's `PATH` could not find `sops`. If a notifier is used at
+all, run it once from a cron-like environment and confirm the alert
+arrives.
+
+## Step plan
+
+| Step | Effort | Model | Isolation | Brief for sub-agent |
+|------|--------|-------|-----------|---------------------|
+| 1 | high | opus | none | Fix #3739. Declare `('namespace', 'body', 'namespace', '<description>', False)` in the `swagger_helper()` parameter list of every handler method decorated with `arg_is_instance_ref`, `arg_is_network_ref`, `arg_is_artifact_ref` or `arg_is_visible_artifact_ref`. The survey counted **55** such methods across `agentoperation.py`, `artifact.py`, `instance.py`, `network.py` and `snapshot.py`; recount with an AST walk rather than trusting that number, and report if it differs. The decorators are `base.py:899` (`arg_is_instance_ref`), `base.py` (`arg_is_network_ref`) and `artifact.py:52` (`_resolve_artifact_ref`, reached via `arg_is_artifact_ref` at 131 and `arg_is_visible_artifact_ref` at 147); each does `kwargs.pop('namespace', None)` and passes it to `resolve_lookup_namespace()`. The description should say what the parameter *does* on that route — it widens or narrows which namespace a *name* resolves in, and is ignored for a UUID lookup on the artifact path — not merely "the namespace". Required is `False`: every one of these routes works without it today. Do not add it to handlers that do not carry one of those four decorators. `python3 tools/fix-api-parameter-locations.py --apply` is not the tool for this; these are additions, not location drift. Verify with `test_parameter_declarations.py` and `test_openapi_spec.py`. Commit subject: `Declare the namespace body parameter on ref lookups.` |
+| 2 | high | opus | none | Close #3739's *class*. Teach `shakenfist/external_api/declarations.py` to derive the kwargs a handler's decorators consume, so a future `kwargs.pop` in a decorator fails CI instead of surfacing in a warn log. Add a function beside `handler_kwargs` (line 408) and `query_parameters` (235) that, for a given handler `ast.FunctionDef`, resolves each name in its `decorator_list` to a `FunctionDef` in the same package (the four in step 1 live in `base.py` and `artifact.py`, and `arg_is_artifact_ref`/`arg_is_visible_artifact_ref` both delegate to `_resolve_artifact_ref(func, widen=...)`, so the walk has to follow one level of delegation) and collects literal `kwargs.pop('<name>', ...)` keys. Wire it into `audit()` (553) so those names must be declared with location `body`, and into `derived_location()` (527) so the location is derivable rather than reported as underivable. **A decorator that cannot be resolved must be reported, not skipped** — the phase 1 rule that an opt-out must be visible. Read `docs/developer_guide/writing_an_endpoint.md` from line 294 ("What is not checked yet"), which documents the derivation's known gaps and must gain or lose an entry accordingly. After step 1 the audit must be clean; run it against `develop` *before* step 1's changes too and confirm it reports 55 problems, because an audit term that reports nothing when the defect is present is worse than no term at all. Commit subject: `Audit the kwargs that decorators consume.` |
+| 3 | medium | sonnet | none | Add an `any` type token and widen the metadata `value` declarations. In `ARGTYPES` (`shakenfist/external_api/base.py:359`) add `'any': {'format': 'any JSON value'}` — deliberately no `type`, so the published schema constrains nothing. `swagger_helper()` refuses object and array tokens outside a body; `any` must be refused outside a body for the same reason. If `openapi_spec_validator` rejects a typeless schema, fall back to `{}` and say so in the commit message; `shakenfist/tests/external_api/test_openapi_spec.py` decides, not the plan. Then change these fourteen declarations from `string` to `any`: `auth.py:664,690`, `instance.py:1387,1536`, `network.py:473,499`, `artifact.py:927,953`, `blob.py:402,427`, `node.py:224,252`, `interface.py:153,180` — verify each is the metadata `value` parameter before editing. **Do not touch `network.py:712`**, which is a different `value` correctly declared `ipv4`. Check whether `STRUCTURED_PARAMETERS` in `test_openapi_spec.py:104` needs entries: its completeness is derived from the published specification, so a typeless schema may or may not register as structured — if it does not, extend the derivation so a token this wide cannot be added invisibly. Add a test pinning that exactly fourteen declarations use `any` and that they are the metadata family. Commit subject: `Declare metadata values as any JSON value.` |
+| — | — | — | — | **Gate: back brief before step 4.** Steps 1-3 merge, sfcbr redeploys, and D22's confirmatory reading is taken and written into this plan's measurement log. Step 4 does not start until the operator has seen it. |
+| 4 | high | opus | none | Flip `API_VALIDATION_MODE`'s default from `'warn'` to `'enforce'` in `shakenfist/config.py:226`, update its description, and update `shakenfist/tests/test_config.py:43-55`. Then write the tests that pin what enforcement means, all of them at request level through the real decorator stack (phase 3's review found two defects that unit tests missed precisely because they tested components in isolation) in `shakenfist/tests/external_api/test_request_validation.py`: an undeclared body key on a declared endpoint answers exactly `{"error": "<name>: not declared by this endpoint", "status": 400}` and the response body contains **no** interpreter text — assert the absence positively, not by eyeballing; `enforce` plus an omitted `required` parameter still reaches the handler (decision D17); a body key colliding with a path parameter is refused (D18); a finding on a request that would have succeeded refuses it, and a request with no findings is untouched. **Mutation-test each assertion**: break the code it covers and confirm the test fails. Do not remove or "tidy" the `missing-required` filter at `base.py:1650`. Commit subject: `Enforce the API parameter declarations.` |
+| 5 | medium | sonnet | none | Documentation and release note. In `docs/developer_guide/writing_an_endpoint.md`, rewrite "What validation does with them" (line 262) and "What is not checked yet" (294): enforcement is on, `enforce` is the default, and the sections currently state the opposite in four places. Add the `any` token wherever the type vocabulary is listed. In `docs/release_notes/v07-v08.md`, add an entry under `## REST API` (line 30) covering: malformed input is now refused with `{"error": "<parameter>: <reason>", "status": 400}`; validation runs ahead of the per-method decorators, **so a request that is both malformed and refers to a missing or unauthorised object now answers 400 where it previously answered 404 or 403** — this is the contract change and it must be stated plainly rather than implied; `required` is still not enforced; and `API_VALIDATION_MODE=warn` or `off` is the rollback for an operator whose callers break. Check `docs/developer_guide/coding_rules.md` and `CLAUDE.md`'s "Parameter declarations are enforced" section for statements that enforcement is off. Commit subject: `Document API input validation enforcement.` |
+| 6 | medium | sonnet | none | Functional CI coverage in `shakenfist/deploy/shakenfist_ci`. Add tests that a request carrying an undeclared body key is refused with a 400 whose error names the parameter and contains no Python interpreter text, and that a cross-namespace lookup passing `namespace` in the body — the exact `shakenfist_client` call pattern from `get_instance`/`get_artifact`/`get_network` — still works after step 1. The second is the regression test for #3739 and is the more important of the two: it is the thing that would have caught this before the warn window did. Follow the existing patterns in the CI suite; find a test that already asserts on an API error body rather than inventing a helper. Commit subject: `Test that malformed API input is refused.` |
+
+## Risks and mitigations
+
+**A caller nobody measured sends an undeclared key.** One sfcbr
+tenant set and one CI suite is not every caller. *Mitigation:*
+`API_VALIDATION_MODE=off` and `warn` remain, named in the release
+note as the rollback, and require no code change to reach. The
+confirmatory reading of D22 is the check, and the operator reads it.
+
+**Status codes move on paths no test covers.** A request that is both
+malformed and refers to a missing object now answers 400 where it
+answered 404. *Mitigation:* stated in the release note as a contract
+change (step 5), not left to be discovered in a bug report. Note for
+review: this is not an information leak — validation runs *after*
+authentication, so the caller learns only that their own request was
+malformed.
+
+**Step 1 is a 55-site sweep and sweeps put things in the wrong
+place.** *Mitigation:* step 2's derivation is the arbiter. It derives
+the required declarations from the decorators themselves, so a
+declaration added to a handler that does not carry one of the four
+decorators, or missing from one that does, fails CI. Step 2's brief
+requires running the new audit term against unmodified `develop` and
+seeing it report 55, so the check is proven to fire.
+
+**`any` is a token that turns validation off for a parameter.** Once
+it exists, it is the easy answer to any inconvenient type error.
+*Mitigation:* step 3 adds a test pinning the exact set of
+declarations that use it, so a fifteenth use is a deliberate,
+visible edit.
+
+**The confirmatory window is watched by something that fails
+silently.** Three times in phase 3. *Mitigation:* D22 requires the
+notifier be exercised from a cron-like environment before it is
+trusted, and requires the metadata signature's *generator* to have
+run, so absence is evidence rather than silence.
+
+## Definition of done
+
+1. Every handler behind a `namespace`-popping decorator declares a
+   body `namespace`, and this is enforced by
+   `test_parameter_declarations.py` rather than asserted here.
+2. `declarations.audit()` reports zero problems on the tree, and
+   reports 55 when run against `develop` before step 1's edits.
+3. Exactly fourteen declarations use the `any` token, all of them the
+   metadata `value` parameter, pinned by a test.
+   `network.py:712` still declares `ipv4`.
+4. `config.API_VALIDATION_MODE` defaults to `'enforce'`, and
+   `test_config.py` asserts that default.
+5. A request-level test proves an undeclared body key answers
+   `{"error": "<name>: not declared by this endpoint", "status": 400}`
+   and that the response body contains no interpreter text; the
+   assertion has been mutation-tested.
+6. A request-level test proves `enforce` plus an omitted required
+   parameter still reaches the handler.
+7. A functional CI test performs a cross-namespace lookup with
+   `namespace` in the body and succeeds.
+8. The published specification validates with zero errors
+   (`test_openapi_spec.py`).
+9. D22's confirmatory reading is written into the measurement log
+   below, naming the CI run and the traffic that would have produced
+   each of the two signatures.
+10. No fact about enforcement is stated differently in
+    `PLAN-api-input-validation.md`, this plan,
+    `docs/developer_guide/writing_an_endpoint.md`,
+    `docs/release_notes/v07-v08.md` and `CLAUDE.md`.
+11. `pre-commit run --all-files` is clean.
+12. An issue exists for the deferred `get_args` fold (D19), linked
+    from the master plan's Future work.
+
+## Back brief
+
+Before executing any step, back brief the operator on the
+understanding of this plan and how the intended work aligns with it.
+
+There is a second, mandatory gate: **step 4 is not started until the
+operator has seen D22's confirmatory reading.** Flipping the default
+is the phase's only irreversible-feeling act, and the whole argument
+for it rests on two signatures having gone quiet after steps 1 to 3.
+That evidence is cheap to gather and expensive to fake, so it is
+gathered and shown before the switch, not after.
+
+## Measurement log
+
+*(D22's confirmatory reading goes here, in the format phase 3's log
+established: the reading command, what ran, and the signature table.)*

--- a/docs/plans/PLAN-api-input-validation-phase-04-enforce.md
+++ b/docs/plans/PLAN-api-input-validation-phase-04-enforce.md
@@ -303,7 +303,7 @@ arrives.
 | 3 | medium | sonnet | none | Add an `any` type token and widen the metadata `value` declarations. In `ARGTYPES` (`shakenfist/external_api/base.py:359`) add `'any': {'format': 'any JSON value'}` — deliberately no `type`, so the published schema constrains nothing. `swagger_helper()` refuses object and array tokens outside a body; `any` must be refused outside a body for the same reason. If `openapi_spec_validator` rejects a typeless schema, fall back to `{}` and say so in the commit message; `shakenfist/tests/external_api/test_openapi_spec.py` decides, not the plan. Then change these fourteen declarations from `string` to `any`: `auth.py:664,690`, `instance.py:1387,1536`, `network.py:473,499`, `artifact.py:927,953`, `blob.py:402,427`, `node.py:224,252`, `interface.py:153,180` — verify each is the metadata `value` parameter before editing. **Do not touch `network.py:712`**, which is a different `value` correctly declared `ipv4`. Check whether `STRUCTURED_PARAMETERS` in `test_openapi_spec.py:104` needs entries: its completeness is derived from the published specification, so a typeless schema may or may not register as structured — if it does not, extend the derivation so a token this wide cannot be added invisibly. Add a test pinning that exactly fourteen declarations use `any` and that they are the metadata family. Commit subject: `Declare metadata values as any JSON value.` |
 | — | — | — | — | **Gate: back brief before step 4.** Steps 1-3 merge, sfcbr redeploys, and D22's confirmatory reading is taken and written into this plan's measurement log. Step 4 does not start until the operator has seen it. |
 | 4 | high | opus | none | Flip `API_VALIDATION_MODE`'s default from `'warn'` to `'enforce'` in `shakenfist/config.py:226`, update its description, and update `shakenfist/tests/test_config.py:43-55`. Then write the tests that pin what enforcement means, all of them at request level through the real decorator stack (phase 3's review found two defects that unit tests missed precisely because they tested components in isolation) in `shakenfist/tests/external_api/test_request_validation.py`: an undeclared body key on a declared endpoint answers exactly `{"error": "<name>: not declared by this endpoint", "status": 400}` and the response body contains **no** interpreter text — assert the absence positively, not by eyeballing; `enforce` plus an omitted `required` parameter still reaches the handler (decision D17); a body key colliding with a path parameter is refused (D18); a finding on a request that would have succeeded refuses it, and a request with no findings is untouched. **Mutation-test each assertion**: break the code it covers and confirm the test fails. Do not remove or "tidy" the `missing-required` filter at `base.py:1650`. Commit subject: `Enforce the API parameter declarations.` |
-| 5 | medium | sonnet | none | Documentation and release note. In `docs/developer_guide/writing_an_endpoint.md`, rewrite "What validation does with them" (line 262) and "What is not checked yet" (294): enforcement is on, `enforce` is the default, and the sections currently state the opposite in four places. Add the `any` token wherever the type vocabulary is listed. In `docs/release_notes/v07-v08.md`, add an entry under `## REST API` (line 30) covering: malformed input is now refused with `{"error": "<parameter>: <reason>", "status": 400}`; validation runs ahead of the per-method decorators, **so a request that is both malformed and refers to a missing or unauthorised object now answers 400 where it previously answered 404 or 403** — this is the contract change and it must be stated plainly rather than implied; `required` is still not enforced; and `API_VALIDATION_MODE=warn` or `off` is the rollback for an operator whose callers break. Check `docs/developer_guide/coding_rules.md` and `CLAUDE.md`'s "Parameter declarations are enforced" section for statements that enforcement is off. Commit subject: `Document API input validation enforcement.` |
+| 5 | medium | sonnet | none | Documentation and release note. In `docs/developer_guide/writing_an_endpoint.md`, rewrite "What validation does with them" (line 262) and "What is not checked yet" (294): enforcement is on, `enforce` is the default, and the sections currently state the opposite in four places. The `any` token and the fifty-five newly published request bodies were documented with the code in step 3 rather than waiting for this step, so check what is already there before writing it again. In `docs/release_notes/v07-v08.md`, add an entry under `## REST API` (line 30) covering: malformed input is now refused with `{"error": "<parameter>: <reason>", "status": 400}`; validation runs ahead of the per-method decorators, **so a request that is both malformed and refers to a missing or unauthorised object now answers 400 where it previously answered 404 or 403** — this is the contract change and it must be stated plainly rather than implied; `required` is still not enforced; and `API_VALIDATION_MODE=warn` or `off` is the rollback for an operator whose callers break. Check `docs/developer_guide/coding_rules.md` and `CLAUDE.md`'s "Parameter declarations are enforced" section for statements that enforcement is off. Commit subject: `Document API input validation enforcement.` |
 | 6 | medium | sonnet | none | Functional CI coverage in `shakenfist/deploy/shakenfist_ci`. Add tests that a request carrying an undeclared body key is refused with a 400 whose error names the parameter and contains no Python interpreter text, and that a cross-namespace lookup passing `namespace` in the body — the exact `shakenfist_client` call pattern from `get_instance`/`get_artifact`/`get_network` — still works after step 1. The second is the regression test for #3739 and is the more important of the two: it is the thing that would have caught this before the warn window did. Follow the existing patterns in the CI suite; find a test that already asserts on an API error body rather than inventing a helper. Commit subject: `Test that malformed API input is refused.` |
 
 ## Progress
@@ -399,6 +399,62 @@ Checked before committing to it: the official client's
 shipped caller is affected. Two of the seven metadata delete handlers
 were cleaned up already, so the pattern is proven.
 
+### Review round 2 on [#4101](https://github.com/shakenfist/shakenfist/pull/4101)
+
+Ten items: 1 `fix`, 2 `document`, 5 `consider`, 2 `none` — down from
+2 `fix`, and every remaining item is against code this branch added
+rather than against the original change, which is the shape the
+`pr-re-review` skill names as a converging round. All seven actionable
+items were taken; each was a single edit.
+
+**The `fix` was the round-1 fix's own shadow.** Round 1 deleted
+`_resolve_artifact_ref`'s dead `artifact_uuid` branch. It did not
+delete `test_artifact_uuid_branch_tenant_foreign_namespace_rejected`,
+which went on passing — the 404 it asserts comes from
+`resolve_lookup_namespace()` long before any artifact lookup, and its
+`from_db.assert_not_called()` became vacuous once nothing could call
+`from_db` at all. A test that cannot fail, guarding code that no
+longer exists: the same fault as mutation 32 and the `any` fallback
+warning, arriving for the third time in this phase because deleting
+code and deleting the test that watched it are two separate acts.
+
+Replaced with three tests over `arg_is_visible_artifact_ref`, which is
+the half of `_resolve_artifact_ref` the parametrised `_CASES` cannot
+reach: an unqualified name widens (`from_db_by_ref_visible_to`, and a
+foreign-namespace artifact reaches the handler), naming a namespace
+turns the widening off (`from_db_by_ref`), and a tenant naming
+somebody else's namespace is refused before either lookup. Both
+lookups are patched in each, so the assertion is *which one ran*.
+
+**Proven, not assumed.** `if widen and not body_namespace:` mutated to
+`if widen:` fails exactly `test_visible_ref_with_body_namespace_does_not_widen`;
+mutated to `if False:` fails exactly
+`test_visible_ref_without_body_namespace_widens`. Likewise for the two
+new `any` constraint cases: relaxing the numeric-type check to admit a
+typeless token fails the first, relaxing the pattern check fails the
+second. Each mutation, each caught, by the intended test alone.
+
+**The exemption disagreement was real and is closed.**
+`test_accepted_parameters_are_declared` honoured `UNDECLARED_BY_DESIGN`
+for a decorator-consumed kwarg while `audit()` — which backs
+`test_declared_locations_are_derivable` *and* the pre-commit fixer —
+had no exemption path at all, so an entry would have satisfied one
+guard, failed the other, and left neither message explaining why the
+documented escape hatch did not work. The rule is now the same in both
+and stated in `writing_an_endpoint.md`: the exemption is for a kwarg
+the signature names and the handler ignores, and a kwarg a decorator
+pops is one a caller can send and act on, so it has no opt-out.
+
+The three latent `consider` items were taken as message and
+documentation edits rather than machinery. An unfollowable delegation
+now names its remedy instead of only its symptom; the bare-name
+resolution's blind spot — a package function sharing a name with an
+import, which no ambiguity check can see — joins the gap list, which
+is now six entries. Both are fail-closed today and neither shape
+exists in the tree; rewriting the resolver to chase module aliases
+would buy a check against something that has never happened, which is
+the trade the gap list exists to record.
+
 ### Review round 1 on [#4101](https://github.com/shakenfist/shakenfist/pull/4101)
 
 Ten items: 2 `fix`, 1 `document`, 4 `consider`, 3 `none`. All seven
@@ -465,12 +521,17 @@ eight sites instead of one. Fragile rather than wrong — a multiplied
 identical defect still proves the guard fires for the reason claimed,
 which is exactly what mutation 32 did not do.
 
-**For step 5.** The release note must say that the specification now
-documents a body on GET and DELETE read routes. That is not new
-behaviour — the ref decorators have always popped `namespace` there —
-but it is newly *visible*, and a reader who takes the published
-specification as the contract will see a body appear on fifty-five
-routes that had none.
+**Moved out of step 5 in review round 2.** The release note saying
+that the specification now documents a body on GET and DELETE read
+routes landed with the declarations rather than with the enforcement
+flip. That is not new behaviour — the ref decorators have always
+popped `namespace` there — but it is newly *visible*, and a reader
+who takes the published specification as the contract sees a body
+appear on fifty-five routes that had none the moment this merges,
+not when enforcement is switched on. Publishing the specification
+diff in one release and the note explaining it in the next was a gap
+with no reason behind it. The same bullet covers the metadata `value`
+widening, which is the other change a regenerated client sees.
 
 ## Risks and mitigations
 

--- a/docs/plans/PLAN-api-input-validation.md
+++ b/docs/plans/PLAN-api-input-validation.md
@@ -312,7 +312,16 @@ the plan was scoped against.
 2026-08-07), #3626 (specification validation in CI), #3616
 (`base.py` under mypy), #3642 (variadic handlers in the audit),
 #3629 (body-supplied `all`, see D6 below), #3615 (`log_request`
-discarding headers).
+discarding headers). #3739 (the ref decorators' undeclared
+`namespace`) is fixed by phase 4 and closes when that branch
+merges.
+
+**Filed by phase 4, and deliberately not fixed by it:** #4098 (the
+`get_args` fold, see the carried section below) and #4100 (an
+explicit `thin: false` on a snapshot request, which two comments
+in the tree wrongly blamed on this plan — the compiled path never
+injects, so no phase of this plan unblocks it; it needs a client
+release which omits the key).
 
 **Still open and still owned by this plan:** #528 (parent), #3612
 (the mechanism), #936, #534, #3269, #323, #3523, #3371, #2094;
@@ -510,8 +519,9 @@ belongs here is the one item phase 4 declined.
   to. That needs signature defaults at runtime and moves
   `blob.py`'s hand-rolled negative-offset check into a field,
   changing an error message -- a second request-visible change in
-  the phase that flips enforcement. It is tracked as its own
-  issue and is a candidate for phase 6, which already touches how
+  the phase that flips enforcement. It is tracked as
+  [#4098](https://github.com/shakenfist/shakenfist/issues/4098)
+  and is a candidate for phase 6, which already touches how
   values reach handlers. Enforcement does not depend on it: the
   compiled check runs first, so the duplication is inert.
 

--- a/docs/plans/PLAN-api-input-validation.md
+++ b/docs/plans/PLAN-api-input-validation.md
@@ -32,7 +32,7 @@ appended.
 I prefer one commit per logical change, and at minimum one
 commit per phase. Each commit should be self-contained.
 
-**Status: phases 0, 1, 2 and 3 planned; 0, 1 and 2 complete.**
+**Status: phases 0 to 4 planned; 0, 1, 2 and 3 complete.**
 The open questions at the bottom are answered in the Decisions
 section; see
 [`PLAN-api-input-validation-phase-00-decisions.md`](PLAN-api-input-validation-phase-00-decisions.md)
@@ -43,7 +43,9 @@ for what the audit found,
 for what the vocabulary work shipped and the four deviations it
 recorded, and
 [`PLAN-api-input-validation-phase-03-compile-and-warn.md`](PLAN-api-input-validation-phase-03-compile-and-warn.md)
-for the phase now ready to start. Phases 4 onward are not yet cut
+for the measurement that closed it, and
+[`PLAN-api-input-validation-phase-04-enforce.md`](PLAN-api-input-validation-phase-04-enforce.md)
+for the phase now ready to start. Phases 5 onward are not yet cut
 into per-phase files.
 
 ## Situation
@@ -294,8 +296,8 @@ declarations are good enough to compile.
 | 0: Research and decisions | Complete | Measured declaration accuracy; chose webargs, compilation, chain placement, error shape, warn-only criterion. See [phase 0](PLAN-api-input-validation-phase-00-decisions.md) |
 | 1: Declaration audit | Complete | Correct 116 path-parameter locations from the route table, 2 invalid location tokens, 5 wrong names (incl. `sshkey`/`userdata` in the published OpenAPI) and 20 undeclared parameters; make `swagger_helper()` reject unknown locations; add a test that keeps declarations honest. A precondition for phase 3, and a documentation-correctness fix worth landing on its own merits. See [phase 1](PLAN-api-input-validation-phase-01-declaration-audit.md) |
 | 2: Type vocabulary | Complete | The specification-validation test (#3626) plus `schemes`/`securityDefinitions` template fixes; one schema-carrying body parameter per operation, taking the validation error count from 129 to zero; `unsignedinteger`/`macaddr`/`base64`/`netblock` tokens and the optional constraints element, rendered into the published OpenAPI so bounds like the events `limit` cap are visible to callers. See [phase 2](PLAN-api-input-validation-phase-02-type-vocabulary.md) |
-| 3: Compile and warn | In progress | Code landed 2026-08-13 via #3726: declarations compiled to schemas, warn-only validation ahead of the handlers; four further decisions (D10-D13) recorded in the phase plan, including that an undeclared body key is *already* a 400 carrying interpreter text. The measurement window opened the same day — sfcbr deployed, apparatus hand-verified, a full functional CI run covered — and exits when every finding is explained, no earlier than 2026-08-20. See [phase 3](PLAN-api-input-validation-phase-03-compile-and-warn.md) |
-| 4: Enforce | Not started | Turn on rejection once the warn log is quiet, with one malformed-input response shape that never contains interpreter text; fold the hand-authored `get_args` schemas into the compiled path |
+| 3: Compile and warn | Complete | Code landed 2026-08-13 via #3726: declarations compiled to schemas, warn-only validation ahead of the handlers; four further decisions (D10-D13) recorded in the phase plan, including that an undeclared body key is *already* a 400 carrying interpreter text. The measurement window opened the same day and closed 2026-08-21 with every finding explained: 33 intended rejections, and two declaration bugs — the undeclared `namespace` of #3739 and fourteen metadata `value` declarations narrower than their handlers — which phase 4 fixes before it enforces. See [phase 3](PLAN-api-input-validation-phase-03-compile-and-warn.md) |
+| 4: Enforce | In progress | Fix the two declaration bugs the warn window found (#3739's undeclared `namespace` on 55 handlers, and fourteen metadata `value` declarations), teach the derivation to see decorator-consumed kwargs so that class cannot recur, then turn on rejection with one malformed-input response shape that never contains interpreter text. The `get_args` fold moves to Future work: read as "delete the four `@use_kwargs` decorators" it is a bug, because the compiled path is check-only and `@use_kwargs` is the only thing that gets a query parameter to a handler. See [phase 4](PLAN-api-input-validation-phase-04-enforce.md) |
 | 5: Narrow the handlers | Not started | Narrow `except TypeError` to JWT errors — still owned by this plan, and still gated on phase 4. The attribution issues are being closed independently: #3615 landed 2026-08-10, #3606 is in flight as PR #3714, leaving #3523 and #3371. See the note below |
 | 6: Required and semantics | Not started | Enforce `required` — or decide not to, since it is the change most likely to break working clients; semantic validators for #534, #3269, #323, #936 |
 | 7: Push audit | Not started | Runs `PUSH-AUDIT.md` over the accumulated diff of every phase in this plan against `develop`, not the last phase's diff alone. Findings land as their own pull request, and the plan is not complete until each is resolved or declined in writing here; if the audit finds nothing, that is recorded in one sentence |
@@ -480,6 +482,38 @@ Phase 3 therefore generalises an existing, tested loader to
 every parameter derived `query`, rather than introducing a
 second precedence rule alongside it. See
 [phase 3](PLAN-api-input-validation-phase-03-compile-and-warn.md).
+
+### Carried into phase 4 from phase 3
+
+The measurement window found two declaration bugs, and phase 4
+fixes both before it enforces. Their detail is in
+[phase 4](PLAN-api-input-validation-phase-04-enforce.md); what
+belongs here is the one item phase 4 declined.
+
+* **The `get_args` fold is deferred, and this plan's description
+  of it was wrong.** Phase 4's line above used to read "fold the
+  hand-authored `get_args` schemas into the compiled path".
+  Read as "delete the four `@use_kwargs` decorators", that is a
+  defect rather than a refactor: `validation.check()` returns
+  findings and `validate_request` calls through, so the compiled
+  path never coerces or injects anything, and `log_request`
+  merges only the JSON body -- nothing merges
+  `flask.request.args`. `@use_kwargs` is therefore the sole
+  mechanism by which a query-string parameter reaches a handler.
+  Removing it from `blob.py` would silently revert `offset` and
+  `limit` to their signature defaults, reading a whole blob where
+  the caller asked for a range.
+
+  The defensible reading is to keep `@use_kwargs` and generate
+  its schema from the same declaration list `swagger_helper()`
+  receives, which removes the second source of truth D2 objected
+  to. That needs signature defaults at runtime and moves
+  `blob.py`'s hand-rolled negative-offset check into a field,
+  changing an error message -- a second request-visible change in
+  the phase that flips enforcement. It is tracked as its own
+  issue and is a candidate for phase 6, which already touches how
+  values reach handlers. Enforcement does not depend on it: the
+  compiled check runs first, so the duplication is inert.
 
 ## Open questions for phase 0
 

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -106,7 +106,7 @@ checker's blind spot, and the only numbers here it cannot recompute.
 | 2026-07-19 | [Node resource health](PLAN-node-resource-health.md) | Declarative dependency checks driving node state, so a dead disk stops scheduling | Complete | 5 of 5 |
 | 2026-07-21 | [Per-host resource reservations](PLAN-per-host-resource-reservations.md) | Per-node RAM, CPU and disk reservation overrides | Complete | 4 of 4 |
 | 2026-07-28 | [sf-netserv](PLAN-netserv.md) | Replace dnsmasq with a Rust per-network service plane | Proposed | — |
-| 2026-08-03 | [API input validation](PLAN-api-input-validation.md) | Declarative request validation and a consistent error contract for the REST API | In progress | 3 of 8 |
+| 2026-08-03 | [API input validation](PLAN-api-input-validation.md) | Declarative request validation and a consistent error contract for the REST API | In progress | 4 of 8 |
 | 2026-08-14 | [Agent operation deadlines](PLAN-agent-operation-deadlines.md) | Client-propagated deadlines and per-command progress timeouts for agent operations; audited, and the one defect of its own making the audit found ([#4074](https://github.com/shakenfist/shakenfist/issues/4074)) was fixed hours later by #4080 -- see Known defects in the plan for the two which remain open | Complete | 9 of 9 |
 | 2026-08-14 | [Dependency-aware agent operations](PLAN-agent-operation-dependencies.md) | `depends_on` and `runs_after` for agent operations, including cross-instance edges | Blocked | — |
 | 2026-08-16 | [Bound gRPC reply sizes](PLAN-grpc-bounded-replies.md) | Make `DatabaseService` replies bounded by construction rather than by the message size limit | Not started | 0 of 7 |

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -146,6 +146,23 @@
   instruction to base64 encode on the caller's behalf — check that a
   regenerated client does not double encode content you already encode
   yourself, as the API has always required.
+* Two more specification changes are visible to anyone regenerating a
+  client, and neither is a change in what the server does. Fifty-five
+  `GET` and `DELETE` routes now publish a request body carrying an
+  optional `namespace` — instance, network and artifact reads and
+  deletes. Those routes have always accepted it: the `*_ref` resolving
+  decorators take `namespace` out of the request body and scope the
+  lookup with it, which is what the shipped client's `get_instance`,
+  `delete_instance`, `get_network`, `delete_network` and `get_artifact`
+  send when given a namespace. It was simply never documented, so a generated
+  client had no way to send it and the specification described the API
+  as narrower than it is. A generator which emits a body only where one
+  is declared will now emit one on those routes. Separately, the `value`
+  parameter of the object metadata routes is published as an
+  unconstrained value rather than as a string, because metadata values
+  have always been able to be dictionaries and lists as well —
+  `sf-client` sends whatever JSON it is given and the server stores it.
+  A regenerated client may bind that parameter more loosely.
 * Malformed values inside the reserved `affinity` instance metadata key
   are now refused with a 400 instead of returning a 500. A list, a
   dictionary, `null` or `Infinity` used as the *value* of an affinity

--- a/shakenfist/external_api/agentoperation.py
+++ b/shakenfist/external_api/agentoperation.py
@@ -196,9 +196,7 @@ class InstanceAgentOperationsEndpoint(api_base.Resource):
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another.', False),
+          api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False),
          ('all', 'body', 'boolean',
           'Include operations which have already completed, rather than '
           'only those still in flight.', False)],

--- a/shakenfist/external_api/agentoperation.py
+++ b/shakenfist/external_api/agentoperation.py
@@ -195,6 +195,10 @@ class InstanceAgentOperationsEndpoint(api_base.Resource):
         'instances', 'List agent operations for an instance.',
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another.', False),
          ('all', 'body', 'boolean',
           'Include operations which have already completed, rather than '
           'only those still in flight.', False)],

--- a/shakenfist/external_api/artifact.py
+++ b/shakenfist/external_api/artifact.py
@@ -329,7 +329,13 @@ class ArtifactEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'artifacts', 'Get artifact information.',
         [('artifact_ref', 'path', 'uuidorname',
-          'The UUID or name of the artifact.', True)],
+          'The UUID or name of the artifact.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the artifact reference in. Omit it and a name is resolved across everything the '
+          'caller can see, which includes shared artifacts and those owned by namespaces which trust the caller; '
+          'naming a namespace narrows the search to that one alone. A UUID is resolved without it, but the artifact '
+          'found must live in the named namespace or the request answers 404. Defaults to the namespace of the caller, '
+          'and only the system namespace may name another.', False)],
         [(200, 'Information about a single artifact.', artifact_get_example),
          (404, 'Artifact not found.', None)]))
     @arg_is_visible_artifact_ref
@@ -350,7 +356,12 @@ class ArtifactEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'artifacts', 'Delete an artifact.',
         [('artifact_ref', 'path', 'uuidorname',
-          'The UUID or name of the artifact.', True)],
+          'The UUID or name of the artifact.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
+          'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved without '
+          'it, but the artifact found must live here or the request answers 404. Defaults to the namespace of the '
+          'caller, and only the system namespace may name another.', False)],
         [(200, ('The artifact has been deleted. The final state of the '
                 'artifact is returned.'), artifact_delete_example),
          (404, 'Artifact not found.', None)]))
@@ -711,6 +722,12 @@ class ArtifactEventsEndpoint(api_base.Resource):
         [
             ('artifact_ref', 'path', 'uuidorname',
              'The UUID or name of the artifact.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the artifact reference in. Omit it and a name is resolved across everything the '
+             'caller can see, which includes shared artifacts and those owned by namespaces which trust the caller; '
+             'naming a namespace narrows the search to that one alone. A UUID is resolved without it, but the artifact '
+             'found must live in the named namespace or the request answers 404. Defaults to the namespace of the '
+             'caller, and only the system namespace may name another.', False),
             ('event_type', 'body', 'string', 'The type of event to return.', False),
             ('limit', 'body', 'integer',
              'The number of events to return, defaults to 100 and is '
@@ -766,7 +783,13 @@ class ArtifactVersionsEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'artifacts', 'Get artifact version information.',
         [('artifact_ref', 'path', 'uuidorname',
-          'The UUID or name of the artifact.', True)],
+          'The UUID or name of the artifact.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the artifact reference in. Omit it and a name is resolved across everything the '
+          'caller can see, which includes shared artifacts and those owned by namespaces which trust the caller; '
+          'naming a namespace narrows the search to that one alone. A UUID is resolved without it, but the artifact '
+          'found must live in the named namespace or the request answers 404. Defaults to the namespace of the caller, '
+          'and only the system namespace may name another.', False)],
         [(200, 'A list of the blobs which form the artifact versions.',
           artifact_versions_example),
          (404, 'Artifact not found.', None)]))
@@ -800,6 +823,11 @@ class ArtifactVersionsEndpoint(api_base.Resource):
         [
             ('artifact_ref', 'path', 'uuidorname',
              'The UUID or name of the artifact.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
+             'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved '
+             'without it, but the artifact found must live here or the request answers 404. Defaults to the namespace '
+             'of the caller, and only the system namespace may name another.', False),
             ('max_versions', 'body', 'unsignedinteger',
              'The maximum number of versions, or revert to the default it not set.',
              False)
@@ -837,7 +865,12 @@ class ArtifactVersionEndpoint(api_base.Resource):
             ('artifact_ref', 'path', 'uuidorname',
              'The UUID or name of the artifact.', True),
             ('version_id', 'path', 'unsignedinteger',
-             'The version number to remove.', True)
+             'The version number to remove.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
+             'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved '
+             'without it, but the artifact found must live here or the request answers 404. Defaults to the namespace '
+             'of the caller, and only the system namespace may name another.', False)
         ],
         [(200, 'Information about a single artifact.', artifact_get_example),
          (404, 'Artifact index not found.', None)]))
@@ -868,7 +901,12 @@ class ArtifactShareEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'artifacts', 'Share the specified artifact with all namespaces.',
         [('artifact_ref', 'path', 'uuidorname',
-          'The UUID or name of the artifact.', True)],
+          'The UUID or name of the artifact.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
+          'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved without '
+          'it, but the artifact found must live here or the request answers 404. Defaults to the namespace of the '
+          'caller, and only the system namespace may name another.', False)],
         [(200, 'Information about a single artifact.', artifact_get_example),
          (403, 'Only artifacts in the system namespace may be shared.', None),
          (404, 'Artifact not found.', None)]))
@@ -889,7 +927,12 @@ class ArtifactUnshareEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'artifacts', 'Unshare the specified artifact with all namespaces.',
         [('artifact_ref', 'path', 'uuidorname',
-          'The UUID or name of the artifact.', True)],
+          'The UUID or name of the artifact.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
+          'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved without '
+          'it, but the artifact found must live here or the request answers 404. Defaults to the namespace of the '
+          'caller, and only the system namespace may name another.', False)],
         [(200, 'Information about a single artifact.', artifact_get_example),
          (403, 'Artifact not shared.', None),
          (404, 'Artifact not found.', None)]))
@@ -909,7 +952,12 @@ class ArtifactMetadatasEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'artifacts', 'Fetch metadata for an artifact.',
         [('artifact_ref', 'path', 'uuidorname',
-          'The artifact to fetch metadata for.', True)],
+          'The artifact to fetch metadata for.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
+          'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved without '
+          'it, but the artifact found must live here or the request answers 404. Defaults to the namespace of the '
+          'caller, and only the system namespace may name another.', False)],
         [(200, 'Artifact metadata, if any.', None),
          (404, 'Artifact not found.', None)],
         requires_admin=True))
@@ -923,6 +971,11 @@ class ArtifactMetadatasEndpoint(api_base.Resource):
         'artifacts', 'Add metadata for an artifact.',
         [
             ('artifact_ref', 'path', 'uuidorname', 'The artifact to add a key to.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
+             'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved '
+             'without it, but the artifact found must live here or the request answers 404. Defaults to the namespace '
+             'of the caller, and only the system namespace may name another.', False),
             ('key', 'body', 'string', 'The metadata key to set', True),
             ('value', 'body', 'string', 'The value of the key.', True)
         ],
@@ -950,6 +1003,11 @@ class ArtifactMetadataEndpoint(api_base.Resource):
         [
             ('artifact_ref', 'path', 'uuidorname', 'The artifact to add a key to.', True),
             ('key', 'path', 'string', 'The metadata key to set', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
+             'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved '
+             'without it, but the artifact found must live here or the request answers 404. Defaults to the namespace '
+             'of the caller, and only the system namespace may name another.', False),
             ('value', 'body', 'string', 'The value of the key.', True)
         ],
         [(200, 'Nothing.', None),
@@ -973,7 +1031,12 @@ class ArtifactMetadataEndpoint(api_base.Resource):
         'artifacts', 'Delete a metadata key for an artifact.',
         [
             ('artifact_ref', 'path', 'uuidorname', 'The artifact to remove a key from.', True),
-            ('key', 'path', 'string', 'The metadata key to set', True)
+            ('key', 'path', 'string', 'The metadata key to set', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
+             'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved '
+             'without it, but the artifact found must live here or the request answers 404. Defaults to the namespace '
+             'of the caller, and only the system namespace may name another.', False)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),
@@ -1020,6 +1083,12 @@ class ArtifactOutstandingOperationsEndpoint(api_base.Resource):
         'artifacts', 'Get the outstanding cluster operations for an artifact.',
         [('artifact_ref', 'path', 'uuidorname',
           'The UUID or name of the artifact.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the artifact reference in. Omit it and a name is resolved across everything the '
+          'caller can see, which includes shared artifacts and those owned by namespaces which trust the caller; '
+          'naming a namespace narrows the search to that one alone. A UUID is resolved without it, but the artifact '
+          'found must live in the named namespace or the request answers 404. Defaults to the namespace of the caller, '
+          'and only the system namespace may name another.', False),
          ('all', 'query', 'boolean',
           'Include operations which have already completed, rather than '
           'only those still in flight.', False)],

--- a/shakenfist/external_api/artifact.py
+++ b/shakenfist/external_api/artifact.py
@@ -57,37 +57,30 @@ def _resolve_artifact_ref(func, widen):
         body_namespace = kwargs.pop('namespace', None)
 
         # Resolve and authorise the namespace once, regardless of
-        # whether the caller named the artifact by UUID or by ref.
-        # The UUID branch does not use `lookup_namespace` because
-        # `Artifact.from_db` takes only a UUID, but the early-reject
-        # for tenants passing a foreign namespace must still apply
-        # so the two paths share an identical authz posture.
+        # whether the caller named the artifact by UUID or by name.
+        # A UUID short circuits `from_db_by_ref` to `from_db`, which
+        # ignores the namespace entirely, but the early reject for
+        # tenants passing a foreign namespace must still apply so both
+        # ways of naming an artifact share an identical authz posture;
+        # the resolved artifact's own namespace is checked below.
         lookup_namespace, err = api_base.resolve_lookup_namespace(
             body_namespace, 'artifact')
         if err:
             return err
 
-        # Older style call: some internal flows pass artifact_uuid
-        # directly. Routes only mount `<artifact_ref>` today, but the
-        # body-key population in generic_wrapper means any body with
-        # `artifact_uuid` would reach this branch.
-        if 'artifact_uuid' in kwargs:
-            kwargs['artifact_from_db'] = Artifact.from_db(
-                kwargs['artifact_uuid'])
-        else:
-            try:
-                # Naming a namespace turns the widening off whatever
-                # the route asked for: that caller asked about one
-                # namespace and must be answered from it or not at all.
-                if widen and not body_namespace:
-                    kwargs['artifact_from_db'] = \
-                        Artifact.from_db_by_ref_visible_to(
-                            kwargs.get('artifact_ref'), lookup_namespace)
-                else:
-                    kwargs['artifact_from_db'] = Artifact.from_db_by_ref(
+        try:
+            # Naming a namespace turns the widening off whatever the
+            # route asked for: that caller asked about one namespace
+            # and must be answered from it or not at all.
+            if widen and not body_namespace:
+                kwargs['artifact_from_db'] = \
+                    Artifact.from_db_by_ref_visible_to(
                         kwargs.get('artifact_ref'), lookup_namespace)
-            except exceptions.MultipleObjects as e:
-                return sf_api.error(400, str(e), suppress_traceback=True)
+            else:
+                kwargs['artifact_from_db'] = Artifact.from_db_by_ref(
+                    kwargs.get('artifact_ref'), lookup_namespace)
+        except exceptions.MultipleObjects as e:
+            return sf_api.error(400, str(e), suppress_traceback=True)
 
         if not kwargs.get('artifact_from_db'):
             return sf_api.error(404, 'artifact not found')
@@ -331,11 +324,7 @@ class ArtifactEndpoint(api_base.Resource):
         [('artifact_ref', 'path', 'uuidorname',
           'The UUID or name of the artifact.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the artifact reference in. Omit it and a name is resolved across everything the '
-          'caller can see, which includes shared artifacts and those owned by namespaces which trust the caller; '
-          'naming a namespace narrows the search to that one alone. A UUID is resolved without it, but the artifact '
-          'found must live in the named namespace or the request answers 404. Defaults to the namespace of the caller, '
-          'and only the system namespace may name another.', False)],
+          api_base.VISIBLE_ARTIFACT_REF_NAMESPACE_DESCRIPTION, False)],
         [(200, 'Information about a single artifact.', artifact_get_example),
          (404, 'Artifact not found.', None)]))
     @arg_is_visible_artifact_ref
@@ -358,10 +347,7 @@ class ArtifactEndpoint(api_base.Resource):
         [('artifact_ref', 'path', 'uuidorname',
           'The UUID or name of the artifact.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
-          'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved without '
-          'it, but the artifact found must live here or the request answers 404. Defaults to the namespace of the '
-          'caller, and only the system namespace may name another.', False)],
+          api_base.ARTIFACT_REF_NAMESPACE_DESCRIPTION, False)],
         [(200, ('The artifact has been deleted. The final state of the '
                 'artifact is returned.'), artifact_delete_example),
          (404, 'Artifact not found.', None)]))
@@ -723,11 +709,7 @@ class ArtifactEventsEndpoint(api_base.Resource):
             ('artifact_ref', 'path', 'uuidorname',
              'The UUID or name of the artifact.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the artifact reference in. Omit it and a name is resolved across everything the '
-             'caller can see, which includes shared artifacts and those owned by namespaces which trust the caller; '
-             'naming a namespace narrows the search to that one alone. A UUID is resolved without it, but the artifact '
-             'found must live in the named namespace or the request answers 404. Defaults to the namespace of the '
-             'caller, and only the system namespace may name another.', False),
+             api_base.VISIBLE_ARTIFACT_REF_NAMESPACE_DESCRIPTION, False),
             ('event_type', 'body', 'string', 'The type of event to return.', False),
             ('limit', 'body', 'integer',
              'The number of events to return, defaults to 100 and is '
@@ -785,11 +767,7 @@ class ArtifactVersionsEndpoint(api_base.Resource):
         [('artifact_ref', 'path', 'uuidorname',
           'The UUID or name of the artifact.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the artifact reference in. Omit it and a name is resolved across everything the '
-          'caller can see, which includes shared artifacts and those owned by namespaces which trust the caller; '
-          'naming a namespace narrows the search to that one alone. A UUID is resolved without it, but the artifact '
-          'found must live in the named namespace or the request answers 404. Defaults to the namespace of the caller, '
-          'and only the system namespace may name another.', False)],
+          api_base.VISIBLE_ARTIFACT_REF_NAMESPACE_DESCRIPTION, False)],
         [(200, 'A list of the blobs which form the artifact versions.',
           artifact_versions_example),
          (404, 'Artifact not found.', None)]))
@@ -824,10 +802,7 @@ class ArtifactVersionsEndpoint(api_base.Resource):
             ('artifact_ref', 'path', 'uuidorname',
              'The UUID or name of the artifact.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
-             'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved '
-             'without it, but the artifact found must live here or the request answers 404. Defaults to the namespace '
-             'of the caller, and only the system namespace may name another.', False),
+             api_base.ARTIFACT_REF_NAMESPACE_DESCRIPTION, False),
             ('max_versions', 'body', 'unsignedinteger',
              'The maximum number of versions, or revert to the default it not set.',
              False)
@@ -867,10 +842,7 @@ class ArtifactVersionEndpoint(api_base.Resource):
             ('version_id', 'path', 'unsignedinteger',
              'The version number to remove.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
-             'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved '
-             'without it, but the artifact found must live here or the request answers 404. Defaults to the namespace '
-             'of the caller, and only the system namespace may name another.', False)
+             api_base.ARTIFACT_REF_NAMESPACE_DESCRIPTION, False)
         ],
         [(200, 'Information about a single artifact.', artifact_get_example),
          (404, 'Artifact index not found.', None)]))
@@ -903,10 +875,7 @@ class ArtifactShareEndpoint(api_base.Resource):
         [('artifact_ref', 'path', 'uuidorname',
           'The UUID or name of the artifact.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
-          'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved without '
-          'it, but the artifact found must live here or the request answers 404. Defaults to the namespace of the '
-          'caller, and only the system namespace may name another.', False)],
+          api_base.ARTIFACT_REF_NAMESPACE_DESCRIPTION, False)],
         [(200, 'Information about a single artifact.', artifact_get_example),
          (403, 'Only artifacts in the system namespace may be shared.', None),
          (404, 'Artifact not found.', None)]))
@@ -929,10 +898,7 @@ class ArtifactUnshareEndpoint(api_base.Resource):
         [('artifact_ref', 'path', 'uuidorname',
           'The UUID or name of the artifact.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
-          'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved without '
-          'it, but the artifact found must live here or the request answers 404. Defaults to the namespace of the '
-          'caller, and only the system namespace may name another.', False)],
+          api_base.ARTIFACT_REF_NAMESPACE_DESCRIPTION, False)],
         [(200, 'Information about a single artifact.', artifact_get_example),
          (403, 'Artifact not shared.', None),
          (404, 'Artifact not found.', None)]))
@@ -954,10 +920,7 @@ class ArtifactMetadatasEndpoint(api_base.Resource):
         [('artifact_ref', 'path', 'uuidorname',
           'The artifact to fetch metadata for.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
-          'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved without '
-          'it, but the artifact found must live here or the request answers 404. Defaults to the namespace of the '
-          'caller, and only the system namespace may name another.', False)],
+          api_base.ARTIFACT_REF_NAMESPACE_DESCRIPTION, False)],
         [(200, 'Artifact metadata, if any.', None),
          (404, 'Artifact not found.', None)],
         requires_admin=True))
@@ -972,10 +935,7 @@ class ArtifactMetadatasEndpoint(api_base.Resource):
         [
             ('artifact_ref', 'path', 'uuidorname', 'The artifact to add a key to.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
-             'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved '
-             'without it, but the artifact found must live here or the request answers 404. Defaults to the namespace '
-             'of the caller, and only the system namespace may name another.', False),
+             api_base.ARTIFACT_REF_NAMESPACE_DESCRIPTION, False),
             ('key', 'body', 'string', 'The metadata key to set', True),
             ('value', 'body', 'any',
              'The value of the key. Stored verbatim as any JSON value and never '
@@ -1006,10 +966,7 @@ class ArtifactMetadataEndpoint(api_base.Resource):
             ('artifact_ref', 'path', 'uuidorname', 'The artifact to add a key to.', True),
             ('key', 'path', 'string', 'The metadata key to set', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
-             'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved '
-             'without it, but the artifact found must live here or the request answers 404. Defaults to the namespace '
-             'of the caller, and only the system namespace may name another.', False),
+             api_base.ARTIFACT_REF_NAMESPACE_DESCRIPTION, False),
             ('value', 'body', 'any',
              'The value of the key. Stored verbatim as any JSON value and never '
              'interpreted by the API.', True)
@@ -1037,10 +994,7 @@ class ArtifactMetadataEndpoint(api_base.Resource):
             ('artifact_ref', 'path', 'uuidorname', 'The artifact to remove a key from.', True),
             ('key', 'path', 'string', 'The metadata key to set', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the artifact reference in. A name is only looked up in this namespace, and is '
-             'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved '
-             'without it, but the artifact found must live here or the request answers 404. Defaults to the namespace '
-             'of the caller, and only the system namespace may name another.', False)
+             api_base.ARTIFACT_REF_NAMESPACE_DESCRIPTION, False)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),
@@ -1088,11 +1042,7 @@ class ArtifactOutstandingOperationsEndpoint(api_base.Resource):
         [('artifact_ref', 'path', 'uuidorname',
           'The UUID or name of the artifact.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the artifact reference in. Omit it and a name is resolved across everything the '
-          'caller can see, which includes shared artifacts and those owned by namespaces which trust the caller; '
-          'naming a namespace narrows the search to that one alone. A UUID is resolved without it, but the artifact '
-          'found must live in the named namespace or the request answers 404. Defaults to the namespace of the caller, '
-          'and only the system namespace may name another.', False),
+          api_base.VISIBLE_ARTIFACT_REF_NAMESPACE_DESCRIPTION, False),
          ('all', 'query', 'boolean',
           'Include operations which have already completed, rather than '
           'only those still in flight.', False)],

--- a/shakenfist/external_api/artifact.py
+++ b/shakenfist/external_api/artifact.py
@@ -977,7 +977,9 @@ class ArtifactMetadatasEndpoint(api_base.Resource):
              'without it, but the artifact found must live here or the request answers 404. Defaults to the namespace '
              'of the caller, and only the system namespace may name another.', False),
             ('key', 'body', 'string', 'The metadata key to set', True),
-            ('value', 'body', 'string', 'The value of the key.', True)
+            ('value', 'body', 'any',
+             'The value of the key. Stored verbatim as any JSON value and never '
+             'interpreted by the API.', True)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),
@@ -1008,7 +1010,9 @@ class ArtifactMetadataEndpoint(api_base.Resource):
              'never widened to shared or trusted artifacts the way it is on the read routes; a UUID is resolved '
              'without it, but the artifact found must live here or the request answers 404. Defaults to the namespace '
              'of the caller, and only the system namespace may name another.', False),
-            ('value', 'body', 'string', 'The value of the key.', True)
+            ('value', 'body', 'any',
+             'The value of the key. Stored verbatim as any JSON value and never '
+             'interpreted by the API.', True)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),

--- a/shakenfist/external_api/auth.py
+++ b/shakenfist/external_api/auth.py
@@ -661,7 +661,9 @@ class AuthMetadatasEndpoint(api_base.Resource):
         [
             ('namespace', 'path', 'string', 'The namespace to add a key to.', True),
             ('key', 'body', 'string', 'The metadata key to set', True),
-            ('value', 'body', 'string', 'The value of the key.', True)
+            ('value', 'body', 'any',
+             'The value of the key. Stored verbatim as any JSON value and never '
+             'interpreted by the API.', True)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),
@@ -687,7 +689,9 @@ class AuthMetadataEndpoint(api_base.Resource):
         [
             ('namespace', 'path', 'string', 'The namespace to add a key to.', True),
             ('key', 'path', 'string', 'The metadata key to set', True),
-            ('value', 'body', 'string', 'The value of the key.', True)
+            ('value', 'body', 'any',
+             'The value of the key. Stored verbatim as any JSON value and never '
+             'interpreted by the API.', True)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -357,6 +357,18 @@ CONSTRAINT_KEYS = frozenset(['minimum', 'maximum', 'pattern'])
 
 # Type MUST be one of "string", "number", "integer", "boolean", "array" or "file".
 ARGTYPES: dict[str, dict[str, Any]] = {
+    # The metadata family's "the API stores this and never interprets
+    # it" case: add_metadata_key() (baseobject.py:669) serialises
+    # whatever it is given, and sfcbr's k3s orchestration traffic
+    # stored both a dict and a list under the same parameter, so
+    # neither 'dict' nor an 'arrayof*' token is wide enough -- callers
+    # store both shapes under one declaration. Deliberately no 'type'
+    # key, so the published schema constrains nothing while still
+    # telling a reader what the parameter is; this is the one token
+    # that deliberately validates nothing. Body-only, like 'dict' and
+    # the array tokens, for the same reason: outside a body there is
+    # no schema object to hold an unconstrained value.
+    'any': {'format': 'any JSON value'},
     # Real array types rather than prose-formatted strings: body
     # parameters render through schema objects, where array is
     # legal JSON Schema. Every use in the tree is body-located, and
@@ -659,18 +671,24 @@ def swagger_helper(section, description, parameters, responses,
 
         if location != 'body':
             # Outside a body a parameter must be primitive: there is
-            # no schema object to nest a structure in, so an object or
-            # an array of objects on a query or path parameter renders
-            # an invalid specification. test_openapi_spec.py would
-            # catch it, but every other declaration defect is refused
-            # at import time so sf-api does not start at all, and a
-            # tree which fails CI should not be able to serve an
-            # invalid specification in the meantime.
+            # no schema object to nest a structure in, so an object, an
+            # array of objects, or 'any's unconstrained value on a
+            # query or path parameter renders an invalid specification.
+            # test_openapi_spec.py would catch it, but every other
+            # declaration defect is refused at import time so sf-api
+            # does not start at all, and a tree which fails CI should
+            # not be able to serve an invalid specification in the
+            # meantime. 'any' is checked by name rather than by
+            # inspecting `rendered`: it is the one token that renders
+            # with no 'type' key at all, so it would otherwise slip
+            # past both checks below.
             if (rendered.get('type') == 'object'
-                    or rendered.get('items', {}).get('type') == 'object'):
+                    or rendered.get('items', {}).get('type') == 'object'
+                    or argtype == 'any'):
                 raise exceptions.InvalidAPIDeclaration(
                     '%s parameter %s declares type %r in the %s, but an '
-                    'object can only be declared in the body'
+                    'object, an array of objects, or an unconstrained '
+                    'value can only be declared in the body'
                     % (section, name, argtype, location))
 
             out['parameters'].append({

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -368,7 +368,7 @@ ARGTYPES: dict[str, dict[str, Any]] = {
     # that deliberately validates nothing. Body-only, like 'dict' and
     # the array tokens, for the same reason: outside a body there is
     # no schema object to hold an unconstrained value.
-    'any': {'format': 'any JSON value'},
+    'any': {'format': validation.ANY_VALUE_FORMAT},
     # Real array types rather than prose-formatted strings: body
     # parameters render through schema objects, where array is
     # legal JSON Schema. Every use in the tree is body-located, and
@@ -912,6 +912,63 @@ def log_token_use(func):
 
         return func(*args, **kwargs)
     return wrapper
+
+
+# The four descriptions of the `namespace` body parameter which the ref
+# resolving decorators consume (issue 3739). One constant each rather
+# than the paragraph pasted at all 55 declaration sites: a wording
+# correction was 55 edits, and drift between copies was invisible to
+# every test. They live here, next to two of the four decorators, and
+# are reachable from the artifact ones too because every endpoint
+# module already imports this one as `api_base`.
+#
+# Which constant belongs with which decorator is not left to the eye:
+# test_namespace_descriptions_match_their_decorator asserts the pairing
+# for every one of the 55 handlers, because using the widened text on a
+# narrow route would publish a false statement about how a name
+# resolves.
+INSTANCE_REF_NAMESPACE_DESCRIPTION = (
+    'The namespace to resolve the instance reference in. A name is only '
+    'looked up in this namespace; a UUID is resolved without it, but the '
+    'instance found must live here or the request answers 404. Defaults '
+    'to the namespace of the caller, and only the system namespace may '
+    'name another.')
+
+NETWORK_REF_NAMESPACE_DESCRIPTION = (
+    'The namespace to resolve the network reference in. A name is only '
+    'looked up in this namespace; a UUID is resolved without it, but the '
+    'network found must live here or the request answers 404. Defaults '
+    'to the namespace of the caller, and only the system namespace may '
+    'name another. The floating network belongs to no namespace, so it '
+    'is reachable only when this is omitted.')
+
+# The narrow artifact variant, for `arg_is_artifact_ref`: a name means
+# "mine", and no amount of sharing or trust widens it.
+ARTIFACT_REF_NAMESPACE_DESCRIPTION = (
+    'The namespace to resolve the artifact reference in. A name is only '
+    'looked up in this namespace, and is never widened to shared or '
+    'trusted artifacts the way it is on the read routes; a UUID is '
+    'resolved without it, but the artifact found must live here or the '
+    'request answers 404. Defaults to the namespace of the caller, and '
+    'only the system namespace may name another.')
+
+# The widened variant, for `arg_is_visible_artifact_ref`. The
+# precedence clause is not decoration: Artifact.from_db_by_ref_visible_to
+# is two phase, and phase one is exactly from_db_by_ref against the
+# caller's own namespace. On a cluster where several namespaces have
+# picked the same name -- everybody has a `debian-11` -- that ordering
+# is what decides which artifact a caller gets.
+VISIBLE_ARTIFACT_REF_NAMESPACE_DESCRIPTION = (
+    'The namespace to resolve the artifact reference in. Omit it and a '
+    'name is resolved across everything the caller can see, which '
+    'includes shared artifacts and those owned by namespaces which '
+    'trust the caller; your own namespace is searched first and wins, '
+    'and the search widens only when your own namespace has no match at '
+    'all -- an ambiguous name there answers 400 rather than widening. '
+    'Naming a namespace narrows the search to that one alone. A UUID is '
+    'resolved without it, but the artifact found must live in the named '
+    'namespace or the request answers 404. Defaults to the namespace of '
+    'the caller, and only the system namespace may name another.')
 
 
 def arg_is_instance_ref(func):

--- a/shakenfist/external_api/blob.py
+++ b/shakenfist/external_api/blob.py
@@ -399,7 +399,9 @@ class BlobMetadatasEndpoint(api_base.Resource):
         [
             ('blob_uuid', 'path', 'uuid', 'The blob to add a key to.', True),
             ('key', 'body', 'string', 'The metadata key to set', True),
-            ('value', 'body', 'string', 'The value of the key.', True)
+            ('value', 'body', 'any',
+             'The value of the key. Stored verbatim as any JSON value and never '
+             'interpreted by the API.', True)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),
@@ -424,7 +426,9 @@ class BlobMetadataEndpoint(api_base.Resource):
         [
             ('blob_uuid', 'path', 'uuid', 'The blob to add a key to.', True),
             ('key', 'path', 'string', 'The metadata key to set', True),
-            ('value', 'body', 'string', 'The value of the key.', True)
+            ('value', 'body', 'any',
+             'The value of the key. Stored verbatim as any JSON value and never '
+             'interpreted by the API.', True)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),

--- a/shakenfist/external_api/declarations.py
+++ b/shakenfist/external_api/declarations.py
@@ -8,7 +8,7 @@ validation, at which point a declaration that disagrees with its handler
 stops being a documentation bug and starts rejecting valid requests. This
 module is the single statement of what agreement means.
 
-Four sources decide where a parameter comes from, in order:
+Five sources decide where a parameter comes from, in order:
 
 * a name appearing in a route the class is mounted on is in the ``path``;
 * a name in the schema of a ``@use_kwargs(..., location='query')`` on the
@@ -17,6 +17,11 @@ Four sources decide where a parameter comes from, in order:
   ``query``, even if it can also arrive in the body -- the published
   documentation and the query-string fallback phase 3 compiles must
   agree;
+* a name one of the handler's decorators pops out of kwargs before the
+  handler runs is in the ``body``. It needs a term of its own precisely
+  because it reaches none of the other three and never appears in the
+  handler's signature either, which is how the ref decorators' popped
+  ``namespace`` went undeclared for years (#3739);
 * everything else is in the ``body``, because ``log_request`` merges the
   JSON body into handler kwargs.
 
@@ -430,6 +435,182 @@ def handler_kwargs(fn: ast.FunctionDef,
             if a.arg != 'self' and not a.arg.endswith(INJECTED_SUFFIX)]
 
 
+def package_functions(api_dir: str = API_DIR
+                      ) -> dict[str, list[ast.FunctionDef]]:
+    """Module level functions of the API package, by bare name.
+
+    The index decorator_kwargs() resolves names through. Keyed on the
+    bare name because that is all a decoration site carries: the ref
+    decorators are written ``@api_base.arg_is_instance_ref`` in one
+    module and ``@arg_is_artifact_ref`` in another, and both name the
+    same kind of thing. A name defined in two modules keeps both
+    definitions, so the ambiguity is visible to the caller rather than
+    resolved by whichever file sorted first.
+
+    Only module level definitions are indexed. A decorator defined
+    inside a class or a function is not something a decoration site in
+    another module could name, and treating one as a match would
+    resolve a name to a function that is not what ran.
+    """
+    out: dict[str, list[ast.FunctionDef]] = collections.defaultdict(list)
+    for path in sorted(glob.glob(os.path.join(api_dir, '*.py'))):
+        for node in _parse(path).body:
+            if isinstance(node, ast.FunctionDef):
+                out[node.name].append(node)
+    return out
+
+
+def _bare_name(node: ast.expr) -> Optional[str]:
+    """The last dotted component of a Name or Attribute, else None."""
+    if isinstance(node, (ast.Name, ast.Attribute)):
+        return ast.unparse(node).split('.')[-1]
+    return None
+
+
+def _kwargs_dicts(fn: ast.FunctionDef) -> set[str]:
+    """Names bound as ``**kwargs`` anywhere inside this function.
+
+    A decorator's pops happen in its wrapper, not in the decorator
+    itself, and they happen to the wrapper's ``**kwargs`` -- the dict
+    flask's dispatch and log_request's body merge fill in. Collecting
+    the names first is what keeps ``some_local_dict.pop('x')`` from
+    reading as a consumed request parameter.
+    """
+    out: set[str] = set()
+    for node in ast.walk(fn):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef,
+                             ast.Lambda)) and node.args.kwarg is not None:
+            out.add(node.args.kwarg.arg)
+    return out
+
+
+def _consumed_kwargs(fn: ast.FunctionDef,
+                     functions: dict[str, list[ast.FunctionDef]],
+                     problems: Optional[list[str]],
+                     seen: set[str]) -> set[str]:
+    """Request parameters this decorator removes from kwargs.
+
+    Two forms are recognised, both with a literal key:
+    ``kwargs.pop('name', ...)`` and ``del kwargs['name']``. A key which
+    is not a literal is reported: the parameter is consumed either way,
+    and answering "this decorator consumes nothing" would leave it
+    undeclarable and unenforceable, which is the defect this whole term
+    exists to catch arriving one level down.
+
+    Delegation is followed through a *top level* ``return
+    some_function(...)``, which is how ``arg_is_artifact_ref`` and
+    ``arg_is_visible_artifact_ref`` are written -- both are one liners
+    returning ``_resolve_artifact_ref(func, widen=...)``, and the pop
+    lives there. Only the top level of the body, because the wrapper's
+    own ``return func(*args, **kwargs)`` is a call to a parameter and
+    following it would mean chasing the handler itself.
+
+    A delegation target this cannot resolve is a problem, not an
+    absence: the decorator's real body is somewhere else, and the empty
+    set returned for it is indistinguishable from a decorator which
+    genuinely consumes nothing.
+    """
+    out: set[str] = set()
+    dicts = _kwargs_dicts(fn)
+
+    for node in ast.walk(fn):
+        key: Optional[ast.expr] = None
+        if (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == 'pop'
+                and _bare_name(node.func.value) in dicts
+                and node.args):
+            key = node.args[0]
+        elif (isinstance(node, ast.Delete) and len(node.targets) == 1
+              and isinstance(node.targets[0], ast.Subscript)
+              and _bare_name(node.targets[0].value) in dicts):
+            key = node.targets[0].slice
+        else:
+            continue
+
+        name = literal(key)
+        if isinstance(name, str):
+            out.add(name)
+        elif problems is not None:
+            problems.append(
+                '%s removes a kwarg named by something this cannot read '
+                '(%s), so a parameter it consumes is missing from the '
+                'derivation' % (fn.name, ast.unparse(key)))
+
+    for stmt in fn.body:
+        if not isinstance(stmt, ast.Return) or not isinstance(stmt.value,
+                                                              ast.Call):
+            continue
+        target = _bare_name(stmt.value.func)
+        candidates = functions.get(target or '', [])
+        if target is None or not candidates or len(candidates) > 1:
+            if problems is not None:
+                problems.append(
+                    '%s delegates to %s, which this cannot resolve to a '
+                    'single module level function, so the kwargs it '
+                    'consumes are missing from the derivation'
+                    % (fn.name, ast.unparse(stmt.value.func)))
+            continue
+        if target in seen:
+            continue
+        out |= _consumed_kwargs(
+            candidates[0], functions, problems, seen | {target})
+
+    return out
+
+
+def decorator_kwargs(fn: ast.FunctionDef,
+                     functions: dict[str, list[ast.FunctionDef]],
+                     problems: Optional[list[str]] = None) -> set[str]:
+    """Request parameters the handler's decorators consume for it.
+
+    ``arg_is_instance_ref``, ``arg_is_network_ref`` and the two
+    artifact ref decorators all ``kwargs.pop('namespace', None)`` and
+    resolve the lookup with it. The parameter is functional -- the
+    official client sends it -- but it is in none of the other three
+    sources: it is not a route segment, not a webargs key and not a
+    flask.request.args read, and it never reaches the handler's
+    signature either, because the decorator took it. Without this term
+    the derivation has nothing to say about it, so it was declared
+    nowhere and phase 3's warn window found it as an
+    ``unknown-parameter`` finding against working callers (#3739).
+
+    A decorator name this cannot find among the package's module level
+    functions is skipped in silence, and that is deliberate rather than
+    an oversight of the "absence must not look like success" rule
+    every other source here follows. Every handler in the tree carries
+    several decorators which are not package functions at all --
+    ``swag_from`` and ``use_kwargs`` are imported from third party
+    libraries -- so reporting an unfound name would report most of the
+    API and mean nothing. "Unresolvable" here means the narrower and
+    more useful thing: the function *was* found and something inside it
+    could not be read. That is what lands in ``problems``.
+
+    The gap this leaves is a decorator defined outside this package
+    which pops a kwarg. There is none today, every ref decorator lives
+    in base.py or artifact.py beside the endpoints they decorate, and
+    the alternative -- resolving imports across the whole tree from
+    source -- buys a check against a shape which has never existed.
+    """
+    out: set[str] = set()
+    for dec in fn.decorator_list:
+        node = dec.func if isinstance(dec, ast.Call) else dec
+        name = _bare_name(node)
+        candidates = functions.get(name or '', [])
+        if not candidates:
+            continue
+        if len(candidates) > 1:
+            if problems is not None:
+                problems.append(
+                    '%s is decorated with %s, which is defined more than '
+                    'once in this package, so the kwargs it consumes cannot '
+                    'be told apart' % (fn.name, name))
+            continue
+        out |= _consumed_kwargs(
+            candidates[0], functions, problems, {name or ''})
+    return out
+
+
 def handlers(api_dir: str = API_DIR,
              problems: Optional[list[str]] = None
              ) -> Iterator[tuple[str, ast.Module, ast.ClassDef,
@@ -527,7 +708,17 @@ def documented(fn: ast.FunctionDef) -> bool:
 def derived_location(name: str, fn: ast.FunctionDef, tree: ast.Module,
                      cls: ast.ClassDef, routes: dict[str, set[str]],
                      problems: Optional[list[str]] = None) -> str:
-    """Where a parameter of this name actually arrives."""
+    """Where a parameter of this name actually arrives.
+
+    Called for the names a handler declares and, since #3739, for the
+    names its decorators consume as well -- see ``audit()``. A consumed
+    name takes no branch of its own: it arrives in the JSON body that
+    ``log_request`` merges into kwargs, which is the fallback below, and
+    a consumed name which is *also* a route segment or a webargs query
+    key really does come from there instead. So the answer for a
+    consumed name is derived by exactly the rules below rather than
+    asserted by the caller.
+    """
     # Every source is consulted before answering, rather than
     # short-circuiting on the first hit, so that a problem in a later
     # source is collected even for a name an earlier one resolved.
@@ -564,10 +755,18 @@ def audit(api_dir: str = API_DIR, app: Optional[str] = None
     ``problems`` is what makes that meaningful, because a source which
     could not be read produces the same empty set as one with nothing
     in it, and the derivation then confidently returns a wrong answer.
+
+    A parameter a decorator consumes and nothing declares lands in
+    ``problems`` too. It is not drift -- there is no location literal to
+    rewrite, so the fixer cannot correct it and must refuse the tree
+    instead -- and it is the one defect in here which reaches callers
+    rather than readers: an undeclared functional parameter is a 400 for
+    everyone using it the moment validation enforces (#3739).
     """
     problems: list[str] = []
     routes = route_parameters(
         app or os.path.join(api_dir, 'app.py'), problems)
+    functions = package_functions(api_dir)
     drifted = []
     underivable = []
 
@@ -580,6 +779,8 @@ def audit(api_dir: str = API_DIR, app: Optional[str] = None
         # unit test, so the pre-commit hook would still rewrite a tree
         # containing one.
         handler_kwargs(fn, problems)
+        consumed = decorator_kwargs(fn, functions, problems)
+        declared_names = set()
 
         for declared in declarations(fn, path=path, cls=cls.name):
             if declared.location in UNDERIVABLE_LOCATIONS:
@@ -598,9 +799,24 @@ def audit(api_dir: str = API_DIR, app: Optional[str] = None
                     % (cls.name, fn.name,
                        'name' if declared.name is None else 'location'))
                 continue
+            declared_names.add(declared.name)
             want = derived_location(
                 declared.name, fn, tree, cls, routes, problems)
             if declared.location != want:
                 drifted.append((declared, want))
+
+        # Gated on carrying a declaration at all, like
+        # test_accepted_parameters_are_declared: a handler absent from
+        # the published API declares nothing on purpose, and demanding
+        # a parameter of it would be demanding it be published.
+        if documented(fn):
+            for name in sorted(consumed - declared_names):
+                problems.append(
+                    '%s.%s has a decorator which consumes %r before the '
+                    'handler runs, so a caller can send it, but nothing '
+                    'declares it; declare it in the %s'
+                    % (cls.name, fn.name, name,
+                       derived_location(name, fn, tree, cls, routes,
+                                        problems)))
 
     return drifted, underivable, sorted(set(problems))

--- a/shakenfist/external_api/declarations.py
+++ b/shakenfist/external_api/declarations.py
@@ -548,8 +548,13 @@ def _consumed_kwargs(fn: ast.FunctionDef,
                 problems.append(
                     '%s delegates to %s, which this cannot resolve to a '
                     'single module level function, so the kwargs it '
-                    'consumes are missing from the derivation'
-                    % (fn.name, ast.unparse(stmt.value.func)))
+                    'consumes are missing from the derivation. If it '
+                    'consumes no request parameter, restructure the return '
+                    'so this can see that (return the wrapper, or apply '
+                    'functools.wraps as a decorator on it); otherwise move '
+                    'the target to module level in %s'
+                    % (fn.name, ast.unparse(stmt.value.func),
+                       os.path.basename(API_DIR)))
             continue
         if target in seen:
             continue
@@ -814,7 +819,10 @@ def audit(api_dir: str = API_DIR, app: Optional[str] = None
                 problems.append(
                     '%s.%s has a decorator which consumes %r before the '
                     'handler runs, so a caller can send it, but nothing '
-                    'declares it; declare it in the %s'
+                    'declares it; declare it in the %s. There is no '
+                    'UNDECLARED_BY_DESIGN exemption for a '
+                    'decorator-consumed parameter: declare it or stop '
+                    'consuming it'
                     % (cls.name, fn.name, name,
                        derived_location(name, fn, tree, cls, routes,
                                         problems)))

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -245,7 +245,9 @@ class InstanceEndpoint(api_base.Resource):
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
          ('namespace', 'body', 'namespace',
-          'Scope the name lookup to this namespace.', False)],
+          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another.', False)],
         [(200, 'Information about a single instance.', instance_get_example),
          (404, 'Instance not found.', None)]))
     @api_base.arg_is_instance_ref
@@ -259,7 +261,9 @@ class InstanceEndpoint(api_base.Resource):
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace containing the instance', False)],
+          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another.', False)],
         [(200, 'Information about the instance post delete.',
           instance_get_example_deleted),
          (404, 'Instance not found.', None)]))
@@ -1067,7 +1071,11 @@ class InstanceInterfacesEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'instances', 'List network interfaces for an instance.',
         [('instance_ref', 'path', 'uuidorname',
-          'The UUID or name of the instance.', True)],
+          'The UUID or name of the instance.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another.', False)],
         [(200, 'A list of network interfaces for an instance.',
           instance_interfaces_example),
          (404, 'Instance not found.', None)]))
@@ -1082,6 +1090,10 @@ class InstanceInterfacesEndpoint(api_base.Resource):
         [
             ('instance_ref', 'path', 'uuidorname',
              'The UUID or name of the instance.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
+             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
+             'the namespace of the caller, and only the system namespace may name another.', False),
             ('network', 'body', 'dict',
              'A networkspec defining the new interface. '
              'See https://shakenfist.com/developer_guide/api_reference/instances/#networkspec '
@@ -1212,6 +1224,10 @@ class InstanceEventsEndpoint(api_base.Resource):
         [
             ('instance_ref', 'path', 'uuidorname',
              'The UUID or name of the instance.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
+             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
+             'the namespace of the caller, and only the system namespace may name another.', False),
             ('event_type', 'body', 'string', 'The type of event to return.', False),
             ('limit', 'body', 'integer',
              'The number of events to return, defaults to 100 and is '
@@ -1231,7 +1247,11 @@ class InstanceRebootSoftEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'instances', 'Soft (ACPI) reboot an instance.',
         [('instance_ref', 'path', 'uuidorname',
-          'The UUID or name of the instance.', True)],
+          'The UUID or name of the instance.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another.', False)],
         [(404, 'Instance not found.', None),
          (409, 'The instance cannot be rebooted.', None)]))
     @api_base.arg_is_instance_ref
@@ -1254,7 +1274,11 @@ class InstanceRebootHardEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'instances', 'Hard (reset switch) reboot an instance.',
         [('instance_ref', 'path', 'uuidorname',
-          'The UUID or name of the instance.', True)],
+          'The UUID or name of the instance.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another.', False)],
         [(404, 'Instance not found.', None),
          (409, 'The instance cannot be rebooted.', None)]))
     @api_base.arg_is_instance_ref
@@ -1277,7 +1301,11 @@ class InstancePowerOffEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'instances', 'Power off an instance.',
         [('instance_ref', 'path', 'uuidorname',
-          'The UUID or name of the instance.', True)],
+          'The UUID or name of the instance.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another.', False)],
         [(404, 'Instance not found.', None),
          (409, 'The instance cannot be powered off.', None)]))
     @api_base.arg_is_instance_ref
@@ -1300,7 +1328,11 @@ class InstancePowerOnEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'instances', 'Power on an instance.',
         [('instance_ref', 'path', 'uuidorname',
-          'The UUID or name of the instance.', True)],
+          'The UUID or name of the instance.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another.', False)],
         [(404, 'Instance not found.', None),
          (409, 'The instance cannot be powered on.', None)]))
     @api_base.arg_is_instance_ref
@@ -1323,7 +1355,11 @@ class InstancePauseEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'instances', 'Pause an instance.',
         [('instance_ref', 'path', 'uuidorname',
-          'The UUID or name of the instance.', True)],
+          'The UUID or name of the instance.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another.', False)],
         [(404, 'Instance not found.', None),
          (409, 'The instance cannot be paused.', None)]))
     @api_base.arg_is_instance_ref
@@ -1346,7 +1382,11 @@ class InstanceUnpauseEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'instances', 'Unpause an instance.',
         [('instance_ref', 'path', 'uuidorname',
-          'The UUID or name of the instance.', True)],
+          'The UUID or name of the instance.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another.', False)],
         [(404, 'Instance not found.', None),
          (409, 'The instance cannot be unpaused.', None)]))
     @api_base.arg_is_instance_ref
@@ -1369,7 +1409,11 @@ class InstanceMetadatasEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'instances', 'Fetch metadata for an instance.',
         [('instance_ref', 'path', 'uuidorname',
-          'The instance to fetch metadata for.', True)],
+          'The instance to fetch metadata for.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another.', False)],
         [(200, 'Instance metadata, if any.', None),
          (404, 'Instance not found.', None)],
         requires_admin=True))
@@ -1383,6 +1427,10 @@ class InstanceMetadatasEndpoint(api_base.Resource):
         'instances', 'Add metadata for an instance.',
         [
             ('instance_ref', 'path', 'uuidorname', 'The instance to add a key to.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
+             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
+             'the namespace of the caller, and only the system namespace may name another.', False),
             ('key', 'body', 'string', 'The metadata key to set', True),
             ('value', 'body', 'string', 'The value of the key.', True)
         ],
@@ -1533,6 +1581,10 @@ class InstanceMetadataEndpoint(api_base.Resource):
         [
             ('instance_ref', 'path', 'uuidorname', 'The instance to add a key to.', True),
             ('key', 'path', 'string', 'The metadata key to set', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
+             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
+             'the namespace of the caller, and only the system namespace may name another.', False),
             ('value', 'body', 'string', 'The value of the key.', True)
         ],
         [(200, 'Nothing.', None),
@@ -1556,7 +1608,11 @@ class InstanceMetadataEndpoint(api_base.Resource):
         'instances', 'Delete a metadata key for an instance.',
         [
             ('instance_ref', 'path', 'uuidorname', 'The instance to remove a key from.', True),
-            ('key', 'path', 'string', 'The metadata key to set', True)
+            ('key', 'path', 'string', 'The metadata key to set', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
+             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
+             'the namespace of the caller, and only the system namespace may name another.', False)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),
@@ -1580,6 +1636,10 @@ class InstanceConsoleDataEndpoint(api_base.Resource):
         [
             ('instance_ref', 'path', 'uuidorname',
              'The instance fetch console data for.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
+             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
+             'the namespace of the caller, and only the system namespace may name another.', False),
             # Not unsignedinteger: -1 is a supported sentinel meaning
             # "the whole log", which get_console_data() special-cases
             # and the functional suite relies on. Publishing minimum 0
@@ -1624,7 +1684,11 @@ class InstanceConsoleDataEndpoint(api_base.Resource):
         'instances', 'Delete console data for an instance.',
         [
             ('instance_ref', 'path', 'uuidorname',
-             'The instance fetch console data for.', True)
+             'The instance fetch console data for.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
+             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
+             'the namespace of the caller, and only the system namespace may name another.', False)
         ],
         [(200, 'Nothing.', None),
          (404, 'Instance not found.', None)],
@@ -1673,7 +1737,11 @@ class InstanceVDIConsoleHelperEndpoint(api_base.Resource):
          'for this instance.'),
         [
             ('instance_ref', 'path', 'uuidorname',
-             'The instance fetch console data for.', True)
+             'The instance fetch console data for.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
+             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
+             'the namespace of the caller, and only the system namespace may name another.', False)
         ],
         [(200, 'A .vv file to open in virt-viewer as a application/x-virt-viewer stream.',
           instance_vv_file_example),
@@ -1752,7 +1820,11 @@ class InstanceVDIProxyConsoleHelperEndpoint(api_base.Resource):
          'proxy URL for the SPICE console of this instance.'),
         [
             ('instance_ref', 'path', 'uuidorname',
-             'The instance to mint a VDI console proxy token for.', True)
+             'The instance to mint a VDI console proxy token for.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
+             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
+             'the namespace of the caller, and only the system namespace may name another.', False)
         ],
         [(200, 'A Kerbside proxy URL and the token expiry time.',
           instance_vdiconsoleproxy_get_example),
@@ -1818,6 +1890,10 @@ class InstanceAgentPutEndpoint(api_base.Resource):
         [
             ('instance_ref', 'path', 'uuidorname',
              'The UUID or name of the instance.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
+             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
+             'the namespace of the caller, and only the system namespace may name another.', False),
             ('blob_uuid', 'body', 'uuid',
              'The UUID of the blob to put onto the instance.', True),
             ('path', 'body', 'string',
@@ -1904,6 +1980,10 @@ class InstanceAgentGetEndpoint(api_base.Resource):
         [
             ('instance_ref', 'path', 'uuidorname',
              'The UUID or name of the instance.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
+             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
+             'the namespace of the caller, and only the system namespace may name another.', False),
             ('path', 'body', 'string',
              'The path to fetch the file from inside the instance.', True),
             ('deadline_seconds', 'body', 'number',
@@ -1965,6 +2045,10 @@ class InstanceAgentExecuteEndpoint(api_base.Resource):
         [
             ('instance_ref', 'path', 'uuidorname',
              'The UUID or name of the instance.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
+             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
+             'the namespace of the caller, and only the system namespace may name another.', False),
             ('command_line', 'body', 'string', 'The command to execute.', True),
             ('deadline_seconds', 'body', 'number',
              DEADLINE_SECONDS_DESCRIPTION, False,
@@ -2020,7 +2104,11 @@ class InstanceScreenshotEndpoint(api_base.Resource):
         'instances', 'Collect a screenshot of an instance.',
         [
             ('instance_ref', 'path', 'uuidorname',
-             'The UUID or name of the instance.', True)
+             'The UUID or name of the instance.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
+             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
+             'the namespace of the caller, and only the system namespace may name another.', False)
         ],
         [(200, 'The UUID of a blob containing the screenshot.', None),
          (404, 'Instance not found.', None)]))
@@ -2085,6 +2173,10 @@ class InstanceOutstandingOperationsEndpoint(api_base.Resource):
         'instances', 'Get the outstanding cluster operations for an instance.',
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another.', False),
          ('all', 'query', 'boolean',
           'Include operations which have already completed, rather than '
           'only those still in flight.', False)],

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -1432,7 +1432,9 @@ class InstanceMetadatasEndpoint(api_base.Resource):
              'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
              'the namespace of the caller, and only the system namespace may name another.', False),
             ('key', 'body', 'string', 'The metadata key to set', True),
-            ('value', 'body', 'string', 'The value of the key.', True)
+            ('value', 'body', 'any',
+             'The value of the key. Stored verbatim as any JSON value and never '
+             'interpreted by the API.', True)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),
@@ -1585,7 +1587,9 @@ class InstanceMetadataEndpoint(api_base.Resource):
              'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
              'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
              'the namespace of the caller, and only the system namespace may name another.', False),
-            ('value', 'body', 'string', 'The value of the key.', True)
+            ('value', 'body', 'any',
+             'The value of the key. Stored verbatim as any JSON value and never '
+             'interpreted by the API.', True)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -245,9 +245,7 @@ class InstanceEndpoint(api_base.Resource):
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another.', False)],
+          api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)],
         [(200, 'Information about a single instance.', instance_get_example),
          (404, 'Instance not found.', None)]))
     @api_base.arg_is_instance_ref
@@ -261,9 +259,7 @@ class InstanceEndpoint(api_base.Resource):
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another.', False)],
+          api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)],
         [(200, 'Information about the instance post delete.',
           instance_get_example_deleted),
          (404, 'Instance not found.', None)]))
@@ -1073,9 +1069,7 @@ class InstanceInterfacesEndpoint(api_base.Resource):
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another.', False)],
+          api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)],
         [(200, 'A list of network interfaces for an instance.',
           instance_interfaces_example),
          (404, 'Instance not found.', None)]))
@@ -1091,9 +1085,7 @@ class InstanceInterfacesEndpoint(api_base.Resource):
             ('instance_ref', 'path', 'uuidorname',
              'The UUID or name of the instance.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
-             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
-             'the namespace of the caller, and only the system namespace may name another.', False),
+             api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False),
             ('network', 'body', 'dict',
              'A networkspec defining the new interface. '
              'See https://shakenfist.com/developer_guide/api_reference/instances/#networkspec '
@@ -1225,9 +1217,7 @@ class InstanceEventsEndpoint(api_base.Resource):
             ('instance_ref', 'path', 'uuidorname',
              'The UUID or name of the instance.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
-             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
-             'the namespace of the caller, and only the system namespace may name another.', False),
+             api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False),
             ('event_type', 'body', 'string', 'The type of event to return.', False),
             ('limit', 'body', 'integer',
              'The number of events to return, defaults to 100 and is '
@@ -1249,9 +1239,7 @@ class InstanceRebootSoftEndpoint(api_base.Resource):
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another.', False)],
+          api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)],
         [(404, 'Instance not found.', None),
          (409, 'The instance cannot be rebooted.', None)]))
     @api_base.arg_is_instance_ref
@@ -1276,9 +1264,7 @@ class InstanceRebootHardEndpoint(api_base.Resource):
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another.', False)],
+          api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)],
         [(404, 'Instance not found.', None),
          (409, 'The instance cannot be rebooted.', None)]))
     @api_base.arg_is_instance_ref
@@ -1303,9 +1289,7 @@ class InstancePowerOffEndpoint(api_base.Resource):
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another.', False)],
+          api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)],
         [(404, 'Instance not found.', None),
          (409, 'The instance cannot be powered off.', None)]))
     @api_base.arg_is_instance_ref
@@ -1330,9 +1314,7 @@ class InstancePowerOnEndpoint(api_base.Resource):
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another.', False)],
+          api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)],
         [(404, 'Instance not found.', None),
          (409, 'The instance cannot be powered on.', None)]))
     @api_base.arg_is_instance_ref
@@ -1357,9 +1339,7 @@ class InstancePauseEndpoint(api_base.Resource):
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another.', False)],
+          api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)],
         [(404, 'Instance not found.', None),
          (409, 'The instance cannot be paused.', None)]))
     @api_base.arg_is_instance_ref
@@ -1384,9 +1364,7 @@ class InstanceUnpauseEndpoint(api_base.Resource):
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another.', False)],
+          api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)],
         [(404, 'Instance not found.', None),
          (409, 'The instance cannot be unpaused.', None)]))
     @api_base.arg_is_instance_ref
@@ -1411,9 +1389,7 @@ class InstanceMetadatasEndpoint(api_base.Resource):
         [('instance_ref', 'path', 'uuidorname',
           'The instance to fetch metadata for.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another.', False)],
+          api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)],
         [(200, 'Instance metadata, if any.', None),
          (404, 'Instance not found.', None)],
         requires_admin=True))
@@ -1428,9 +1404,7 @@ class InstanceMetadatasEndpoint(api_base.Resource):
         [
             ('instance_ref', 'path', 'uuidorname', 'The instance to add a key to.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
-             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
-             'the namespace of the caller, and only the system namespace may name another.', False),
+             api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False),
             ('key', 'body', 'string', 'The metadata key to set', True),
             ('value', 'body', 'any',
              'The value of the key. Stored verbatim as any JSON value and never '
@@ -1584,9 +1558,7 @@ class InstanceMetadataEndpoint(api_base.Resource):
             ('instance_ref', 'path', 'uuidorname', 'The instance to add a key to.', True),
             ('key', 'path', 'string', 'The metadata key to set', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
-             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
-             'the namespace of the caller, and only the system namespace may name another.', False),
+             api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False),
             ('value', 'body', 'any',
              'The value of the key. Stored verbatim as any JSON value and never '
              'interpreted by the API.', True)
@@ -1614,9 +1586,7 @@ class InstanceMetadataEndpoint(api_base.Resource):
             ('instance_ref', 'path', 'uuidorname', 'The instance to remove a key from.', True),
             ('key', 'path', 'string', 'The metadata key to set', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
-             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
-             'the namespace of the caller, and only the system namespace may name another.', False)
+             api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),
@@ -1641,9 +1611,7 @@ class InstanceConsoleDataEndpoint(api_base.Resource):
             ('instance_ref', 'path', 'uuidorname',
              'The instance fetch console data for.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
-             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
-             'the namespace of the caller, and only the system namespace may name another.', False),
+             api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False),
             # Not unsignedinteger: -1 is a supported sentinel meaning
             # "the whole log", which get_console_data() special-cases
             # and the functional suite relies on. Publishing minimum 0
@@ -1690,9 +1658,7 @@ class InstanceConsoleDataEndpoint(api_base.Resource):
             ('instance_ref', 'path', 'uuidorname',
              'The instance fetch console data for.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
-             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
-             'the namespace of the caller, and only the system namespace may name another.', False)
+             api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)
         ],
         [(200, 'Nothing.', None),
          (404, 'Instance not found.', None)],
@@ -1743,9 +1709,7 @@ class InstanceVDIConsoleHelperEndpoint(api_base.Resource):
             ('instance_ref', 'path', 'uuidorname',
              'The instance fetch console data for.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
-             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
-             'the namespace of the caller, and only the system namespace may name another.', False)
+             api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)
         ],
         [(200, 'A .vv file to open in virt-viewer as a application/x-virt-viewer stream.',
           instance_vv_file_example),
@@ -1826,9 +1790,7 @@ class InstanceVDIProxyConsoleHelperEndpoint(api_base.Resource):
             ('instance_ref', 'path', 'uuidorname',
              'The instance to mint a VDI console proxy token for.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
-             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
-             'the namespace of the caller, and only the system namespace may name another.', False)
+             api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)
         ],
         [(200, 'A Kerbside proxy URL and the token expiry time.',
           instance_vdiconsoleproxy_get_example),
@@ -1895,9 +1857,7 @@ class InstanceAgentPutEndpoint(api_base.Resource):
             ('instance_ref', 'path', 'uuidorname',
              'The UUID or name of the instance.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
-             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
-             'the namespace of the caller, and only the system namespace may name another.', False),
+             api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False),
             ('blob_uuid', 'body', 'uuid',
              'The UUID of the blob to put onto the instance.', True),
             ('path', 'body', 'string',
@@ -1985,9 +1945,7 @@ class InstanceAgentGetEndpoint(api_base.Resource):
             ('instance_ref', 'path', 'uuidorname',
              'The UUID or name of the instance.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
-             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
-             'the namespace of the caller, and only the system namespace may name another.', False),
+             api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False),
             ('path', 'body', 'string',
              'The path to fetch the file from inside the instance.', True),
             ('deadline_seconds', 'body', 'number',
@@ -2050,9 +2008,7 @@ class InstanceAgentExecuteEndpoint(api_base.Resource):
             ('instance_ref', 'path', 'uuidorname',
              'The UUID or name of the instance.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
-             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
-             'the namespace of the caller, and only the system namespace may name another.', False),
+             api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False),
             ('command_line', 'body', 'string', 'The command to execute.', True),
             ('deadline_seconds', 'body', 'number',
              DEADLINE_SECONDS_DESCRIPTION, False,
@@ -2110,9 +2066,7 @@ class InstanceScreenshotEndpoint(api_base.Resource):
             ('instance_ref', 'path', 'uuidorname',
              'The UUID or name of the instance.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
-             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
-             'the namespace of the caller, and only the system namespace may name another.', False)
+             api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)
         ],
         [(200, 'The UUID of a blob containing the screenshot.', None),
          (404, 'Instance not found.', None)]))
@@ -2178,9 +2132,7 @@ class InstanceOutstandingOperationsEndpoint(api_base.Resource):
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another.', False),
+          api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False),
          ('all', 'query', 'boolean',
           'Include operations which have already completed, rather than '
           'only those still in flight.', False)],

--- a/shakenfist/external_api/interface.py
+++ b/shakenfist/external_api/interface.py
@@ -150,7 +150,9 @@ class InterfaceMetadatasEndpoint(api_base.Resource):
         [
             ('interface_uuid', 'path', 'uuid', 'The interface to add a key to.', True),
             ('key', 'body', 'string', 'The metadata key to set', True),
-            ('value', 'body', 'string', 'The value of the key.', True)
+            ('value', 'body', 'any',
+             'The value of the key. Stored verbatim as any JSON value and never '
+             'interpreted by the API.', True)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),
@@ -177,7 +179,9 @@ class InterfaceMetadataEndpoint(api_base.Resource):
         [
             ('interface_uuid', 'path', 'uuid', 'The interface to add a key to.', True),
             ('key', 'path', 'string', 'The metadata key to set', True),
-            ('value', 'body', 'string', 'The value of the key.', True)
+            ('value', 'body', 'any',
+             'The value of the key. Stored verbatim as any JSON value and never '
+             'interpreted by the API.', True)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),

--- a/shakenfist/external_api/network.py
+++ b/shakenfist/external_api/network.py
@@ -496,7 +496,9 @@ class NetworkMetadatasEndpoint(api_base.Resource):
              'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
              'no namespace, so it is reachable only when this is omitted.', False),
             ('key', 'body', 'string', 'The metadata key to set', True),
-            ('value', 'body', 'string', 'The value of the key.', True)
+            ('value', 'body', 'any',
+             'The value of the key. Stored verbatim as any JSON value and never '
+             'interpreted by the API.', True)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),
@@ -527,7 +529,9 @@ class NetworkMetadataEndpoint(api_base.Resource):
              'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
              'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
              'no namespace, so it is reachable only when this is omitted.', False),
-            ('value', 'body', 'string', 'The value of the key.', True)
+            ('value', 'body', 'any',
+             'The value of the key. Stored verbatim as any JSON value and never '
+             'interpreted by the API.', True)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),

--- a/shakenfist/external_api/network.py
+++ b/shakenfist/external_api/network.py
@@ -140,10 +140,7 @@ class NetworkEndpoint(api_base.Resource):
         [('network_ref', 'path', 'uuidorname',
           'The UUID or name of the network.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another. The floating network belongs to no '
-          'namespace, so it is reachable only when this is omitted.', False)],
+          api_base.NETWORK_REF_NAMESPACE_DESCRIPTION, False)],
         [(200, 'Information about a single network.', network_get_example),
          (404, 'Network not found.', None)]))
     @api_base.arg_is_network_ref
@@ -157,10 +154,7 @@ class NetworkEndpoint(api_base.Resource):
         [('network_ref', 'path', 'uuidorname',
           'The UUID or name of the network.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another. The floating network belongs to no '
-          'namespace, so it is reachable only when this is omitted.', False)],
+          api_base.NETWORK_REF_NAMESPACE_DESCRIPTION, False)],
         [(202,
           'Deletion has been queued. The response body identifies the cluster '
           'operation that will perform the work; clients should poll the '
@@ -395,10 +389,7 @@ class NetworkEventsEndpoint(api_base.Resource):
             ('network_ref', 'path', 'uuidorname',
              'The UUID or name of the network.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
-             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
-             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
-             'no namespace, so it is reachable only when this is omitted.', False),
+             api_base.NETWORK_REF_NAMESPACE_DESCRIPTION, False),
             ('event_type', 'body', 'string', 'The type of event to return.', False),
             ('limit', 'body', 'integer',
              'The number of events to return, defaults to 100 and is '
@@ -448,10 +439,7 @@ class NetworkInterfacesEndpoint(api_base.Resource):
         [('network_ref', 'path', 'uuidorname',
           'The UUID or name of the network.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another. The floating network belongs to no '
-          'namespace, so it is reachable only when this is omitted.', False)],
+          api_base.NETWORK_REF_NAMESPACE_DESCRIPTION, False)],
         [(200, 'The network interfaces on a single network.',
           network_interfaces_example),
          (404, 'Network not found.', None)]))
@@ -473,10 +461,7 @@ class NetworkMetadatasEndpoint(api_base.Resource):
         [('network_ref', 'path', 'uuidorname',
           'The network fetch metadata for.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another. The floating network belongs to no '
-          'namespace, so it is reachable only when this is omitted.', False)],
+          api_base.NETWORK_REF_NAMESPACE_DESCRIPTION, False)],
         [(200, 'Artifact metadata, if any.', None),
          (404, 'Artifact not found.', None)],
         requires_admin=True))
@@ -491,10 +476,7 @@ class NetworkMetadatasEndpoint(api_base.Resource):
         [
             ('network_ref', 'path', 'uuidorname', 'The network to add a key to.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
-             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
-             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
-             'no namespace, so it is reachable only when this is omitted.', False),
+             api_base.NETWORK_REF_NAMESPACE_DESCRIPTION, False),
             ('key', 'body', 'string', 'The metadata key to set', True),
             ('value', 'body', 'any',
              'The value of the key. Stored verbatim as any JSON value and never '
@@ -525,10 +507,7 @@ class NetworkMetadataEndpoint(api_base.Resource):
             ('network_ref', 'path', 'uuidorname', 'The network to add a key to.', True),
             ('key', 'path', 'string', 'The metadata key to set', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
-             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
-             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
-             'no namespace, so it is reachable only when this is omitted.', False),
+             api_base.NETWORK_REF_NAMESPACE_DESCRIPTION, False),
             ('value', 'body', 'any',
              'The value of the key. Stored verbatim as any JSON value and never '
              'interpreted by the API.', True)
@@ -556,10 +535,7 @@ class NetworkMetadataEndpoint(api_base.Resource):
             ('network_ref', 'path', 'uuidorname', 'The network to remove a key from.', True),
             ('key', 'path', 'string', 'The metadata key to set', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
-             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
-             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
-             'no namespace, so it is reachable only when this is omitted.', False)
+             api_base.NETWORK_REF_NAMESPACE_DESCRIPTION, False)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),
@@ -610,10 +586,7 @@ class NetworkPingEndpoint(api_base.Resource):
              'The network to send traffic on.', True),
             ('address', 'path', 'string', 'The IPv4 address to ping.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
-             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
-             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
-             'no namespace, so it is reachable only when this is omitted.', False)
+             api_base.NETWORK_REF_NAMESPACE_DESCRIPTION, False)
         ],
         [(200, 'The stdout and stderr of the ping request.', None),
          (400, 'The IPv4 address is not in the network\'s netblock or is invalid.',
@@ -665,10 +638,7 @@ class NetworkAddressesEndpoint(api_base.Resource):
             ('network_ref', 'path', 'uuidorname',
              'The network to return address allocation information about.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
-             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
-             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
-             'no namespace, so it is reachable only when this is omitted.', False)
+             api_base.NETWORK_REF_NAMESPACE_DESCRIPTION, False)
         ],
         [(200, 'Address allocations', network_allocations_example),
          (404, 'Network not found.', None)]))
@@ -691,10 +661,7 @@ class NetworkRouteAddressEndpoint(api_base.Resource):
             ('network_ref', 'path', 'uuidorname',
              'The network route the address to.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
-             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
-             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
-             'no namespace, so it is reachable only when this is omitted.', False)
+             api_base.NETWORK_REF_NAMESPACE_DESCRIPTION, False)
         ],
         [(200, 'The address that was routed', None),
          (507, 'No floating addresses are available', None),
@@ -728,10 +695,7 @@ class NetworkUnrouteAddressEndpoint(api_base.Resource):
              'The network route the address to.', True),
             ('address', 'path', 'string', 'The address to remove routing for', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
-             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
-             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
-             'no namespace, so it is reachable only when this is omitted.', False)
+             api_base.NETWORK_REF_NAMESPACE_DESCRIPTION, False)
         ],
         [(200, 'The address that was routed', None),
          (403, 'That address is not routed by this network.', None),
@@ -769,10 +733,7 @@ class NetworkDNSAddressEndpoint(api_base.Resource):
               'enabled.'),
              True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
-             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
-             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
-             'no namespace, so it is reachable only when this is omitted.', False),
+             api_base.NETWORK_REF_NAMESPACE_DESCRIPTION, False),
             ('name', 'body', 'string', 'The DNS entry', True),
             ('value', 'body', 'ipv4',
              'The IP address the DNS entry resolves to', True)
@@ -804,10 +765,7 @@ class NetworkDNSAddressEndpoint(api_base.Resource):
             ('network_ref', 'path', 'uuidorname',
              'The network route the address to.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
-             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
-             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
-             'no namespace, so it is reachable only when this is omitted.', False),
+             api_base.NETWORK_REF_NAMESPACE_DESCRIPTION, False),
             ('name', 'body', 'string', 'The DNS entry', True)
         ],
         [(200, 'DNS entry removed', None),
@@ -860,10 +818,7 @@ class NetworkOutstandingOperationsEndpoint(api_base.Resource):
         [('network_ref', 'path', 'uuidorname',
           'The UUID or name of the network.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another. The floating network belongs to no '
-          'namespace, so it is reachable only when this is omitted.', False),
+          api_base.NETWORK_REF_NAMESPACE_DESCRIPTION, False),
          ('all', 'query', 'boolean',
           'Include operations which have already completed, rather than '
           'only those still in flight.', False)],

--- a/shakenfist/external_api/network.py
+++ b/shakenfist/external_api/network.py
@@ -140,7 +140,10 @@ class NetworkEndpoint(api_base.Resource):
         [('network_ref', 'path', 'uuidorname',
           'The UUID or name of the network.', True),
          ('namespace', 'body', 'namespace',
-          'Scope the name lookup to this namespace.', False)],
+          'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another. The floating network belongs to no '
+          'namespace, so it is reachable only when this is omitted.', False)],
         [(200, 'Information about a single network.', network_get_example),
          (404, 'Network not found.', None)]))
     @api_base.arg_is_network_ref
@@ -154,7 +157,10 @@ class NetworkEndpoint(api_base.Resource):
         [('network_ref', 'path', 'uuidorname',
           'The UUID or name of the network.', True),
          ('namespace', 'body', 'namespace',
-          'Scope the name lookup to this namespace.', False)],
+          'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another. The floating network belongs to no '
+          'namespace, so it is reachable only when this is omitted.', False)],
         [(202,
           'Deletion has been queued. The response body identifies the cluster '
           'operation that will perform the work; clients should poll the '
@@ -388,6 +394,11 @@ class NetworkEventsEndpoint(api_base.Resource):
         [
             ('network_ref', 'path', 'uuidorname',
              'The UUID or name of the network.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
+             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
+             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
+             'no namespace, so it is reachable only when this is omitted.', False),
             ('event_type', 'body', 'string', 'The type of event to return.', False),
             ('limit', 'body', 'integer',
              'The number of events to return, defaults to 100 and is '
@@ -435,7 +446,12 @@ class NetworkInterfacesEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'networks', 'Get network interface information.',
         [('network_ref', 'path', 'uuidorname',
-          'The UUID or name of the network.', True)],
+          'The UUID or name of the network.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another. The floating network belongs to no '
+          'namespace, so it is reachable only when this is omitted.', False)],
         [(200, 'The network interfaces on a single network.',
           network_interfaces_example),
          (404, 'Network not found.', None)]))
@@ -455,7 +471,12 @@ class NetworkMetadatasEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'networks', 'Fetch metadata for a network.',
         [('network_ref', 'path', 'uuidorname',
-          'The network fetch metadata for.', True)],
+          'The network fetch metadata for.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another. The floating network belongs to no '
+          'namespace, so it is reachable only when this is omitted.', False)],
         [(200, 'Artifact metadata, if any.', None),
          (404, 'Artifact not found.', None)],
         requires_admin=True))
@@ -469,6 +490,11 @@ class NetworkMetadatasEndpoint(api_base.Resource):
         'networks', 'Add metadata for a network.',
         [
             ('network_ref', 'path', 'uuidorname', 'The network to add a key to.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
+             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
+             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
+             'no namespace, so it is reachable only when this is omitted.', False),
             ('key', 'body', 'string', 'The metadata key to set', True),
             ('value', 'body', 'string', 'The value of the key.', True)
         ],
@@ -496,6 +522,11 @@ class NetworkMetadataEndpoint(api_base.Resource):
         [
             ('network_ref', 'path', 'uuidorname', 'The network to add a key to.', True),
             ('key', 'path', 'string', 'The metadata key to set', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
+             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
+             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
+             'no namespace, so it is reachable only when this is omitted.', False),
             ('value', 'body', 'string', 'The value of the key.', True)
         ],
         [(200, 'Nothing.', None),
@@ -519,7 +550,12 @@ class NetworkMetadataEndpoint(api_base.Resource):
         'networks', 'Delete a metadata key for a network.',
         [
             ('network_ref', 'path', 'uuidorname', 'The network to remove a key from.', True),
-            ('key', 'path', 'string', 'The metadata key to set', True)
+            ('key', 'path', 'string', 'The metadata key to set', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
+             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
+             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
+             'no namespace, so it is reachable only when this is omitted.', False)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),
@@ -568,7 +604,12 @@ class NetworkPingEndpoint(api_base.Resource):
         [
             ('network_ref', 'path', 'uuidorname',
              'The network to send traffic on.', True),
-            ('address', 'path', 'string', 'The IPv4 address to ping.', True)
+            ('address', 'path', 'string', 'The IPv4 address to ping.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
+             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
+             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
+             'no namespace, so it is reachable only when this is omitted.', False)
         ],
         [(200, 'The stdout and stderr of the ping request.', None),
          (400, 'The IPv4 address is not in the network\'s netblock or is invalid.',
@@ -618,7 +659,12 @@ class NetworkAddressesEndpoint(api_base.Resource):
         'networks', 'Return information about the address reservations in a network.',
         [
             ('network_ref', 'path', 'uuidorname',
-             'The network to return address allocation information about.', True)
+             'The network to return address allocation information about.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
+             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
+             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
+             'no namespace, so it is reachable only when this is omitted.', False)
         ],
         [(200, 'Address allocations', network_allocations_example),
          (404, 'Network not found.', None)]))
@@ -639,7 +685,12 @@ class NetworkRouteAddressEndpoint(api_base.Resource):
         'networks', 'Route a floating address to this network, with no DNAT.',
         [
             ('network_ref', 'path', 'uuidorname',
-             'The network route the address to.', True)
+             'The network route the address to.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
+             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
+             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
+             'no namespace, so it is reachable only when this is omitted.', False)
         ],
         [(200, 'The address that was routed', None),
          (507, 'No floating addresses are available', None),
@@ -671,7 +722,12 @@ class NetworkUnrouteAddressEndpoint(api_base.Resource):
         [
             ('network_ref', 'path', 'uuidorname',
              'The network route the address to.', True),
-            ('address', 'path', 'string', 'The address to remove routing for', True)
+            ('address', 'path', 'string', 'The address to remove routing for', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
+             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
+             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
+             'no namespace, so it is reachable only when this is omitted.', False)
         ],
         [(200, 'The address that was routed', None),
          (403, 'That address is not routed by this network.', None),
@@ -708,6 +764,11 @@ class NetworkDNSAddressEndpoint(api_base.Resource):
              ('The network to add a DNS record for, which must have provide_dns '
               'enabled.'),
              True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
+             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
+             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
+             'no namespace, so it is reachable only when this is omitted.', False),
             ('name', 'body', 'string', 'The DNS entry', True),
             ('value', 'body', 'ipv4',
              'The IP address the DNS entry resolves to', True)
@@ -738,6 +799,11 @@ class NetworkDNSAddressEndpoint(api_base.Resource):
         [
             ('network_ref', 'path', 'uuidorname',
              'The network route the address to.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
+             'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
+             'namespace of the caller, and only the system namespace may name another. The floating network belongs to '
+             'no namespace, so it is reachable only when this is omitted.', False),
             ('name', 'body', 'string', 'The DNS entry', True)
         ],
         [(200, 'DNS entry removed', None),
@@ -789,6 +855,11 @@ class NetworkOutstandingOperationsEndpoint(api_base.Resource):
         'networks', 'Get the outstanding cluster operations for a network.',
         [('network_ref', 'path', 'uuidorname',
           'The UUID or name of the network.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the network reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the network found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another. The floating network belongs to no '
+          'namespace, so it is reachable only when this is omitted.', False),
          ('all', 'query', 'boolean',
           'Include operations which have already completed, rather than '
           'only those still in flight.', False)],

--- a/shakenfist/external_api/node.py
+++ b/shakenfist/external_api/node.py
@@ -221,7 +221,9 @@ class NodeMetadatasEndpoint(api_base.Resource):
         [
             ('node', 'path', 'node', 'The node to add a key to.', True),
             ('key', 'body', 'string', 'The metadata key to set', True),
-            ('value', 'body', 'string', 'The value of the key.', True)
+            ('value', 'body', 'any',
+             'The value of the key. Stored verbatim as any JSON value and never '
+             'interpreted by the API.', True)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),
@@ -249,7 +251,9 @@ class NodeMetadataEndpoint(api_base.Resource):
         [
             ('node', 'path', 'node', 'The node to add a key to.', True),
             ('key', 'path', 'string', 'The metadata key to set', True),
-            ('value', 'body', 'string', 'The value of the key.', True)
+            ('value', 'body', 'any',
+             'The value of the key. Stored verbatim as any JSON value and never '
+             'interpreted by the API.', True)
         ],
         [(200, 'Nothing.', None),
          (400, 'One of key or value are missing.', None),

--- a/shakenfist/external_api/snapshot.py
+++ b/shakenfist/external_api/snapshot.py
@@ -34,6 +34,10 @@ class InstanceSnapshotEndpoint(api_base.Resource):
         [
             ('instance_ref', 'path', 'uuidorname',
              'The UUID or name of the instance.', True),
+            ('namespace', 'body', 'namespace',
+             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
+             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
+             'the namespace of the caller, and only the system namespace may name another.', False),
             ('all', 'body', 'boolean',
              'Snapshot every disk, rather than only the first.', False),
             ('device', 'body', 'string',
@@ -88,7 +92,11 @@ class InstanceSnapshotEndpoint(api_base.Resource):
     @swag_from(api_base.swagger_helper(
         'instances', 'List the snapshots of an instance.',
         [('instance_ref', 'path', 'uuidorname',
-          'The UUID or name of the instance.', True)],
+          'The UUID or name of the instance.', True),
+         ('namespace', 'body', 'namespace',
+          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
+          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
+          'namespace of the caller, and only the system namespace may name another.', False)],
         [(200, 'Information about the snapshots of an instance.', None),
          (404, 'Instance not found.', None)]))
     @api_base.arg_is_instance_ref

--- a/shakenfist/external_api/snapshot.py
+++ b/shakenfist/external_api/snapshot.py
@@ -35,9 +35,7 @@ class InstanceSnapshotEndpoint(api_base.Resource):
             ('instance_ref', 'path', 'uuidorname',
              'The UUID or name of the instance.', True),
             ('namespace', 'body', 'namespace',
-             'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID '
-             'is resolved without it, but the instance found must live here or the request answers 404. Defaults to '
-             'the namespace of the caller, and only the system namespace may name another.', False),
+             api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False),
             ('all', 'body', 'boolean',
              'Snapshot every disk, rather than only the first.', False),
             ('device', 'body', 'string',
@@ -98,9 +96,7 @@ class InstanceSnapshotEndpoint(api_base.Resource):
         [('instance_ref', 'path', 'uuidorname',
           'The UUID or name of the instance.', True),
          ('namespace', 'body', 'namespace',
-          'The namespace to resolve the instance reference in. A name is only looked up in this namespace; a UUID is '
-          'resolved without it, but the instance found must live here or the request answers 404. Defaults to the '
-          'namespace of the caller, and only the system namespace may name another.', False)],
+          api_base.INSTANCE_REF_NAMESPACE_DESCRIPTION, False)],
         [(200, 'Information about the snapshots of an instance.', None),
          (404, 'Instance not found.', None)]))
     @api_base.arg_is_instance_ref

--- a/shakenfist/external_api/snapshot.py
+++ b/shakenfist/external_api/snapshot.py
@@ -67,10 +67,14 @@ class InstanceSnapshotEndpoint(api_base.Resource):
         # client has always transmitted `thin: false` when the caller did
         # not ask for thin (the CLI flag defaults to False), so honouring
         # an explicit false here would make SNAPSHOTS_DEFAULT_TO_THIN
-        # inert for every shipped client. The absent-versus-false
-        # distinction cannot be drawn until phase 4 of
-        # PLAN-api-input-validation, alongside a client that omits the
-        # key when unset.
+        # inert for every shipped client. This used to say the
+        # absent-versus-false distinction waits on phase 4 of
+        # PLAN-api-input-validation; it does not. Request validation is
+        # check-only, so the handler receives thin=False from
+        # log_request's body merge whatever the mode, and
+        # `'thin' in flask.request.json` draws the distinction today
+        # without any schema layer. The blocker is only ever the
+        # client: see issue 4100.
         if not thin:
             thin = config.SNAPSHOTS_DEFAULT_TO_THIN
 

--- a/shakenfist/external_api/validation.py
+++ b/shakenfist/external_api/validation.py
@@ -57,6 +57,19 @@ LOG, _ = logs.setup(__name__)
 # 'header' carries the JWT, which the authentication decorators own.
 _IGNORED_LOCATIONS = frozenset(['header', 'formData'])
 
+# How the 'any' type token (D15) renders: a `format` annotation and no
+# `type` at all, so the published schema constrains nothing while still
+# telling a reader what the parameter is.
+#
+# It lives here rather than in base.py, where the rest of the type
+# vocabulary lives, because base.py imports this module and the reverse
+# would be an import cycle. ARGTYPES['any'] is built from this constant,
+# so the rendering and the compiler's recognition of it are the same
+# string by construction: a token that renders as one thing and compiles
+# as another is precisely the drift the "compile from the rendered
+# specification" design of this module exists to prevent.
+ANY_VALUE_FORMAT = 'any JSON value'
+
 _SCALARS: dict[str, type[fields.Field[Any]]] = {
     'string': fields.String,
     'integer': fields.Integer,
@@ -142,6 +155,33 @@ def _field(spec: dict[str, Any]) -> fields.Field[Any]:
         # items is always present: swagger_helper() renders the array
         # tokens with it, and OpenAPI 2.0 requires it.
         return fields.List(_field(spec.get('items', {})), **kwargs)
+
+    if 'type' not in spec and spec.get('format') == ANY_VALUE_FORMAT:
+        # The 'any' token, which is typeless deliberately rather than
+        # by omission. Without this branch it fell into the fallback
+        # below and logged "unrecognised type" once per site at every
+        # sf-api start -- fourteen warnings about a token the
+        # vocabulary defines, which is noise, and worse, it made a
+        # genuinely unrecognised token indistinguishable from expected
+        # noise. That warning is the only signal the fallback produces,
+        # so anything expected has to be kept out of it.
+        #
+        # Keyed on the absence of the `type` key rather than on
+        # `declared` being empty: the normalisation above flattens an
+        # unreadable type to '' too, and a schema whose type is present
+        # but not a string should still reach the warning. Absent and
+        # unreadable are different facts, and only the first is
+        # deliberate.
+        #
+        # Bounds are dropped for the same reason the fallback drops
+        # them: Raw does not coerce, so a Range or Regexp validator
+        # would raise TypeError from inside schema.validate() the
+        # moment it met a value of the wrong Python type.
+        # `_validated_constraints` already refuses a bound on a
+        # typeless token at import time, so 'any' carries none today;
+        # this keeps the next typeless token from depending on that.
+        kwargs.pop('validate', None)
+        return fields.Raw(**kwargs)
 
     field_class = _SCALARS.get(declared)
     if field_class is None:

--- a/shakenfist/tests/external_api/test_openapi_spec.py
+++ b/shakenfist/tests/external_api/test_openapi_spec.py
@@ -233,11 +233,51 @@ class OpenAPISpecificationTestCase(base.ShakenFistTestCase):
          {'type': 'integer', 'minimum': 1, 'maximum': 1000}),
         ('/auth/namespaces/{namespace}/claims/{claim_ref}/events', 'get',
          'limit', {'type': 'integer', 'minimum': 1, 'maximum': 1000}),
+        # The fourteen metadata `value` declarations (D15): 'any'
+        # renders with no 'type' key at all, so a typeless schema is
+        # exactly as much this table's business as an object or an
+        # array -- see the typeless branch of
+        # test_every_published_structure_or_bound_is_registered.
+        # Do not add network.py's DNS record `value` here: it is a
+        # different parameter, declared 'ipv4', and correctly typed.
+        ('/artifacts/{artifact_ref}/metadata', 'post', 'value',
+         {'format': 'any JSON value'}),
+        ('/artifacts/{artifact_ref}/metadata/{key}', 'put', 'value',
+         {'format': 'any JSON value'}),
+        ('/auth/namespaces/{namespace}/metadata', 'post', 'value',
+         {'format': 'any JSON value'}),
+        ('/auth/namespaces/{namespace}/metadata/{key}', 'put', 'value',
+         {'format': 'any JSON value'}),
+        ('/blobs/{blob_uuid}/metadata', 'post', 'value',
+         {'format': 'any JSON value'}),
+        ('/blobs/{blob_uuid}/metadata/{key}', 'put', 'value',
+         {'format': 'any JSON value'}),
+        ('/instances/{instance_ref}/metadata', 'post', 'value',
+         {'format': 'any JSON value'}),
+        ('/instances/{instance_ref}/metadata/{key}', 'put', 'value',
+         {'format': 'any JSON value'}),
+        ('/interfaces/{interface_uuid}/metadata', 'post', 'value',
+         {'format': 'any JSON value'}),
+        ('/interfaces/{interface_uuid}/metadata/{key}', 'put', 'value',
+         {'format': 'any JSON value'}),
+        ('/networks/{network_ref}/metadata', 'post', 'value',
+         {'format': 'any JSON value'}),
+        ('/networks/{network_ref}/metadata/{key}', 'put', 'value',
+         {'format': 'any JSON value'}),
+        ('/nodes/{node}/metadata', 'post', 'value',
+         {'format': 'any JSON value'}),
+        ('/nodes/{node}/metadata/{key}', 'put', 'value',
+         {'format': 'any JSON value'}),
     ]
 
     # A published parameter is this table's business if it carries a
     # structure or a bound. Everything else is a plain scalar whose
-    # type token says all there is to say.
+    # type token says all there is to say. A schema with no 'type' key
+    # at all counts too: 'any' (D15) is the one token that renders
+    # this way, and it constrains nothing, so a declaration changing to
+    # it must be exactly as visible here as one gaining an object or an
+    # array -- see the typeless check in
+    # test_every_published_structure_or_bound_is_registered().
     STRUCTURE_TYPES = frozenset(['object', 'array'])
 
     def _published_parameters(self, operation):
@@ -349,7 +389,14 @@ class OpenAPISpecificationTestCase(base.ShakenFistTestCase):
                     continue
                 published, _ = self._published_parameters(operation)
                 for (name, schema) in published.items():
-                    structured = schema.get('type') in self.STRUCTURE_TYPES
+                    # A schema with no 'type' key at all is 'any'
+                    # (D15): unconstrained rather than structured in
+                    # the object/array sense, but exactly as wide, so
+                    # it must register here too -- otherwise the
+                    # widest token in the vocabulary is the one type
+                    # change this table would never catch.
+                    structured = ('type' not in schema
+                                  or schema.get('type') in self.STRUCTURE_TYPES)
                     bounded = bool(set(schema) & api_base.CONSTRAINT_KEYS)
                     if not structured and not bounded:
                         continue
@@ -360,7 +407,7 @@ class OpenAPISpecificationTestCase(base.ShakenFistTestCase):
                             % (method, path, name,
                                {k: v for (k, v) in schema.items()
                                 if k in api_base.CONSTRAINT_KEYS
-                                or k in ('type', 'items')}))
+                                or k in ('type', 'items', 'format')}))
 
         self.assertEqual(
             [], unregistered,

--- a/shakenfist/tests/external_api/test_parameter_declarations.py
+++ b/shakenfist/tests/external_api/test_parameter_declarations.py
@@ -67,11 +67,65 @@ UNDOCUMENTED_BY_DESIGN = {
     ('Readyz', 'get'),
 }
 
+# Every declaration allowed to use the 'any' type token (D15). 'any'
+# turns validation off for a parameter, so once it exists it is the
+# easy answer to any inconvenient type error; a fifteenth use must be
+# a deliberate, visible edit to this set rather than a quiet one. All
+# fourteen are the metadata `value` parameter -- the one place the API
+# stores a caller-supplied value it never interprets -- and
+# network.py's DNS record `value` (declared 'ipv4') is deliberately
+# not among them. (cls, method, name).
+ANY_TOKEN_DECLARATIONS = {
+    ('ArtifactMetadatasEndpoint', 'post', 'value'),
+    ('ArtifactMetadataEndpoint', 'put', 'value'),
+    ('AuthMetadatasEndpoint', 'post', 'value'),
+    ('AuthMetadataEndpoint', 'put', 'value'),
+    ('BlobMetadatasEndpoint', 'post', 'value'),
+    ('BlobMetadataEndpoint', 'put', 'value'),
+    ('InstanceMetadatasEndpoint', 'post', 'value'),
+    ('InstanceMetadataEndpoint', 'put', 'value'),
+    ('InterfaceMetadatasEndpoint', 'post', 'value'),
+    ('InterfaceMetadataEndpoint', 'put', 'value'),
+    ('NetworkMetadatasEndpoint', 'post', 'value'),
+    ('NetworkMetadataEndpoint', 'put', 'value'),
+    ('NodeMetadatasEndpoint', 'post', 'value'),
+    ('NodeMetadataEndpoint', 'put', 'value'),
+}
+
 
 def _endpoints():
     """Yield (class name, method name, method node) per handler."""
     for _, _, cls, fn in declarations.handlers():
         yield cls.name, fn.name, fn
+
+
+def _declared_types():
+    """(cls, method, name, location, argtype) for every declared
+    parameter in the tree.
+
+    declarations.Declaration never carries the type token -- nothing
+    in phase 3's derivation needs it -- so this mirrors
+    declarations.declarations()'s AST walk far enough to pull out
+    item.elts[2] as well, which is all pinning 'any' usage needs.
+    """
+    out = []
+    for _, _, cls, fn in declarations.handlers():
+        for dec in fn.decorator_list:
+            if 'swagger_helper' not in ast.unparse(dec):
+                continue
+            call = dec.args[0] if isinstance(dec, ast.Call) and dec.args else None
+            if not (isinstance(call, ast.Call) and len(call.args) >= 3
+                    and isinstance(call.args[2], ast.List)):
+                continue
+            for item in call.args[2].elts:
+                if not (isinstance(item, ast.Tuple) and len(item.elts) in (5, 6)):
+                    continue
+                out.append((
+                    cls.name, fn.name,
+                    declarations.literal(item.elts[0]),
+                    declarations.literal(item.elts[1]),
+                    declarations.literal(item.elts[2])))
+    return out
 
 
 class ParameterDeclarationTestCase(base.ShakenFistTestCase):
@@ -222,6 +276,55 @@ class ParameterDeclarationTestCase(base.ShakenFistTestCase):
                     'flask_restful passes the segment to every method on '
                     'the class' % (cls, name, cls, method))
         self.assertEqual([], problems)
+
+    def test_any_token_use_is_pinned(self):
+        """'any' (D15) turns validation off for a parameter. Once it
+        exists it is the easy answer to any inconvenient type error, so
+        pin the exact set of declarations using it -- the metadata
+        `value` family and nothing else -- so a fifteenth use is a
+        deliberate, visible edit to ANY_TOKEN_DECLARATIONS rather than
+        a quiet one."""
+        any_uses = [(cls, method, name, location)
+                    for (cls, method, name, location, argtype)
+                    in _declared_types() if argtype == 'any']
+        found = {(cls, method, name) for (cls, method, name, _) in any_uses}
+
+        self.assertEqual(
+            set(), found - ANY_TOKEN_DECLARATIONS,
+            'these declarations started using the \'any\' type token, '
+            'which this test does not expect. If that is deliberate, read '
+            'D15 in docs/plans/PLAN-api-input-validation-phase-04-enforce'
+            '.md, confirm the parameter really is a value the API stores '
+            'but never interprets, and add it to ANY_TOKEN_DECLARATIONS')
+        self.assertEqual(
+            set(), ANY_TOKEN_DECLARATIONS - found,
+            'these ANY_TOKEN_DECLARATIONS entries no longer match a '
+            'declaration using \'any\'; remove them, or the declaration '
+            'was narrowed back and this set has fallen behind')
+        self.assertEqual(
+            14, len(any_uses),
+            '\'any\' should be used by exactly fourteen declarations (the '
+            'metadata value family); if that count is changing '
+            'deliberately, update this number and ANY_TOKEN_DECLARATIONS '
+            'together')
+
+        wrong_name = [(cls, method, name) for (cls, method, name, _)
+                      in any_uses if name != 'value']
+        self.assertEqual(
+            [], wrong_name,
+            'every existing use of \'any\' is the metadata value '
+            'parameter; %r declares a different parameter as \'any\', '
+            'which is a new kind of use this test has not been told to '
+            'expect' % (wrong_name,))
+
+        wrong_location = [(cls, method, name, location) for
+                          (cls, method, name, location) in any_uses
+                          if location != 'body']
+        self.assertEqual(
+            [], wrong_location,
+            '\'any\' is body-only -- swagger_helper() refuses it '
+            'elsewhere -- so a non-body use here means that refusal has '
+            'a hole: %r' % (wrong_location,))
 
     def test_every_mounted_class_is_an_endpoint_and_vice_versa(self):
         """route_parameters() and handlers() must agree on what an
@@ -1902,8 +2005,13 @@ class SwaggerHelperValidationTestCase(base.ShakenFistTestCase):
         in, so the specification would be invalid. Refused at import
         time like every other declaration defect, rather than left for
         test_openapi_spec.py to find after sf-api has started serving
-        it."""
-        for argtype in ('arrayofdict', 'dict'):
+        it.
+
+        'any' (D15) is included for the same reason even though it
+        renders no 'type' key at all: it is body-only like 'dict' and
+        the array tokens, refused outside a body by name rather than
+        by inspecting the rendered schema."""
+        for argtype in ('arrayofdict', 'dict', 'any'):
             for location in ('query', 'path', 'header', 'formData'):
                 with self.subTest(argtype=argtype, location=location):
                     self.assertRaises(

--- a/shakenfist/tests/external_api/test_parameter_declarations.py
+++ b/shakenfist/tests/external_api/test_parameter_declarations.py
@@ -40,13 +40,17 @@ UNDECLARED_BY_DESIGN = {
     ('NodeMetadataEndpoint', 'delete', 'value'),
 }
 
-# Deferred to phase 4 for the same reason: InstanceSnapshotEndpoint.post
-# treats an explicit `thin: false` as unset. The official client has
-# always transmitted the key (`--thin/--flatten` defaults to False and
-# apiclient sends it unconditionally), so honouring false today would
-# make SNAPSHOTS_DEFAULT_TO_THIN inert for every shipped client. The
-# absent-versus-false distinction needs the schema layer plus a client
-# release that omits the key when unset.
+# Not deferred to phase 4 after all, though it long said it was:
+# InstanceSnapshotEndpoint.post treats an explicit `thin: false` as
+# unset. The official client has always transmitted the key
+# (`--thin/--flatten` defaults to False and apiclient sends it
+# unconditionally), so honouring false today would make
+# SNAPSHOTS_DEFAULT_TO_THIN inert for every shipped client. No phase of
+# PLAN-api-input-validation unblocks that: the validation layer is
+# check-only and never injects, so the handler sees thin=False
+# regardless, and the distinction is drawable today without it. It
+# needs a client release which omits the key, and a capability token to
+# detect one. Tracked as issue 4100.
 
 # Declarations exempt from location derivation. `header` and `formData`
 # cannot be derived from the code, so a declaration using one bypasses

--- a/shakenfist/tests/external_api/test_parameter_declarations.py
+++ b/shakenfist/tests/external_api/test_parameter_declarations.py
@@ -97,6 +97,52 @@ ANY_TOKEN_DECLARATIONS = {
 }
 
 
+# The `namespace` body parameter every ref resolving decorator pops
+# (issue 3739) is described by one of four module constants in
+# api_base, and which constant goes with which decorator is a statement
+# about how a name resolves: the widened text promises a search across
+# shared and trusted artifacts, the narrow one promises the opposite.
+# Pasting the wrong one publishes a false statement that no other test
+# could see, so the pairing is pinned here.
+REF_DECORATOR_NAMESPACE_DESCRIPTIONS = {
+    'arg_is_instance_ref': 'INSTANCE_REF_NAMESPACE_DESCRIPTION',
+    'arg_is_network_ref': 'NETWORK_REF_NAMESPACE_DESCRIPTION',
+    'arg_is_artifact_ref': 'ARTIFACT_REF_NAMESPACE_DESCRIPTION',
+    'arg_is_visible_artifact_ref':
+        'VISIBLE_ARTIFACT_REF_NAMESPACE_DESCRIPTION',
+}
+
+
+def _bare_decorator_name(node):
+    """The undotted name of a decoration site, `@a.b.c(...)` -> 'c'."""
+    while isinstance(node, ast.Call):
+        node = node.func
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    return None
+
+
+def _namespace_description_node(fn):
+    """The description element of a handler's body `namespace` tuple."""
+    for dec in fn.decorator_list:
+        if not (isinstance(dec, ast.Call)
+                and 'swagger_helper' in ast.unparse(dec)):
+            continue
+        call = dec.args[0] if dec.args else None
+        if not (isinstance(call, ast.Call) and len(call.args) >= 3
+                and isinstance(call.args[2], ast.List)):
+            continue
+        for item in call.args[2].elts:
+            if not (isinstance(item, ast.Tuple) and len(item.elts) >= 5):
+                continue
+            if (declarations.literal(item.elts[0]) == 'namespace'
+                    and declarations.literal(item.elts[1]) == 'body'):
+                return item.elts[3]
+    return None
+
+
 def _endpoints():
     """Yield (class name, method name, method node) per handler."""
     for _, _, cls, fn in declarations.handlers():
@@ -577,6 +623,83 @@ class ParameterDeclarationTestCase(base.ShakenFistTestCase):
                     '%s.%s declares %r, which is injected by a decorator '
                     'rather than sent by a caller'
                     % (cls, method, parameter.name))
+
+    def test_namespace_descriptions_match_their_decorator(self):
+        """Each of the 55 ref lookup handlers uses the right constant.
+
+        The four descriptions were pasted inline at every site before
+        they were hoisted, which made a wording fix 55 edits and drift
+        between copies invisible. Hoisting them fixes that and creates
+        a new way to be wrong -- referencing the constant next to the
+        one the decorator implements -- so the pairing is asserted
+        rather than eyeballed. It is checked per handler, and the count
+        is pinned, because a derivation which silently stopped finding
+        the decorators would otherwise pass by examining nothing.
+        """
+        checked = 0
+        for cls, method, fn in _endpoints():
+            decorators = [
+                name for name in map(_bare_decorator_name, fn.decorator_list)
+                if name in REF_DECORATOR_NAMESPACE_DESCRIPTIONS]
+            if not decorators:
+                continue
+            self.assertEqual(
+                1, len(decorators),
+                '%s.%s carries more than one ref resolving decorator (%s), '
+                'so which namespace description is correct is ambiguous'
+                % (cls, method, ', '.join(decorators)))
+
+            node = _namespace_description_node(fn)
+            self.assertIsNotNone(
+                node,
+                '%s.%s is behind %s, which pops `namespace` out of kwargs, '
+                'but declares no body namespace parameter'
+                % (cls, method, decorators[0]))
+            name = node.attr if isinstance(node, ast.Attribute) else (
+                node.id if isinstance(node, ast.Name) else None)
+            self.assertEqual(
+                REF_DECORATOR_NAMESPACE_DESCRIPTIONS[decorators[0]], name,
+                '%s.%s is behind %s but describes its namespace parameter '
+                'with %s. The four descriptions differ in what they promise '
+                'about how a name resolves, so this publishes a false '
+                'statement.'
+                % (cls, method, decorators[0],
+                   repr(name) if name else 'text written inline rather than '
+                   'one of the api_base constants'))
+            checked += 1
+
+        self.assertEqual(
+            55, checked,
+            'expected 55 handlers behind a ref resolving decorator, found '
+            '%d. If the count changed on purpose, update it here.' % checked)
+
+    def test_artifact_uuid_is_not_a_parameter(self):
+        """`artifact_uuid` is an ordinary undeclared body key.
+
+        `_resolve_artifact_ref` used to resolve an artifact from a body
+        `artifact_uuid` without popping it, so the derivation could not
+        see it and the handler it then called could not accept it: the
+        branch resolved the artifact and the call raised TypeError,
+        which the broad except turned into a 400 carrying interpreter
+        text. It was deleted rather than declared, because declaring it
+        would publish a parameter that never worked.
+
+        The property asserted is the one that made the branch dead --
+        no handler accepts the kwarg -- rather than the absence of the
+        branch, so reintroducing the shape in any decorator fails here
+        too.
+        """
+        for cls, method, fn in _endpoints():
+            self.assertNotIn(
+                'artifact_uuid', declarations.handler_kwargs(fn),
+                '%s.%s accepts an artifact_uuid kwarg. Nothing populates '
+                'it from a route, so it can only arrive as an undeclared '
+                'body key; declare it or remove it.' % (cls, method))
+            for parameter in declarations.declarations(fn):
+                self.assertNotEqual(
+                    'artifact_uuid', parameter.name,
+                    '%s.%s declares artifact_uuid, but no handler accepts '
+                    'it and no route mounts it' % (cls, method))
 
     def test_every_endpoint_is_documented(self):
         """A handler with no swag_from is absent from the published API.

--- a/shakenfist/tests/external_api/test_parameter_declarations.py
+++ b/shakenfist/tests/external_api/test_parameter_declarations.py
@@ -254,15 +254,23 @@ class ParameterDeclarationTestCase(base.ShakenFistTestCase):
     def test_declared_names_are_real_parameters(self):
         """A declared name must be something the handler can receive.
 
+        Receiving it is not the same as it reaching the signature. A
+        decorator which pops a name out of kwargs consumes a parameter
+        the caller really sends -- `namespace` on every ref lookup --
+        and the handler never sees it, so the signature alone would
+        call fifty-five true declarations false (#3739).
+
         An empty declaration list is legitimate -- eight endpoints
         accept nothing -- and needs no guard, because the loop below is
         already a no-op for one. The sibling assertion's version of that
         guard was load-bearing and wrong, so it is deliberately absent
         here rather than kept for symmetry.
         """
+        functions = declarations.package_functions()
         for cls, method, fn in _endpoints():
             problems = []
-            accepted = declarations.handler_kwargs(fn, problems)
+            accepted = set(declarations.handler_kwargs(fn, problems))
+            accepted |= declarations.decorator_kwargs(fn, functions, problems)
             self.assertEqual(
                 [], problems,
                 '%s.%s: the accepted parameter list could not be '
@@ -287,7 +295,15 @@ class ParameterDeclarationTestCase(base.ShakenFistTestCase):
         parameters have been emptied while the handler still accepts
         them. The three UNDOCUMENTED_BY_DESIGN handlers take no kwargs,
         so this loop is a no-op for them.
+
+        A parameter a decorator consumes counts as accepted, and is the
+        half of #3739 that matters going forward: the signature-only
+        rule declared the popped `namespace` invisible, so nobody had to
+        publish it, and the warn window found it as a rejection against
+        the official client. The next `kwargs.pop` in a decorator fails
+        here instead.
         """
+        functions = declarations.package_functions()
         for cls, method, fn in _endpoints():
             if not declarations.documented(fn):
                 continue
@@ -298,6 +314,9 @@ class ParameterDeclarationTestCase(base.ShakenFistTestCase):
             # unreadable parameter list is a failure, not an absence.
             problems = []
             kwargs = declarations.handler_kwargs(fn, problems)
+            kwargs += sorted(
+                declarations.decorator_kwargs(fn, functions, problems)
+                - set(kwargs))
             self.assertEqual(
                 [], problems,
                 '%s.%s: the accepted parameter list could not be '
@@ -1113,6 +1132,277 @@ class FakeEndpoint(api_base.Resource):
         self.assertEqual(
             api_base.RAW_BODY_PARAMETER,
             declarations.base_constants()['RAW_BODY_PARAMETER'])
+
+    def test_decorator_consumed_kwargs_are_derived(self):
+        """A decorator which pops a kwarg consumes a real parameter.
+
+        The shape of #3739: the caller sends `namespace` in the body,
+        log_request merges it into kwargs, and the decorator takes it
+        before the handler runs. None of the other derivation sources
+        can see it -- it is not a route segment, not a webargs key, not
+        a flask.request.args read, and not in the signature -- so
+        without this term the parameter is functional and undeclarable.
+        """
+        source = '''
+def arg_is_thing_ref(func):
+    def wrapper(*args, **kwargs):
+        body_namespace = kwargs.pop('namespace', None)
+        del kwargs['scope']
+        return func(*args, **kwargs)
+    return wrapper
+
+
+class Thing:
+    @arg_is_thing_ref
+    def get(self, thing_ref=None):
+        pass
+'''
+        tree = ast.parse(source)
+        functions = {'arg_is_thing_ref': [tree.body[0]]}
+        fn = tree.body[1].body[0]
+
+        problems = []
+        self.assertEqual(
+            {'namespace', 'scope'},
+            declarations.decorator_kwargs(fn, functions, problems))
+        self.assertEqual([], problems)
+
+    def test_decorator_delegation_is_followed(self):
+        """arg_is_artifact_ref and arg_is_visible_artifact_ref are both
+        one-liners returning _resolve_artifact_ref(func, widen=...), so
+        the pop is a level below the name at the decoration site. A walk
+        which stopped at the decorator would answer "consumes nothing"
+        for nine handlers.
+        """
+        source = '''
+def _resolve(func, widen):
+    def wrapper(*args, **kwargs):
+        body_namespace = kwargs.pop('namespace', None)
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def arg_is_thing_ref(func):
+    return _resolve(func, widen=False)
+
+
+class Thing:
+    @arg_is_thing_ref
+    def get(self, thing_ref=None):
+        pass
+'''
+        tree = ast.parse(source)
+        functions = {'_resolve': [tree.body[0]],
+                     'arg_is_thing_ref': [tree.body[1]]}
+        fn = tree.body[2].body[0]
+
+        problems = []
+        self.assertEqual(
+            {'namespace'},
+            declarations.decorator_kwargs(fn, functions, problems))
+        self.assertEqual([], problems)
+
+    def test_unfollowable_delegation_is_a_problem(self):
+        """The decorator's real body is somewhere this cannot read, so
+        the empty set it would otherwise return is a confident wrong
+        answer rather than an absence."""
+        source = '''
+def arg_is_thing_ref(func):
+    return somewhere_else.resolve(func)
+
+
+class Thing:
+    @arg_is_thing_ref
+    def get(self, thing_ref=None):
+        pass
+'''
+        tree = ast.parse(source)
+        functions = {'arg_is_thing_ref': [tree.body[0]]}
+        fn = tree.body[1].body[0]
+
+        problems = []
+        self.assertEqual(
+            set(), declarations.decorator_kwargs(fn, functions, problems))
+        self.assertEqual(1, len(problems), problems)
+        self.assertIn('delegates to', problems[0])
+
+    def test_non_literal_pop_key_is_a_problem(self):
+        """The parameter is consumed whether or not its name can be
+        read, so saying nothing about it would leave it undeclarable and
+        unenforceable -- #3739 one level down."""
+        source = '''
+def arg_is_thing_ref(func):
+    def wrapper(*args, **kwargs):
+        value = kwargs.pop(KEY, None)
+        return func(*args, **kwargs)
+    return wrapper
+
+
+class Thing:
+    @arg_is_thing_ref
+    def get(self, thing_ref=None):
+        pass
+'''
+        tree = ast.parse(source)
+        functions = {'arg_is_thing_ref': [tree.body[0]]}
+        fn = tree.body[1].body[0]
+
+        problems = []
+        self.assertEqual(
+            set(), declarations.decorator_kwargs(fn, functions, problems))
+        self.assertEqual(1, len(problems), problems)
+        self.assertIn('cannot read', problems[0])
+
+    def test_decorators_outside_the_package_are_not_problems(self):
+        """"Unresolvable" has to mean "found it and could not read it".
+
+        Every handler in the tree carries decorators which are not
+        package functions at all -- swag_from and use_kwargs come from
+        third party libraries -- so reporting a name this cannot find
+        would report the whole API and mean nothing. A pop on something
+        which is not a kwargs dict is not a consumed parameter either.
+        """
+        source = '''
+def helper(func):
+    def wrapper(*args, **kwargs):
+        local = {'a': 1}
+        local.pop('a', None)
+        return func(*args, **kwargs)
+    return wrapper
+
+
+class Thing:
+    @swag_from(api_base.swagger_helper('things', 'A thing.', [], []))
+    @use_kwargs(get_args, location='query')
+    @helper
+    def get(self, thing_ref=None):
+        pass
+'''
+        tree = ast.parse(source)
+        functions = {'helper': [tree.body[0]]}
+        fn = tree.body[1].body[0]
+
+        problems = []
+        self.assertEqual(
+            set(), declarations.decorator_kwargs(fn, functions, problems))
+        self.assertEqual([], problems)
+
+    def test_ambiguous_decorator_name_is_a_problem(self):
+        """Names are resolved bare, because that is all a decoration
+        site carries. Two modules defining one is therefore a name this
+        cannot resolve, not a name it may pick a winner for."""
+        source = '''
+def arg_is_thing_ref(func):
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+
+
+class Thing:
+    @arg_is_thing_ref
+    def get(self, thing_ref=None):
+        pass
+'''
+        tree = ast.parse(source)
+        functions = {'arg_is_thing_ref': [tree.body[0], tree.body[0]]}
+        fn = tree.body[1].body[0]
+
+        problems = []
+        self.assertEqual(
+            set(), declarations.decorator_kwargs(fn, functions, problems))
+        self.assertEqual(1, len(problems), problems)
+        self.assertIn('defined more than once', problems[0])
+
+    def test_a_consumed_parameter_must_be_declared(self):
+        """The audit term, end to end, on constructed sources.
+
+        Not drift -- there is no location literal to rewrite -- so it
+        lands in problems, which is what makes the fixer and the
+        pre-commit hook refuse the tree rather than silently pass it.
+        """
+        self._write('app.py', "api.add_resource(FakeEndpoint, '/fakes')\n")
+        self._write('fake.py', '''
+def arg_is_fake_ref(func):
+    def wrapper(*args, **kwargs):
+        body_namespace = kwargs.pop('namespace', None)
+        return func(*args, **kwargs)
+    return wrapper
+
+
+class FakeEndpoint(api_base.Resource):
+    @swag_from(api_base.swagger_helper(
+        'fakes', 'A fake.',
+        [('alpha', 'body', 'string', 'A parameter.', False)],
+        []))
+    @arg_is_fake_ref
+    def get(self, alpha=None):
+        pass
+''')
+
+        drifted, _, problems = declarations.audit(self.tempdir)
+
+        self.assertEqual([], drifted)
+        self.assertEqual(1, len(problems), problems)
+        self.assertIn("consumes 'namespace'", problems[0])
+        self.assertIn('declare it in the body', problems[0])
+
+        # And declaring it makes the audit clean, which is the other
+        # side of the assertion: a term which reports whatever it is
+        # given is no better than one which reports nothing.
+        self._write('fake.py', '''
+def arg_is_fake_ref(func):
+    def wrapper(*args, **kwargs):
+        body_namespace = kwargs.pop('namespace', None)
+        return func(*args, **kwargs)
+    return wrapper
+
+
+class FakeEndpoint(api_base.Resource):
+    @swag_from(api_base.swagger_helper(
+        'fakes', 'A fake.',
+        [('alpha', 'body', 'string', 'A parameter.', False),
+         ('namespace', 'body', 'namespace', 'A namespace.', False)],
+        []))
+    @arg_is_fake_ref
+    def get(self, alpha=None):
+        pass
+''')
+
+        drifted, _, problems = declarations.audit(self.tempdir)
+
+        self.assertEqual([], drifted)
+        self.assertEqual([], problems)
+
+    def test_the_ref_decorators_are_seen_to_consume_namespace(self):
+        """The derivation must find the real thing, not just synthetic ones.
+
+        Every assertion above is written on constructed source, and a
+        decorator_kwargs() which returned the empty set for the actual
+        tree would satisfy all of them while leaving #3739 exactly
+        where it was: fifty-five declarations nothing requires and an
+        audit which reports a clean tree either way. So the four
+        decorators are named here and their pop is asserted through the
+        same index the audit uses.
+        """
+        functions = declarations.package_functions()
+        for decorator in ('arg_is_instance_ref', 'arg_is_network_ref',
+                          'arg_is_artifact_ref',
+                          'arg_is_visible_artifact_ref'):
+            self.assertEqual(
+                1, len(functions.get(decorator, [])),
+                '%s is not a single module level function of the API '
+                'package' % decorator)
+            fake = ast.parse('class Thing:\n    def get(self):\n        pass')
+            fn = fake.body[0].body[0]
+            fn.decorator_list = [ast.Name(id=decorator, ctx=ast.Load())]
+
+            problems = []
+            self.assertEqual(
+                {'namespace'},
+                declarations.decorator_kwargs(fn, functions, problems),
+                '%s no longer consumes namespace, or the walk stopped '
+                'seeing it' % decorator)
+            self.assertEqual([], problems)
 
     def setUp(self):
         super().setUp()

--- a/shakenfist/tests/external_api/test_parameter_declarations.py
+++ b/shakenfist/tests/external_api/test_parameter_declarations.py
@@ -467,23 +467,40 @@ class ParameterDeclarationTestCase(base.ShakenFistTestCase):
             # unreadable parameter list is a failure, not an absence.
             problems = []
             kwargs = declarations.handler_kwargs(fn, problems)
-            kwargs += sorted(
-                declarations.decorator_kwargs(fn, functions, problems)
-                - set(kwargs))
+            consumed = declarations.decorator_kwargs(fn, functions, problems)
+            kwargs += sorted(consumed - set(kwargs))
             self.assertEqual(
                 [], problems,
                 '%s.%s: the accepted parameter list could not be '
                 'enumerated, so this assertion cannot hold: %s'
                 % (cls, method, '; '.join(problems)))
             for kwarg in kwargs:
-                if (cls, method, kwarg) in UNDECLARED_BY_DESIGN:
+                # A decorator-consumed parameter has no opt-out, and
+                # this is where that has to be said: declarations.audit()
+                # -- which backs test_declared_locations_are_derivable
+                # and the pre-commit fixer -- reports the same fact with
+                # no exemption path, so honouring one here would leave
+                # two guards disagreeing about a single handler with
+                # neither message explaining why. It is also the right
+                # rule on its own terms. UNDECLARED_BY_DESIGN exists for
+                # a kwarg the signature names and the handler ignores;
+                # a kwarg a decorator pops is one the caller can send
+                # and act on, so hiding it from the published API is
+                # exactly the invisibility this assertion exists to
+                # refuse.
+                if (kwarg not in consumed
+                        and (cls, method, kwarg) in UNDECLARED_BY_DESIGN):
                     continue
                 self.assertIn(
                     kwarg, names,
                     '%s.%s accepts %r but does not declare it, so it is '
-                    'invisible in the published API. Declare it, stop '
-                    'accepting it, or add it to UNDECLARED_BY_DESIGN with a '
-                    'reason.' % (cls, method, kwarg))
+                    'invisible in the published API. Declare it%s.'
+                    % (cls, method, kwarg,
+                       ' -- a decorator consumes it, so there is no '
+                       'UNDECLARED_BY_DESIGN exemption; declare it or stop '
+                       'consuming it' if kwarg in consumed
+                       else ', stop accepting it, or add it to '
+                       'UNDECLARED_BY_DESIGN with a reason'))
 
     def test_declared_locations_are_valid(self):
         """swagger_helper enforces this at import time; pin it here too, so
@@ -2095,7 +2112,15 @@ class SwaggerHelperValidationTestCase(base.ShakenFistTestCase):
                 [('thing', 'body', 'integer', 'A thing.', False,
                   {'minimum': 1.5})],
                 # Seven elements.
-                [('thing', 'body', 'string', 'A thing.', False, {}, 8)]):
+                [('thing', 'body', 'string', 'A thing.', False, {}, 8)],
+                # A bound and a pattern on the typeless `any` token.
+                # validation._field()'s `any` branch drops bounds and
+                # says it may because nothing can carry one here; that
+                # is a claim about this check, so pin it.
+                [('thing', 'body', 'any', 'A thing.', False,
+                  {'minimum': 1})],
+                [('thing', 'body', 'any', 'A thing.', False,
+                  {'pattern': '^a$'})]):
             with self.subTest(parameters=parameters):
                 self.assertRaises(
                     exceptions.InvalidAPIDeclaration, self._helper, parameters)

--- a/shakenfist/tests/external_api/test_validation_compiler.py
+++ b/shakenfist/tests/external_api/test_validation_compiler.py
@@ -8,6 +8,8 @@ which is the property phase 4 turns into rejections, and so the last
 point at which a mistake is cheap.
 """
 
+from unittest import mock
+
 import marshmallow
 from marshmallow import fields
 
@@ -270,6 +272,62 @@ class ValidationCompilerTestCase(base.ShakenFistTestCase):
                 self.assertEqual([1, 2, 3], value.deserialize([1, 2, 3]))
                 self.assertEqual('a string', value.deserialize('a string'))
                 self.assertIsNone(value.deserialize(None))
+
+    def test_any_is_not_compiled_through_the_unrecognised_type_path(self):
+        """'any' is deliberate, so it must not use the fallback.
+
+        Both paths return fields.Raw, so the resulting *field* cannot
+        tell them apart -- only the warning can, and the warning is the
+        point. The fallback shouts "unrecognised parameter type in the
+        published specification", which is a real signal: a token the
+        vocabulary defines and the compiler does not is a compiler bug.
+        While 'any' took that path, sf-api logged fourteen of those at
+        every start and a genuinely unrecognised token was
+        indistinguishable from the expected noise.
+
+        Asserted over a whole registry build rather than one call,
+        because the property wanted is that a correct tree compiles
+        silently -- which also fails the day a real unrecognised token
+        arrives, and that is a failure worth having.
+        """
+        with mock.patch.object(validation, 'LOG') as mock_log:
+            validation.build_registry(external_api.app)
+
+        self.assertEqual(
+            [], mock_log.with_fields.return_value.warning.call_args_list,
+            'compiling the published specification warned. Either a type '
+            'token really is unrecognised, or a deliberate one has fallen '
+            'back into the unrecognised path the way `any` once did.')
+
+    def test_an_unrecognised_token_still_warns(self):
+        """The mutation check on the test above.
+
+        A LOG patched over the whole build would also record nothing if
+        the warning had simply been deleted, so this proves the
+        fallback is still there and still audible, and that the
+        assertion above is looking in the place a warning would land.
+        """
+        with mock.patch.object(validation, 'LOG') as mock_log:
+            field = validation._field({'type': 'widget'})
+
+        self.assertIsInstance(field, fields.Raw)
+        self.assertEqual(
+            1, mock_log.with_fields.return_value.warning.call_count)
+
+    def test_the_any_rendering_is_the_one_the_vocabulary_publishes(self):
+        """The compiler recognises `any` by ARGTYPES' own rendering.
+
+        The recognition is a comparison against a rendered `format`
+        string, which is a shape a hand-written duplicate would drift
+        from silently -- the compiled schema would then say something
+        the published specification does not. base.py builds the token
+        from validation.ANY_VALUE_FORMAT for that reason, and this
+        holds it there.
+        """
+        self.assertEqual(
+            {'format': validation.ANY_VALUE_FORMAT},
+            api_base.ARGTYPES['any'])
+        self.assertNotIn('type', api_base.ARGTYPES['any'])
 
     def test_console_length_keeps_its_sentinel(self):
         """-1 means "the whole log", and the functional suite sends it.

--- a/shakenfist/tests/external_api/test_validation_compiler.py
+++ b/shakenfist/tests/external_api/test_validation_compiler.py
@@ -18,7 +18,13 @@ from shakenfist.external_api import declarations
 from shakenfist.external_api import validation
 from shakenfist.tests import base
 from shakenfist.tests.external_api.test_parameter_declarations import (
-    UNDOCUMENTED_BY_DESIGN)
+    ANY_TOKEN_DECLARATIONS, UNDOCUMENTED_BY_DESIGN)
+
+# The fourteen metadata endpoints, without the (always 'value')
+# parameter name ANY_TOKEN_DECLARATIONS also carries -- this module
+# indexes the compiled registry by (cls, method) alone.
+ANY_TOKEN_ENDPOINTS = sorted({(cls, method)
+                             for (cls, method, _) in ANY_TOKEN_DECLARATIONS})
 
 
 class ValidationCompilerTestCase(base.ShakenFistTestCase):
@@ -246,6 +252,24 @@ class ValidationCompilerTestCase(base.ShakenFistTestCase):
         self.assertIsInstance(
             instance_create.fields['disk'].inner, fields.Dict)
         self.assertIsInstance(instance_create.fields['cpus'], fields.Integer)
+
+    def test_any_accepts_every_json_shape(self):
+        """'any' (D15) compiles to fields.Raw, the same fallback the
+        compiler already uses for a type token it does not recognise --
+        phase 3's third review round made that path drop published
+        bounds, so a Raw field carrying none is already the supported
+        case. Proved at every one of the fourteen metadata `value`
+        sites, not just one, because a future compiler change could
+        special-case the token by name and treat the others
+        differently."""
+        for (cls, method) in ANY_TOKEN_ENDPOINTS:
+            value = self.registry[(cls, method)].body.fields['value']
+            with self.subTest(cls=cls, method=method):
+                self.assertIsInstance(value, fields.Raw)
+                self.assertEqual({'a': 1}, value.deserialize({'a': 1}))
+                self.assertEqual([1, 2, 3], value.deserialize([1, 2, 3]))
+                self.assertEqual('a string', value.deserialize('a string'))
+                self.assertIsNone(value.deserialize(None))
 
     def test_console_length_keeps_its_sentinel(self):
         """-1 means "the whole log", and the functional suite sends it.

--- a/shakenfist/tests/test_arg_is_ref_namespace_scoping.py
+++ b/shakenfist/tests/test_arg_is_ref_namespace_scoping.py
@@ -3,7 +3,8 @@
 # Parametrised tests for the arg_is_*_ref decorator family.
 #
 # The decorators (arg_is_instance_ref, arg_is_network_ref,
-# arg_is_artifact_ref) historically passed request_namespace() straight to
+# arg_is_artifact_ref and arg_is_visible_artifact_ref) historically
+# passed request_namespace() straight to
 # Object.from_db_by_ref, which collapsed to "search every namespace" for
 # system callers regardless of what namespace the request body asked for.
 # A system admin invoking `client.get_instance(name, namespace='ns1')`
@@ -198,30 +199,82 @@ class ArgIsRefNamespaceScopingTestCase(base.ShakenFistTestCase):
             self.assertNotIn(case.obj_kwarg, captured)
 
     # ------------------------------------------------------------------
-    # Artifact-specific: the `artifact_uuid` branch goes through
-    # Artifact.from_db rather than from_db_by_ref, but must still honour
-    # the namespace authz check so a tenant cannot bypass scoping by
-    # providing artifact_uuid in the request body.
+    # Artifact-specific: arg_is_visible_artifact_ref widens a *name*
+    # across everything the caller can see, while arg_is_artifact_ref
+    # (covered by _CASES above) does not. Both are one liners over
+    # _resolve_artifact_ref, so which of its two lookups runs is the
+    # only part of that function _CASES cannot reach.
     # ------------------------------------------------------------------
 
-    def test_artifact_uuid_branch_tenant_foreign_namespace_rejected(self):
+    def _run_visible(self, caller_ns, body_namespace, returned_obj_namespace):
+        """Drive arg_is_visible_artifact_ref, mocking both lookups.
+
+        Patching both is the point: the assertion is which one ran, so
+        a refactor that widened where it should not, or stopped
+        widening where it should, fails here rather than silently
+        answering the same 'ok'.
+        """
         captured = {}
 
-        @api_artifact.arg_is_artifact_ref
+        @api_artifact.arg_is_visible_artifact_ref
         def endpoint(**kwargs):
             captured.update(kwargs)
             return 'ok'
 
-        with mock.patch(_REQUEST_NS_TARGET, return_value='ns1'), \
-                mock.patch('shakenfist.external_api.artifact.Artifact'
-                           '.from_db') as from_db, \
-                mock.patch('shakenfist.external_api.artifact.Artifact'
-                           '.from_db_by_ref') as from_db_by_ref:
-            response = endpoint(artifact_uuid='some-uuid', namespace='ns2')
+        returned = _fake_obj(returned_obj_namespace)
 
+        with mock.patch(_REQUEST_NS_TARGET, return_value=caller_ns), \
+                mock.patch('shakenfist.external_api.artifact.Artifact'
+                           '.from_db_by_ref_visible_to',
+                           return_value=returned) as widened, \
+                mock.patch('shakenfist.external_api.artifact.Artifact'
+                           '.from_db_by_ref',
+                           return_value=returned) as scoped:
+            kwargs = {'artifact_ref': _REF}
+            if body_namespace is not None:
+                kwargs['namespace'] = body_namespace
+            response = endpoint(**kwargs)
+
+        return response, captured, widened, scoped
+
+    def test_visible_ref_without_body_namespace_widens(self):
+        # A shared artifact owned elsewhere reaches the handler: this
+        # is the whole reason the widening variant exists, and the
+        # post-lookup namespace check must not undo it when the caller
+        # named no namespace.
+        response, captured, widened, scoped = self._run_visible(
+            caller_ns='ns1', body_namespace=None, returned_obj_namespace='ns2')
+        self.assertEqual(
+            'ok', response,
+            f'unqualified visible lookup should succeed, got {response!r}')
+        widened.assert_called_once_with(_REF, 'ns1')
+        scoped.assert_not_called()
+        self.assertIn('artifact_from_db', captured)
+
+    def test_visible_ref_with_body_namespace_does_not_widen(self):
+        # Naming a namespace turns the widening off whatever the route
+        # asked for: that caller asked about one namespace and must be
+        # answered from it or not at all.
+        response, captured, widened, scoped = self._run_visible(
+            caller_ns='system', body_namespace='ns1',
+            returned_obj_namespace='ns1')
+        self.assertEqual(
+            'ok', response,
+            f'scoped visible lookup should succeed, got {response!r}')
+        scoped.assert_called_once_with(_REF, 'ns1')
+        widened.assert_not_called()
+        self.assertIn('artifact_from_db', captured)
+
+    def test_visible_ref_tenant_foreign_namespace_rejected(self):
+        # Widening does not weaken the authz posture: a tenant naming
+        # somebody else's namespace is refused before either lookup,
+        # exactly as it is on the narrow decorator.
+        response, captured, widened, scoped = self._run_visible(
+            caller_ns='ns1', body_namespace='ns2',
+            returned_obj_namespace='ns2')
         self.assertEqual(
             404, response.status_code,
             f'foreign-namespace tenant should be 404, got {response!r}')
-        from_db.assert_not_called()
-        from_db_by_ref.assert_not_called()
+        widened.assert_not_called()
+        scoped.assert_not_called()
         self.assertNotIn('artifact_from_db', captured)

--- a/tools/check-api-declaration-guards.sh
+++ b/tools/check-api-declaration-guards.sh
@@ -479,13 +479,40 @@ check 'undocumented handler compiled as empty'
 
 # 32. A ref-lookup handler which stops declaring the namespace its
 # decorator consumes. This is #3739 itself, reintroduced on one route.
+#
+# Anchored on the get handler's summary, with every later index bounded
+# to the region after it. The first version searched for the namespace
+# tuple by its nine-space indentation, which is a *substring* of the
+# twelve-space declaration in the post above it: the search matched
+# post, the terminator search then ran on to the next handler, and the
+# splice removed the rest of post's parameters, its response list, all
+# five of its decorators, its entire body and the head of get's
+# declaration. The result still parsed, so the harness reported a catch
+# -- of "a handler vanished", not of "a ref lookup handler stopped
+# declaring namespace". Mutation 4 was rewritten for the same class of
+# fault in the same commit.
+#
+# The assertions are the standing defence, and they are why this is
+# safe to leave keyed on source text at all: if the splice ever escapes
+# its handler again, the write does not happen, the tree is unchanged
+# and check() reports NO-OP rather than a catch. A mutation that
+# reports a catch for the wrong reason is worse than no mutation, and
+# this file has produced two of them.
 python3 - <<'PY'
 p = 'shakenfist/external_api/snapshot.py'
 s = open(p).read()
-start = s.index("         ('namespace', 'body', 'namespace',")
-end = s.index("False)]", start) + len('False)')
-s = s[:s.rindex(',', 0, start)] + s[end:]
-open(p, 'w').write(s)
+anchor = s.index("'instances', 'List the snapshots of an instance.',")
+start = s.index("('namespace', 'body', 'namespace',", anchor)
+end = s.index(', False)', start) + len(', False)')
+cut = s.rindex(',', anchor, start)
+
+removed = s[cut:end]
+assert removed.lstrip(", \n").startswith(
+    "('namespace', 'body', 'namespace',"), removed
+assert 'def ' not in removed and '@' not in removed, removed
+assert removed.count('False)') == 1, removed
+
+open(p, 'w').write(s[:cut] + s[end:])
 PY
 check 'ref lookup handler stops declaring namespace'
 

--- a/tools/check-api-declaration-guards.sh
+++ b/tools/check-api-declaration-guards.sh
@@ -192,18 +192,20 @@ open(p, 'w').write(s)
 PY
 check 'emptied parameter list, swag_from present'
 
-# 4. A handler with no declaration at all.
+# 4. A handler with no declaration at all. Bounded by its first and
+# last lines rather than quoted in full: an earlier version pasted the
+# whole decorator here and silently became a NO-OP the day a parameter
+# was added to it (#3739's namespace sweep), so the mutation stopped
+# proving anything while still reporting.
 python3 - <<'PY'
 p = 'shakenfist/external_api/snapshot.py'
 s = open(p).read()
-s = s.replace("""    @swag_from(api_base.swagger_helper(
-        'instances', 'List the snapshots of an instance.',
-        [('instance_ref', 'path', 'uuidorname',
-          'The UUID or name of the instance.', True)],
-        [(200, 'Information about the snapshots of an instance.', None),
-         (404, 'Instance not found.', None)]))
-""", '', 1)
-open(p, 'w').write(s)
+head = ("    @swag_from(api_base.swagger_helper(\n"
+        "        'instances', 'List the snapshots of an instance.',")
+tail = "(404, 'Instance not found.', None)]))\n"
+start = s.index(head)
+end = s.index(tail, start) + len(tail)
+open(p, 'w').write(s[:start] + s[end:])
 PY
 check 'handler with no swag_from'
 
@@ -467,6 +469,44 @@ s = s.replace("""                # quietly arriving here.
 open(p, 'w').write(s)
 PY
 check 'undocumented handler compiled as empty'
+
+# 32-34 cover the term the derivation gained for #3739: the kwargs a
+# handler's decorators consume on its behalf. Without it the popped
+# `namespace` on 55 ref-lookup routes was a functional parameter which
+# nothing required anybody to declare, and phase 3's warn window found
+# it as a rejection against the official client rather than CI finding
+# it as a defect.
+
+# 32. A ref-lookup handler which stops declaring the namespace its
+# decorator consumes. This is #3739 itself, reintroduced on one route.
+python3 - <<'PY'
+p = 'shakenfist/external_api/snapshot.py'
+s = open(p).read()
+start = s.index("         ('namespace', 'body', 'namespace',")
+end = s.index("False)]", start) + len('False)')
+s = s[:s.rindex(',', 0, start)] + s[end:]
+open(p, 'w').write(s)
+PY
+check 'ref lookup handler stops declaring namespace'
+
+# 33. The decorator walk resolving nothing, which silently exempts
+# every handler in the tree. The most dangerous shape here: a term
+# which reports nothing when the defect is present is worse than no
+# term at all, because the 55 declarations then look enforced and are
+# not.
+sed -i "s/        candidates = functions.get(name or '', \[\])/        candidates = []/" \
+    shakenfist/external_api/declarations.py
+check 'decorator walk resolves nothing'
+
+# 34. Delegation not followed. arg_is_artifact_ref and
+# arg_is_visible_artifact_ref are one-liners returning
+# _resolve_artifact_ref(func, widen=...), so a walk which stopped at
+# the decorator would answer "consumes nothing" for thirteen artifact
+# handlers -- and their declarations would then read as parameters the
+# handler cannot receive.
+sed -i "s/        target = _bare_name(stmt.value.func)/        continue/" \
+    shakenfist/external_api/declarations.py
+check 'decorator delegation not followed'
 
 echo
 if [ "${failures}" -ne 0 ]; then


### PR DESCRIPTION
Phase 4 of [PLAN-api-input-validation](docs/plans/PLAN-api-input-validation.md),
up to its measurement gate. This lands the declaration fixes that
enforcement depends on; **it does not turn enforcement on** —
`API_VALIDATION_MODE` still defaults to `warn` and no response changes.

Phase 3 ran warn-only validation on sfcbr for eight days and one full
functional CI run. Every finding was explained, and two of the five
signatures were declaration bugs rather than intended rejections. Both
would have become a 400 for a working caller the moment enforcement is
on, so both are fixed here, and the phase then pauses to watch them go
quiet before the switch is thrown.

## The undeclared `namespace` (fixes #3739)

Four decorators — `arg_is_instance_ref`, `arg_is_network_ref`,
`arg_is_artifact_ref` and `arg_is_visible_artifact_ref` — pop a
`namespace` key out of kwargs before the handler runs and resolve the
object reference with it. The warn window saw nine findings against one
route family. The real exposure is **55 handler methods**, of which 51
declared nothing at all, and the shipped client sends the key from
`get_instance`, `delete_instance`, `get_artifact`, `get_network` and
`delete_network`. Enforcing without this would have refused the official
client's own cross-namespace lookups.

The declarations say what the parameter does on each route family rather
than repeating one string 55 times, because the semantics genuinely
differ: the artifact read routes widen an unqualified name across shared
and trusted artifacts where the write routes deliberately do not, and the
floating network belongs to no namespace and so is reachable only when
the parameter is omitted.

**Declaring them is not enough on its own, because nothing would keep it
true.** The audit derives a handler's parameters from its signature, its
`use_kwargs` schema and its `flask.request.args` reads, and a kwarg a
decorator removes appears in none of the three — the defect was invisible
by construction rather than by oversight. So the derivation gains a fifth
source: `decorator_kwargs()` resolves each decorator to its definition in
the package and collects the literal keys it removes from kwargs. A
consumed parameter nothing declares is now an audit failure.

That check was proven to fire rather than assumed to. With the derivation
in place and the declarations reverted it reports 51 problems and nothing
else; with them applied it reports none.

## Metadata values are not strings

On 2026-08-17 a tenant stored structured state under four namespace
metadata keys: 21 findings carrying a dict and one a list, against a
declaration of `string`. Every request answered 200, because the handler
passes the value to `add_metadata_key()`, which serialises whatever it is
given. There are **fourteen** such declarations and only one was
exercised by traffic during the window.

Neither `dict` nor an `arrayof*` token is wide enough, since callers
store both shapes under the same parameter, so the vocabulary gains an
`any` token: no `type` key, a `format` annotation, and therefore a
published schema which constrains nothing while still saying what the
parameter is.

This is the one token that deliberately validates nothing, so two things
hold it in place. A test pins the exact set of fourteen declarations
using it. And the specification test's completeness derivation — which
asked whether a schema was an object or an array — now also fires on a
schema with no `type`, because otherwise the widest token available would
have been the one type change that table could never catch.

## Deliberately not here

* **Enforcement.** Decision D22 gates it behind a confirmatory reading:
  one functional CI run with zero `namespace` findings, plus 72 hours in
  which the traffic that produced the metadata signature has actually run
  and did not produce it. An absent signature whose generator did not run
  is not evidence — phase 3's log records three separate occasions where
  a quiet channel was mistaken for a quiet system.
* **The `get_args` fold** (#4098). The master plan asked to "fold the
  hand-authored schemas into the compiled path". Read as "delete the four
  `@use_kwargs` decorators" that is a defect: the compiled path is
  check-only and nothing merges `flask.request.args`, so `@use_kwargs` is
  the sole mechanism by which a query parameter reaches a handler.
  Removing it from `blob.py` would read a whole blob where the caller
  asked for a byte range. The master plan is corrected at source.
* **`thin: false` on snapshots** (#4100). Two comments in the tree said
  this waits on phase 4. It does not — validation never injects, so the
  handler sees `thin=False` whatever the mode. The blocker is a client
  which sends the key unconditionally. Both comments now say so.

## Also found

* A mutation in `tools/check-api-declaration-guards.sh` was silently
  defanged by this change — it deleted a `swag_from` by pasting the
  decorator's text, which stopped matching — so it became a no-op while
  still reporting success. Rewritten to bound the deletion by line.
* `requires_namespace_exist_if_specified` is dead on two routes, sitting
  after the ref decorator that already popped what it reads.
  Pre-existing, recorded, untouched.

## Verification

`pre-commit run --all-files` clean at every commit. The guard mutation
harness catches all 34 mutations including three added here. The
published specification still validates with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019M9kQBiC4WxmX6w2NPjrBe
