### PR TITLE
Stop enforcing the queue worker's churn as a poll

### DIFF
--- a/docs/operator_guide/database.md
+++ b/docs/operator_guide/database.md
@@ -409,8 +409,12 @@ Two flags in that output mean "expected, do not report":
   worth defending. Read the issue: it may already be fixed, in which case
   the entry over-predicts until the budget is next re-derived. Either way
   the pair is reported and never enforced.
-* `activity` -- the level is set by what you and your tooling do rather
-  than by one of our loops, so only you can say whether it is reasonable.
+* `activity` -- the level is set by how much work is flowing rather than
+  by one of our loops, so only you can say whether it is reasonable. Most
+  of these are the API serving your own requests, but a few are ours: a
+  queue worker reads and writes object state once per work item, not once
+  per tick, so its rate follows your workload however many nodes you run.
+  Each such entry's note in the budget says which it is and why.
 
 If a gateway does not answer, the command says which and reports on the
 rest. It never quietly reports part of the tier as the whole of it,
@@ -471,9 +475,9 @@ those coefficients were fitted against the API traffic of the cluster the
 budget was derived from -- which is ours, and is mostly CI. If your users
 and tooling call the API differently, and they will, those two lines
 diverge steadily and permanently without anything being wrong. The
-`enforced` lines cover only the pairs produced by Shaken Fist's own loops,
-so they are comparable across deployments, and they are the ones which
-should track each other as the cluster grows.
+`enforced` lines cover only the pairs whose rate one of our loops sets, so
+they are comparable across deployments, and they are the ones which should
+track each other as the cluster grows.
 
 #### When a pair is over budget
 

--- a/examples/prometheus-database-load-rules.yaml
+++ b/examples/prometheus-database-load-rules.yaml
@@ -853,8 +853,6 @@ groups:
           or
           label_replace(label_replace(vector(1), "operation", "GetObjectState", "", ""), "caller_daemon", "net", "", "")
           or
-          label_replace(label_replace(vector(1), "operation", "GetObjectState", "", ""), "caller_daemon", "queues", "", "")
-          or
           label_replace(label_replace(vector(1), "operation", "GetObjectState", "", ""), "caller_daemon", "resources", "", "")
           or
           label_replace(label_replace(vector(1), "operation", "GetObjectsByState", "", ""), "caller_daemon", "cluster", "", "")
@@ -877,8 +875,6 @@ groups:
           or
           label_replace(label_replace(vector(1), "operation", "RecordEventBatch", "", ""), "caller_daemon", "net", "", "")
           or
-          label_replace(label_replace(vector(1), "operation", "RecordEventBatch", "", ""), "caller_daemon", "queues", "", "")
-          or
           label_replace(label_replace(vector(1), "operation", "RecordRelationship", "", ""), "caller_daemon", "cleaner", "", "")
           or
           label_replace(label_replace(vector(1), "operation", "ReleaseLock", "", ""), "caller_daemon", "cleaner", "", "")
@@ -888,8 +884,6 @@ groups:
           label_replace(label_replace(vector(1), "operation", "SetNodeDaemonState", "", ""), "caller_daemon", "queues", "", "")
           or
           label_replace(label_replace(vector(1), "operation", "SetObjectState", "", ""), "caller_daemon", "net", "", "")
-          or
-          label_replace(label_replace(vector(1), "operation", "SetObjectState", "", ""), "caller_daemon", "queues", "", "")
           or
           label_replace(label_replace(vector(1), "operation", "UpdateBlobLastUsed", "", ""), "caller_daemon", "cleaner", "", "")
           or

--- a/shakenfist/data/database_load_budget.yaml
+++ b/shakenfist/data/database_load_budget.yaml
@@ -418,11 +418,23 @@ entries:
     caller_daemon: queues
     per_node_base_qps: 0.113
     per_instance_qps: 0.04
+    activity_coupled: true
     measured:
       mean_qps: 1.408
       r2: 0.512
     note: >-
-      State reads while processing queued work.
+      State reads while processing queued work, plus one per node every
+      ten seconds which is not. Node.set_daemon_state() reads the node's
+      own state row on every call and sf-queues calls it three times per
+      thirty second health check pass, which is what per_node_base_qps
+      measures -- the two sibling pairs from those same three calls,
+      SetNodeDaemonState and GetAllNodeDaemonStates, are both 0.099. The
+      rest is per work item: an operation's dependency scan, its two
+      state transitions, and one read per task. The model has no term
+      for that, so on a cluster small enough for the poll floor to be
+      dwarfed by a busy suite this reads far over model with nothing
+      wrong. Activity coupled for that reason (#4092); the poll half
+      stays enforced through those two siblings, which carry no churn.
   - operation: GetQueueLength
     caller_daemon: resources
     per_node_base_qps: 0.229
@@ -841,11 +853,22 @@ entries:
     caller_daemon: queues
     per_node_base_qps: 0.01
     per_instance_qps: 0.016
+    activity_coupled: true
     measured:
       mean_qps: 0.349
       r2: 0.405
     note: >-
-      Event logging from queue workers.
+      Event logging from queue workers. The drainer thread wakes every
+      hundred milliseconds but returns before the RPC when the spool is
+      empty (eventlog_drainer.py, _drain_one_batch), so a worker doing
+      nothing issues none of these at all: the rate is the event
+      production rate divided by the batch size. In this daemon that
+      production is per work item -- a state mutation audit, the
+      execution duration event, a defer event -- so the level is set by
+      how much work is flowing. Activity coupled (#3999). The cluster
+      and net entries for this operation are deliberately left enforced,
+      because their event production is driven by maintenance sweeps on
+      a fixed cadence rather than by dequeued work.
   - operation: GetInstanceAttributes
     caller_daemon: resources
     per_node_base_qps: 0.008
@@ -881,12 +904,18 @@ entries:
     caller_daemon: queues
     per_node_base_qps: 0.007
     per_instance_qps: 0.013
+    activity_coupled: true
     measured:
       mean_qps: 0.272
       r2: 0.54
     note: >-
-      State transitions written as objects move through their
-      lifecycle. This is work rather than polling, so it tracks churn.
+      State transitions written as objects move through their lifecycle.
+      This is work rather than polling, so it tracks churn, and unlike
+      the GetObjectState pair there is no poll underneath it: the only
+      write on the health check path is Node.set_daemon_state()'s
+      degraded reconcile, which is guarded on the state actually
+      changing and so never fires on a healthy cluster. The per-node
+      term is fit noise. Activity coupled (#4092).
   - operation: GetObjectsByState
     caller_daemon: cluster
     cluster_base_qps: 0.222

--- a/shakenfist/tests/test_database_load_budget.py
+++ b/shakenfist/tests/test_database_load_budget.py
@@ -108,6 +108,26 @@ class DatabaseLoadBudgetTestCase(base.ShakenFistTestCase):
             if entry.activity_coupled:
                 self.assertFalse(entry.enforced)
 
+    def test_the_queue_workers_health_check_poll_stays_enforced(self):
+        # sf-queues calls Node.set_daemon_state() three times per thirty
+        # second health check pass, and that one function issues a
+        # SetNodeDaemonState, a GetAllNodeDaemonStates and -- because it
+        # reads the node's own state to reconcile degraded -- a
+        # GetObjectState. The GetObjectState pair is activity coupled,
+        # because the same counter also carries a queue worker's
+        # per work item reads and the model has no term for those (#4092).
+        # These two carry no churn at all, so they are what is left
+        # watching that poll. Reclassify them and nothing is.
+        b = budget.load_budget()
+        for operation in ('SetNodeDaemonState', 'GetAllNodeDaemonStates'):
+            entry = b.get(operation, 'queues')
+            self.assertIsNotNone(entry, '%s/queues is not budgeted'
+                                 % operation)
+            self.assertTrue(entry.enforced,
+                            '%s/queues no longer guards the health check '
+                            'poll' % operation)
+            self.assertIsNotNone(entry.per_node_base_qps)
+
     def test_every_entry_names_the_loop_that_produces_it(self):
         # A budget entry whose note does not say what makes the traffic is
         # a number nobody can act on when it goes red.

--- a/shakenfist/tests/test_derive_database_load_budget.py
+++ b/shakenfist/tests/test_derive_database_load_budget.py
@@ -170,6 +170,16 @@ class DeriveBudgetTestCase(base.ShakenFistTestCase):
                                     mean=6.7), nodes=6)
         self.assertTrue(entry['activity_coupled'])
 
+    def test_one_of_our_own_loops_is_not_marked_by_the_caller_rule(self):
+        # The rule is a default for callers which are nobody's loop, not a
+        # judgement about the pair. If it reached wider it would unenforce
+        # pairs nobody looked at, and a detector which fails nothing
+        # passes everything.
+        entry = tool.to_entry(('GetObjectState', 'queues'),
+                              stats(slope=0.04, intercept=0.68, r2=0.51,
+                                    mean=1.4), nodes=6)
+        self.assertNotIn('activity_coupled', entry)
+
     def test_every_entry_gets_at_least_one_term(self):
         # A pair with no measurable base and no slope still needs a term,
         # or the budget carries an entry which predicts nothing and the
@@ -223,11 +233,19 @@ class EmitRoundTripTestCase(base.ShakenFistTestCase):
         # Re-measuring every shipped pair is what a re-derivation of the
         # same cluster looks like: the same pairs, freshly fitted terms,
         # and a placeholder note for every one of them.
+        #
+        # The activity coupling goes with the provisional marking rather
+        # than staying on the entry, because to_entry() derives it from
+        # the caller alone. Leaving it on would hand emit() a flag a real
+        # re-derivation never produces for one of our own daemons, and the
+        # carry-forward this class exists to check would never be
+        # exercised.
         entries = []
         for e in self.previous['entries']:
             entry = dict(e)
             entry['note'] = tool.PLACEHOLDER_NOTE
             entry.pop('provisional', None)
+            entry.pop('activity_coupled', None)
             entries.append(entry)
 
         out = io.StringIO()
@@ -261,6 +279,43 @@ class EmitRoundTripTestCase(base.ShakenFistTestCase):
                     if tool.PLACEHOLDER_NOTE in e.note]))
         self.assertNotEqual(
             0, len([e for e in parsed.entries if e.provisional is not None]))
+
+    def test_a_hand_marked_activity_coupling_survives_a_rederivation(self):
+        # to_entry() can only tell an activity coupled pair from a poll by
+        # its caller, so a pair called from one of our own daemons whose
+        # level is set by how much work is flowing has to be marked by
+        # hand. That marking used to be deleted by the next re-derivation
+        # without failing anything, which is issue 4092: the flag was
+        # written from the freshly fitted entry while the note and
+        # provisional marking beside it were read from the file.
+        previous = copy.deepcopy(self.previous)
+        marked = None
+        for entry in previous['entries']:
+            if (entry['caller_daemon'] not in tool.NOT_OUR_LOOPS
+                    and not entry.get('activity_coupled')):
+                entry['activity_coupled'] = True
+                marked = (entry['operation'], entry['caller_daemon'])
+                break
+        self.assertIsNotNone(marked, 'no enforced pair to mark')
+
+        parsed = budget.DatabaseLoadBudget.model_validate(
+            yaml.safe_load(io.StringIO(self.emit(previous))))
+        self.assertTrue(parsed.get(*marked).activity_coupled,
+                        '%s/%s lost its activity coupling' % marked)
+        self.assertFalse(parsed.get(*marked).enforced)
+
+    def test_a_rederivation_does_not_invent_an_activity_coupling(self):
+        # The carry forward must only restore a marking somebody made. If
+        # it reached wider than that it would quietly unenforce pairs,
+        # which is the failure this whole file is about in the other
+        # direction: a detector that fails nothing passes everything.
+        parsed = budget.DatabaseLoadBudget.model_validate(
+            yaml.safe_load(io.StringIO(self.emit(self.previous))))
+        before = {(e['operation'], e['caller_daemon'])
+                  for e in self.previous['entries']
+                  if e.get('activity_coupled')}
+        after = {e.key for e in parsed.entries if e.activity_coupled}
+        self.assertEqual(before, after)
 
     def test_a_tuned_default_is_not_reverted_to_the_tools_own_value(self):
         # emit() used to write the three defaults as literals, so tuning

--- a/shakenfist/tests/test_derive_database_load_budget.py
+++ b/shakenfist/tests/test_derive_database_load_budget.py
@@ -180,6 +180,26 @@ class DeriveBudgetTestCase(base.ShakenFistTestCase):
                                     mean=1.4), nodes=6)
         self.assertNotIn('activity_coupled', entry)
 
+    def test_a_hand_marked_pair_says_why_in_its_note(self):
+        # to_entry() derives the marking for NOT_OUR_LOOPS and nothing
+        # else, so an activity coupled entry with any other caller is
+        # somebody's judgement that a loop of ours runs at a rate the
+        # workload sets. That judgement lives only in the note, is carried
+        # forward verbatim by every future re-derivation, and is the only
+        # thing standing between a deliberate exemption and a pair which
+        # quietly stopped being checked. Make it cite the issue it came
+        # from, the way a provisional marking does.
+        hand_marked = [e for e in budget.load_budget().entries
+                       if e.activity_coupled
+                       and e.caller_daemon not in tool.NOT_OUR_LOOPS]
+        # Vacuous if the list empties, which would retire the mechanism.
+        self.assertNotEqual(0, len(hand_marked))
+        for entry in hand_marked:
+            self.assertRegex(
+                entry.note, r'#\d{3,}',
+                '%s/%s is activity coupled but its note cites no issue '
+                'saying who decided that and why' % entry.key)
+
     def test_every_entry_gets_at_least_one_term(self):
         # A pair with no measurable base and no slope still needs a term,
         # or the budget carries an entry which predicts nothing and the

--- a/tools/derive-database-load-budget.py
+++ b/tools/derive-database-load-budget.py
@@ -46,13 +46,21 @@ issue number. Provisional entries are reported by every consumer and
 enforced by none, so the defect does not become the floor that every
 detector then protects.
 
+**A pair whose level the workload sets is not a poll.** The caller rule
+below marks every ``api``, ``unknown`` and ``ctl`` pair ``activity_coupled``
+because none of those is one of our loops, but a pair called from one of
+our daemons can be workload driven too -- a queue worker's state reads
+happen once per work item, not once per tick. Mark those by hand, the same
+way as ``provisional``, and say in the note which of the two it is.
+
 Everything which is judgement rather than measurement is carried forward
 from the budget being replaced, named by ``--previous`` and defaulting to
-the shipped file: the ``defaults`` block, and each surviving pair's note
-and provisional marking. Only a pair which did not exist before gets a
-placeholder note, and the tool says on stderr how many did. This used to be
-a hand restoration step described in this docstring, which meant running
-the command above emitted a file that failed the repository's own tests --
+the shipped file: the ``defaults`` block, and each surviving pair's note,
+provisional marking and activity coupling. Only a pair which did not exist
+before gets a placeholder note, and the tool says on stderr how many did.
+This used to be a hand restoration step described in this docstring, which
+meant running the command above emitted a file that failed the
+repository's own tests --
 ``test_doc_block_records_its_provenance`` and
 ``test_provisional_entries_name_an_issue_and_are_not_enforced`` both assert
 things ``emit()`` never wrote. A generator whose output does not pass is a
@@ -311,6 +319,19 @@ def collect(args):
     return by_time, pairs
 
 
+# Callers which are nobody's loop: api is gunicorn serving whatever a
+# client asked for, ctl is the operator's CLI, and unknown is a caller
+# which never claimed an identity. to_entry() marks these activity coupled
+# without being asked, because their level is set by what somebody does
+# rather than by a cadence we choose.
+#
+# This is the default for a pair nobody has judged, not the definition of
+# the flag. A pair called from one of our own daemons can be workload
+# driven too -- a queue worker reads and writes object state once per work
+# item -- and those are marked by hand and carried forward by emit().
+NOT_OUR_LOOPS = ('api', 'unknown', 'ctl')
+
+
 def to_entry(key, stats, nodes):
     operation, caller = key
     # The elected cluster daemon does its maintenance sweeps once for the
@@ -343,7 +364,7 @@ def to_entry(key, stats, nodes):
             entry.pop(term, None)
         entry.update(override)
 
-    if caller in ('api', 'unknown', 'ctl'):
+    if caller in NOT_OUR_LOOPS:
         entry['activity_coupled'] = True
     entry['measured'] = {'mean_qps': round(stats['mean'], 3),
                          'r2': round(stats['r2'], 3)}
@@ -366,9 +387,10 @@ def load_previous(path):
     Everything in a budget which is judgement rather than measurement --
     the tuned defaults, the note naming the loop behind each pair, the
     provisional marking saying a pair is a known defect rather than a
-    floor -- lives only in this file. A re-derivation which does not read
-    it deletes all of it, which is why the tool used to emit something
-    that failed the repository's own tests.
+    floor, the activity coupling saying its level is set by the workload
+    rather than by a loop -- lives only in this file. A re-derivation
+    which does not read it deletes all of it, which is why the tool used
+    to emit something that failed the repository's own tests.
     """
     if not path:
         return None
@@ -383,7 +405,12 @@ def load_previous(path):
 
 
 def carried_forward(previous):
-    """Per-pair notes and provisional markings from the previous budget."""
+    """Per-pair judgement from the previous budget.
+
+    The note naming the loop, the provisional marking and the activity
+    coupling: three things a measurement cannot produce and a
+    re-derivation must not lose.
+    """
     if not previous:
         return {}
     return {(e.get('operation'), e.get('caller_daemon')): e
@@ -437,7 +464,16 @@ def emit(entries, by_time, args, out, coverage=None, previous=None):
                   'per_instance_qps'):
             if k in entry:
                 out.write('    %s: %s\n' % (k, entry[k]))
-        if entry.get('activity_coupled'):
+        # An activity coupled marking says "the level of this pair is set
+        # by how much work is flowing, not by one of our loops, so it is
+        # not a floor worth failing a build over". to_entry() can only
+        # derive that from the caller, which catches api, ctl and unknown
+        # and cannot catch a queue worker's per-work-item reads. Those are
+        # marked by hand, and a re-derivation used to silently delete
+        # them: the flag was emitted from the freshly fitted entry alone
+        # while the note and provisional marking beside it were read from
+        # the file. That is issue 4092.
+        if entry.get('activity_coupled') or before.get('activity_coupled'):
             out.write('    activity_coupled: true\n')
 
         # A provisional marking says "there is an open bug about this pair
@@ -551,8 +587,9 @@ def main():
     carried = carried_forward(previous)
     new_pairs = [k for k in kept if k not in carried]
     sys.stderr.write(
-        '%d pairs carried their note and provisional marking forward from '
-        '%s; %d are new and have a placeholder note to write: %s\n'
+        '%d pairs carried their note, provisional marking and activity '
+        'coupling forward from %s; %d are new and have a placeholder note '
+        'to write: %s\n'
         % (len(kept) - len(new_pairs), args.previous or 'nothing',
            len(new_pairs),
            ', '.join('%s/%s' % k for k in sorted(new_pairs)) or 'none'))


### PR DESCRIPTION
Three `(operation, queues)` budget entries model churn-driven work with size-driven coefficients, so the smallest topology we run fails a build on them with nothing wrong.

`Fixes #4092`
`Fixes #3999`

## The mechanism

`shakenfist/data/database_load_budget.yaml` predicts a pair's rate as `per_node_base_qps × nodes + cluster_base_qps + per_instance_qps × standing_instances`. Both terms available to a per-daemon pair say the traffic follows the *cluster's shape*. For a queue worker most of it follows the *suite's workload* — an operation's dependency scan, its two state transitions, one read per task, the events each of those emits — and the model has no term for that at all.

On the run in #4092 (1 node, 1 standing instance) `(GetObjectState, queues)` measured **1.516/s** against a 0.806/s ceiling. That is essentially the `mean_qps: 1.408` the entry was *fitted at*, on a cluster of six nodes and eighteen instances. The pair is not running away; the shape terms have shrunk out from under it.

## Two things the research changed

**The fix #4092 asks for would have been deleted by the next re-derivation.** `activity_coupled` is not a curated flag. `tools/derive-database-load-budget.py` derives it from `caller in ('api', 'unknown', 'ctl')` — which is why all 23 flagged entries are `api` and every `api` entry is flagged — and `emit()` writes it from the freshly fitted entry alone. The `defaults` block, each pair's note and each pair's provisional marking are all read back from `--previous`; this one was not, and no test covered it. Since the flag decides whether exceeding a budget fails a build, what a re-derivation silently restores is enforcement of a ceiling somebody had already decided was not a ceiling. **Commit 1** fixes that first, and renames the caller rule `NOT_OUR_LOOPS` so it reads as the default for an unjudged pair rather than the definition of the flag.

**`(GetObjectState, queues)` is not pure workload, and #4092 is wrong to read it that way.** `Node.set_daemon_state()` reads the node's own state row on every call (`node.py`, the degraded reconcile), and sf-queues calls it three times per thirty-second health check pass (`daemons/queues/main.py`, `_health_checks`). That is a genuine 0.1/s-per-node poll, and it is what `per_node_base_qps: 0.113` measures — corroborated independently by the two sibling pairs issued by those same three calls, `SetNodeDaemonState/queues` and `GetAllNodeDaemonStates/queues`, both budgeted at **0.099**. On the derivation cluster the poll is about half the pair; on the one-node smoke topology it is a fifteenth.

## Commit 2 — the reclassification

It reclassifies anyway, because no coefficient change fixes a term the model does not have, but it does not throw the poll away with it. `SetNodeDaemonState/queues` and `GetAllNodeDaemonStates/queues` come from the identical call site and carry no churn, so a health check that started running every five seconds would still fail a build through them. `test_the_queue_workers_health_check_poll_stays_enforced` pins that, so reclassifying *those* later cannot quietly take the poll's last watcher with it.

`(SetObjectState, queues)` has no poll under it at all — the only write on the health check path is the degraded reconcile, guarded on the state actually changing, so on a healthy cluster it never fires and the per-node term is fit noise.

`(RecordEventBatch, queues)` is **#3999**, and is the same argument about the same daemon. `mariadb.record_event_batch()` has exactly one caller in the tree, `eventlog_drainer.py:251`, and `_drain_one_batch` returns at `if not batch: return 0` before ever reaching the RPC. A worker producing no events issues none of these, forever — it is structurally incapable of being the fixed-rate poll the assertion accuses it of being.

## Why three pairs and not a sweep

#4092 suggests a budget-wide sweep would retire several issues at once. I traced the other daemons' entries and it would not, at least not this way — most of them are genuine *size-driven sweeps* which the model describes correctly in kind:

- `(GetInstanceAttributes, cleaner)` — two reads per libvirt domain on this node per minute, `0.033`/s per instance against a budgeted `0.027`. Textbook.
- `(GetInstanceAttributes, resources)` — one per running instance per `USAGE_EVENT_FREQUENCY` (60s), `0.0167` against `0.014`.
- `(FindNetworkInterfaces, net)`, `(GetNetworkInterfaceAttributes, net)`, `(GetInstanceAttributes, net)` — 30-second sweeps, but over `nodes × networks` or `nodes × interfaces`, a product fitted into a per-instance slope at six nodes. Wrong dimension, not the wrong *kind* of term.

The same distinction applies inside this operation: `RecordEventBatch` for the **cluster** and **net** daemons is deliberately left enforced, because their event production is driven by maintenance sweeps on a fixed cadence rather than by dequeued work. Reclassifying every pair with a churn term in it on one afternoon would retire the detector rather than the issues.

## What this gives up

Stated rather than hidden: a new sf-queues loop reading or writing object state, or emitting events, will no longer fail a build. It is still *reported* — by the check's `over_budget_but_not_enforced` list, by `sf-ctl database-load`, and on the Grafana panel.

Raising `per_node_base_qps` or `per_instance_qps` was the alternative and is worse. The budget file's own header forbids it, the assertion message forbids it, and it would be wrong on the merits here: the coefficients are not too small, they are measuring the wrong thing, and inflating them would raise the ceiling on every large cluster where these pairs genuinely do run higher.

## Verification

- Full unit suite: 4438 tests, green.
- `pre-commit run --all-files`: all ten hooks pass, including mypy.
- Commit 1 verified green standing alone, with the budget file still at `develop`.
- Five mutations, each failing the assertions that claim to prove the fix: dropping a marking from the budget (2 tests), letting a hand marking stop citing its issue (1), reclassifying `SetNodeDaemonState/queues` alongside these (4), widening `NOT_OUR_LOOPS` to swallow a daemon of ours (2), and dropping the carry-forward from `emit()` (2).

`examples/prometheus-database-load-rules.yaml` is regenerated through `tools/generate-database-load-rules.py`, so the three pairs leave `sf_database:budget:enforced` and their alerts with them.

## Left for the other issues in this family

`(SetObjectState, queues)` failed by 1.8% — it is modelled at 0.02/s, so `modelled × 2 + 0.5` is 0.54, very nearly the tolerance floor on its own. #4092 is right that at that level the entry has effectively no model left in it. That is a general property of every tiny entry rather than a fact about this pair, and moving `tolerance_floor_qps` to make a check pass is the move the file forbids, so it is not touched here.

#4021, #4039 and #4072 are unaffected by this change and remain open; I have left what the tracing turned up on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrU2FCqx1mUnQCiACcSqcy
