### PR TITLE
Make routed and floating addresses answer from inside their own network

### DIFF
--- a/docs/operator_guide/installation.md
+++ b/docs/operator_guide/installation.md
@@ -52,6 +52,13 @@ Each machine in the cluster should match this description:
   standard MTU of 1,500 bytes would result in fragmentation. I generally
   select 9,000 bytes.
 * Has at least 1 gigabit connectivity on the "mesh interface".
+* Has the iptables connection tracking match (`xt_conntrack`, what
+  `iptables -m conntrack` loads) available if it will be a network node. It
+  is present in any stock Ubuntu or Debian kernel, so this only bites a
+  custom or heavily stripped kernel. A network node without it cannot bring
+  up a NAT providing virtual network at all, rather than degrading -- see
+  the floating IP discussion in [the networking overview](networking/overview.md)
+  for why the rule needs it.
 
 Your ansible control node needs `ansible-core >= 2.15`.
 

--- a/docs/operator_guide/networking/overview.md
+++ b/docs/operator_guide/networking/overview.md
@@ -372,13 +372,56 @@ work equally well for other traffic.
     intended for a specific floating IP, but in return must have been configured
     to use that floating IP.
 
-The implementation of routed IPs is relatively trivial. For each routed IP, a
-route on the network node into the relevant virtual network bridge is created.
-Such a route might look like this:
+The implementation of routed IPs is relatively trivial. For each routed IP,
+two routes are created on the network node, one in each of the two routing
+tables which decide where the address's traffic goes.
+
+The first is in the network node's own routing table, and is how traffic
+from outside the cluster arrives. It puts the address onto the virtual
+network's bridge, where whichever interface was configured to answer ARP for
+it picks it up:
 
 ```
-ip route add 192.168.15.29/32 dev br-vxlan-e2300f
+ip route replace 192.168.15.29/32 dev br-vxlan-e2300f
 ```
+
+The second is inside the virtual network's own network namespace, and is how
+an instance *on* that network reaches the address:
+
+```
+ip netns exec 17be6538-8f96-4ccb-b71e-a7e3022fead3 \
+    ip route replace 192.168.15.29/32 dev veth-e2300f-i
+```
+
+That second route is needed because a routed IP comes from the floating pool,
+and as the routing table above shows, the namespace has the whole floating
+block on link on its egress veth. Without a more specific route an instance's
+packet reaches its default gateway and the namespace then ARPs for the address
+out on the egress bridge, where nothing answers -- unlike a floating IP, a
+routed IP is not configured on an interface anywhere on the network node, it
+exists only as a route. The `/32` turns that into a u-turn back into the
+network, which is the same delivery the network node performs for everybody
+else, and it means a routed address behaves identically whether the client is
+on the virtual network the address is routed to, or outside the cluster
+entirely (github issue #3662).
+
+A client on a *different* Shaken Fist virtual network is not covered by
+either route, and remains unsupported. That namespace also has the whole
+floating block on link on its egress veth, so it ARPs for the routed address
+on the egress bridge -- and unlike a floating IP, which the namespace owning
+it answers for from its egress veth, a routed IP is configured on no
+interface there and nothing replies. Reach a routed address from another
+virtual network the same way anything outside the cluster does, by way of the
+network node.
+
+Both routes use `ip route replace` rather than `ip route add` because they are
+re-applied: the network daemon's maintenance pass restores a network's routed
+addresses whenever it rebuilds the network on the network node, and also
+checks each maintenance pass that both routes are still there -- the one in
+the root namespace and the one inside the network's namespace. An address
+missing either is re-routed, which installs both, so a network which is
+otherwise healthy is not dragged through a rebuild to recover one route.
+Removing a routed IP deletes both routes, and tolerates either being absent.
 
 ## Interface naming conventions
 

--- a/docs/operator_guide/networking/overview.md
+++ b/docs/operator_guide/networking/overview.md
@@ -166,6 +166,7 @@ target     prot opt source               destination
 Chain POSTROUTING (policy ACCEPT)
 target     prot opt source               destination
 MASQUERADE  all  --  172.16.0.0/24        anywhere
+MASQUERADE  all  --  172.16.0.0/24        anywhere             ctstate DNAT
 ```
 
 So, the default route is via the egress veth at `egr-e2300f-i` (inside the
@@ -177,9 +178,11 @@ which is wired to the linux kernel VXLAN interface at `vxlan-e2300f`. Finally,
 traffic to other floating IPs on `192.168.15.0/24` is routed to the egress
 bridge as well.
 
-The iptables `MASQUERADE` entry is there to convert internal addresses to the
-external `192.168.15.194` "floating gateway" address so instances can talk outside
-their virtual network.
+The first iptables `MASQUERADE` entry is there to convert internal addresses to
+the external `192.168.15.194` "floating gateway" address so instances can talk
+outside their virtual network. The second one, which only matches connections
+whose destination has been rewritten, is for floating IP traffic which turns
+around here instead of leaving -- see the floating IP section below.
 
 Perhaps a diagram would help!
 
@@ -311,11 +314,53 @@ target     prot opt source               destination
 Chain POSTROUTING (policy ACCEPT)
 target     prot opt source               destination
 MASQUERADE  all  --  172.16.0.0/24        anywhere
+MASQUERADE  all  --  172.16.0.0/24        anywhere             ctstate DNAT
 ```
 
 So our floating IP of `192.168.15.29` is DNAT'ed to the instance's IP of
 `172.16.0.37`. This means floating IP traffic "bounces" off the network namespace.
-To make that work, the inside of the veth is configured with the floating IP:
+
+The second `MASQUERADE` rule above handles the case where the client is
+itself an instance on the same virtual network. That traffic is DNAT'ed by
+the same rule and then sent straight back out the veth it arrived on, so the
+reply would travel directly over the virtual network's own layer 2 and never
+return through the namespace -- which means it would never have its source
+rewritten back to the floating address, and the client would discard it.
+Masquerading those u-turned connections to the network's gateway address puts
+the namespace back on the return path, where conntrack can undo the
+destination rewrite.
+
+The two matches on that rule each exclude something different, and both are
+needed. The `-s` match confines the rule to connections which started inside
+the virtual network, which is what preserves the real source address for
+clients outside the cluster -- their traffic is DNAT'ed here too, so without
+`-s` it would be masqueraded as well. The `--ctstate DNAT` match confines the
+rule to connections whose destination was rewritten, which is what excludes a
+routed IP turning around in the same namespace, since a routed IP is never
+DNAT'ed and its whole point is that it arrives unrewritten.
+
+The cost is that the instance holding the floating IP sees such a connection
+as coming from the network's gateway rather than from the calling instance;
+if the destination needs to know who is calling, use a routed IP, which is
+not rewritten at all.
+
+The network daemon's maintenance pass checks each cycle that this rule is
+present in the namespace, and rebuilds the network on the network node if it
+is not. That check is how a cluster which was upgraded while all of its
+networks were healthy acquires the rule at all -- nothing else re-runs the
+namespace's iptables setup for a network which is otherwise working.
+
+`--ctstate DNAT` means a network node now needs the iptables conntrack match
+(`xt_conntrack`, which is present in any stock Ubuntu or Debian kernel and is
+what `iptables -m conntrack` loads). This is a hard requirement rather than a
+degradation: a node which cannot install the rule fails the whole
+`enable_nat` step, so a NAT-providing network will not come up there at all
+rather than coming up without in-network floating IPs. The error reported
+against the failed operation carries iptables' own complaint about the rule
+it refused.
+
+To make the DNAT bounce work, the inside of the veth is configured with
+the floating IP:
 
 ```bash
 debian@test:~$ sudo ip netns exec 17be6538-8f96-4ccb-b71e-a7e3022fead3 ip a

--- a/docs/operator_guide/upgrades.md
+++ b/docs/operator_guide/upgrades.md
@@ -86,6 +86,24 @@ the existing definition. Recreating the instance is the supported
 route; this is a workaround, and it is on you to confirm the instance
 comes back.
 
+### Network nodes need the iptables conntrack match
+
+Since the release which made floating addresses answer from inside their own
+network, a NAT providing network's namespace carries a hairpin masquerade
+rule matched with `-m conntrack --ctstate DNAT`. A network node whose kernel
+lacks `xt_conntrack` will fail to install that rule, and the network will not
+come up there at all.
+
+Every stock Ubuntu and Debian kernel has it, so this is only a concern if you
+run a custom kernel. Check before you roll the daemons:
+
+```bash
+iptables -m conntrack --help > /dev/null && echo ok
+```
+
+See the floating IP discussion in [the networking overview](networking/overview.md)
+for what the rule does and why both of its matches are needed.
+
 ## MariaDB schema migrations
 
 Starting with v0.8, Shaken Fist uses MariaDB to store object state data. The

--- a/protos/privexec.proto
+++ b/protos/privexec.proto
@@ -44,6 +44,15 @@ message EnableNATReply {
     enum Errors {
         OK = 0;
         IPTABLES_FAILED = 1;
+
+        // Retired, and a trap: do not return this. The client
+        // (util.concurrency.enable_nat) raises EnableNATFailed for any
+        // reply which is not OK, so "the rules were already there" --
+        // the normal outcome every time the maintain loop recreates a
+        // healthy network -- became a hard failure and the network
+        // never came up (issue 3662). Each rule now carries its own
+        // iptables -C instead, and success is success either way. The
+        // number stays claimed so no later member reuses it.
         RULES_ALREADY_PRESENT = 2;
     }
 

--- a/shakenfist/daemons/network/maintain.py
+++ b/shakenfist/daemons/network/maintain.py
@@ -8,6 +8,7 @@ from shakenfist.config import config
 from shakenfist.constants import EVENT_TYPE_AUDIT
 from shakenfist.constants import EVENT_TYPE_STATUS
 from shakenfist.daemons import daemon
+from shakenfist.exceptions import ProcessExecutionError
 from shakenfist import instance
 from shakenfist import mariadb
 from shakenfist.network import network
@@ -68,6 +69,61 @@ _TERMINAL_OP_STATES = {
     dbo.STATE_DELETED,
     dbo.STATE_ERROR,
 }
+
+
+def missing_routed_address_routes(n, addresses):
+    """Which of a network's routed addresses are missing either route.
+
+    A routed address is two routes, not one: the network node's root
+    namespace routes it onto the network's bridge so the world can reach
+    it, and the network's own namespace routes it back out the veth so
+    the network's instances can (issue 3662). Only the first of those
+    existed until recently, and nothing re-applies either route while the
+    network is otherwise healthy -- the reconciliation below fires only
+    for a network which has drifted far enough to need rebuilding. A
+    cluster which upgraded while all its networks were well would
+    therefore never acquire the second route for the addresses it already
+    had.
+
+    Both tables are read, and an address missing from either is
+    reported: re-routing installs both and is idempotent, so the repair
+    does not care which one drifted. The root namespace route is the
+    less likely of the two to go missing -- losing the bridge takes it
+    with it, and that takes ``is_created()`` false and drives a full
+    recreate -- but it can be lost while the bridge survives, and in
+    that state the address is unreachable from outside the cluster with
+    nothing looking for it. That is the same silent drift this reads
+    the namespace for, in the other direction.
+
+    This costs two execs per pass for each network which has routed
+    addresses at all, which is a small number of networks even on a
+    large cluster.
+    """
+    subst = n.subst_dict()
+    try:
+        present = util_network.get_host_routes(
+            str(n.uuid), subst['vx_veth_inner'])
+        present &= util_network.get_host_routes(None, subst['vx_bridge'])
+    except ProcessExecutionError as e:
+        # No namespace, no veth inside it, or no bridge. Each is a
+        # larger drift than a missing route, and rebuilding the network
+        # is what fixes it -- which re-applies these routes on the way
+        # past.
+        #
+        # A transient privexec failure or a timed out exec lands here
+        # too, and is indistinguishable from real drift: both say
+        # "nothing missing" and this pass emits nothing. That
+        # self-corrects on the next pass, but a persistent exec layer
+        # fault would go on looking exactly like a healthy network, so
+        # say so in the journal.
+        LOG.with_fields({
+            'network': n,
+            'exit_code': e.exit_code,
+            'stderr': e.stderr
+        }).info('Could not read routing tables for routed address audit')
+        return []
+
+    return [address for address in addresses if address not in present]
 
 
 class Job(util_concurrency.Job):
@@ -498,6 +554,66 @@ class Job(util_concurrency.Job):
         for vxid, reason in reapable:
             self._reap_stray_vxlan(vxid, reason, this_node)
 
+    def _reconciliation_guard_fired(self, n, op_type):
+        """Should this pass leave a drifted network alone?
+
+        Two guards, both reading the network's own recent terminal
+        operation history for one operation type. The type matters: a
+        repair enqueued as a NetIPOp which can never succeed -- a
+        permanently absent veth, a namespace in a state nothing here can
+        fix -- would otherwise be re-enqueued on every pass forever,
+        because a NetOp history knows nothing about it.
+
+        The cooldown lets a single recent failure breathe before the
+        same repair is tried again. The circuit breaker quiesces a
+        network whose last K repairs all errored, until an operator (or
+        a later successful reconciliation) clears it.
+
+        The two histories clear differently, and the ``net_ip_op`` one
+        is worth knowing about. It covers both halves of the routed
+        address lifecycle, so a user's errored *unroute* counts against
+        the automatic *route* repair; and because these repairs are the
+        only thing which enqueues a NetIPOp for an otherwise-healthy
+        network, K errored ops of either kind quiesce the repair with no
+        self-clearing path. An operator clears it by routing or
+        unrouting an address on the network by hand, which is the
+        operator attention the circuit breaker is asking for anyway.
+
+        Returns True if the caller should skip this network.
+        """
+        recent = mariadb.get_recent_terminal_op_states_for_target(
+            target_object_type=ObjectType.NETWORK,
+            target_uuid=str(n.uuid),
+            limit=1,
+            op_type=op_type)
+        if recent:
+            _, state_value, update_time = recent[0]
+            if (state_value == dbo.STATE_ERROR
+                    and update_time > time.time()
+                    - config.MAINTAIN_RECONCILE_COOLDOWN_SECONDS):
+                n.add_event(
+                    EVENT_TYPE_AUDIT,
+                    'maintain pass skipped for network: recent '
+                    'reconciliation error within cooldown window')
+                return True
+
+        circuit_k = config.MAINTAIN_RECONCILE_CIRCUIT_K
+        history = mariadb.get_recent_terminal_op_states_for_target(
+            target_object_type=ObjectType.NETWORK,
+            target_uuid=str(n.uuid),
+            limit=circuit_k,
+            op_type=op_type)
+        if (len(history) == circuit_k
+                and all(h[1] == dbo.STATE_ERROR for h in history)):
+            n.add_event(
+                EVENT_TYPE_AUDIT,
+                'network has failed reconciliation %d times in a '
+                'row; quiesced pending operator attention' % (
+                    circuit_k))
+            return True
+
+        return False
+
     def execute(self):
         LOG.info('Starting network maintenance')
         last_loop = 0
@@ -614,62 +730,84 @@ class Job(util_concurrency.Job):
 
                 network_okay = n.is_okay()
                 mesh_okay = n.is_mesh_okay() if network_okay else False
-                if network_okay and mesh_okay:
+
+                # Routed addresses are the third thing which can drift:
+                # either of the two routes for one can be missing on a
+                # network which is otherwise perfectly healthy (issue
+                # 3662). Reading the routing tables costs execs, so only
+                # networks which have routed addresses at all are
+                # candidates, and only on the node whose namespaces they
+                # are.
+                #
+                # ``mesh_okay`` is part of this for the same reason the
+                # pending-operation gate sits above the probe below: a
+                # network whose mesh has drifted takes the mesh repair
+                # branch and discards whatever the probe would have
+                # said, so paying for the execs is pure waste.
+                routed_here = (config.NODE_IS_NETWORK_NODE and network_okay
+                               and mesh_okay
+                               and n.uuid in routed_by_network)
+
+                if network_okay and mesh_okay and not routed_here:
                     # No drift detected for this network on this pass.
                     continue
 
                 # Per-network gating. If a cluster operation targeting
                 # this network is already in flight, skip this pass --
-                # the in-flight op will fix the drift when it runs.
+                # the in-flight op will fix the drift when it runs. This
+                # sits above the namespace route read so a network which
+                # is already being reconciled does not pay for a probe
+                # whose answer is discarded here anyway.
                 if mariadb.has_pending_cluster_operation_target(
                         target_object_type=ObjectType.NETWORK,
                         target_uuid=str(n.uuid)):
                     continue
 
-                # Cooldown. If the most recent terminal reconciliation
-                # for this network ended in ERROR within the cooldown
-                # window, let the previous failure breathe before
-                # retrying.
-                recent = mariadb.get_recent_terminal_op_states_for_target(
-                    target_object_type=ObjectType.NETWORK,
-                    target_uuid=str(n.uuid),
-                    limit=1,
-                    op_type='net_op')
-                if recent:
-                    _, state_value, update_time = recent[0]
-                    if (state_value == dbo.STATE_ERROR
-                            and update_time > time.time()
-                            - config.MAINTAIN_RECONCILE_COOLDOWN_SECONDS):
-                        n.add_event(
-                            EVENT_TYPE_AUDIT,
-                            'maintain pass skipped for network: recent '
-                            'reconciliation error within cooldown window')
-                        continue
+                missing_routes = []
+                if routed_here:
+                    missing_routes = missing_routed_address_routes(
+                        n, routed_by_network[n.uuid])
 
-                # Circuit breaker. If the last K terminal reconciliations
-                # all ended in ERROR, quiesce this network until a fresh
-                # reconciliation succeeds (operator intervention).
-                circuit_k = config.MAINTAIN_RECONCILE_CIRCUIT_K
-                history = mariadb.get_recent_terminal_op_states_for_target(
-                    target_object_type=ObjectType.NETWORK,
-                    target_uuid=str(n.uuid),
-                    limit=circuit_k,
-                    op_type='net_op')
-                if (len(history) == circuit_k
-                        and all(h[1] == dbo.STATE_ERROR for h in history)):
-                    n.add_event(
-                        EVENT_TYPE_AUDIT,
-                        'network has failed reconciliation %d times in a '
-                        'row; quiesced pending operator attention' % (
-                            circuit_k))
+                if network_okay and mesh_okay and not missing_routes:
+                    # The only thing which might have drifted had not.
+                    continue
+
+                # Which repair this pass is heading for decides which
+                # operation history the guards below should read. A
+                # network whose only problem is a missing route is
+                # repaired with a NetIPOp, and a NetOp history says
+                # nothing about whether that has been failing.
+                route_repair_only = network_okay and mesh_okay
+                guard_op_type = 'net_ip_op' if route_repair_only else 'net_op'
+
+                if self._reconciliation_guard_fired(n, guard_op_type):
                     continue
 
                 # Drift remains and no guard fired.
+                if route_repair_only:
+                    # The network and its mesh are both fine; all that is
+                    # missing is the in-namespace route for one or more
+                    # routed addresses. Re-routing the address installs
+                    # both of its routes and is idempotent, so this needs
+                    # nothing rebuilt.
+                    n.add_event(
+                        EVENT_TYPE_STATUS,
+                        'restoring in-namespace routes for routed addresses',
+                        extra={'floating': missing_routes})
+                    for address in missing_routes:
+                        net_ip_create_and_enqueue(
+                            network_uuid=str(n.uuid),
+                            ip=address,
+                            tasks=[net_ip_tasks.route_address],
+                            priority=PRIORITY.background)
+                    continue
+
                 if network_okay:
                     # The network itself is fine; only the vxlan mesh
                     # has drifted. A full recreate is not needed --
                     # enqueue the targeted repair on this node's queue
-                    # and move on.
+                    # and move on. Any missing routed address route waits
+                    # for the pass after the mesh comes back.
                     n.add_event(
                         EVENT_TYPE_STATUS,
                         'Repairing drifted vxlan mesh on this node')

--- a/shakenfist/daemons/privexec/main.py
+++ b/shakenfist/daemons/privexec/main.py
@@ -27,6 +27,7 @@ from shakenfist.daemons.privexec import util as privexec_util
 from shakenfist.protos import common_pb2
 from shakenfist.protos import privexec_pb2
 from shakenfist.util import exceptions as util_exceptions
+from shakenfist.util import iptables as util_iptables
 
 
 LOG, _ = logs.setup(__name__)
@@ -57,6 +58,100 @@ MESH_RE = re.compile(r'00:00:00:00:00:00 dst (.*) self permanent')
 
 class VXLANMeshDiscoveryFailure(Exception):
     ...
+
+
+def ensure_netns_iptables_rule(netns, table, rule):
+    """Append an iptables rule inside a network namespace, at most once.
+
+    ``rule`` is the chain name followed by the match and target arguments,
+    exactly as they are written after ``-A``. The rule is checked for with
+    ``-C`` first, because iptables has no "append if absent" and appending
+    unconditionally is not harmless: the first matching rule wins, so a
+    duplicate left behind by an earlier attempt masks any later change to
+    the rule beside it. ``_add_floating_ip`` installs its DNAT rule
+    through here for the same reason.
+
+    A namespace which predates that check can hold several identical
+    copies of one of these rules, and this deliberately leaves them
+    alone: extra copies of a rule which is byte for byte the one we
+    want are inert (the first match wins and they all say the same
+    thing), while converging on one copy would mean deleting the rule
+    and appending it again, which opens a window with no rule at all.
+    That window is unacceptable for ``_add_floating_ip``, which installs
+    a live floating address's DNAT through here. A rule we no longer
+    believe in is a different matter and
+    ``remove_netns_iptables_rule`` drains every copy of it.
+
+    Returns ``(present, error_text)``. ``error_text`` is empty unless
+    the append failed, in which case it carries iptables' own complaint
+    so the caller can report something more useful than "iptables
+    failed".
+    """
+    base = _netns_iptables_base(netns, table)
+
+    _, _, returncode = privexec_util.command_helper(
+        *base, '-C', *rule, failure_is_error=False)
+    if returncode == 0:
+        return True, ''
+
+    _, stderr, returncode = privexec_util.command_helper(*base, '-A', *rule)
+    if returncode != 0:
+        return False, (
+            f'failed to append {" ".join(rule)} to the {table} table in '
+            f'namespace {netns}: {stderr}')
+    return True, ''
+
+
+def _netns_iptables_base(netns, table):
+    return [
+        privexec_util.locate_command('ip'), 'netns', 'exec', netns,
+        privexec_util.locate_command('iptables'), '-w', '10', '-t', table]
+
+
+# The most copies of one rule we will delete before giving up. A
+# namespace should never hold more than a handful, and the bound is here
+# so that a command_helper which somehow always reports success cannot
+# spin forever.
+MAX_DUPLICATE_IPTABLES_RULES = 32
+
+
+def remove_netns_iptables_rule(netns, table, rule):
+    """Delete every copy of an iptables rule inside a network namespace.
+
+    Absence is the desired end state, so a delete which finds nothing to
+    delete has succeeded. iptables exits non-zero and says "does a rule
+    with that specification exist in that chain?" in that case, which is
+    indistinguishable here from any other failure -- and does not need
+    to be distinguished, because nothing downstream depends on the rule
+    having been present.
+
+    ``-D`` removes one matching rule, not all of them, and one match is
+    not enough here. The ``_enable_nat`` this replaced appended its
+    rules unconditionally on every network create and every maintain
+    driven recreate, so a long lived namespace on an upgraded cluster
+    can hold several copies of the rule we no longer believe in.
+    Deleting one of them would leave the rest, and no later pass would
+    ever look again -- so the loop runs until iptables says there is
+    nothing left to remove.
+
+    Returns the number of copies removed, which is zero when the rule
+    was not there at all.
+    """
+    base = _netns_iptables_base(netns, table)
+    removed = 0
+    while removed < MAX_DUPLICATE_IPTABLES_RULES:
+        _, _, returncode = privexec_util.command_helper(
+            *base, '-D', *rule, failure_is_error=False)
+        if returncode != 0:
+            return removed
+        removed += 1
+
+    LOG.with_fields({
+        'netns': netns,
+        'table': table,
+        'rule': ' '.join(rule)
+    }).warning('Stopped deleting duplicate iptables rules at the bound')
+    return removed
 
 
 class PrivExecJob:
@@ -211,40 +306,6 @@ class PrivExecJob:
         )
 
     def _enable_nat(self, req):
-        iptables_failed_error = privexec_pb2.PrivExecReply(
-            enable_nat_reply=privexec_pb2.EnableNATReply(
-                network_uuid=req.network_uuid,
-                network_address=req.network_address,
-                network_mask=req.network_mask,
-                vxid=req.vxid,
-                error=privexec_pb2.EnableNATReply.IPTABLES_FAILED
-            )
-        )
-
-        # Determine if we have NAT already
-        stdout, _, returncode = privexec_util.command_helper(
-            privexec_util.locate_command('iptables'), '-w', '10', '-t', 'nat',
-            '-L', 'POSTROUTING', '-n', '-v'
-        )
-        if returncode != 0:
-            return iptables_failed_error
-
-        # Output looks like this:
-        # Chain POSTROUTING (policy ACCEPT 199 packets, 18189 bytes)
-        # pkts bytes target     prot opt in     out     source               destination
-        #   23  1736 MASQUERADE  all  --  *      ens4    192.168.242.0/24     0.0.0.0/0
-        for line in stdout.split('\n'):
-            if line.find(str(req.network_address)) != -1:
-                return privexec_pb2.PrivExecReply(
-                    enable_nat_reply=privexec_pb2.EnableNATReply(
-                        network_uuid=req.network_uuid,
-                        network_address=req.network_address,
-                        network_mask=req.network_mask,
-                        vxid=req.vxid,
-                        error=privexec_pb2.EnableNATReply.RULES_ALREADY_PRESENT
-                    )
-                )
-
         # Ensure IP forwarding is enabled
         with open('/proc/sys/net/ipv4/ip_forward') as f:
             forwarding_enabled = f.read().rstrip() == '1'
@@ -253,37 +314,43 @@ class PrivExecJob:
             with open('/proc/sys/net/ipv4/ip_forward', 'w') as f:
                 f.write('1\n')
 
-        # Create iptables rules
-        egress_veth_inner = f'egr-{req.vxid:06x}-i'
-        vx_veth_inner = f'veth-{req.vxid:06x}-i'
+        # Create iptables rules. There used to be a "do we have NAT
+        # already?" probe here, which returned RULES_ALREADY_PRESENT and
+        # skipped the lot. It listed POSTROUTING in the *root* namespace
+        # while every rule it guarded is installed inside the network's own
+        # namespace, so it could not see the rules it was guarding. That
+        # went wrong in both directions: normally it matched nothing, and
+        # a network recreated by the maintain loop had these rules
+        # appended again on every pass; and when it did match -- the
+        # comparison was a substring search over the whole listing, so a
+        # 172.16.0.0/16 line elsewhere on the node matches a 172.16.0.0/24
+        # network -- the caller turned the reply into an EnableNATFailed
+        # and the network never came up. Each rule now carries its own -C
+        # check instead, which needs no cross-namespace guesswork.
+        # Rules an older Shaken Fist wrote which this one no longer
+        # believes in. Every copy of each is removed, and before the
+        # install, so the namespace ends up holding no rule which is not
+        # in util_iptables. It may still hold more than one copy of a
+        # rule which is -- see ensure_netns_iptables_rule for why those
+        # are left where they are.
+        for table, rule in util_iptables.stale_nat_rules(req.vxid):
+            remove_netns_iptables_rule(req.network_uuid, table, rule)
 
-        _, _, returncode = privexec_util.command_helper(
-            privexec_util.locate_command('ip'), 'netns', 'exec',
-            req.network_uuid, privexec_util.locate_command('iptables'),
-            '-w', '10', '-A', 'FORWARD', '-o', egress_veth_inner,
-            '-i', vx_veth_inner, '-j', 'ACCEPT'
-        )
-        if returncode != 0:
-            return iptables_failed_error
-
-        _, _, returncode = privexec_util.command_helper(
-            privexec_util.locate_command('ip'), 'netns', 'exec',
-            req.network_uuid, privexec_util.locate_command('iptables'),
-            '-w', '10', '-A', 'FORWARD', '-i', egress_veth_inner,
-            '-o', 'vx_veth_inner', '-j', 'ACCEPT'
-        )
-        if returncode != 0:
-            return iptables_failed_error
-
-        _, _, returncode = privexec_util.command_helper(
-            privexec_util.locate_command('ip'), 'netns', 'exec',
-            req.network_uuid, privexec_util.locate_command('iptables'),
-            '-w', '10', '-t', 'nat', '-A', 'POSTROUTING', '-s',
-            f'{req.network_address}/{req.network_mask}',
-            '-o', egress_veth_inner, '-j', 'MASQUERADE'
-        )
-        if returncode != 0:
-            return iptables_failed_error
+        for table, rule in util_iptables.network_nat_rules(
+                req.network_address, req.network_mask, req.vxid):
+            present, error_text = ensure_netns_iptables_rule(
+                req.network_uuid, table, rule)
+            if not present:
+                return privexec_pb2.PrivExecReply(
+                    enable_nat_reply=privexec_pb2.EnableNATReply(
+                        network_uuid=req.network_uuid,
+                        network_address=req.network_address,
+                        network_mask=req.network_mask,
+                        vxid=req.vxid,
+                        error=privexec_pb2.EnableNATReply.IPTABLES_FAILED,
+                        error_text=error_text
+                    )
+                )
 
         return privexec_pb2.PrivExecReply(
             enable_nat_reply=privexec_pb2.EnableNATReply(
@@ -471,33 +538,23 @@ class PrivExecJob:
         # Only append the DNAT rule if an identical rule is not already
         # present. Duplicated rules aren't just clutter -- the first match
         # wins, so a duplicate from an earlier partial attempt would mask
-        # later changes.
+        # later changes. That is exactly what ensure_netns_iptables_rule
+        # is for, so the check lives in one place rather than two.
         dnat_rule = [
             'PREROUTING', '-d', req.floating_address, '-j', 'DNAT',
             '--to-destination', req.inner_address]
-        _, _, returncode = privexec_util.command_helper(
-            privexec_util.locate_command('ip'), 'netns', 'exec',
-            req.network_uuid, privexec_util.locate_command('iptables'),
-            '-w', '10', '-t', 'nat', '-C', *dnat_rule,
-            failure_is_error=False)
-        if returncode != 0:
-            _, stderr, returncode = privexec_util.command_helper(
-                privexec_util.locate_command('ip'), 'netns', 'exec',
-                req.network_uuid, privexec_util.locate_command('iptables'),
-                '-w', '10', '-t', 'nat', '-A', *dnat_rule)
-            if returncode != 0:
-                return privexec_pb2.PrivExecReply(
-                    add_floating_ip_reply=privexec_pb2.AddFloatingIPReply(
-                        network_uuid=req.network_uuid,
-                        floating_address=req.floating_address,
-                        inner_address=req.inner_address,
-                        error=privexec_pb2.AddFloatingIPReply.IPTABLES_FAILED,
-                        error_text=(
-                            f'failed to append DNAT rule for '
-                            f'{req.floating_address} in namespace '
-                            f'{req.network_uuid}: {stderr}')
-                    )
+        present, error_text = ensure_netns_iptables_rule(
+            req.network_uuid, 'nat', dnat_rule)
+        if not present:
+            return privexec_pb2.PrivExecReply(
+                add_floating_ip_reply=privexec_pb2.AddFloatingIPReply(
+                    network_uuid=req.network_uuid,
+                    floating_address=req.floating_address,
+                    inner_address=req.inner_address,
+                    error=privexec_pb2.AddFloatingIPReply.IPTABLES_FAILED,
+                    error_text=error_text
                 )
+            )
 
         # Announce the address with a gratuitous ARP out the egress
         # veth once the datapath is complete. Floating addresses are

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_in_network_reachability.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_in_network_reachability.py
@@ -8,23 +8,27 @@ from shakenfist_ci import base
 
 
 class TestInNetworkReachability(base.BaseNamespacedTestCase):
-    """An address which is routed into a network must work inside it too.
+    """An address which answers from outside must answer from inside too.
 
-    A routed address is handed to a virtual network by the network
-    node, and it used to work only for clients which were not on that
-    network: it was never routed inside the network's own namespace, so
-    an instance's packet reached its default gateway and died there
-    (github issue #3662).
+    Both of Shaken Fist's externally reachable address types are handed
+    to a virtual network by the network node, and both used to work only
+    for clients which were not on that network. A routed address was
+    never routed inside the network's own namespace, so an instance's
+    packet reached its default gateway and died there; a floating
+    address was DNAT'ed into the network and the reply then travelled
+    back over the virtual network's own layer 2, so it never had its
+    source rewritten and the caller discarded it (github issue #3662).
 
-    The consequence was that a routed address was not usable from inside
-    the network -- which is what a Kubernetes service address, or any
-    other load balanced address, has to be. It stayed hidden because the
+    The consequence was that no Shaken Fist address was both stable
+    across instance replacement and usable from inside the network --
+    which is what a Kubernetes service address, or any other
+    load-balanced address, has to be. It stayed hidden because the
     clients which most wanted it (kube-proxy, on a cluster member)
     intercept the address in iptables before routing ever happens.
 
-    This is deliberately black box: the assertion is that an instance
-    can reach the address, not that any particular route exists. The
-    host side commands are pinned by the unit tests.
+    These are deliberately black box: the assertion is that an instance
+    can reach the address, not that any particular rule or route exists.
+    The host side commands are pinned by the unit tests.
     """
 
     def __init__(self, *args, **kwargs):
@@ -111,9 +115,21 @@ class TestInNetworkReachability(base.BaseNamespacedTestCase):
         self.fail('Could not ping %s (%s) from instance %s'
                   % (address, description, instance_uuid))
 
-    def test_a_routed_address_answers_from_inside(self):
-        # Both instances are shared by every assertion below. Booting a
-        # guest is by far the most expensive thing this test does.
+    def _await_floating_address(self, interface_uuid):
+        start_time = time.time()
+        while time.time() - start_time < 120:
+            floating = self.test_client.get_interface(
+                interface_uuid).get('floating')
+            if floating:
+                return floating
+            time.sleep(5)
+        self.fail('No floating address appeared on interface %s'
+                  % interface_uuid)
+
+    def test_routed_and_floating_addresses_answer_from_inside(self):
+        # Both halves share these two instances. Booting a guest is by
+        # far the most expensive thing this test does, and splitting the
+        # two scenarios into separate test methods would boot four.
         server = self._create_instance('uturn-server')
         client = self._create_instance('uturn-client')
         self._await_instance_ready(server['uuid'])
@@ -157,3 +173,11 @@ class TestInNetworkReachability(base.BaseNamespacedTestCase):
         # routed by this network, so returning at all is an assertion
         # about the half of the lifecycle the ping cannot see.
         self.test_client.unroute_network_address(self.net['uuid'], routed)
+
+        # A floating address, which is DNAT'ed rather than routed, and
+        # which the instance holding it never sees.
+        self.test_client.float_interface(server_iface['uuid'])
+        floating = self._await_floating_address(server_iface['uuid'])
+        self.addDetail('floating address', content.text_content(floating))
+
+        self._await_ping(client['uuid'], floating, 'floating address ping')

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_in_network_reachability.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_in_network_reachability.py
@@ -1,0 +1,159 @@
+# Copyright 2026 Michael Still and contributors
+import json
+import time
+
+from testtools import content
+
+from shakenfist_ci import base
+
+
+class TestInNetworkReachability(base.BaseNamespacedTestCase):
+    """An address which is routed into a network must work inside it too.
+
+    A routed address is handed to a virtual network by the network
+    node, and it used to work only for clients which were not on that
+    network: it was never routed inside the network's own namespace, so
+    an instance's packet reached its default gateway and died there
+    (github issue #3662).
+
+    The consequence was that a routed address was not usable from inside
+    the network -- which is what a Kubernetes service address, or any
+    other load balanced address, has to be. It stayed hidden because the
+    clients which most wanted it (kube-proxy, on a cluster member)
+    intercept the address in iptables before routing ever happens.
+
+    This is deliberately black box: the assertion is that an instance
+    can reach the address, not that any particular route exists. The
+    host side commands are pinned by the unit tests.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs['namespace_prefix'] = 'uturn'
+        super().__init__(*args, **kwargs)
+
+    def setUp(self):
+        super().setUp()
+        self.net = self.test_client.allocate_network(
+            '192.168.242.0/24', True, True, '%s-net' % self.namespace)
+        self.addDetail(
+            'net',
+            content.text_content(json.dumps(self.net, indent=4,
+                                            sort_keys=True)))
+        self._await_networks_ready([self.net['uuid']])
+
+    def _create_instance(self, name):
+        inst = self.test_client.create_instance(
+            name, 1, 1024,
+            [
+                {
+                    'network_uuid': self.net['uuid']
+                }
+            ],
+            [
+                {
+                    'size': 8,
+                    'base': base.CLUSTER_CI_IMAGE,
+                    'type': 'disk'
+                }
+            ], None, None, side_channels=['sf-agent2'])
+        self.addDetail(
+            name,
+            content.text_content(json.dumps(inst, indent=4, sort_keys=True)))
+        self.assertIsNotNone(inst['uuid'])
+        return inst
+
+    def _guest_device_for_mac(self, instance_uuid, macaddr):
+        """Find the guest's name for the interface with this MAC.
+
+        Nothing guarantees the guest calls it eth0, and the API knows the
+        MAC it gave the interface, so ask the guest to match them up
+        rather than guessing a name.
+        """
+        results = self._await_command(instance_uuid, 'ip -o link')
+        self.addDetail(
+            'guest links',
+            content.text_content(json.dumps(results, indent=4,
+                                            sort_keys=True)))
+        for line in results['stdout'].split('\n'):
+            if macaddr not in line:
+                continue
+            # "2: ens3: <BROADCAST,MULTICAST,UP> mtu 7950 ... link/ether ..."
+            return line.split(':')[1].strip().split('@')[0]
+
+        self.fail('No interface with MAC %s in guest %s: %s'
+                  % (macaddr, instance_uuid, results['stdout']))
+
+    def _await_ping(self, instance_uuid, address, description, timeout=180):
+        """Ping from inside an instance until it works, or give up.
+
+        Making an address reachable is asynchronous -- the REST call
+        returns once the operation is enqueued -- so the first ping can
+        legitimately lose.
+        """
+        start_time = time.time()
+        results = None
+        while time.time() - start_time < timeout:
+            results = self._await_command(
+                instance_uuid, 'ping -c 3 -W 2 %s' % address)
+            if results['return-code'] == 0 and ' 0% packet' in results[
+                    'stdout']:
+                self.addDetail(
+                    description,
+                    content.text_content(json.dumps(results, indent=4,
+                                                    sort_keys=True)))
+                return
+            time.sleep(5)
+
+        self.addDetail(
+            description,
+            content.text_content(json.dumps(results, indent=4,
+                                            sort_keys=True)))
+        self.fail('Could not ping %s (%s) from instance %s'
+                  % (address, description, instance_uuid))
+
+    def test_a_routed_address_answers_from_inside(self):
+        # Both instances are shared by every assertion below. Booting a
+        # guest is by far the most expensive thing this test does.
+        server = self._create_instance('uturn-server')
+        client = self._create_instance('uturn-client')
+        self._await_instance_ready(server['uuid'])
+        self._await_instance_ready(client['uuid'])
+
+        server_iface = self.test_client.get_instance_interfaces(
+            server['uuid'])[0]
+
+        # A routed address. Shaken Fist only routes it to the network;
+        # answering for it is the user's job, exactly as metallb does for
+        # a Kubernetes service address.
+        routed = self.test_client.route_network_address(self.net['uuid'])
+        self.addDetail('routed address', content.text_content(routed))
+
+        device = self._guest_device_for_mac(
+            server['uuid'], server_iface['macaddr'])
+        results = self._await_command(
+            server['uuid'], 'ip addr add %s/32 dev %s' % (routed, device))
+        self.assertEqual(
+            0, results['return-code'],
+            'Could not claim %s in the guest: %s'
+            % (routed, results['stderr']))
+
+        self._await_ping(client['uuid'], routed, 'routed address ping')
+
+        # The unroute happens here rather than through addCleanup(),
+        # because testtools runs cleanups *after* tearDown() -- and
+        # BaseNamespacedTestCase.tearDown() ends by deleting the
+        # namespace, after which the namespaced client cannot even
+        # authenticate, so a cleanup registered on it could only ever
+        # raise. Two earlier tests in this repository failed every merge
+        # group from the day they landed for exactly that reason, and
+        # both carry a comment saying so (database_tier.py and
+        # cluster_ci_tests/test_namespace_claims.py).
+        #
+        # Nothing leaks if the test fails before reaching this line:
+        # tearDown deletes the network, and that is what releases the
+        # address. The call is therefore coverage rather than cleanup,
+        # which is the other reason it belongs in the test body -- the
+        # endpoint answers 403 or 404 unless the address really is
+        # routed by this network, so returning at all is an assertion
+        # about the half of the lifecycle the ping cannot see.
+        self.test_client.unroute_network_address(self.net['uuid'], routed)

--- a/shakenfist/exceptions.py
+++ b/shakenfist/exceptions.py
@@ -527,7 +527,23 @@ class UnknownPrivExecReplyException(Exception):
 
 
 class EnableNATFailed(Exception):
-    ...
+    """A network's namespace NAT rules could not be installed.
+
+    Carries the EnableNATReply error details, which name the rule
+    iptables refused and repeat its own complaint about it. Without
+    them the ErrorReport an operator eventually reads records
+    ``network.nat.enable_failed`` and nothing else, which does not
+    distinguish a missing conntrack match from a namespace which has
+    gone away (issue 3662).
+    """
+
+    def __init__(self, error: str, error_text: str,
+                 network_uuid: str) -> None:
+        super().__init__(
+            f'{error}: {error_text} (network={network_uuid})')
+        self.error = error
+        self.error_text = error_text
+        self.network_uuid = network_uuid
 
 
 class EnsureMeshFailed(Exception):

--- a/shakenfist/network/bridged_vxlan_network.py
+++ b/shakenfist/network/bridged_vxlan_network.py
@@ -44,6 +44,7 @@ from shakenfist.constants import FLOATING_NETWORK_UUID
 from shakenfist.exceptions import CongestedNetwork
 from shakenfist.exceptions import DeadNetwork
 from shakenfist.exceptions import NotOnNetworkNode
+from shakenfist.exceptions import ProcessExecutionError
 from shakenfist.managed_executables import dnsmasq
 from shakenfist.node import Nodes
 from shakenfist.schema.operations.baseclusteroperation import PRIORITY
@@ -223,7 +224,7 @@ class BridgedVXLanNetwork:
             str(self.network.uuid), floating_address)
 
     def _apply_route_address(self, ip: str) -> None:
-        """Add a host route for a floating IP onto the network's vx bridge.
+        """Route a floating IP into the network, from both directions.
 
         Lifted from ``Network.route_address`` (network.py:938-947). The
         single-target audit event on the wrapped network is preserved here
@@ -251,29 +252,103 @@ class BridgedVXLanNetwork:
             extra={'floating': ip})
         subst = self.network.subst_dict()
         subst['floating_address'] = ip
+
+        # Two routes, because the two directions of traffic for a routed
+        # address are decided in two different routing tables.
+        #
+        # The root namespace's route is how the world gets in: traffic
+        # arriving at the network node for the address is put onto the
+        # network's bridge, and whichever instance the user configured to
+        # answer ARP for it picks it up.
+        #
+        # The namespace's route is how an instance on the network itself
+        # gets there (issue 3662). A routed address comes out of the
+        # floating pool, and the namespace has that entire block on link
+        # on its egress veth -- so without a more specific route, an
+        # instance's packet reaches its default gateway and the namespace
+        # ARPs for the address out on the egress bridge. Nothing answers:
+        # unlike a floating address, a routed address is not anchored on
+        # an interface anywhere, it only exists as a route. The packet
+        # dies one hop from home while the same address answers happily
+        # from outside the cluster. A /32 back out the veth turns that
+        # into the u-turn the root namespace already performs for
+        # everybody else.
+        #
+        # ``replace`` rather than ``add`` because both of these are
+        # re-applied: the maintain loop restores a network node's routed
+        # addresses whenever it rebuilds a network, and ``ip route add``
+        # exits non-zero on a route which is already present. That would
+        # error the operation, and -- worse than the noise -- abandon the
+        # second route because the first one raised.
         util_concurrency.execute(
-            'ip route add %(floating_address)s/32 dev %(vx_bridge)s'
+            'ip route replace %(floating_address)s/32 dev %(vx_bridge)s'
             % subst)
+        util_concurrency.execute(
+            'ip route replace %(floating_address)s/32 dev %(vx_veth_inner)s'
+            % subst, netns=self.network.uuid)
 
     def _apply_unroute_address(self, ip: str) -> None:
-        """Remove a host route for a floating IP from the network's vx bridge.
+        """Remove both of a routed address's routes.
 
         Lifted from ``Network.unroute_address`` (network.py:950-960). As with
         ``_apply_route_address``, the single-target audit event on the
         wrapped network is preserved. The single-threaded net-worker
         dispatcher is the only caller of this method and provides natural
         serialisation; no explicit lock is required.
+
+        Declines quietly on a deleted network for the same reason as
+        ``_apply_route_address`` (issue 3962). That guard is not the
+        whole story for the namespace delete below, though: a network in
+        ``delete_wait``, or one on a network node which has rebooted
+        before the namespace was rebuilt, is not ``deleted`` and still
+        has no namespace to exec into. ``ip netns exec`` reports that
+        with an exit code of its own (255, verified against iproute2)
+        rather than the 2 which means "no such route", so it is
+        tolerated separately below. The end state this method exists to
+        reach -- no route -- is already true of a namespace which is not
+        there, and failing here would leave the address reserved
+        forever, which is exactly what the exit code 2 tolerance was
+        added to prevent.
         """
         self._require_network_node('_apply_unroute_address')
+
+        if self.network.state.value == dbo.STATE_DELETED:
+            self.network.add_event(
+                EVENT_TYPE_AUDIT,
+                'refusing to unroute address on deleted network',
+                extra={'floating': ip})
+            return
 
         self.network.add_event(
             EVENT_TYPE_AUDIT, 'unrouting floating ip to network',
             extra={'floating': ip})
         subst = self.network.subst_dict()
         subst['floating_address'] = ip
+
+        # Both deletes tolerate exit code 2, which is what ip reports for
+        # a route which is not there. The namespace route needs that most:
+        # an address routed before the namespace half of this existed has
+        # only the root namespace's route, and an unroute which failed
+        # against the missing one would leave the address reserved
+        # forever. The end state we want is "no route", and a route which
+        # was never there already satisfies it.
         util_concurrency.execute(
             'ip route del %(floating_address)s/32 dev %(vx_bridge)s'
-            % subst)
+            % subst, check_exit_code=[0, 2])
+
+        # And the namespace delete tolerates the namespace itself being
+        # gone, which the deleted-network guard above does not cover.
+        try:
+            util_concurrency.execute(
+                'ip route del %(floating_address)s/32 dev %(vx_veth_inner)s'
+                % subst, netns=self.network.uuid, check_exit_code=[0, 2])
+        except ProcessExecutionError as e:
+            if e.exit_code != util_network.NETNS_MISSING_EXIT_CODE:
+                raise
+            self.network.add_event(
+                EVENT_TYPE_AUDIT,
+                'namespace absent while unrouting address, nothing to remove',
+                extra={'floating': ip})
 
     def _apply_remove_nat(self) -> None:
         """Tear down the network node's NAT for the wrapped network.

--- a/shakenfist/network/network.py
+++ b/shakenfist/network/network.py
@@ -43,6 +43,7 @@ from shakenfist.node import Node
 from shakenfist.schema.object_filter import ObjectFilterCriteria
 from shakenfist.schema.object_types import ObjectType
 from shakenfist.util import general as util_general
+from shakenfist.util import iptables as util_iptables
 from shakenfist.util import network as util_network
 
 
@@ -559,7 +560,54 @@ class Network(dbowo):
                     EVENT_TYPE_STATUS, 'network not ok, dnsmasq not running')
                 return False
 
+        if self.provide_nat and not self.is_nat_okay():
+            return False
+
         return True
+
+    def is_nat_okay(self):
+        """Audit the namespace NAT rules for this network.
+
+        Only the hairpin masquerade is checked, and only because
+        checking is what gets it onto a cluster which already has this
+        network. Nothing re-installs these rules while a network is
+        otherwise healthy -- ``is_created`` looks at the bridge and the
+        dnsmasq check looks at dnsmasq, and neither has ever looked at
+        iptables -- so a cluster which upgraded while all of its
+        networks were well would never acquire a rule added by the
+        upgrade, and floating address u-turns would go on hanging
+        exactly as they did before (issue 3662).
+
+        The hairpin rule stands in for the other three because all four
+        are installed by the same privexec call, so a namespace either
+        went through it or did not. Checking one rule keeps this to a
+        single exec per NAT providing network per maintain pass.
+        """
+        # The floating network has no namespace of its own, and no NAT
+        # rules to audit.
+        if self.uuid == FLOATING_NETWORK_UUID:
+            return True
+
+        # A network's namespace only exists on the network node, so
+        # anywhere else the honest answer is "nothing here to audit"
+        # rather than "drifted". is_okay() gates on the node role before
+        # it gets here, but this is a public method and the next caller
+        # -- a debugging path, sf-ctl -- will not necessarily do that,
+        # and reporting drift from a hypervisor would emit a status
+        # event which is simply false.
+        if not config.NODE_IS_NETWORK_NODE:
+            return True
+
+        rule = util_iptables.hairpin_masquerade_rule(
+            self.network_address, self.netmask, self.vxid)
+        if util_network.check_for_iptables_rule(
+                str(self.uuid), util_iptables.HAIRPIN_TABLE, rule):
+            return True
+
+        self.add_event(
+            EVENT_TYPE_STATUS,
+            'network not ok, namespace nat rules have drifted')
+        return False
 
     def is_created(self):
         """Attempt to ensure network has been created successfully."""

--- a/shakenfist/tests/test_bridged_vxlan_network.py
+++ b/shakenfist/tests/test_bridged_vxlan_network.py
@@ -15,6 +15,7 @@ from shakenfist.constants import EVENT_TYPE_AUDIT
 from shakenfist.constants import EVENT_TYPE_MUTATE
 from shakenfist.constants import FLOATING_NETWORK_UUID
 from shakenfist.exceptions import NotOnNetworkNode
+from shakenfist.exceptions import ProcessExecutionError
 from shakenfist.network import bridged_vxlan_network
 from shakenfist.tests import base
 
@@ -344,18 +345,42 @@ class BridgedVXLanNetworkApplyRouteAddressTestCase(base.ShakenFistTestCase):
         network = _make_network_mock(vxid=vxid)
         network.subst_dict.return_value = {
             'vx_bridge': 'br-vxlan-%06x' % vxid,
+            'vx_veth_inner': 'veth-%06x-i' % vxid,
         }
         return network
 
-    def test_apply_route_address_runs_ip_route_add(self):
+    def test_apply_route_address_routes_in_both_namespaces(self):
+        """A routed address is two routes, one per namespace.
+
+        The root namespace route puts traffic arriving from outside onto
+        the network's bridge. The namespace route is what lets an
+        instance on the network reach the address at all: the namespace
+        has the whole floating block on link on its egress veth, so
+        without a more specific route it ARPs for the address out on the
+        egress bridge, where nothing answers (issue 3662).
+
+        Both are installed with ``replace`` rather than ``add``, because
+        both are re-applied: the maintain loop restores a network node's
+        routed addresses whenever it rebuilds a network, and ``ip route
+        add`` exits non-zero on a route which is already there. That
+        would error the operation, and would abandon the namespace route
+        entirely because the root namespace one raised first.
+        """
         network = self._make_network_with_subst(vxid=0xabc)
         bvn = bridged_vxlan_network.BridgedVXLanNetwork(network)
 
         bvn._apply_route_address('203.0.113.10')
 
         network.get_lock.assert_not_called()
-        self.mock_execute.assert_called_once_with(
-            'ip route add 203.0.113.10/32 dev br-vxlan-000abc')
+        self.assertEqual(
+            [
+                mock.call(
+                    'ip route replace 203.0.113.10/32 dev br-vxlan-000abc'),
+                mock.call(
+                    'ip route replace 203.0.113.10/32 dev veth-000abc-i',
+                    netns=network.uuid),
+            ],
+            self.mock_execute.call_args_list)
         # The single-target audit event is preserved at the apply layer.
         network.add_event.assert_called_once_with(
             EVENT_TYPE_AUDIT, 'routing floating ip to network',
@@ -377,18 +402,107 @@ class BridgedVXLanNetworkApplyRouteAddressTestCase(base.ShakenFistTestCase):
             'refusing to route address on deleted network',
             extra={'floating': '203.0.113.12'})
 
-    def test_apply_unroute_address_runs_ip_route_del(self):
+    def test_apply_unroute_address_removes_both_routes(self):
+        """Unroute undoes both routes, and tolerates either being absent.
+
+        An address routed before the namespace route existed has only the
+        root namespace's route. Exit code 2 is what ip reports for a
+        route which is not there, and failing on it would leave such an
+        address reserved forever.
+        """
         network = self._make_network_with_subst(vxid=0xdef)
         bvn = bridged_vxlan_network.BridgedVXLanNetwork(network)
 
         bvn._apply_unroute_address('203.0.113.11')
 
         network.get_lock.assert_not_called()
-        self.mock_execute.assert_called_once_with(
-            'ip route del 203.0.113.11/32 dev br-vxlan-000def')
+        self.assertEqual(
+            [
+                mock.call(
+                    'ip route del 203.0.113.11/32 dev br-vxlan-000def',
+                    check_exit_code=[0, 2]),
+                mock.call(
+                    'ip route del 203.0.113.11/32 dev veth-000def-i',
+                    netns=network.uuid, check_exit_code=[0, 2]),
+            ],
+            self.mock_execute.call_args_list)
         network.add_event.assert_called_once_with(
             EVENT_TYPE_AUDIT, 'unrouting floating ip to network',
             extra={'floating': '203.0.113.11'})
+
+    def test_apply_unroute_address_tolerates_a_missing_namespace(self):
+        """An absent namespace is the end state, not a failure.
+
+        The deleted-network guard does not cover every namespace which
+        is not there: a network in ``delete_wait``, or one on a network
+        node which has rebooted before the namespace was rebuilt, is not
+        ``deleted`` and still has nothing to exec into. ``ip netns exec``
+        reports that with 255, which is outside the exit codes ``ip``
+        itself uses, so it is tolerated separately. Failing here would
+        leave the address reserved forever, which is the outcome the
+        exit code 2 tolerance beside it was added to prevent.
+        """
+        network = self._make_network_with_subst(vxid=0xfed)
+        bvn = bridged_vxlan_network.BridgedVXLanNetwork(network)
+
+        self.mock_execute.side_effect = [
+            ('', ''),
+            ProcessExecutionError(
+                stdout='', stderr='Cannot open network namespace "%s": No '
+                                  'such file or directory' % network.uuid,
+                exit_code=255,
+                cmd='ip route del 203.0.113.14/32 dev veth-000fed-i'),
+        ]
+
+        bvn._apply_unroute_address('203.0.113.14')
+
+        self.assertEqual(2, self.mock_execute.call_count)
+        network.add_event.assert_any_call(
+            EVENT_TYPE_AUDIT,
+            'namespace absent while unrouting address, nothing to remove',
+            extra={'floating': '203.0.113.14'})
+
+    def test_apply_unroute_address_still_raises_other_failures(self):
+        """Only the missing namespace is tolerated, not everything.
+
+        A route delete which fails inside a namespace which is there is
+        a real failure, and must error the operation rather than being
+        swallowed as "well, it is gone now".
+        """
+        network = self._make_network_with_subst(vxid=0xfee)
+        bvn = bridged_vxlan_network.BridgedVXLanNetwork(network)
+
+        self.mock_execute.side_effect = [
+            ('', ''),
+            ProcessExecutionError(
+                stdout='', stderr='RTNETLINK answers: Network is down',
+                exit_code=1,
+                cmd='ip route del 203.0.113.15/32 dev veth-000fee-i'),
+        ]
+
+        self.assertRaises(
+            ProcessExecutionError, bvn._apply_unroute_address, '203.0.113.15')
+
+    def test_apply_unroute_address_declines_deleted_network(self):
+        """A deleted network declines quietly, as its sibling does.
+
+        The namespace of a deleted network is gone too, and while the
+        delete below now tolerates that, declining here means the
+        network's teardown does not depend on an exec which is only
+        going to say the namespace is not there (issue 3962).
+        """
+        network = self._make_network_with_subst(vxid=0xbcd)
+        network.state = mock.Mock()
+        network.state.value = 'deleted'
+        bvn = bridged_vxlan_network.BridgedVXLanNetwork(network)
+
+        bvn._apply_unroute_address('203.0.113.13')
+
+        self.mock_execute.assert_not_called()
+        network.add_event.assert_called_once_with(
+            EVENT_TYPE_AUDIT,
+            'refusing to unroute address on deleted network',
+            extra={'floating': '203.0.113.13'})
 
 
 class BridgedVXLanNetworkApplyRemoveNATTestCase(base.ShakenFistTestCase):

--- a/shakenfist/tests/test_daemon_network_maintain.py
+++ b/shakenfist/tests/test_daemon_network_maintain.py
@@ -96,7 +96,10 @@ class MaintainPipelineTest(base.ShakenFistTestCase):
                            node_missing=False, execute_side_effect=None,
                            present_devices=None, bridge_members=None,
                            bridge_members_error=None,
-                           find_network_vxids_error=None):
+                           find_network_vxids_error=None,
+                           namespace_routes=None,
+                           root_routes=None,
+                           namespace_routes_error=None):
         """Drive Job.execute() through exactly one pass of the outer loop
         and return a dict of the mocks that callers will most likely
         want to assert on.
@@ -120,6 +123,17 @@ class MaintainPipelineTest(base.ShakenFistTestCase):
         ``get_bridge_members()`` raise. Both drive the host side
         cross-check the reaper performs before it mutates anything;
         the default is a bridge with no members at all.
+
+        ``namespace_routes`` is the set of host route destinations
+        ``get_host_routes()`` reports from inside a network namespace,
+        and ``root_routes`` the set it reports for the bridge in the
+        root namespace. Between them they are how the pass decides
+        whether a routed address still has both of its routes; the
+        default is none in the namespace, and whatever the namespace has
+        in the root, so a test which only cares about one side does not
+        have to say anything about the other.
+        ``namespace_routes_error`` makes the read raise instead, which
+        is what a namespace that is not there looks like.
         """
         if networks is None:
             networks = []
@@ -152,6 +166,16 @@ class MaintainPipelineTest(base.ShakenFistTestCase):
 
             active['util_network'].discover_interfaces.return_value = (
                 None, None, vxid_to_mac)
+            if namespace_routes_error is not None:
+                active['util_network'].get_host_routes.side_effect = (
+                    namespace_routes_error)
+            else:
+                in_namespace = set(namespace_routes or [])
+                in_root = (in_namespace if root_routes is None
+                           else set(root_routes))
+                active['util_network'].get_host_routes.side_effect = (
+                    lambda netns, device:
+                        in_root if netns is None else in_namespace)
             if present_devices is not None:
                 active['util_network'].check_for_interface.side_effect = (
                     lambda device: device in present_devices)
@@ -637,6 +661,233 @@ class MaintainPipelineTest(base.ShakenFistTestCase):
         rc = routed_calls[0]
         self.assertEqual(fake_addr, rc.kwargs.get('ip'))
         self.assertEqual(PRIORITY.background, rc.kwargs.get('priority'))
+
+    def _routed_floating_network(self, network, address):
+        """A floating network whose IPAM has one routed address."""
+        from shakenfist.schema.ipam_reservation import ReservationType
+
+        reservation = mock.MagicMock()
+        reservation.reservation_type = ReservationType.ROUTED
+        reservation.user_uuid = network.uuid
+
+        fn = mock.MagicMock()
+        fn.ipam.in_use = [address]
+        fn.ipam.get_all_reservations.return_value = {address: reservation}
+        return fn
+
+    def test_a_missing_namespace_route_is_restored_on_its_own(self):
+        """A routed address with no in-namespace route is re-routed.
+
+        A routed address is two routes: one in the network node's root
+        namespace so the world can reach it, and one in the network's own
+        namespace so the network's instances can (issue 3662). Nothing
+        else re-applies the second one while the network is healthy, so a
+        cluster which upgraded into it while everything was well would
+        never acquire it for the addresses it already had.
+
+        Re-routing is idempotent and installs both routes, so this must
+        not drag the whole network through a rebuild to get there.
+        """
+        from shakenfist.schema.operations.baseclusteroperation import PRIORITY
+        from shakenfist.schema.operations.net_ip_op \
+            import model_tasks as net_ip_tasks
+
+        n = _build_mock_network(is_okay=True, is_mesh_okay=True)
+        active = self._run_one_iteration(
+            network_node=True,
+            networks=[n],
+            floating_network=self._routed_floating_network(n, '10.10.10.1'),
+            namespace_routes=[],
+        )
+
+        active['net_ip_create_and_enqueue'].assert_called_once()
+        call = active['net_ip_create_and_enqueue'].call_args
+        self.assertEqual('10.10.10.1', call.kwargs.get('ip'))
+        self.assertEqual(
+            [net_ip_tasks.route_address], call.kwargs.get('tasks'))
+        self.assertEqual(PRIORITY.background, call.kwargs.get('priority'))
+
+        # Nothing was rebuilt to achieve it.
+        active['net_create_and_enqueue'].assert_not_called()
+        active['nn_create_and_enqueue'].assert_not_called()
+
+    def test_a_present_namespace_route_is_left_alone(self):
+        """The pass is a no-op when both of the routes are already there."""
+        n = _build_mock_network(is_okay=True, is_mesh_okay=True)
+        active = self._run_one_iteration(
+            network_node=True,
+            networks=[n],
+            floating_network=self._routed_floating_network(n, '10.10.10.1'),
+            namespace_routes=['10.10.10.1'],
+        )
+
+        active['net_ip_create_and_enqueue'].assert_not_called()
+        active['net_create_and_enqueue'].assert_not_called()
+        active['nn_create_and_enqueue'].assert_not_called()
+
+    def test_a_missing_root_route_is_restored_too(self):
+        """The root namespace route is audited alongside the namespace one.
+
+        The root route is how the world reaches a routed address, and it
+        can be lost while the bridge it points at survives -- in which
+        case ``is_created()`` stays true, the network looks perfectly
+        healthy, and the address is silently unreachable from outside
+        the cluster. That is the same drift this pass reads the
+        namespace for, in the other direction, and re-routing installs
+        both so the repair does not care which one went missing.
+        """
+        from shakenfist.schema.operations.net_ip_op \
+            import model_tasks as net_ip_tasks
+
+        n = _build_mock_network(is_okay=True, is_mesh_okay=True)
+        active = self._run_one_iteration(
+            network_node=True,
+            networks=[n],
+            floating_network=self._routed_floating_network(n, '10.10.10.1'),
+            namespace_routes=['10.10.10.1'],
+            root_routes=[],
+        )
+
+        active['net_ip_create_and_enqueue'].assert_called_once()
+        call = active['net_ip_create_and_enqueue'].call_args
+        self.assertEqual('10.10.10.1', call.kwargs.get('ip'))
+        self.assertEqual(
+            [net_ip_tasks.route_address], call.kwargs.get('tasks'))
+
+        # Both tables really were read, rather than the namespace read
+        # answering for both.
+        self.assertEqual(
+            {None, str(n.uuid)},
+            {c.args[0] for c in
+             active['util_network'].get_host_routes.call_args_list})
+
+        # And nothing was rebuilt to get there.
+        active['net_create_and_enqueue'].assert_not_called()
+        active['nn_create_and_enqueue'].assert_not_called()
+
+    def test_a_drifted_mesh_defers_the_route_probe(self):
+        """A network heading for a mesh repair is not probed for routes.
+
+        The mesh repair branch discards whatever the probe would have
+        said -- any missing route waits for the pass after the mesh
+        comes back -- so paying an exec per pass for the answer is the
+        same waste the pending-operation gate already avoids.
+        """
+        n = _build_mock_network(is_okay=True, is_mesh_okay=False)
+        active = self._run_one_iteration(
+            network_node=True,
+            networks=[n],
+            floating_network=self._routed_floating_network(n, '10.10.10.1'),
+            namespace_routes=[],
+        )
+
+        active['util_network'].get_host_routes.assert_not_called()
+        active['net_ip_create_and_enqueue'].assert_not_called()
+        # The mesh repair itself still happens.
+        active['net_create_and_enqueue'].assert_called_once()
+
+    def test_only_the_network_node_reads_namespace_routes(self):
+        """A hypervisor has no namespace to read, and must not look.
+
+        The namespaces exist only on the network node, so asking on a
+        hypervisor would be one wasted exec per network per pass, and
+        would report every routed address as missing.
+        """
+        n = _build_mock_network(is_okay=True, is_mesh_okay=True)
+        active = self._run_one_iteration(
+            network_node=False,
+            networks=[n],
+            floating_network=self._routed_floating_network(n, '10.10.10.1'),
+            namespace_routes=[],
+        )
+
+        active['util_network'].get_host_routes.assert_not_called()
+        active['net_ip_create_and_enqueue'].assert_not_called()
+
+    def test_a_missing_namespace_is_left_to_the_rebuild(self):
+        """A namespace which cannot be read is not a missing route.
+
+        ``ip route list`` inside a namespace which is not there fails,
+        and that is a larger drift than one absent route -- rebuilding
+        the network is what fixes it, and re-applies the routes on the
+        way past. Reporting every address as missing here would enqueue a
+        re-route per address per pass against a namespace which cannot
+        accept any of them.
+        """
+        n = _build_mock_network(is_okay=True, is_mesh_okay=True)
+        active = self._run_one_iteration(
+            network_node=True,
+            networks=[n],
+            floating_network=self._routed_floating_network(n, '10.10.10.1'),
+            namespace_routes_error=ProcessExecutionError(
+                'Cannot open network namespace'),
+        )
+
+        active['util_network'].get_host_routes.assert_called_once()
+        active['net_ip_create_and_enqueue'].assert_not_called()
+
+    def test_namespace_routes_are_not_read_while_an_op_is_pending(self):
+        """A network already being reconciled is not probed.
+
+        The in-flight operation will re-route the address when it runs,
+        and the pending-op gate discards whatever the probe would have
+        said, so paying an exec per pass for it is pure waste.
+        """
+        n = _build_mock_network(is_okay=True, is_mesh_okay=True)
+        active = self._run_one_iteration(
+            network_node=True,
+            networks=[n],
+            floating_network=self._routed_floating_network(n, '10.10.10.1'),
+            namespace_routes=[],
+            pending_op=True,
+        )
+
+        active['util_network'].get_host_routes.assert_not_called()
+        active['net_ip_create_and_enqueue'].assert_not_called()
+
+    def test_a_failing_route_repair_is_guarded_by_its_own_history(self):
+        """The route repair is a NetIPOp, so its guards read NetIPOp state.
+
+        A re-route which can never succeed -- an absent veth, a namespace
+        in a state nothing here can fix -- would otherwise be enqueued
+        again on every pass forever, with a fresh event on the network
+        each time, because the network's NetOp history says nothing about
+        whether its NetIPOps have been failing.
+        """
+        n = _build_mock_network(is_okay=True, is_mesh_okay=True)
+        active = self._run_one_iteration(
+            network_node=True,
+            networks=[n],
+            floating_network=self._routed_floating_network(n, '10.10.10.1'),
+            namespace_routes=[],
+            recent_history=[('op-uuid-1', 'error', 9_995.0)],
+        )
+
+        active['net_ip_create_and_enqueue'].assert_not_called()
+        active['net_create_and_enqueue'].assert_not_called()
+
+        op_types = {
+            call.kwargs.get('op_type') for call in
+            active['mariadb'].get_recent_terminal_op_states_for_target
+            .call_args_list}
+        self.assertEqual({'net_ip_op'}, op_types)
+
+    def test_a_rebuild_is_still_guarded_by_net_op_history(self):
+        """Structural drift is repaired with a NetOp, and guarded as one."""
+        n = _build_mock_network(is_okay=False)
+        active = self._run_one_iteration(
+            network_node=True,
+            networks=[n],
+            recent_history=[('op-uuid-1', 'error', 9_995.0)],
+        )
+
+        active['net_create_and_enqueue'].assert_not_called()
+
+        op_types = {
+            call.kwargs.get('op_type') for call in
+            active['mariadb'].get_recent_terminal_op_states_for_target
+            .call_args_list}
+        self.assertEqual({'net_op'}, op_types)
 
     def test_stray_vxlan_within_grace_period_not_touched(self):
         """A stray vxlan seen for less than five minutes is only tracked,

--- a/shakenfist/tests/test_error_report.py
+++ b/shakenfist/tests/test_error_report.py
@@ -82,7 +82,8 @@ class ErrorReportFromExceptionTestCase(base.ShakenFistTestCase):
             report.origin_class)
 
     def test_enable_nat_failed_maps_to_nat_enable_failed(self):
-        report = ErrorReport.from_exception(EnableNATFailed('nat failed'))
+        report = ErrorReport.from_exception(
+            EnableNATFailed('IPTABLES_FAILED', 'nat failed', 'netuuid'))
         self.assertEqual('network.nat.enable_failed', report.code)
         self.assertEqual(
             'shakenfist.exceptions.EnableNATFailed', report.origin_class)

--- a/shakenfist/tests/test_net.py
+++ b/shakenfist/tests/test_net.py
@@ -13,6 +13,7 @@ from shakenfist.operations.net_op import NetOp
 from shakenfist.schema.operations.baseclusteroperation import PRIORITY
 from shakenfist.tests import base
 from shakenfist.tests.mock_mariadb import MockMariaDB
+from shakenfist.util import iptables as util_iptables
 
 
 class NetworkTestCase(base.ShakenFistTestCase):
@@ -64,6 +65,29 @@ class NetworkNormalNodeTestCase(NetworkTestCase):
         n = network.Network.from_db(network_uuid)
         self.assertTrue(n.is_okay())
 
+    @mock.patch('shakenfist.util.network.check_for_iptables_rule',
+                return_value=False)
+    def test_is_nat_okay_off_the_network_node(self, mock_check):
+        """A hypervisor has no namespace to audit, and must not claim drift.
+
+        is_okay() gates on the node role before it reaches here, but
+        is_nat_okay() is public and the next caller -- sf-ctl, a
+        debugging path -- will not necessarily do the same. Without its
+        own guard it would exec into a namespace which does not exist,
+        get nothing, and emit a status event saying the network's NAT
+        rules have drifted, which is simply false.
+        """
+        self.mock_mariadb = MockMariaDB(self, node_count=4)
+        self.mock_mariadb.setup()
+
+        network_uuid = str(uuid.uuid4())
+        self.mock_mariadb.create_network('bobnet', network_uuid, provide_dhcp=True,
+                                         provide_nat=True)
+        n = network.Network.from_db(network_uuid)
+
+        self.assertTrue(n.is_nat_okay())
+        mock_check.assert_not_called()
+
     @mock.patch('shakenfist.network.network.Network.has_pending_cluster_operation',
                 return_value=False)
     @mock.patch('shakenfist.network.network.Network.is_created', return_value=False)
@@ -113,7 +137,9 @@ class NetworkNetNodeTestCase(NetworkTestCase):
                 return_value=False)
     @mock.patch('shakenfist.network.network.Network.is_created', return_value=True)
     @mock.patch('shakenfist.network.network.Network.is_dnsmasq_running', return_value=True)
-    def test_is_okay_yes(self, mock_is_dnsmasq, mock_is_created, mock_pending):
+    @mock.patch('shakenfist.network.network.Network.is_nat_okay', return_value=True)
+    def test_is_okay_yes(self, mock_is_nat_okay, mock_is_dnsmasq, mock_is_created,
+                         mock_pending):
         self.mock_mariadb = MockMariaDB(self, node_count=4)
         self.mock_mariadb.setup()
 
@@ -122,6 +148,105 @@ class NetworkNetNodeTestCase(NetworkTestCase):
                                          provide_nat=True)
         n = network.Network.from_db(network_uuid)
         self.assertTrue(n.is_okay())
+
+    @mock.patch('shakenfist.network.network.Network.has_pending_cluster_operation',
+                return_value=False)
+    @mock.patch('shakenfist.network.network.Network.is_created', return_value=True)
+    @mock.patch('shakenfist.network.network.Network.is_dnsmasq_running', return_value=True)
+    @mock.patch('shakenfist.network.network.Network.is_nat_okay', return_value=False)
+    def test_is_okay_no_nat_rules(self, mock_is_nat_okay, mock_is_dnsmasq,
+                                  mock_is_created, mock_pending):
+        """A network node network with drifted namespace NAT rules is not okay.
+
+        Nothing else re-runs the namespace's iptables setup for a network
+        which is otherwise healthy, so a cluster upgraded into a new rule
+        while all of its networks were well would never acquire it. The
+        maintain pass only ever asks is_okay() (issue 3662).
+        """
+        self.mock_mariadb = MockMariaDB(self, node_count=4)
+        self.mock_mariadb.setup()
+
+        network_uuid = str(uuid.uuid4())
+        self.mock_mariadb.create_network('bobnet', network_uuid, provide_dhcp=True,
+                                         provide_nat=True)
+        n = network.Network.from_db(network_uuid)
+        self.assertFalse(n.is_okay())
+
+    @mock.patch('shakenfist.network.network.Network.has_pending_cluster_operation',
+                return_value=False)
+    @mock.patch('shakenfist.network.network.Network.is_created', return_value=True)
+    @mock.patch('shakenfist.network.network.Network.is_dnsmasq_running', return_value=True)
+    @mock.patch('shakenfist.network.network.Network.is_nat_okay', return_value=False)
+    def test_is_okay_ignores_nat_rules_without_nat(
+            self, mock_is_nat_okay, mock_is_dnsmasq, mock_is_created, mock_pending):
+        """A network which does not provide NAT has no NAT rules to audit."""
+        self.mock_mariadb = MockMariaDB(self, node_count=4)
+        self.mock_mariadb.setup()
+
+        network_uuid = str(uuid.uuid4())
+        self.mock_mariadb.create_network('bobnet', network_uuid, provide_dhcp=True,
+                                         provide_nat=False)
+        n = network.Network.from_db(network_uuid)
+        self.assertTrue(n.is_okay())
+        mock_is_nat_okay.assert_not_called()
+
+    #
+    #  is_nat_okay()
+    #
+    @mock.patch('shakenfist.util.network.check_for_iptables_rule',
+                return_value=True)
+    def test_is_nat_okay_present(self, mock_check):
+        """The rule asked for is the hairpin rule, in the network's namespace.
+
+        The rule text comes from shakenfist.util.iptables, which is also
+        where sf-privexec gets it, so the audit cannot ask for a rule the
+        install never wrote.
+        """
+        self.mock_mariadb = MockMariaDB(self, node_count=4)
+        self.mock_mariadb.setup()
+
+        network_uuid = str(uuid.uuid4())
+        self.mock_mariadb.create_network('bobnet', network_uuid, provide_dhcp=True,
+                                         provide_nat=True)
+        n = network.Network.from_db(network_uuid)
+        self.assertTrue(n.is_nat_okay())
+
+        mock_check.assert_called_once_with(
+            network_uuid, 'nat',
+            util_iptables.hairpin_masquerade_rule(
+                n.network_address, n.netmask, n.vxid))
+
+    @mock.patch('shakenfist.util.network.check_for_iptables_rule',
+                return_value=False)
+    def test_is_nat_okay_absent(self, mock_check):
+        self.mock_mariadb = MockMariaDB(self, node_count=4)
+        self.mock_mariadb.setup()
+
+        network_uuid = str(uuid.uuid4())
+        self.mock_mariadb.create_network('bobnet', network_uuid, provide_dhcp=True,
+                                         provide_nat=True)
+        n = network.Network.from_db(network_uuid)
+        self.assertFalse(n.is_nat_okay())
+
+    @mock.patch('shakenfist.util.network.check_for_iptables_rule',
+                return_value=False)
+    def test_is_nat_okay_skips_the_floating_network(self, mock_check):
+        """The floating network has no namespace, and so no rules to audit.
+
+        It is not a bridged VXLAN network -- there is no namespace named
+        for its uuid to exec into -- so probing it would fail on every
+        pass and report drift which nothing could ever repair.
+        """
+        self.mock_mariadb = MockMariaDB(self, node_count=4)
+        self.mock_mariadb.setup()
+
+        self.mock_mariadb.create_network(
+            'floatnet', str(FLOATING_NETWORK_UUID),
+            provide_dhcp=False, provide_nat=True)
+        n = network.Network.from_db(str(FLOATING_NETWORK_UUID))
+
+        self.assertTrue(n.is_nat_okay())
+        mock_check.assert_not_called()
 
     @mock.patch('shakenfist.network.network.Network.has_pending_cluster_operation',
                 return_value=False)
@@ -188,8 +313,9 @@ class NetworkNetNodeTestCase(NetworkTestCase):
                 return_value=False)
     @mock.patch('shakenfist.network.network.Network.is_created', return_value=True)
     @mock.patch('shakenfist.network.network.Network.is_dnsmasq_running', return_value=True)
+    @mock.patch('shakenfist.network.network.Network.is_nat_okay', return_value=True)
     def test_is_okay_falls_through_when_no_pending_operation(
-            self, mock_is_dnsmasq, mock_is_created, mock_pending):
+            self, mock_is_nat_okay, mock_is_dnsmasq, mock_is_created, mock_pending):
         """is_okay() falls through to bridge/dnsmasq checks when no op is in flight."""
         self.mock_mariadb = MockMariaDB(self, node_count=4)
         self.mock_mariadb.setup()

--- a/shakenfist/tests/test_privexec_enable_nat.py
+++ b/shakenfist/tests/test_privexec_enable_nat.py
@@ -1,0 +1,436 @@
+# Copyright 2026 Michael Still and contributors
+"""Tests for the privexec enable NAT handler.
+
+Every rule `_enable_nat` installs lives inside the network's own network
+namespace, and every rule is installed at most once. Both halves of that
+have been wrong: the idempotency probe this replaced listed POSTROUTING in
+the root namespace, where none of these rules are, and the return
+direction FORWARD rule named a literal string rather than the interface
+the variable beside it holds.
+"""
+
+from unittest import mock
+
+from shakenfist import exceptions
+from shakenfist.daemons.privexec import main as privexec_main
+from shakenfist.protos import privexec_pb2
+from shakenfist.tests import base
+from shakenfist.tests.test_privexec_floating_ip import CommandRecorder
+from shakenfist.util import concurrency as util_concurrency
+
+
+NETWORK_UUID = 'ccc652aa-f7b6-4f99-b76d-443ae4d91412'
+VXID = 0xe2300f
+EGRESS_VETH = 'egr-e2300f-i'
+VX_VETH = 'veth-e2300f-i'
+
+# A -C which cannot find the rule. This is what iptables says when the
+# rule is genuinely absent, and it is what makes the append run.
+RULE_ABSENT = {'-C': ('', 'iptables: Bad rule (does a matching rule exist '
+                          'in that chain?).\n', 1)}
+
+# A -D which removes one copy and then finds nothing left, which is what
+# a namespace holding exactly one copy of a rule looks like.
+RULE_DELETED_ONCE = {'-D': [('', '', 0),
+                            ('', 'iptables: Bad rule (does a matching rule '
+                                 'exist in that chain?).\n', 1)]}
+
+
+class PrivExecEnableNATTestCase(base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.locate_command = mock.patch(
+            'shakenfist.daemons.privexec.util.locate_command',
+            side_effect=lambda c: c)
+        self.locate_command.start()
+        self.addCleanup(self.locate_command.stop)
+
+        self.job = privexec_main.PrivExecJob(mock.MagicMock())
+
+    def patch_commands(self, results=None):
+        recorder = CommandRecorder(results)
+        patcher = mock.patch(
+            'shakenfist.daemons.privexec.util.command_helper',
+            side_effect=recorder)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return recorder
+
+    def _request(self):
+        return privexec_pb2.EnableNATRequest(
+            network_uuid=NETWORK_UUID,
+            network_address='172.16.0.0',
+            network_mask='255.255.255.0',
+            vxid=VXID)
+
+    def _enable_nat(self):
+        # _enable_nat reads (and would write) the host's ip_forward
+        # sysctl. Report it as already on so the write never happens, and
+        # keep the patch off everything else the test framework does.
+        with mock.patch('builtins.open', mock.mock_open(read_data='1\n')):
+            return self.job._enable_nat(self._request())
+
+    def _appends(self, recorder):
+        return [c for c in recorder.calls if '-A' in c]
+
+    def _deletes(self, recorder):
+        return [c for c in recorder.calls if '-D' in c]
+
+    def test_enable_nat_installs_the_expected_rules(self):
+        recorder = self.patch_commands(RULE_ABSENT)
+
+        reply = self._enable_nat()
+
+        self.assertEqual(
+            privexec_pb2.EnableNATReply.OK, reply.enable_nat_reply.error)
+        self.assertEqual(
+            [
+                ('ip', 'netns', 'exec', NETWORK_UUID, 'iptables', '-w', '10',
+                 '-t', 'filter', '-A', 'FORWARD', '-o', EGRESS_VETH,
+                 '-i', VX_VETH, '-j', 'ACCEPT'),
+                ('ip', 'netns', 'exec', NETWORK_UUID, 'iptables', '-w', '10',
+                 '-t', 'filter', '-A', 'FORWARD', '-i', EGRESS_VETH,
+                 '-o', VX_VETH, '-j', 'ACCEPT'),
+                ('ip', 'netns', 'exec', NETWORK_UUID, 'iptables', '-w', '10',
+                 '-t', 'nat', '-A', 'POSTROUTING', '-s',
+                 '172.16.0.0/255.255.255.0', '-o', EGRESS_VETH,
+                 '-j', 'MASQUERADE'),
+            ],
+            self._appends(recorder))
+
+    def test_the_return_path_names_the_vx_veth(self):
+        """The inbound FORWARD rule matches the interface, not its name.
+
+        It used to be built with the literal string 'vx_veth_inner' where
+        the variable of that name was intended, so it matched an interface
+        which will never exist. Nothing broke, because the namespace's
+        FORWARD policy is ACCEPT and these rules only ever accept -- but
+        the rule was the wrong rule, and the day the policy tightens is
+        not the day to discover that.
+        """
+        recorder = self.patch_commands(RULE_ABSENT)
+
+        self._enable_nat()
+
+        # The literal survives in exactly one place: the delete which
+        # removes the rule an older Shaken Fist wrote with it. No rule
+        # is installed naming it.
+        self.assertEqual(
+            [], [c for c in self._appends(recorder) if 'vx_veth_inner' in c])
+        inbound = [c for c in self._appends(recorder)
+                   if '-i' in c and c[c.index('-i') + 1] == EGRESS_VETH]
+        self.assertEqual(1, len(inbound))
+        self.assertIn(VX_VETH, inbound[0])
+
+    def test_the_stale_return_path_rule_is_deleted(self):
+        """The broken rule an older Shaken Fist wrote is removed.
+
+        A -C for the corrected rule cannot match the old one, so without
+        an explicit delete an upgraded namespace holds both forever: the
+        right rule and a rule matching an interface which will never
+        exist. Harmless while the FORWARD policy is ACCEPT, but it means
+        the namespace never converges on what util_iptables describes.
+        """
+        recorder = self.patch_commands(dict(RULE_ABSENT, **RULE_DELETED_ONCE))
+
+        self._enable_nat()
+
+        stale = ('ip', 'netns', 'exec', NETWORK_UUID, 'iptables', '-w', '10',
+                 '-t', 'filter', '-D', 'FORWARD', '-i', EGRESS_VETH,
+                 '-o', 'vx_veth_inner', '-j', 'ACCEPT')
+        # Two deletes: the one which removed the rule, and the one which
+        # established there was not a second copy of it.
+        self.assertEqual([stale, stale], self._deletes(recorder))
+
+        # And it happens before the installs, so a namespace ends up
+        # holding exactly the rules util_iptables names.
+        self.assertLess(recorder.calls.index(self._deletes(recorder)[0]),
+                        recorder.calls.index(self._appends(recorder)[0]))
+
+    def test_every_copy_of_the_stale_rule_is_deleted(self):
+        """Duplicates of the broken rule are drained, not just one.
+
+        iptables -D removes one matching rule. The _enable_nat this
+        replaced appended its rules unconditionally on every create and
+        every maintain driven recreate, so a namespace on an upgraded
+        cluster can hold several copies of the rule we no longer believe
+        in. Deleting one of them leaves the rest, and nothing ever looks
+        again -- the -C for the corrected rule cannot match a broken one,
+        so the install appends and moves on.
+        """
+        recorder = self.patch_commands(dict(
+            RULE_ABSENT,
+            **{'-D': [('', '', 0), ('', '', 0), ('', '', 0),
+                      ('', 'iptables: Bad rule (does a matching rule exist '
+                           'in that chain?).\n', 1)]}))
+
+        self._enable_nat()
+
+        # Three copies removed, then a fourth call which found nothing
+        # left. Not one delete and three survivors.
+        self.assertEqual(4, len(self._deletes(recorder)))
+
+    def test_duplicate_deletion_is_bounded(self):
+        """A delete which always succeeds still terminates.
+
+        Nothing should be able to report success forever, but a loop
+        driven by an external command's exit code does not get to
+        assume that. The bound is asserted as a literal rather than by
+        naming the constant, because a test which reads the constant
+        moves with it and therefore cannot fail.
+        """
+        recorder = self.patch_commands(RULE_ABSENT)
+
+        self._enable_nat()
+
+        self.assertEqual(32, privexec_main.MAX_DUPLICATE_IPTABLES_RULES)
+        self.assertEqual(32, len(self._deletes(recorder)))
+
+    def test_an_absent_stale_rule_is_not_an_error(self):
+        """A namespace which never had the broken rule still comes up.
+
+        Absence is the end state the delete wants, so iptables failing
+        to find anything to delete is success. Treating it as a failure
+        would break every network on a cluster installed after the fix.
+        """
+        recorder = self.patch_commands({
+            '-C': ('', '', 1),
+            '-D': ('', 'iptables: Bad rule (does a matching rule exist in '
+                       'that chain?).\n', 1),
+        })
+
+        reply = self._enable_nat()
+
+        self.assertEqual(
+            privexec_pb2.EnableNATReply.OK, reply.enable_nat_reply.error)
+        # The whole install still ran: every rule was checked for and,
+        # finding none of them, appended.
+        checks = [c for c in recorder.calls if '-C' in c]
+        self.assertNotEqual([], checks)
+        self.assertEqual(len(checks), len(self._appends(recorder)))
+
+    def test_every_rule_is_installed_inside_the_namespace(self):
+        """No iptables invocation may run in the root namespace.
+
+        The idempotency probe this replaced did exactly that: it listed
+        the root namespace's POSTROUTING looking for rules which are only
+        ever written inside the network's namespace, so it could neither
+        see a rule that was there nor avoid matching one that was not.
+        """
+        recorder = self.patch_commands(RULE_ABSENT)
+
+        self._enable_nat()
+
+        self.assertNotEqual([], recorder.calls)
+        for call in recorder.calls:
+            self.assertEqual(
+                ('ip', 'netns', 'exec', NETWORK_UUID), call[:4],
+                'command ran outside the network namespace: %s' % (call,))
+
+    def test_an_existing_rule_is_not_appended_again(self):
+        """A rule which -C finds is left alone.
+
+        _enable_nat runs again every time the maintain loop recreates a
+        network on the network node. Appending unconditionally accumulates
+        duplicates, and the first match wins, so a duplicate laid down by
+        an earlier pass would go on masking whatever the rule beside it
+        later became.
+        """
+        recorder = self.patch_commands()
+
+        reply = self._enable_nat()
+
+        self.assertEqual(
+            privexec_pb2.EnableNATReply.OK, reply.enable_nat_reply.error)
+        self.assertEqual([], self._appends(recorder))
+        self.assertEqual(3, len([c for c in recorder.calls if '-C' in c]))
+
+    def test_a_failed_append_stops_and_reports_iptables_failed(self):
+        recorder = self.patch_commands({
+            '-C': ('', '', 1),
+            '-A FORWARD -o %s' % EGRESS_VETH: (
+                '', 'iptables: No chain/target/match by that name.\n', 1),
+        })
+
+        reply = self._enable_nat()
+
+        self.assertEqual(
+            privexec_pb2.EnableNATReply.IPTABLES_FAILED,
+            reply.enable_nat_reply.error)
+        # The reply says which rule failed and why, rather than just
+        # "iptables failed".
+        self.assertIn(
+            'No chain/target/match by that name',
+            reply.enable_nat_reply.error_text)
+        self.assertIn('FORWARD -o %s' % EGRESS_VETH,
+                      reply.enable_nat_reply.error_text)
+        # The first rule failed, so nothing after it was attempted.
+        self.assertEqual(1, len(self._appends(recorder)))
+
+
+class NetnsIptablesHelperTestCase(base.ShakenFistTestCase):
+    """The two rule helpers, tested as helpers.
+
+    Both are exercised through ``_enable_nat`` above, but that only ever
+    walks them over the rule table. Their contracts -- "present, and
+    here is why not if it is not" and "every copy is gone" -- belong to
+    them, and the next caller (``_add_floating_ip`` is already one) gets
+    those contracts and not the rule table.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.locate_command = mock.patch(
+            'shakenfist.daemons.privexec.util.locate_command',
+            side_effect=lambda c: c)
+        self.locate_command.start()
+        self.addCleanup(self.locate_command.stop)
+
+    def patch_commands(self, results=None):
+        recorder = CommandRecorder(results)
+        patcher = mock.patch(
+            'shakenfist.daemons.privexec.util.command_helper',
+            side_effect=recorder)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return recorder
+
+    RULE = ['FORWARD', '-i', EGRESS_VETH, '-o', VX_VETH, '-j', 'ACCEPT']
+
+    def test_ensure_leaves_an_existing_rule_alone(self):
+        recorder = self.patch_commands()
+
+        present, error_text = privexec_main.ensure_netns_iptables_rule(
+            NETWORK_UUID, 'filter', self.RULE)
+
+        self.assertTrue(present)
+        self.assertEqual('', error_text)
+        self.assertEqual([], [c for c in recorder.calls if '-A' in c])
+
+    def test_ensure_appends_an_absent_rule(self):
+        recorder = self.patch_commands(RULE_ABSENT)
+
+        present, error_text = privexec_main.ensure_netns_iptables_rule(
+            NETWORK_UUID, 'filter', self.RULE)
+
+        self.assertTrue(present)
+        self.assertEqual('', error_text)
+        self.assertEqual(
+            [('ip', 'netns', 'exec', NETWORK_UUID, 'iptables', '-w', '10',
+              '-t', 'filter', '-A', *self.RULE)],
+            [c for c in recorder.calls if '-A' in c])
+
+    def test_ensure_reports_why_an_append_failed(self):
+        """The caller gets iptables' complaint, not just "it failed".
+
+        This is the only thing which distinguishes a kernel with no
+        conntrack match from a namespace which has gone away, and it is
+        what ``EnableNATFailed`` carries to the operator's ErrorReport.
+        """
+        self.patch_commands(dict(
+            RULE_ABSENT,
+            **{'-A': ('', 'iptables: No chain/target/match by that name.\n',
+                      1)}))
+
+        present, error_text = privexec_main.ensure_netns_iptables_rule(
+            NETWORK_UUID, 'filter', self.RULE)
+
+        self.assertFalse(present)
+        self.assertIn('No chain/target/match by that name', error_text)
+        self.assertIn(' '.join(self.RULE), error_text)
+        self.assertIn(NETWORK_UUID, error_text)
+        self.assertIn('filter', error_text)
+
+    def test_remove_tolerates_an_absent_rule(self):
+        recorder = self.patch_commands({
+            '-D': ('', 'iptables: Bad rule (does a matching rule exist in '
+                       'that chain?).\n', 1)})
+
+        removed = privexec_main.remove_netns_iptables_rule(
+            NETWORK_UUID, 'filter', self.RULE)
+
+        self.assertEqual(0, removed)
+        self.assertEqual(1, len(recorder.calls))
+
+    def test_remove_drains_every_copy(self):
+        recorder = self.patch_commands({
+            '-D': [('', '', 0), ('', '', 0),
+                   ('', 'iptables: Bad rule (does a matching rule exist in '
+                        'that chain?).\n', 1)]})
+
+        removed = privexec_main.remove_netns_iptables_rule(
+            NETWORK_UUID, 'filter', self.RULE)
+
+        self.assertEqual(2, removed)
+        self.assertEqual(3, len(recorder.calls))
+        for call in recorder.calls:
+            self.assertEqual(
+                ('ip', 'netns', 'exec', NETWORK_UUID, 'iptables', '-w', '10',
+                 '-t', 'filter', '-D', *self.RULE), call)
+
+    def test_remove_is_bounded(self):
+        recorder = self.patch_commands()
+
+        removed = privexec_main.remove_netns_iptables_rule(
+            NETWORK_UUID, 'filter', self.RULE)
+
+        self.assertEqual(32, removed)
+        self.assertEqual(32, len(recorder.calls))
+
+
+class ConcurrencyEnableNATTestCase(base.ShakenFistTestCase):
+    """The client side must surface the error detail from the reply.
+
+    ``_enable_nat`` goes to the trouble of putting iptables' own
+    complaint about the rule it refused into ``error_text``, which is
+    the only thing which distinguishes "this kernel has no conntrack
+    match" from "the namespace has gone away". A bare
+    ``EnableNATFailed()`` threw all of that away and left the operator
+    an ErrorReport reading ``network.nat.enable_failed`` and nothing
+    else.
+    """
+
+    def _reply(self, error, error_text):
+        return privexec_pb2.PrivExecReply(
+            enable_nat_reply=privexec_pb2.EnableNATReply(
+                network_uuid=NETWORK_UUID,
+                network_address='172.16.0.0',
+                network_mask='255.255.255.0',
+                vxid=VXID,
+                error=error,
+                error_text=error_text))
+
+    def test_enable_nat_raises_with_detail(self):
+        reply = self._reply(
+            privexec_pb2.EnableNATReply.IPTABLES_FAILED,
+            'failed to append POSTROUTING -s 172.16.0.0/255.255.255.0 -o '
+            'veth-e2300f-i -m conntrack --ctstate DNAT -j MASQUERADE to the '
+            'nat table in namespace %s: iptables: No chain/target/match by '
+            'that name.' % NETWORK_UUID)
+        with mock.patch(
+                'shakenfist.util.concurrency._marshal_privexec_request',
+                return_value=reply):
+            exc = self.assertRaises(
+                exceptions.EnableNATFailed,
+                util_concurrency.enable_nat,
+                NETWORK_UUID, '172.16.0.0', '255.255.255.0', VXID)
+
+        self.assertEqual('IPTABLES_FAILED', exc.error)
+        self.assertIn('No chain/target/match by that name', exc.error_text)
+        self.assertEqual(NETWORK_UUID, exc.network_uuid)
+
+        # And all of it reaches the message, which is what an
+        # ErrorReport records.
+        self.assertIn('IPTABLES_FAILED', str(exc))
+        self.assertIn('conntrack', str(exc))
+        self.assertIn(NETWORK_UUID, str(exc))
+
+    def test_enable_nat_is_quiet_on_ok(self):
+        reply = self._reply(privexec_pb2.EnableNATReply.OK, '')
+        with mock.patch(
+                'shakenfist.util.concurrency._marshal_privexec_request',
+                return_value=reply):
+            self.assertIsNone(util_concurrency.enable_nat(
+                NETWORK_UUID, '172.16.0.0', '255.255.255.0', VXID))

--- a/shakenfist/tests/test_privexec_enable_nat.py
+++ b/shakenfist/tests/test_privexec_enable_nat.py
@@ -17,6 +17,7 @@ from shakenfist.protos import privexec_pb2
 from shakenfist.tests import base
 from shakenfist.tests.test_privexec_floating_ip import CommandRecorder
 from shakenfist.util import concurrency as util_concurrency
+from shakenfist.util import iptables as util_iptables
 
 
 NETWORK_UUID = 'ccc652aa-f7b6-4f99-b76d-443ae4d91412'
@@ -96,6 +97,10 @@ class PrivExecEnableNATTestCase(base.ShakenFistTestCase):
                  '-t', 'nat', '-A', 'POSTROUTING', '-s',
                  '172.16.0.0/255.255.255.0', '-o', EGRESS_VETH,
                  '-j', 'MASQUERADE'),
+                ('ip', 'netns', 'exec', NETWORK_UUID, 'iptables', '-w', '10',
+                 '-t', 'nat', '-A', 'POSTROUTING', '-s',
+                 '172.16.0.0/255.255.255.0', '-o', VX_VETH,
+                 '-m', 'conntrack', '--ctstate', 'DNAT', '-j', 'MASQUERADE'),
             ],
             self._appends(recorder))
 
@@ -228,6 +233,40 @@ class PrivExecEnableNATTestCase(base.ShakenFistTestCase):
                 ('ip', 'netns', 'exec', NETWORK_UUID), call[:4],
                 'command ran outside the network namespace: %s' % (call,))
 
+    def test_the_hairpin_rule_only_matches_the_u_turn(self):
+        """The hairpin masquerade is confined to DNATed local traffic.
+
+        An instance reaching another instance's floating address is
+        DNATed here and sent straight back out the veth it arrived on;
+        the reply goes directly over the virtual network's L2 and is
+        never un-DNATed, so the connection hangs. Masquerading the u-turn
+        puts this namespace back on the return path.
+
+        Both of the matches beside it are load bearing, and each
+        excludes a different thing. Without -s the rule would also
+        rewrite traffic arriving from outside the cluster for a floating
+        address -- that is DNATed here too, and it reaches the holder
+        with the caller's real address today. Without --ctstate DNAT it
+        would catch anything this namespace forwards back into the
+        network without rewriting it, a routed address included, whose
+        whole point is that it is not rewritten.
+        """
+        recorder = self.patch_commands(RULE_ABSENT)
+
+        self._enable_nat()
+
+        hairpin = [c for c in self._appends(recorder)
+                   if 'conntrack' in c]
+        self.assertEqual(1, len(hairpin))
+        rule = hairpin[0]
+        self.assertEqual(('--ctstate', 'DNAT'),
+                         rule[rule.index('--ctstate'):
+                              rule.index('--ctstate') + 2])
+        self.assertEqual('172.16.0.0/255.255.255.0',
+                         rule[rule.index('-s') + 1])
+        self.assertEqual(VX_VETH, rule[rule.index('-o') + 1])
+        self.assertEqual('MASQUERADE', rule[-1])
+
     def test_an_existing_rule_is_not_appended_again(self):
         """A rule which -C finds is left alone.
 
@@ -244,7 +283,34 @@ class PrivExecEnableNATTestCase(base.ShakenFistTestCase):
         self.assertEqual(
             privexec_pb2.EnableNATReply.OK, reply.enable_nat_reply.error)
         self.assertEqual([], self._appends(recorder))
-        self.assertEqual(3, len([c for c in recorder.calls if '-C' in c]))
+        self.assertEqual(4, len([c for c in recorder.calls if '-C' in c]))
+
+    def test_the_audited_rule_is_one_of_the_installed_rules(self):
+        """What is checked for later is what is installed here.
+
+        ``Network.is_nat_okay`` audits a namespace for the hairpin rule,
+        which is how a cluster that upgraded while all of its networks
+        were healthy ever acquires it. The audit asks
+        ``hairpin_masquerade_rule`` and the install walks
+        ``network_nat_rules``; this is the assertion that the first is
+        still one of the second, so an edit to either cannot leave the
+        audit hunting for a rule nothing writes.
+        """
+        rules = util_iptables.network_nat_rules(
+            '172.16.0.0', '255.255.255.0', VXID)
+        hairpin = util_iptables.hairpin_masquerade_rule(
+            '172.16.0.0', '255.255.255.0', VXID)
+
+        self.assertIn((util_iptables.HAIRPIN_TABLE, hairpin), rules)
+
+        # And the install really does write it, rather than the pairing
+        # above being true of a list nothing uses.
+        recorder = self.patch_commands(RULE_ABSENT)
+        self._enable_nat()
+        self.assertIn(
+            ('ip', 'netns', 'exec', NETWORK_UUID, 'iptables', '-w', '10',
+             '-t', util_iptables.HAIRPIN_TABLE, '-A', *hairpin),
+            self._appends(recorder))
 
     def test_a_failed_append_stops_and_reports_iptables_failed(self):
         recorder = self.patch_commands({

--- a/shakenfist/tests/test_privexec_floating_ip.py
+++ b/shakenfist/tests/test_privexec_floating_ip.py
@@ -32,18 +32,30 @@ class CommandRecorder:
     `results` maps a substring to a (stdout, stderr, returncode) tuple.
     The first key found in the space-joined command wins. Unmatched
     commands succeed with no output.
+
+    A value may instead be a list of such tuples, which are returned one
+    per matching call and the last of which repeats once the list is
+    exhausted. That is how a command whose answer changes because of
+    what an earlier call did -- a delete which removes one of several
+    copies of a rule and eventually runs out -- is described.
     """
 
     def __init__(self, results=None):
         self.calls = []
         self.results = results or {}
+        self.sequence_positions = {}
 
     def __call__(self, *command, failure_is_error=True):
         self.calls.append(command)
         joined = ' '.join(command)
         for match, result in self.results.items():
-            if match in joined:
+            if match not in joined:
+                continue
+            if not isinstance(result, list):
                 return result
+            position = self.sequence_positions.get(match, 0)
+            self.sequence_positions[match] = position + 1
+            return result[min(position, len(result) - 1)]
         return ('', '', 0)
 
     def find(self, substring):

--- a/shakenfist/tests/test_util_network.py
+++ b/shakenfist/tests/test_util_network.py
@@ -238,6 +238,32 @@ class UtilTestCase(base.ShakenFistTestCase):
         mock_execute.assert_called_with(
             'ip route list dev veth-e2300f-i', netns='mynamespace')
 
+    @mock.patch('shakenfist.util.concurrency.execute', return_value=('', ''))
+    def test_check_for_iptables_rule_present(self, mock_execute):
+        found = util_network.check_for_iptables_rule(
+            'mynamespace', 'nat',
+            ['POSTROUTING', '-s', '172.16.0.0/255.255.255.0', '-j',
+             'MASQUERADE'])
+        self.assertEqual(True, found)
+        mock_execute.assert_called_with(
+            'iptables -w 10 -t nat -C POSTROUTING -s 172.16.0.0/255.255.255.0 '
+            '-j MASQUERADE',
+            netns='mynamespace')
+
+    @mock.patch('shakenfist.util.concurrency.execute',
+                side_effect=ProcessExecutionError('Bad rule'))
+    def test_check_for_iptables_rule_absent(self, mock_execute):
+        """A rule iptables cannot find, or cannot look for, is absent.
+
+        iptables exits non-zero for a rule which is not there, and ip
+        netns exec exits non-zero for a namespace which is not there.
+        Both mean the same repair, so both answer False rather than
+        raising into the maintain pass.
+        """
+        found = util_network.check_for_iptables_rule(
+            'mynamespace', 'nat', ['POSTROUTING', '-j', 'MASQUERADE'])
+        self.assertEqual(False, found)
+
     @mock.patch('shakenfist.util.concurrency.execute')
     def test_create_interface_bridge(self, mock_execute):
         util_network.create_interface('eth0', 'bridge', '')

--- a/shakenfist/tests/test_util_network.py
+++ b/shakenfist/tests/test_util_network.py
@@ -213,6 +213,31 @@ class UtilTestCase(base.ShakenFistTestCase):
         mock_execute.assert_called_with(
             'ip route list default', netns='mynamespace')
 
+    @mock.patch(
+        'shakenfist.util.concurrency.execute',
+        return_value=('192.168.15.29 scope link\n'
+                      '192.168.15.30 scope link\n'
+                      '172.16.0.0/24 proto kernel scope link src 172.16.0.1\n'
+                      'default via 192.168.15.1\n'
+                      'unreachable 10.0.0.0/8\n'
+                      '\n',
+                      ''))
+    def test_get_host_routes(self, mock_execute):
+        """Only routes somebody added, and only ones which are addresses.
+
+        The kernel derives the connected 172.16.0.0/24 route from the
+        address on the device, and the presence of a prefix length is
+        what separates it from a host route. The other two lines are
+        neither: "default" and a route type keyword are not
+        destinations, and returning them would make the function a trap
+        for a caller which does something with the values rather than
+        just testing membership.
+        """
+        found = util_network.get_host_routes('mynamespace', 'veth-e2300f-i')
+        self.assertEqual({'192.168.15.29', '192.168.15.30'}, found)
+        mock_execute.assert_called_with(
+            'ip route list dev veth-e2300f-i', netns='mynamespace')
+
     @mock.patch('shakenfist.util.concurrency.execute')
     def test_create_interface_bridge(self, mock_execute):
         util_network.create_interface('eth0', 'bridge', '')

--- a/shakenfist/util/concurrency.py
+++ b/shakenfist/util/concurrency.py
@@ -222,7 +222,9 @@ def enable_nat(
     reply = _marshal_privexec_request(request, 'enable_nat_reply')
     response = reply.enable_nat_reply
     if response.error != privexec_pb2.EnableNATReply.OK:
-        raise EnableNATFailed()
+        raise EnableNATFailed(
+            privexec_pb2.EnableNATReply.Errors.Name(response.error),
+            response.error_text, network_uuid_str)
 
 
 def ensure_vxlan_mesh(

--- a/shakenfist/util/iptables.py
+++ b/shakenfist/util/iptables.py
@@ -1,0 +1,78 @@
+# Copyright 2026 Michael Still and contributors
+
+"""The iptables rules a NAT providing network needs in its namespace.
+
+The rules are data here rather than statements inside sf-privexec, so
+that the set can be walked -- which is what makes installing each of
+them at most once a loop rather than several hand written copies of the
+same check.
+
+A rule is the chain name followed by the match and target arguments
+exactly as iptables writes them after ``-A``, which is also exactly
+what it wants after ``-C``. So the same list serves both.
+
+This module deliberately imports nothing. sf-privexec runs as root and
+is kept as small as we can manage.
+"""
+
+
+def veth_names(vxid: int) -> tuple[str, str]:
+    """The inside ends of a network's egress and virtual network veths.
+
+    Interface names are limited to 15 characters on Linux, which is why
+    the vxid is rendered in hex here (and in ``Network.subst_dict``,
+    which is where these same names come from on the object side).
+    """
+    return 'egr-%06x-i' % vxid, 'veth-%06x-i' % vxid
+
+
+def stale_nat_rules(vxid: int) -> list[tuple[str, list[str]]]:
+    """Rules an older Shaken Fist installed here which are now wrong.
+
+    The return-direction FORWARD rule used to name the literal string
+    ``vx_veth_inner`` rather than the interface the variable of that
+    name held. ``network_nat_rules`` fixes that, but a ``-C`` for the
+    corrected rule cannot match the broken one, so on an existing
+    cluster the fixed rule is appended beside a wrong rule which stays
+    forever. It is harmless -- the namespace's FORWARD policy is
+    ACCEPT, which is why nobody noticed the bug in the first place --
+    but leaving it there means the namespace never converges on what
+    this file says it should hold.
+
+    Deleting is tolerant of absence, so a namespace which never had the
+    broken rule pays one failed exec per network create and nothing
+    else. It is also repeated until there is nothing left to delete: the
+    ``_enable_nat`` which wrote this rule appended it unconditionally
+    every time it ran, so an old namespace can hold several copies and
+    removing one of them would leave the rest.
+    """
+    egress_veth_inner, _ = veth_names(vxid)
+    return [
+        ('filter', ['FORWARD', '-i', egress_veth_inner,
+                    '-o', 'vx_veth_inner', '-j', 'ACCEPT']),
+    ]
+
+
+def network_nat_rules(
+        network_address: str, network_mask: str,
+        vxid: int) -> list[tuple[str, list[str]]]:
+    """Every rule a NAT providing network needs, as (table, rule) pairs."""
+    egress_veth_inner, vx_veth_inner = veth_names(vxid)
+
+    return [
+        # Traffic from the virtual network out to the world, and the
+        # replies to it coming back. Both are decorative while the
+        # namespace's FORWARD policy is ACCEPT, which is what a fresh
+        # namespace has and nothing here changes -- which is why nobody
+        # noticed that the return direction used to match the literal
+        # string 'vx_veth_inner' rather than the interface named by the
+        # variable of that name.
+        ('filter', ['FORWARD', '-o', egress_veth_inner,
+                    '-i', vx_veth_inner, '-j', 'ACCEPT']),
+        ('filter', ['FORWARD', '-i', egress_veth_inner,
+                    '-o', vx_veth_inner, '-j', 'ACCEPT']),
+
+        # Instances reach the world as the network's floating gateway.
+        ('nat', ['POSTROUTING', '-s', f'{network_address}/{network_mask}',
+                 '-o', egress_veth_inner, '-j', 'MASQUERADE']),
+    ]

--- a/shakenfist/util/iptables.py
+++ b/shakenfist/util/iptables.py
@@ -2,14 +2,18 @@
 
 """The iptables rules a NAT providing network needs in its namespace.
 
-The rules are data here rather than statements inside sf-privexec, so
-that the set can be walked -- which is what makes installing each of
-them at most once a loop rather than several hand written copies of the
-same check.
+These live here rather than beside the daemon which installs them
+because they have two users, not one. sf-privexec writes them when a
+network is created on the network node, and ``Network.is_okay()`` asks
+whether the hairpin rule is still there -- which is how a cluster that
+upgraded while all of its networks were healthy ever acquires it.
+Written out in both places they would drift; derived from here they
+cannot.
 
 A rule is the chain name followed by the match and target arguments
 exactly as iptables writes them after ``-A``, which is also exactly
-what it wants after ``-C``. So the same list serves both.
+what it wants after ``-C``. So the same list serves both the install
+and the audit.
 
 This module deliberately imports nothing. sf-privexec runs as root and
 is kept as small as we can manage.
@@ -53,6 +57,52 @@ def stale_nat_rules(vxid: int) -> list[tuple[str, list[str]]]:
     ]
 
 
+def hairpin_masquerade_rule(
+        network_address: str, network_mask: str, vxid: int) -> list[str]:
+    """Masquerade a floating address connection which turns around here.
+
+    An instance reaching another instance's floating address sends it to
+    its default gateway, which is the network's namespace; the
+    PREROUTING DNAT rewrites the destination to the holder's address and
+    the packet goes straight back out the veth it came in on. The reply
+    then travels directly over the virtual network's L2, never returns
+    through the namespace, and so is never un-DNATed: the client sees a
+    packet from an address it never spoke to and drops it, and the
+    connection hangs until it times out (issue 3662).
+
+    Masquerading the u-turn to the namespace's own address on the
+    network puts the namespace back on the return path, where conntrack
+    can undo the destination rewrite. The cost is that the holder sees
+    the connection as coming from the network's gateway rather than from
+    the calling instance -- which is inherent to hairpin NAT, and is the
+    price of the floating address being invisible to its holder in the
+    first place. An instance which needs to know who is calling should
+    be reached on a routed address, which is not rewritten at all.
+
+    Both matches beside the target are load bearing, and each excludes a
+    different thing:
+
+    * ``-s`` is what preserves the caller's address for clients outside
+      the cluster. Their traffic is DNATed here too, so the conntrack
+      match alone would masquerade it and the holder would lose the
+      real source address it sees today.
+    * ``--ctstate DNAT`` is what excludes the routed address u-turn, and
+      anything else this namespace forwards back into the network
+      without rewriting. A routed address is never DNATed, and its whole
+      point is that it arrives unrewritten.
+    """
+    _, vx_veth_inner = veth_names(vxid)
+    return [
+        'POSTROUTING', '-s', f'{network_address}/{network_mask}',
+        '-o', vx_veth_inner, '-m', 'conntrack', '--ctstate', 'DNAT',
+        '-j', 'MASQUERADE']
+
+
+# The table the hairpin rule lives in, named here so the audit does not
+# have to know it independently of the install.
+HAIRPIN_TABLE = 'nat'
+
+
 def network_nat_rules(
         network_address: str, network_mask: str,
         vxid: int) -> list[tuple[str, list[str]]]:
@@ -75,4 +125,7 @@ def network_nat_rules(
         # Instances reach the world as the network's floating gateway.
         ('nat', ['POSTROUTING', '-s', f'{network_address}/{network_mask}',
                  '-o', egress_veth_inner, '-j', 'MASQUERADE']),
+
+        (HAIRPIN_TABLE, hairpin_masquerade_rule(
+            network_address, network_mask, vxid)),
     ]

--- a/shakenfist/util/network.py
+++ b/shakenfist/util/network.py
@@ -1,3 +1,4 @@
+import ipaddress
 import json
 import os
 import random
@@ -227,6 +228,16 @@ def get_interface_mtu(interface: str, netns: str | None = None) -> int | None:
     return None
 
 
+# What ``ip netns exec`` exits with when the namespace it was asked for
+# does not exist ("Cannot open network namespace ...: No such file or
+# directory"). It is distinct from the exit codes ip itself uses for the
+# command it was asked to run -- 2 for "no such route", for example --
+# so a caller which wants to tolerate a vanished namespace can tell that
+# apart from the command having failed inside a namespace which is
+# there. Verified against iproute2 rather than assumed.
+NETNS_MISSING_EXIT_CODE = 255
+
+
 def get_default_routes(netns: str | None) -> list[str]:
     stdout, _ = concurrency.execute(
         'ip route list default', netns=netns)
@@ -240,6 +251,36 @@ def get_default_routes(netns: str | None) -> list[str]:
         if len(elems) > 3 and elems[2] not in routes:
             routes.append(elems[2])
     return routes
+
+
+def get_host_routes(netns: str | None, device: str) -> set[str]:
+    """Return the host route destinations pointing at a device.
+
+    Host routes list without a prefix length ("192.168.15.29 dev ..."),
+    while a connected network route lists with one, so the presence of a
+    "/" is what separates the routes somebody added from the ones the
+    kernel derived from an address. Used to tell whether a routed
+    address's route is actually installed inside a network namespace.
+    """
+    stdout, _ = concurrency.execute(
+        f'ip route list dev {device}', netns=netns)
+
+    destinations = set()
+    for line in stdout.split('\n'):
+        candidate = line.split(' ')[0]
+        if '/' in candidate:
+            # A connected route the kernel derived from an address on
+            # the device, not one somebody added.
+            continue
+        try:
+            ipaddress.ip_address(candidate)
+        except ValueError:
+            # A blank line, "default", or a route type keyword such as
+            # "unreachable" or "blackhole". None of them is a host
+            # route destination, and the caller asked for destinations.
+            continue
+        destinations.add(candidate)
+    return destinations
 
 
 def add_default_route(netns: str, router: str) -> None:

--- a/shakenfist/util/network.py
+++ b/shakenfist/util/network.py
@@ -283,6 +283,38 @@ def get_host_routes(netns: str | None, device: str) -> set[str]:
     return destinations
 
 
+def check_for_iptables_rule(netns: str | None, table: str,
+                            rule: list[str]) -> bool:
+    """Is an iptables rule present, optionally inside a namespace?
+
+    ``rule`` is the chain name followed by the match and target
+    arguments, as ``shakenfist.util.iptables`` builds them.
+
+    This asks iptables with ``-C`` rather than parsing ``-S`` output,
+    because iptables normalises what it prints: a rule written with a
+    dotted quad netmask -- which is how the network object holds one --
+    lists back as a prefix length, so a textual comparison would report
+    a rule which is right there as missing. Anything which stops the
+    check running at all, a namespace which is not there included,
+    counts as absent: the repair for both is the same rebuild.
+
+    The elements of ``rule`` are joined with spaces and interpolated
+    into a command string which sf-privexec runs as root through a
+    shell, so they must never carry user supplied data. Today's callers
+    build rules from ``shakenfist.util.iptables``, whose only inputs are
+    an IPAM derived address and netmask and a hex formatted vxid; a
+    caller which wants to check something a user chose needs to quote it
+    first.
+    """
+    try:
+        concurrency.execute(
+            'iptables -w 10 -t {} -C {}'.format(table, ' '.join(rule)),
+            netns=netns)
+        return True
+    except ProcessExecutionError:
+        return False
+
+
 def add_default_route(netns: str, router: str) -> None:
     try:
         concurrency.execute(

--- a/tox.ini
+++ b/tox.ini
@@ -102,6 +102,7 @@ commands =
   mypy --ignore-missing-imports --follow-imports=silent --disallow-untyped-defs --disable-error-code=no-untyped-call shakenfist/util/callstack.py
   mypy --ignore-missing-imports --follow-imports=silent --disallow-untyped-defs --disable-error-code=no-untyped-call shakenfist/util/general.py
   mypy --ignore-missing-imports --follow-imports=silent --disallow-untyped-defs --disable-error-code=no-untyped-call --disable-error-code=no-any-return shakenfist/util/image.py
+  mypy --strict --ignore-missing-imports shakenfist/util/iptables.py
   mypy --ignore-missing-imports --follow-imports=silent --disallow-untyped-defs --disable-error-code=no-untyped-call --disable-error-code=no-any-return --disable-error-code=assignment --disable-error-code=union-attr --disable-error-code=return-value shakenfist/util/network.py
   mypy --ignore-missing-imports --follow-imports=silent --disallow-untyped-defs --disable-error-code=no-untyped-call --disable-error-code=no-any-return --disable-error-code=union-attr shakenfist/util/libvirt.py
   mypy --ignore-missing-imports --follow-imports=silent --disallow-untyped-defs --disable-error-code=no-untyped-call --disable-error-code=no-any-return --disable-error-code=attr-defined --disable-error-code=arg-type --disable-error-code=assignment shakenfist/util/concurrency.py


### PR DESCRIPTION
Fixes #3662.

Both of Shaken Fist's externally reachable address types answer from
everywhere except the network they belong to. This makes them answer from
inside it too, so a routed or floating address behaves the same whether the
client is an instance on the network, elsewhere in the cluster, or outside
it entirely.

## The routed address

A routed address is exactly one route, in the network node's **root**
namespace, pointing the `/32` at the network's bridge. An instance's packet
never reaches that table. It goes to its default gateway, which is the
network's own namespace, and the namespace decides for itself.

Routed addresses come from the floating pool, and the namespace has that
whole block on link on its egress veth — that is where the floating gateway
address lives. So the namespace treats the routed address as a neighbour on
the egress bridge and ARPs for it there. Nothing answers. Unlike a floating
address, which is anchored as a `/32` on a veth *inside* the namespace and so
has something to reply for it, a routed address is configured on no interface
anywhere; it exists only as a route. The packet dies at the instance's own
gateway while the same address answers happily from outside the cluster.

The fix is the matching `/32` inside the namespace, pointing back out the veth
into the network — the same u-turn the root namespace already performs for
everybody else.

## The floating address

The namespace's DNAT rule carries no incoming interface match, so it fires for
in-network traffic exactly as it would for traffic from outside, and sends the
packet straight back out the veth it arrived on. The holder then replies
directly over the virtual network's layer 2, because the caller is its
neighbour, and that reply never passes through the namespace again. Nothing
un-DNATs it, so the caller receives a packet from an address it never spoke to
and waits until it gives up.

The fix is one POSTROUTING masquerade scoped by `-s <netblock>` and
`-m conntrack --ctstate DNAT`, which puts the namespace back on the return
path for the u-turn and leaves everything else alone. Both matches are load
bearing, and they exclude different things: `-s` is what preserves the
caller's real address for clients outside the cluster, whose traffic is
DNAT'ed here too and would otherwise be masqueraded as well; `--ctstate DNAT`
is what excludes a routed address turning around in the same namespace, and
anything else forwarded back into the network unrewritten, since a routed
address is never DNAT'ed and its whole point is that it arrives unrewritten.

The cost is stated rather than hidden: the holder sees an in-network caller as
the network's gateway. That is inherent to hairpin NAT, and a small extension
of what a floating address already is — an address its holder cannot see.
Something that needs to know who is calling should be reached on a routed
address.

## Three commits

1. **Install a network's NAT rules idempotently.** Prerequisite, and two
   defects in its own right. `_enable_nat`'s "do we have NAT already?" probe
   listed POSTROUTING in the *root* namespace while every rule it guards is in
   the network's namespace, so it could not see the rules it was checking for.
   Usually it matched nothing and a rebuilt network re-appended all three
   rules; and because the comparison was a substring search over the whole
   listing, an unrelated `172.16.0.0/16` rule matches a `172.16.0.0/24`
   network — on which path it returned `RULES_ALREADY_PRESENT`, which
   `util_concurrency.enable_nat` turns into `EnableNATFailed`, so the network
   failed to come up. Each rule now carries its own `-C`. Turning the rules
   into data also showed the return-direction FORWARD rule has been matching
   the literal string `'vx_veth_inner'` rather than the interface; harmless
   only because the namespace's FORWARD policy is ACCEPT. The rules move to
   `shakenfist/util/iptables.py`, which imports nothing and so can be read by
   something other than the root daemon -- which is what lets commit 3 both
   add a rule and audit for it without writing it out twice.
2. **Route a routed address inside its own network.** The `/32` above, plus
   `ip route replace` on both routes (they are re-applied, and `add` errors on
   an existing route — which would also abandon the second route because the
   first raised), plus tolerance of an absent route on both deletes.
3. **Hairpin a floating address turned around inside.** The masquerade above,
   plus the audit which gets it onto a cluster that already exists --
   `Network.is_okay()` now asks the namespace for the hairpin rule, one
   `iptables -C` per NAT-providing network per maintain pass, because nothing
   has ever re-run a network's namespace iptables setup while the network was
   otherwise working.

## Reaching existing clusters

This applies to both halves, and the iptables half was missed in the first
round of this PR -- see the review response below.

Nothing re-applies either route while a network is healthy — the
reconciliation that does fires only for a network which has drifted far enough
to need rebuilding. A cluster upgrading while all its networks were well would
never acquire the namespace route for the addresses it already had. So the
maintain pass now reads the namespace routing table for the networks which
actually have routed addresses (a handful even on a large cluster, one exec
each) and re-routes only the missing ones, without dragging the network
through a rebuild. A namespace which cannot be read at all is left to the
rebuild path, which owns that drift.

The same reasoning is why the unroute deletes tolerate a missing route: an
address routed before this branch has only one of the two, and failing the
unroute against the absent one would leave it reserved forever.

## Verification

- Full unit suite green; all ten pre-commit hooks pass, including mypy.
- New functional test, `cluster_ci_tests/test_in_network_reachability.py`: the
  black box version of the bug report. Two instances on a network, one claims
  a routed address the way metallb would, the other pings it; then the same
  for a floating address. It derives the guest's interface name from the MAC
  the API assigned rather than assuming `eth0`.
- Ten mutations, each failing the assertions which claim to prove it, against
  a green baseline: dropping the namespace route, going back to `ip route
  add`, dropping the delete's tolerance, restoring the `'vx_veth_inner'`
  literal, dropping the `-C` check, dropping the hairpin rule, dropping its
  conntrack match, making the reconciliation never find anything, letting it
  run on a hypervisor, and letting an unreadable namespace report every
  address as missing.
- The `iptables` and `ip link`/`ip route` behaviours the change depends on
  (`-m conntrack --ctstate DNAT`, `-C` idempotency, `ip route replace`, exit
  code 2 for an absent route) were reproduced locally in a user namespace
  rather than assumed.

## Review round 1

All twelve items triaged: 2 `fix`, 2 `document`, 8 `consider`. Eleven
addressed, amended into the three commits above rather than added as a
fourth.

The one that mattered was item 1, and it was right: `_enable_nat` is only
reached from `_apply_create_on_network_node`, and neither `is_created()` nor
the dnsmasq check has ever looked at iptables, so a cluster upgrading while
its networks were healthy would never acquire the hairpin rule. That is the
same gap this PR had already closed for routed addresses, not carried over.
Rather than write the rule out a second time in the audit, the rule table
moved to `shakenfist/util/iptables.py` and both the installer and the audit
derive from it; a unit test asserts the audited rule is one the install
actually writes. The audit uses `iptables -C` rather than parsing `-S`,
because iptables normalises what it prints and the dotted-quad netmask the
network object holds lists back as a prefix length -- verified in a user
namespace, not assumed.

Item 5 was also right and is corrected here, in the rule's comment, the test
docstring and the docs: `-s` excludes the external caller, `--ctstate DNAT`
excludes the routed-address u-turn. The rules themselves were always correct.

Also addressed: the route-repair guards now read `net_ip_op` history rather
than `net_op`, so a repair which can never succeed is no longer re-enqueued
every pass forever (2); the namespace probe moved below the pending-operation
gate (10); `get_host_routes` validates its tokens (4) and gained the parsing
test its sibling already had (3); `_apply_unroute_address` declines a deleted
network the way its sibling does (6); the cross-network routed-address case
is documented as unsupported, with the missing blank line fixed (7);
`_add_floating_ip` now uses the shared idempotency helper, which grew an
error-text return so the distinct message was not lost (9); copyright header
(11); the redundant idempotency test dropped with its rationale folded into
the stronger test above it (12).

Not addressed: item 8, an end-to-end assertion that an externally originated
connection still reaches the holder with the caller's real address. It needs
a listener in the guest or conntrack inspection on the network node, and it
guards against a future edit to the rule rather than against a code change;
the `-s` match is pinned by unit test instead. Happy to add it if you disagree.

Nineteen mutations now, each failing the assertions which claim to prove it
against a green baseline -- the original ten plus nine for this round:
dropping the NAT audit from `is_okay`, making the rule check always answer
present, letting the install's rule drift from the audited one, dropping the
address validation, pointing the repair guards back at `net_op`, moving the
probe back above the pending gate, removing the unroute deleted-network
guard, dropping the append failure text, and dropping the conntrack match.

## Review round 2

Eleven items: 2 `fix`, 1 `document`, 7 `consider`, 1 `none`. Ten addressed,
amended into the same three commits.

Both `fix` items were right and are small. `enable_nat`'s client raised a bare
`EnableNATFailed()`, so the `error_text` the previous round added to the reply
never reached the `ErrorReport` -- an operator saw `network.nat.enable_failed`
and nothing else. The exception now carries the reply's error name, text and
network uuid, the way `HashFailed` does, and a test asserts all three reach
`str(exc)`. `shakenfist/util/iptables.py` is now in the tox mypy rollout at
`--strict`, which it passes.

The `consider` item worth the most was 3, and it is the mirror of the bug this
PR is about: the maintain pass audited the in-namespace route but not the
root-namespace one, which can be lost while the bridge survives -- leaving an
address unreachable from *outside* the cluster with nothing looking for it, in
a network `is_created()` still calls healthy. Both tables are read now, and an
address missing from either is re-routed; re-routing installs both, so the
repair path is unchanged.

Also taken: the stale `-o vx_veth_inner` FORWARD rule an older Shaken Fist
wrote is now deleted before the install, tolerating absence, so an upgraded
namespace converges on exactly what `util_iptables` describes rather than
carrying the broken rule beside the fixed one forever (4); `mesh_okay` folds
into `routed_here` so a network heading for mesh repair does not pay for a
probe whose answer that branch discards (6); `is_nat_okay()` gained its own
node-role guard, so calling it from a hypervisor reports "nothing here to
audit" rather than emitting a status event saying the rules have drifted (8);
the `net_ip_op` history's two properties -- it counts a user's errored unroute
against the automatic route repair, and only a manual route or unroute clears
a quiesced one -- are documented on the guard (9); the docs name the subject
of "to make that work" now that four paragraphs separate it from the DNAT
explanation (10); and the new `xt_conntrack` requirement is called out as a
hard one, since a node without it fails network creation rather than degrading
(7).

Not addressed: item 2, the succeed-but-not-converge repair loop. The reviewer
is right that the shape exists, but it is not new here and not specific to
these probes -- a dnsmasq which starts cleanly and still fails
`is_dnsmasq_running()` drives the identical full-recreate-every-pass loop
today. Both new probes are pinned to their installers rather than
independently reimplemented: `-C` takes the same argument list `-A` wrote,
from one module, with a test asserting the audited rule is one the install
writes; and a `/32` lists without its prefix, which is what `get_host_routes`
matches on. Both were checked against real `iptables` and `ip` in a user
namespace rather than assumed. A second circuit breaker keyed on a different
signal is more machinery to grow an untested edge, so the existing ERROR
breaker stays the guard. Happy to add it if you disagree.

Seven more mutations, each failing the assertions which claim to prove it
against a green baseline: raising `EnableNATFailed` without the reply detail,
dropping the node-role guard, dropping the floating-network guard, reading
only the namespace routing table, probing routes for a drifted mesh, leaving
the stale FORWARD rule in place, and treating an absent stale rule as a
failure. Twenty-six across the three rounds.

## Review round 3

Twelve items: 2 `fix`, 1 `document`, 7 `consider`, 2 `none`. Eight
addressed, amended into the same three commits.

Both `fix` items were right. Item 1 is the one that mattered, and it is a
defect in the cleanup the round before added: `remove_netns_iptables_rule`
issued a single `-D`, and `-D` removes one matching rule. The `_enable_nat`
this PR replaced appended unconditionally on every create and every
maintain-driven recreate, so the namespaces the cleanup exists for can hold
several copies of the broken `-o vx_veth_inner` rule -- and removing one of
them left the rest, with nothing ever looking again, because the `-C` for the
corrected rule cannot match a broken one. The delete now loops until iptables
says there is nothing left, bounded at 32 with a warning if it ever reaches
the bound.

Duplicates of the *current* rules are deliberately left where they are, which
is now stated at the helper rather than implied. Extra copies of a rule which
is byte for byte the one we want are inert -- the first match wins and they
all say the same thing -- while converging on one copy means deleting the
rule and appending it again, which opens a window with no rule at all. That
window is not acceptable for `_add_floating_ip`, which installs a live
floating address's DNAT through the same helper. The comment on the install
no longer claims more than that: the namespace ends up holding no rule which
is not in `util_iptables`, and may hold more than one copy of a rule which
is.

Item 2 was right on the substance and wrong on the exit code, which is worth
recording because the docstring said so: `ip netns exec` against a missing
namespace exits **255**, reproduced against iproute2 rather than assumed --
not the 1 the review claims. The gap it names is real, though. The
deleted-network guard does not cover every namespace which is not there: a
network in `delete_wait`, or one on a network node which rebooted before the
namespace was rebuilt, is not `deleted` and still has nothing to exec into,
so the unroute errored and the address stayed reserved forever -- exactly the
outcome the exit-code-2 tolerance beside it was added to prevent. 255 is now
tolerated separately with an audit event, and every other exit code still
raises. The code itself is named once, in `util_network`, with the
distinction from `ip`'s own exit codes written down.

Also taken: the `xt_conntrack` requirement is now in the installation
prerequisites and the upgrade notes rather than only in a subsection of the
networking overview, with the one-line check an operator can run before
rolling the daemons (7); `check_for_iptables_rule` says in its docstring that
its argument is interpolated into a command sf-privexec runs as root through
a shell and must never carry user-supplied data (6); the retired
`RULES_ALREADY_PRESENT` enum member carries a comment recording that
returning it is the bug this PR fixed, and that its number stays claimed (8);
the route audit's `except ProcessExecutionError: return []` logs the
exit code and stderr before returning, so a persistent exec-layer fault no
longer looks exactly like a healthy network (9); and the two rule helpers
have direct unit tests for their own contracts rather than only being walked
over the rule table by `_enable_nat`, including the append-failure text, the
tolerance of an absent rule, the drain, and the bound (10).

Not addressed, all `consider`:

- **3**, a targeted NAT repair instead of a full recreate. The routed-address
  branch exists because a NetIPOp task for it already did; a NAT-only repair
  needs a new NetOp task type, a dispatcher entry and a coalescing decision.
  That is more surface than the one-off upgrade wave saves: the recreate is
  idempotent, runs at background priority, and is gated by both the
  pending-operation check and the circuit breaker, so it is one recreate per
  NAT network, once.
- **4**, the audit's cadence. One `iptables -C` per NAT-providing network per
  pass, which is the same order as the `check_for_interface` probe
  `is_created()` already runs for every network on every pass. Worth
  measuring if the audit ever grows past one rule; not worth a skip-N-passes
  mechanism now.
- **5**, narrowing the repair's guard history to `route_address`. The
  property is real and was documented on the guard last round. Item 2's fix
  removes the most likely source of the errored unroutes that would trip it,
  and a per-task-type history is new query surface for a case which already
  wants operator attention.

Five more mutations, each failing the assertions which claim to prove it
against a green baseline: a single `-D` rather than draining every copy, a
changed duplicate bound, dropping the 255 tolerance on unroute, swallowing
every unroute failure rather than only the missing namespace, and never
removing the stale rule. The first attempt at the bound assertion read the
constant, so it moved with the mutation and could not fail; it asserts the
literal now. Thirty-one across the four rounds.

Each of the three commits passes the unit suite on its own, all ten
pre-commit hooks pass on the final tree, and the two documentation links
resolve.

## Merge CI round 1

The first merge group ejected the PR, and the cause was this PR's own new
test rather than anything it changes. 110 of the 111 cluster tests passed on
every topology and the one failure was
`test_routed_and_floating_addresses_answer_from_inside` -- in cleanup, after
both of its assertions had already passed. Both pings succeeded with 0%
packet loss on Debian 12 tier, Debian 12 cluster and Ubuntu 24.04 cluster,
and the routed one even shows the ICMP redirect the new namespace route
produces, so the run is evidence for the change:

```
routed:   3 packets transmitted, 3 received, 0% packet loss   (ttl=64)
          From 192.168.242.1: icmp_seq=2 Redirect Host (New nexthop: ...)
floating: 3 packets transmitted, 3 received, 0% packet loss   (ttl=63)
```

What failed was the `addCleanup(unroute_network_address, ...)` the routed
commit registered. testtools runs cleanups *after* `tearDown()`, and
`BaseNamespacedTestCase.tearDown()` ends by deleting the namespace, so by the
time the cleanup ran the namespaced client could not authenticate: 401 on the
route DELETE, then 404 `namespace not found` from `/auth`. Deterministic, and
identical on all three topologies. The `pull_request` gate could not have
caught it -- `cluster_ci_tests` do not run there, so the merge group was this
test's first execution.

The unroute now happens at the end of the test body instead, with a comment
recording why, the way `smoke_ci_tests/test_loki.py` and
`cluster_ci_tests/test_namespace_claims.py` already do for the same trap.
Nothing leaks by moving it: `tearDown()` deletes the network, and that is
what releases the address. Moving it also turns it into coverage rather than
cleanup, which is the better reason it belongs in the body -- the endpoint
answers 403 or 404 unless the address really is routed by this network, so
the call returning is an assertion about the half of the routed-address
lifecycle the ping cannot see, and the unroute path is one this PR changes.

Amended into commit 2 rather than added as a fourth commit, and the whole
tree passes all ten pre-commit hooks.

## Not in this PR

Two adjacent defects found while tracing, filed rather than fixed here:

- #4114 — unroute never releases the IPAM reservation, so the floating pool
  only recovers on network delete.
- #4115 — inner veth ends stay at MTU 1500, so the 7950 advertised to guests
  only holds inside the virtual network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrU2FCqx1mUnQCiACcSqcy




