### PR TITLE
Gate enqueue on the issue link check

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -762,6 +762,27 @@ jobs:
       - name: "Immediate success"
         run: true
 
+  # GitHub only acts on an issue-closing stanza in a pull request's
+  # description. A stanza wrapped in backticks is a code span and is
+  # ignored, and a commit message stanza is not parsed at all on the merge
+  # queue path -- so a fix can merge with the issue left open and nobody
+  # any the wiser. This fails while the description can still be edited.
+  # It also prints what the pull request will close, which is how a closing
+  # keyword in ordinary prose shows itself before it shuts a live bug.
+  issue_link_check:
+    name: "Issue links"
+    if: github.event_name == 'pull_request'
+    uses: shakenfist/actions/.github/workflows/issue-link-check.yml@main
+    # This file grants only "contents: read" at the top, and a called
+    # workflow cannot hold more than its caller was given, so the reads it
+    # needs are granted here rather than widening the whole file.
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+    with:
+      runs_on: '["self-hosted","static"]'
+
   can_enqueue:
     name: "Can enqueue"
     needs:
@@ -769,6 +790,7 @@ jobs:
       - sanity_checks
       - check_paths
       - credential_scan
+      - issue_link_check
     if: always() && github.event_name != 'merge_group'
     permissions:
       actions: read

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -769,6 +769,15 @@ jobs:
   # any the wiser. This fails while the description can still be edited.
   # It also prints what the pull request will close, which is how a closing
   # keyword in ordinary prose shows itself before it shuts a live bug.
+  #
+  # This job deliberately carries no same-repo guard, unlike
+  # smoke_collection above. The called workflow checks out only
+  # shakenfist/actions and reads the pull request entirely through the
+  # API, so no fork-controlled code executes on the runner -- and
+  # skipping fork pull requests would silently exempt them from the
+  # gate, since can_enqueue treats a skipped dependency as success.
+  # Those are the terms on which the exposure is accepted; it is not an
+  # omission.
   issue_link_check:
     name: "Issue links"
     if: github.event_name == 'pull_request'

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -434,6 +434,50 @@ A failed `Can merge` ejects the pull request from the queue, and
 [merge failure triage](#merge-failure-triage) then classifies the failure
 automatically.
 
+### The issue link check
+
+`Can enqueue` also needs the `Issue links` job, which calls the reusable
+`issue-link-check.yml` in `shakenfist/actions`. It compares what a pull
+request claims to fix -- its branch name, its description, and its commit
+messages -- against `closingIssuesReferences`, which is GitHub's own parse
+of what will actually close, and fails when the two disagree.
+
+**The closing stanza has to be in the pull request description.** Two
+things that look like they would work do not:
+
+- A stanza wrapped in backticks is a code span. GitHub renders it and
+  parses nothing.
+- A stanza in a *commit message* closes nothing on this repository. GitHub
+  acts on commit-message stanzas only for commits pushed to the default
+  branch in the ordinary way, and the merge queue advances `develop` from
+  its own staging ref. Putting the stanza in the commit message as well is
+  still worth doing -- it is how `git log` records why a change was made --
+  but it is traceability, not closure.
+
+So a description needs a plain, unbackticked `Fixes #NNNN` on a line of its
+own. `issue-fix.yml` already emits one: the workflow appends its own
+`Fixes #${ISSUE_NUMBER}` as the *first* line of the body, after
+`tools/neutralise-pr-body.sh` has run over the model's prose, so bot-authored
+fix pull requests satisfy this gate as they stand. Do not "fix" a failure
+here by loosening the branch-name pattern in the checker.
+
+Where a pull request is deliberately only part of the work on an issue, opt
+out with a line of the form `X-No-Autoclose: #NNNN` in the description.
+
+The job also prints the issues GitHub *will* close that nobody asked for --
+the other direction of the same defect, and how a closing keyword sitting
+beside a reference in ordinary prose reveals itself before it shuts a live
+bug. That direction is reported and never enforced: real descriptions carry
+headings and table cells of the same shape, and a check that cried wolf on
+those would be ignored within a week.
+
+**Editing the description does not re-run the check.** `functional-tests.yml`
+declares no `types:` on its `pull_request` trigger, so it fires on `opened`,
+`synchronize` and `reopened` only. After correcting a description, re-run the
+failed jobs from the Actions tab (or push a commit) to clear the required
+check. Adding `edited` to the trigger is not the fix -- it would re-run the
+entire functional matrix on every description tweak.
+
 ### Superseded merge groups are cancelled
 
 Every job that can run in the queue and holds a scarce runner carries a
@@ -859,6 +903,12 @@ model having complied. Fenced code is passed through untouched --
 GitHub does not linkify inside a fence, and a description quoting a
 decorator or an email address is a normal description.
 `shakenfist/tests/test_neutralise_pr_body.py` covers both halves.
+
+Neutralising the model's prose does not leave the draft unable to close
+its issue. The workflow appends its own `Fixes #${ISSUE_NUMBER}` as the
+first line of the body *after* this pass, above the model text and
+outside any fence the model may have left open, which is what satisfies
+[the issue link check](#the-issue-link-check).
 
 `issue-fix.yml` runs its fix attempt through
 `tools/claude-model-fallback.sh`, which takes a comma-separated


### PR DESCRIPTION
A pull request here can merge with the issue it repairs left open, and
nothing says so.

## Why this repository in particular

GitHub acts on an issue-closing stanza only when it appears in a pull
request's **description**. A stanza wrapped in backticks is a code span and
is never parsed. A stanza in a **commit message** is parsed only for a commit
pushed to the default branch in the ordinary way — and the merge queue
advances develop from its own staging ref, so a commit stanza on this
repository does nothing whatsoever. The convention of putting the stanza in
the commit message is buying traceability here, not closure.

An audit on 2026-09-07 found five issues sitting open behind merged work:
4087 behind 4106, 3999 behind 4108, and 3370, 3371 and 3373 behind 3374,
whose description was empty. 4087 needed both failures at once, which is why
this has looked rare while being one mistake away from happening every time.
The first four have since been dealt with by hand; 3373 turned out not to be
resolved at all, and stays open.

## What this adds

An `issue_link_check` job which runs on pull requests and joins the enqueue
gate's `needs`, so a description which will not do what it says fails while
it can still be edited. The implementation is the reusable workflow in
shakenfist/actions.

It also prints what the pull request will shut, which is the other direction
of the same defect — three issues were shut by accident in the same hundred
days by a keyword sitting beside a reference in ordinary prose. That
direction is reported and never enforced, because descriptions here
legitimately carry headings and table cells of the same shape and a check
which cried wolf on those would be ignored inside a week.

`X-No-Autoclose: #NNNN` in a description opts out, for a pull request which
is deliberately only part of the work.

## Verification

Ten pre-commit hooks pass, including actionlint. The checker itself carries
21 unit tests in shakenfist/actions, and was run against this repository's
real pull requests: 4106 fails naming 4087, 3374 fails naming 3373, 4118 and
4108 pass, and 3816 passes while reporting the issue it shut by accident.

It was also run against the four most recent bot-authored fix pull requests
— 4121, 4122, 4124 and 4130 — which all pass. `issue-fix.yml` appends its
own `Fixes #NNNN` as the first line of the description after
`neutralise-pr-body.sh` runs, so the automated fixer and this gate agree
rather than fighting.

The gate is documented in `docs/developer_guide/ci.md`, under the merge
queue pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrU2FCqx1mUnQCiACcSqcy

