### PR TITLE
Log an unresolvable node UUID once per API worker

### DIFF
--- a/docs/operator_guide/logging.md
+++ b/docs/operator_guide/logging.md
@@ -276,6 +276,25 @@ requires the query to find *that* before it will assert that
 nothing else matched. A detector which has never been observed
 firing is not evidence of anything.
 
+## Conditions logged once per worker
+
+A few warnings describe a condition of the process rather than of
+a request, and those are logged at most once for the lifetime of
+that process. `Failed to resolve node UUID in API worker` is the
+one you are most likely to meet: an `sf-api` gunicorn worker
+resolves this node's UUID lazily on its first non-probe request,
+from the persisted UUID file or from the node's FQDN in the
+database, and warns if neither answers.
+
+Seeing that line once does **not** mean the condition has since
+cleared. The worker keeps retrying on every subsequent request --
+a node absent from the database now may be present later -- but
+it does not repeat the warning, because a per-request copy of it
+would bury every other line the worker emits. Confirm the
+condition is resolved by looking for the matching
+`Resolved node UUID in API worker` line (which carries the
+`node_uuid` field), not by the absence of further warnings.
+
 ## Events vs logs
 
 Shaken Fist has two structured-record streams, and they are not

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -134,6 +134,17 @@ def _record_exception(sender, exception, **extra):
 got_request_exception.connect(_record_exception, app)
 
 
+# The failure to resolve is logged at most once per worker. Resolution
+# itself is still retried on every request, because a node which is
+# missing from the database now may be present later -- but the log
+# line is not news a second time, and repeating it per request is how a
+# genuinely unresolvable worker buries every other line in its journal.
+# It buried the unit tests too: a single test module emitted six
+# thousand copies of this warning, none of which said anything the
+# first one did not.
+_node_uuid_warning_emitted = False
+
+
 @app.before_request
 def resolve_node_uuid():
     """Resolve config.NODE_UUID if not already set.
@@ -142,6 +153,8 @@ def resolve_node_uuid():
     populated by _resolve_node_uuid(). We resolve it lazily on the first
     request instead.
     """
+    global _node_uuid_warning_emitted
+
     # Health probes must never touch the database. On a configured node
     # NODE_UUID is already set so this is a no-op anyway, but short-circuit
     # explicitly so the "a /readyz burst makes zero DB calls" guarantee holds
@@ -159,7 +172,8 @@ def resolve_node_uuid():
         config.NODE_UUID = node_uuid
         LOG.with_fields({'node_uuid': node_uuid}).info(
             'Resolved node UUID in API worker')
-    else:
+    elif not _node_uuid_warning_emitted:
+        _node_uuid_warning_emitted = True
         LOG.warning('Failed to resolve node UUID in API worker')
 
 

--- a/shakenfist/tests/external_api/test_node_uuid_resolution_logging.py
+++ b/shakenfist/tests/external_api/test_node_uuid_resolution_logging.py
@@ -1,0 +1,80 @@
+# Copyright 2019 Michael Still and contributors
+import logging
+from unittest import mock
+
+from shakenfist.config import config
+from shakenfist.external_api import app as external_api
+from shakenfist.tests import base
+
+
+class _CaptureHandler(logging.Handler):
+    """Collect emitted log records for assertion."""
+
+    def __init__(self):
+        super().__init__()
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+class NodeUuidResolutionLoggingTestCase(base.ShakenFistTestCase):
+    """An unresolvable node UUID is reported once per worker, not per request.
+
+    resolve_node_uuid runs before every non-probe request, and on a
+    worker which cannot resolve its own UUID every one of those
+    requests used to emit a warning. That is one line per request
+    forever in a misconfigured deployment, and it dominated the unit
+    test output: shakenfist.tests.external_api.test_auth alone produced
+    over six thousand copies. Resolution is still attempted every
+    request -- the node may appear in the database later -- so what is
+    asserted here is the log bound, not a bound on the attempts.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.saved_node_uuid = config.NODE_UUID
+        config.NODE_UUID = None
+        self.addCleanup(self._restore_node_uuid)
+
+        external_api._node_uuid_warning_emitted = False
+        self.addCleanup(
+            setattr, external_api, '_node_uuid_warning_emitted', False)
+
+        self.capture = _CaptureHandler()
+        logging.getLogger('shakenfist.external_api.app').addHandler(
+            self.capture)
+        self.addCleanup(
+            logging.getLogger('shakenfist.external_api.app').removeHandler,
+            self.capture)
+
+        self.client = external_api.app.test_client()
+
+    def _restore_node_uuid(self):
+        config.NODE_UUID = self.saved_node_uuid
+
+    def _warnings(self):
+        return [r for r in self.capture.records
+                if r.getMessage() == 'Failed to resolve node UUID in API worker']
+
+    def test_unresolvable_node_warns_once_across_many_requests(self):
+        with mock.patch.object(external_api.Node, '_load_persisted_uuid',
+                               return_value=None), \
+                mock.patch.object(external_api.Node, 'from_db',
+                                  return_value=None) as mock_from_db:
+            for _ in range(20):
+                self.client.get('/instances')
+
+        # One warning, but every request still tried to resolve.
+        self.assertEqual(1, len(self._warnings()))
+        self.assertEqual(20, mock_from_db.call_count)
+
+    def test_resolution_success_is_still_logged(self):
+        with mock.patch.object(external_api.Node, '_load_persisted_uuid',
+                               return_value='a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'):
+            self.client.get('/instances')
+
+        self.assertEqual([], self._warnings())
+        self.assertEqual(
+            'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d', config.NODE_UUID)


### PR DESCRIPTION
`resolve_node_uuid()` is an `sf-api` `before_request` hook. On a worker
which cannot resolve its own node UUID it warned **once per request**,
forever — the wrong bound for a fact about the process rather than
about a request. The second copy says nothing the first did not, and at
request volume it buries every other line the worker emits.

It buried the unit tests too, which is how this was noticed: no test
resolves a node UUID, and every API test drives requests through the
hook.

| test module | warnings before | after |
|---|---|---|
| `external_api.test_auth` | 6022 | 1 |
| `external_api.test_claims` | 5566 | 1 |
| `external_api.test_scopes` | 284 | 1 |
| `external_api.test_network` | 180 | 1 |

## What changed

The log line is bounded, not the work. Resolution is still attempted on
every request — a node missing from the database now may be present
later — but the failure is logged at most once per worker process.

The alternative, pinning `config.NODE_UUID` in `ShakenFistTestCase` the
way `test_health_endpoints.py` already does locally, would have quieted
the tests while leaving a misconfigured production worker emitting one
warning per request. That is why the fix is in the application rather
than in the test base.

`shakenfist/tests/external_api/test_node_uuid_resolution_logging.py`
asserts the bound the right way round: 20 requests produce exactly one
warning but 20 `Node.from_db` calls, so a future change which "fixes"
the noise by giving up on resolution fails the test. Reverting
`app.py` to the old `else:` makes the first assertion fail, which was
checked rather than assumed.

`docs/operator_guide/logging.md` gains a short section, because the
absence of repeats no longer means the condition has cleared — the
matching `Resolved node UUID in API worker` line is now what confirms
it did.

## Testing

`pre-commit run --all-files` passes in the branch worktree: all ten
hooks, including the full 4498-test `py3` suite and mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2FS2dRJgimXTSGXRqcTZL
