### PR TITLE
API input validation phase 4: enforce the declarations

### DIFF
--- a/docs/developer_guide/writing_an_endpoint.md
+++ b/docs/developer_guide/writing_an_endpoint.md
@@ -305,19 +305,28 @@ enumerate is a shape nothing checks.
 
 The declarations are compiled into marshmallow schemas at startup
 (`shakenfist/external_api/validation.py`) and checked against every
-request. **Nothing is rejected**: `API_VALIDATION_MODE` defaults to
-`warn`, which logs what would have been refused and changes no
-response. Setting it to `enforce` answers `400` in the usual
-`{"error": ..., "status": ...}` shape, and is the switch to throw once
-the warn log is understood.
+request. `API_VALIDATION_MODE` defaults to `enforce`: a finding other
+than `missing-required` answers `400` in the usual
+`{"error": "<parameter>: <reason>", "status": ...}` shape, naming the
+offending parameter, before the handler or any of its per-method
+decorators ever run. `warn` is the operator's rollback for a caller
+that breaks — it logs what would have been refused and changes no
+response — and `off` disables the layer entirely, as a further safety
+valve against unexpected log volume.
 
-A warn record carries the endpoint, the parameter, the reason, the
-offending value's **type** — never its value — and the status the
-request went on to return anyway. That last field is the interesting
-one: a finding on a request which returned 200 is a rejection
-enforcement would introduce, while one on a request which returned 404
-is a status code enforcement would merely change, because validation
-runs ahead of the per-method decorators which produce those.
+A validation record carries the endpoint, the parameter, the reason,
+the offending value's **type** — never its value — and, in `warn`
+mode, the status the request went on to return anyway. That last
+field is what told `enforce` and `warn` apart before the default was
+flipped: a finding on a request that returned 200 was a rejection
+enforcement would introduce, while one on a request that returned 404
+or 403 was a status code enforcement would merely change, because
+validation runs ahead of the per-method decorators which produce
+those. That second case is now the enforced default's own contract
+change: a request that is both malformed and refers to a missing or
+unauthorised object answers 400 rather than 404 or 403 — see the
+[v0.7 to v0.8 release notes](../release_notes/v07-v08.md) for the
+caller-visible shape of it.
 
 Reasons are counted separately because they answer different
 questions: `unknown-parameter`, `type-mismatch`, `missing-required`
@@ -325,9 +334,9 @@ and `body-path-collision`.
 
 Two things it deliberately does not do. `required` is recorded but
 never enforced — not even in `enforce` mode, where missing-required
-findings are filtered out of the rejection decision. Several
-parameters are declared required while omitting them has always
-worked, and what to do about that is still open — see [PLAN-api-input-validation](../plans/PLAN-api-input-validation.md).
+findings are filtered out of the rejection decision before the 400 is
+built. Several parameters are declared required while omitting them
+has always worked, and what to do about that is still open — see [PLAN-api-input-validation](../plans/PLAN-api-input-validation.md).
 And the prose `format` on a type token is documentation: `netblock`,
 `uuidorname`, `namespace`, `node`, `url` and `ipv4` compile to plain
 strings, because semantic validation of them is not built yet. Only
@@ -335,9 +344,13 @@ strings, because semantic validation of them is not built yet. Only
 
 ## What is not checked yet
 
-Enforcement is off, so a correct declaration still does not stop a
-caller sending something else. Six known gaps in the derivation
-itself:
+Enforcement checks every request against its published declarations,
+but a declaration is only as good as what the derivation could see
+when it was written or audited. None of the six known gaps below are
+about whether enforcement runs — they are about a kwarg the derivation
+cannot yet turn into a declaration in the first place, so a handler
+carrying one of these shapes can still accept something undeclared and
+unchecked:
 
 (The published specification itself *is* checked:
 `shakenfist/tests/external_api/test_openapi_spec.py` validates the

--- a/docs/developer_guide/writing_an_endpoint.md
+++ b/docs/developer_guide/writing_an_endpoint.md
@@ -309,10 +309,19 @@ request. `API_VALIDATION_MODE` defaults to `enforce`: a finding other
 than `missing-required` answers `400` in the usual
 `{"error": "<parameter>: <reason>", "status": ...}` shape, naming the
 offending parameter, before the handler or any of its per-method
-decorators ever run. `warn` is the operator's rollback for a caller
-that breaks — it logs what would have been refused and changes no
-response — and `off` disables the layer entirely, as a further safety
-valve against unexpected log volume.
+decorators ever run. A refusal names the **first** finding only, so a
+request with several problems is fixed one round trip at a time; every
+finding is logged either way, so an operator sees the rest. `warn` is
+the operator's rollback for a caller that breaks — it logs what would
+have been refused and changes no response — and `off` disables the
+layer entirely, as a further safety valve against unexpected log
+volume.
+
+Because a refusal is answered from outside every per-method decorator,
+`log_token_use` never runs for one. The refusal writes its own
+`request refused by input validation` audit event against the caller's
+namespace instead, so a namespace's audit trail still shows the
+credential being used.
 
 A validation record carries the endpoint, the parameter, the reason,
 the offending value's **type** — never its value — and, in `warn`

--- a/docs/operator_guide/logging.md
+++ b/docs/operator_guide/logging.md
@@ -168,33 +168,69 @@ metrics endpoint:
 ## API request validation findings
 
 After upgrading you may see `API request validation finding` lines
-from `sf-api` in your log stream. These are **informational**: they
-record a request which did not match its endpoint's published
-parameter declarations, and while `API_VALIDATION_MODE` is `warn`
-(the default) they change no response — the request was answered
-exactly as it always was. Do not set `enforce` yet; it only makes
-sense once the warn log for your own callers has been read and
-understood. See
-[PLAN-api-input-validation](../plans/PLAN-api-input-validation.md). If
-the lines themselves become a problem — a chatty caller sending an
-undeclared key on every request is an extra line per request —
-`API_VALIDATION_MODE` can be set to `off`, which disables the layer
-entirely.
+from `sf-api` in your log stream. Each records a request which did not
+match its endpoint's published parameter declarations.
+
+`API_VALIDATION_MODE` decides what happens to such a request, and
+since v0.8.0 it defaults to **`enforce`**: a finding other than
+`missing-required` refuses the request with a 400 in the usual
+`{"error": "<parameter>: <reason>", "status": 400}` shape, and the
+finding line records the refusal. A refusal names the first finding
+only, so a request with several problems is fixed one round trip at a
+time — but every finding is logged, so the log has the whole picture
+even when the caller does not. A parameter declared required but not
+supplied is recorded and never enforced.
+
+The other two modes are the rollback, in order of severity:
+
+* `warn` restores the pre-v0.8.0 behaviour: findings are recorded and
+  change no response, so the request is answered exactly as it always
+  was. Set this if a caller of yours breaks against enforcement while
+  you fix it — the finding lines tell you which parameter to fix.
+* `off` disables the layer entirely, including the log lines. This is
+  the valve for the lines themselves becoming a problem: a chatty
+  caller sending an undeclared key on every request is an extra line
+  per request.
+
+The caller-visible consequences of enforcement — including requests
+which used to answer 404 or 403 and now answer 400 — are described in
+the [v0.7 to v0.8 release notes](../release_notes/v07-v08.md), and the
+design in
+[PLAN-api-input-validation](../plans/PLAN-api-input-validation.md).
 
 Each line carries:
 
 | Field | Meaning |
 |---|---|
 | `validation-reason` | Which rule the request missed: `unknown-parameter` (a body key the endpoint does not declare), `type-mismatch` (a declared parameter with a value of the wrong type), `missing-required` (a declared-required parameter that was not supplied), or `body-path-collision` (a body key with the same name as a URL path parameter). |
-| `validation-parameter` | The parameter concerned, truncated to 64 characters. |
+| `validation-parameter` | The parameter concerned, truncated to 64 characters. When the wrong value is inside a container the offending element is named — `disk[0]` for the first entry of the disk array, `disk.size` for a sub-field. |
 | `validation-detail` | The specific rule that was missed — for a `type-mismatch`, the validation message (for example `Not a valid integer.`). |
-| `validation-value-type` | The Python type of the offending value. The value itself is never logged. |
+| `validation-value-type` | The Python type of the offending value — of the named element, where one was named. The value itself is never logged. |
 | `route` | The route template (for example `/instances/<instance_ref>`), so findings aggregate by endpoint; `path` carries the concrete request path. |
-| `validation-response-status` | The status the request went on to return anyway, which is what separates a rejection enforcement would introduce from a status code it would merely change. |
+| `validation-response-status` | The status the request returned. In `enforce` this is the 400 the finding itself produced; in `warn` it is what the request returned anyway, which is what separates a rejection enforcement would introduce from a status code it would merely change. |
 | `validation-mode` | The active `API_VALIDATION_MODE`. |
 
+The number of findings one request can produce is bounded, because a
+request body is not: at most 20 `unknown-parameter` findings and 20
+`type-mismatch` findings, each followed by a single `(overflow)`
+finding carrying the count of the rest. A caller sending a thousand
+malformed disk specifications therefore costs a bounded number of log
+lines.
+
 The reason codes and the measurement they feed are described in
-`docs/plans/PLAN-api-input-validation-phase-03-compile-and-warn.md`.
+`docs/plans/PLAN-api-input-validation-phase-03-compile-and-warn.md`,
+and the reading which supported turning enforcement on in
+`docs/plans/PLAN-api-input-validation-phase-04-enforce.md`.
+
+A refused request never reaches its handler, so it does not produce
+the `token used to authenticate request` audit event a well formed
+request would. It writes a `request refused by input validation` audit
+event against the caller's namespace instead, carrying the same key
+name, method, path and remote address, plus the reason and parameter
+the refusal named. As in the log line, the parameter name is replaced
+with `*****` on the `/auth` routes: the name comes from the caller, so
+a buggy one can put secret-bearing material in a key position, and a
+namespace event is readable by anyone who can read the namespace.
 
 ## Secrets in the log stream
 

--- a/docs/plans/PLAN-api-input-validation-phase-04-enforce.md
+++ b/docs/plans/PLAN-api-input-validation-phase-04-enforce.md
@@ -406,6 +406,103 @@ Checked before committing to it: the official client's
 shipped caller is affected. Two of the seven metadata delete handlers
 were cleaned up already, so the pattern is proven.
 
+### Review round 1 on [#4141](https://github.com/shakenfist/shakenfist/pull/4141)
+
+Eleven items: 2 `fix`, 3 `document`, 5 `consider`, 1 `none`. Both
+fixes and all three documentation items were taken, as were four of
+the five `consider` items. The round is against the flip itself
+rather than against machinery an earlier round added, which is the
+first review this branch has had.
+
+**Both `fix` items were in the element-naming commit**, which is the
+one piece of the branch that was not a plan step -- it was written
+because enforcement turned a finding's detail into the caller's error
+message. Neither defect existed before that commit, and both are the
+same kind of mistake: the code walked marshmallow's error structure
+correctly and then handled the *result* of the walk carelessly.
+
+* **The fan-out was unbounded.** `check()` has capped
+  unknown-parameter findings since phase 3 because a body key is
+  bounded only by what a caller sends and each finding is a log line.
+  Naming elements individually gave type mismatches exactly that
+  property -- a thousand-element disk array became a thousand
+  findings, of which the caller saw one. `MAX_TYPE_MISMATCH_FINDINGS`
+  now bounds them in the same shape, with the same `(overflow)`
+  summary finding. The leaves are sliced before their values are
+  resolved, so the elements past the bound cost a tuple each.
+* **Indices sorted lexically**, so `disk[10]` was reported ahead of
+  `disk[2]`. Since a refusal names the first finding only, a caller
+  with two bad disks was told about the wrong one. `_sort_key` keeps
+  integers in numeric order ahead of sub-field names, and the ordering
+  test now uses twelve elements, because two cannot tell the two
+  orders apart -- which is why the test named "in order" did not catch
+  this.
+
+**The audit gap was taken as a fix rather than as documentation.**
+The reviewer offered either. A refusal returns from outside every
+per-method decorator, so `log_token_use` never runs and an
+authenticated caller could send malformed requests indefinitely
+leaving nothing in the namespace's own audit trail -- only sf-api's
+log, which carries neither key name nor remote address. Preserving
+event coverage is a standing goal of this project, so enforcement now
+writes a `request refused by input validation` audit event carrying
+the same fields plus the reason and parameter. It is deliberately a
+different message from `token used to authenticate request`, because
+it is a different fact: this request reached no handler. Failures are
+swallowed -- an unavailable database must not upgrade a malformed
+request into a 503 -- but the swallow logs.
+
+**The rollback path is now asserted rather than promised.** Six
+comments added by the flip said a handler's own guard "remains and
+still answers when API_VALIDATION_MODE is not enforce", while every
+test that covered those messages had been rewritten to assert the
+validator's wording. `set_validation_mode()` on the test base restores
+the mode on cleanup, and six warn-mode tests now assert those guards'
+own messages -- one of the six covers the three claim bounds, which
+are three guards in one handler. Mutating the helper into a no-op fails them, so they are
+about the mode rather than incidentally passing at it.
+
+**Writing the audit event turned up a leak of its own**, which is the
+reason the reviewer's item 11 was worth recording even though it asked
+for no change. It observed that a refusal puts the parameter name --
+which `log_validation_findings` redacts on `/auth` routes, because a
+buggy caller can put secret-bearing material in a key position -- into
+the response body, and that this is safe only because
+`log_response_info` drops the whole body on the same predicate. A
+namespace event has no such protection and is readable by anyone who
+can read the namespace, so the new audit event redacts the name on the
+same predicate. `REDACTED_PARAMETER` is now one constant used by both
+sites, so the two records of one refusal cannot disagree about what is
+safe to say, and the coupling between the two redactions is written
+down where the predicate lives.
+
+**Verification.** Eleven mutations over the new assertions, each caught
+by the test that names the property: lexical index sorting, an
+unbounded fan-out, a missing overflow finding, the container's type
+reported instead of the element's, an unresolvable path answering None
+rather than falling back, the raw-body skip removed, the audit event
+removed, the audit helper allowed to raise on a `@public` endpoint,
+the last enforceable finding reported instead of the first, the
+parameter name left unredacted on a credential route, and the
+warn-mode helper turned into a no-op. A twelfth mutation --
+validating a raw body against its schema -- was **not** caught, and
+should not be: a raw body declaration cannot be combined with named
+body parameters, so a raw-body route's compiled body schema is always
+None and the guard is unobservable belt-and-braces. A test for it
+would be a test that cannot fail. The first attempt at the raw-body
+test *was* that test -- it sent bytes with an octet-stream content
+type, which no scan could have reported on whether the route was
+skipped or not; it earns its place only because the body it now sends
+is JSON the scan would otherwise refuse.
+
+The one `consider` not taken is the cluster CI test's base class.
+`TestUndeclaredParameterRefused` keeps `BaseNamespacedTestCase`
+because the property has to hold for an ordinary caller rather than
+for an admin -- the namespaced client is the point, not incidental --
+and the teardown loops it pays for break out immediately on empty
+lists. The reason is now in the class docstring, along with why the
+private `_request_url` is the right call there.
+
 ### Review round 2 on [#4101](https://github.com/shakenfist/shakenfist/pull/4101)
 
 Ten items: 1 `fix`, 2 `document`, 5 `consider`, 2 `none` — down from
@@ -611,6 +708,13 @@ run, so absence is evidence rather than silence.
 13. `UNDECLARED_BY_DESIGN` in `test_parameter_declarations.py` is
     empty, and the five metadata delete handlers no longer accept a
     `value` kwarg they never read.
+14. The findings one request can produce are bounded whatever it
+    sends, in every reason, and a test proves it.
+15. A refused request writes an audit event against the caller's
+    namespace, so enforcement costs no audit coverage.
+16. Each handler guard which enforcement now answers ahead of has a
+    warn-mode test asserting the guard's own message, so the
+    documented rollback path is exercised rather than described.
 
 ## Back brief
 

--- a/docs/plans/PLAN-api-input-validation-phase-04-enforce.md
+++ b/docs/plans/PLAN-api-input-validation-phase-04-enforce.md
@@ -288,6 +288,13 @@ merge until:
   run is not evidence, and phase 3's log records three separate
   occasions where a quiet channel was mistaken for a quiet system.
 
+Read this condition as "any JSON-valued metadata write", not as
+k3s specifically: the declaration is per route, so any such write
+exercises the same schema, and the traffic named here turned out to be
+`client-python-k3s` run by hand rather than anything scheduled. The
+measurement log records the reading actually taken, and why waiting on
+that traffic would have been waiting on nothing in particular.
+
 Whatever watches this window is exercised by hand before it is
 trusted — phase 3's notifier failed silently for its last three runs
 because cron's `PATH` could not find `sops`. If a notifier is used at
@@ -619,5 +626,129 @@ gathered and shown before the switch, not after.
 
 ## Measurement log
 
-*(D22's confirmatory reading goes here, in the format phase 3's log
-established: the reading command, what ran, and the signature table.)*
+**2026-09-08 -- D22's confirmatory reading. Both conditions met; the
+switch may be thrown.** Steps 1 to 3 merged as [#4101][pr] on
+2026-09-07 (three review rounds; #3739 closed by the merge). sfcbr
+redeployed between 07:48 and 08:48 UTC the same day at
+`shakenfist=f5cf6a3fa`, which carries the phase's head `5168935b8`.
+
+The deploy was confirmed *live* rather than merely installed, because
+a mirror sha only says what was written to disk: the running server
+reports `0.8.0rc5.dev1236+gf5cf6a3fa.d20260907`, and its published
+specification carries both fixes -- fourteen metadata `value`
+parameters rendered as `format: any JSON value` with no `type`
+(including `PUT /auth/namespaces/{namespace}/metadata/{key}`), and
+`POST /networks/{network_ref}/dns` still `string`/ipv4 as D15
+requires. Body `namespace` declarations went 14 to 65 across the
+package, the +51 matching the 51 problems the audit reported when run
+against unmodified `develop`.
+
+### Reading 1 -- the functional CI run. Nine to zero.
+
+[Run 34074436494][run] (the `merge_group` run of #4101 itself, so the
+first full suite over the merged code; all jobs green). Graded from
+the per-node journals in the six bundles, since the central Loki dump
+in each bundle is still zero bytes -- actions repo issue #16 is not
+fixed and the phase 3 note about it still applies.
+
+| n | signature | 2026-08-13 | classification |
+|---|-----------|-----------|----------------|
+| 21 | missing-required, `POST /auth/federated`, 400 | 21 | Intended rejection: the federation suite's deliberately malformed bodies. Unchanged. |
+| 0 | **unknown-parameter `namespace`, artifact ref, 200/404** | **9** | **Fixed.** The #3739 population, gone. |
+| 6 | type-mismatch `length`, consoledata, 400 | 6 | Intended rejection. Unchanged. |
+| 6 | type-mismatch `key_ttl`, rules create, 400 | 6 | Intended rejection. Unchanged. |
+| **33** | **total** | **42** | Only the nine moved. |
+
+Both of phase 3's guards against a false negative were re-run, because
+a zero that is not proven to be capable of being non-zero is not a
+reading. The apparatus was live: `Compiled API parameter declarations`
+with `handlers: 139` appears in all six bundles. And the generator ran:
+`test_artifact_system_creds_namespace_scoped` and
+`test_same_name_different_namespace` -- the two cluster CI tests that
+drive a system-credentialed lookup with an explicit `namespace=` --
+both executed and passed at 02:11.
+
+### Reading 2 -- the metadata `value` type mismatch. Probed, not waited out.
+
+D22 asked for 72 hours of absence "during which the k3s orchestration
+traffic that produced it has actually run". That wording named the
+wrong thing, and the correction matters more than the wait:
+
+* The traffic is not a running k3s cluster. It is `client-python-k3s`
+  exercised by hand, storing its state in namespace metadata under
+  `orchestrated_k3s_*` keys. It appears on the days that library is
+  worked on (08-09, 08-17, 08-22 to 08-24, 08-28, 08-30, 09-04, 09-05)
+  and stops otherwise -- it last ran 2026-09-05 21:00 UTC, some 35
+  hours *before* the fix deployed. Waiting for it would have been
+  waiting on an unscheduled human activity.
+* Nothing about k3s is load-bearing. The declaration is per route, not
+  per key: `value` on that route compiles to `fields.Raw`, so **any**
+  JSON-valued metadata write exercises the identical schema. The
+  requirement should read "any JSON-valued metadata write", and does
+  from here.
+
+So the reading was taken by probe on 2026-09-08 at 07:05:50 UTC. A
+scratch namespace took a dict-valued and a list-valued metadata write
+-- the exact `_set_metadata` shape (`PUT .../metadata/<key>` with
+`{'value': ...}`) behind all 294 of the historical findings -- both
+stored and read back verbatim, and the namespace was deleted.
+
+The probe carried its own positive control, for the same reason the
+apparatus is hand-verified: an undeclared body key on `GET /instances`
+in the same second, which **must** still be reported. Reading, 35
+seconds later:
+
+    loki-query '{job="shakenfist"} |= "API request validation finding"' \
+        --tenant sfcbr --since 15m --limit 200
+
+| n | signature | meaning |
+|---|-----------|---------|
+| 1 | unknown-parameter `banana`, `GET /instances`, 400 | Control fired. The pipeline is alive and findings reach Loki. |
+| **0** | **type-mismatch `value`, metadata, 200** | **Fixed.** Two writes that would each have produced one. |
+
+A silent channel would have produced neither line. This is positive
+evidence rather than an absence, which is what 72 hours of quiet could
+not have given us.
+
+### What thirty days of sfcbr says about the flip's blast radius
+
+Widening the query to the whole warn window, and splitting on the
+status the request *actually* got, isolates what enforcement changes:
+
+| n | response | signature |
+|---|----------|-----------|
+| 294 | **200** | type-mismatch `value`, namespace metadata |
+| 40 | 400 | type-mismatch, namespace claims |
+| 12 | 400 | missing-required, `POST /auth` |
+| 8 | 400 | missing-required, namespace claims |
+| 2 | 400 | type-mismatch `limit`, instance events |
+| 1 | 400 | unknown-parameter `banana` (the 08-13 hand probe) |
+
+Every finding on a request that *succeeded* is the metadata one, and
+it is fixed. Everything else already answers 400 and answers 400 after
+the flip, so the enforceable surface on sfcbr is now empty.
+
+Two of those signatures postdate phase 3's reading and are classified
+here for the first time. Both are the `key_ttl` pattern -- the
+published bound and the server already agree, so validation only
+restates a refusal the handler was already making:
+
+* **Namespace claims, 48 findings on 2026-08-24 and 08-25.** The
+  scheduler-reservations phase 4 suite: `Must be greater than or equal
+  to 1`, `Must be greater than or equal to 0`, and `Not a valid
+  integer` against a bool. All 400 already.
+* **Instance events `limit`, 2 findings on 2026-08-25.** A string
+  where the declared bound wants 1..1000. Already 400.
+
+### The remaining caveat, stated rather than buried
+
+The control's own response is the phase's motivating defect, still
+visible: `GET /instances` with an undeclared key answered
+`{"error": "InstancesEndpoint.get() got an unexpected keyword argument
+'banana'", "status": 400}` -- interpreter text, leaked to the caller.
+Step 4 replaces exactly that with `banana: not declared by this
+endpoint`, and its tests assert the absence of interpreter text
+positively.
+
+[pr]: https://github.com/shakenfist/shakenfist/pull/4101
+[run]: https://github.com/shakenfist/shakenfist/actions/runs/34074436494

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -105,16 +105,17 @@
   offsets are published as non-negative integers, and `user_data` is
   published as base64 content. A rule's `key_ttl` also documents its real
   bounds of 1 to 86400 seconds, which the server has always enforced.
-  These are documentation — requests are not yet rejected against them.
-  The API now checks every request against these declarations, but in
-  **warn-only** mode: it logs what it would have refused and changes no
-  response. The new `API_VALIDATION_MODE` setting controls this and
-  defaults to `warn`; `enforce` answers 400 instead (except for
-  parameters declared required but omitted, which are recorded and
-  never enforced), and is not recommended until you have read your
-  own warn logs; `off` disables the layer entirely, as a safety
-  valve against unexpected log volume. Three related
-  behaviour changes did ship:
+  These were documentation only at first: the API checked every
+  request against these declarations, but in a **warn-only** mode that
+  logged what it would have refused and changed no response. The new
+  `API_VALIDATION_MODE` setting controls this, and — see the
+  validation enforcement entry below — now defaults to `enforce`, which
+  answers 400 instead (except for parameters declared required but
+  omitted, which are recorded and never enforced); `warn` restores the
+  original logging-only behaviour and `off` disables the layer
+  entirely, as a safety valve against unexpected log volume. Three
+  related behaviour changes shipped with the original, warn-only
+  rollout:
     * A webargs validation failure (a malformed query parameter on the
       four endpoints which parse one) now returns `400` in the usual
       `{"error": ..., "status": ...}` shape. It previously returned a
@@ -132,8 +133,8 @@
       `passed_uuid` before being merged into the handler's arguments.
       No handler accepted that name, so sending `uuid` in a body was a
       guaranteed 400 on every endpoint in the API; it is now treated as
-      an ordinary undeclared parameter, which in warn mode means the
-      request behaves as it always did and the occurrence is logged.
+      an ordinary undeclared parameter, which `API_VALIDATION_MODE=warn`
+      merely logs and `enforce` refuses outright.
   Separately, two of the newly published bounds are backed by the
   server's own handlers rather than waiting for enforcement -- both
   cases where publishing a bound the server did not back would have
@@ -181,6 +182,36 @@
   have always been able to be dictionaries and lists as well —
   `sf-client` sends whatever JSON it is given and the server stores it.
   A regenerated client may bind that parameter more loosely.
+* **Behaviour change:** `API_VALIDATION_MODE` now defaults to
+  `enforce`. A request that does not match its endpoint's published
+  parameter declarations -- an undeclared body key, a value of the
+  wrong type, or a body key that overwrites a path parameter, such as
+  sending `key` in the body of
+  `PUT /auth/namespaces/...namespace.../metadata/...key...` -- is
+  refused with a 400 in the usual
+  `{"error": "<parameter>: <reason>", "status": 400}` shape, naming
+  the parameter and why. Validation runs after authentication but
+  before every per-method decorator, including the ones that look up
+  and authorise access to an object, so **a request that is both
+  malformed and refers to a missing or unauthorised object now answers
+  400 where it previously answered 404 or 403** -- this is not an
+  information leak, since the caller was already authenticated and
+  learns only that its own request was malformed, nothing about the
+  object it named. `required` is still recorded and never enforced: a
+  parameter declared required can still be omitted, exactly as before.
+  If a caller breaks against this, set `API_VALIDATION_MODE=warn` to
+  log findings without refusing anything while you fix it, or `off` to
+  disable the layer entirely.
+  Two narrower changes come with the flip. Eleven refusals that a
+  handler's own guard already produced now speak with validation's
+  wording instead, because validation answers first: `key is not a
+  string` becomes `key: Not a valid string.`, and `expiry is not a
+  number` becomes `expiry: Not a valid number.`, for example. Those
+  handler guards are unchanged and still answer whenever
+  `API_VALIDATION_MODE` is not `enforce`. And a body key that repeats a
+  path parameter -- the `key` example above -- is now refused as a
+  body/path collision; the shipped `shakenfist_client` never sends one,
+  but a caller that does will need to stop.
 * Malformed values inside the reserved `affinity` instance metadata key
   are now refused with a 400 instead of returning a 500. A list, a
   dictionary, `null` or `Infinity` used as the *value* of an affinity

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -190,7 +190,12 @@
   `PUT /auth/namespaces/...namespace.../metadata/...key...` -- is
   refused with a 400 in the usual
   `{"error": "<parameter>: <reason>", "status": 400}` shape, naming
-  the parameter and why. Validation runs after authentication but
+  the parameter and why. A refusal names the *first* problem found, so
+  a request with several of them is fixed one round trip at a time;
+  `sf-api` logs every finding, so an operator sees the rest. Where the
+  offending value is inside a container the element is named --
+  `disk[0]: Not a valid mapping type.` rather than the whole array.
+  Validation runs after authentication but
   before every per-method decorator, including the ones that look up
   and authorise access to an object, so **a request that is both
   malformed and refers to a missing or unauthorised object now answers
@@ -212,6 +217,20 @@
   path parameter -- the `key` example above -- is now refused as a
   body/path collision; the shipped `shakenfist_client` never sends one,
   but a caller that does will need to stop.
+  One change is not undone by the rollback: a `value` key in the body
+  of a metadata `DELETE` is refused in every mode after this release.
+  It was previously accepted and ignored, and the handlers no longer
+  accept it at all, so `warn` and `off` answer 400 for it too -- with
+  the interpreter's wording rather than validation's. The shipped
+  client sends no body on a metadata delete, so this reaches
+  hand-rolled callers only.
+  Finally, a refused request never reaches its handler, so it does not
+  produce the `token used to authenticate request` audit event a well
+  formed request would. It writes a `request refused by input
+  validation` audit event against the caller's namespace instead,
+  carrying the same key name, method, path and remote address, plus
+  the reason and the parameter the refusal named (the parameter name
+  is redacted on the `/auth` routes, as it already is in the log).
 * Malformed values inside the reserved `affinity` instance metadata key
   are now refused with a 400 instead of returning a 500. A list, a
   dictionary, `null` or `Infinity` used as the *value* of an affinity

--- a/shakenfist/config.py
+++ b/shakenfist/config.py
@@ -278,21 +278,22 @@ class SFConfig(BaseSettings):
         15,
         description='How long in minutes an API token is valid for.'
     )
-    # Literal rather than str so a typo fails at config load. The
-    # setting exists to be flipped, and 'Enforce' or 'enforced'
-    # silently meaning warn is exactly the operator error that would
-    # otherwise go unnoticed until an incident.
+    # Literal rather than str so a typo fails at config load. 'Enforce'
+    # or 'enforced' silently meaning warn is exactly the operator error
+    # that would otherwise go unnoticed until an incident.
     API_VALIDATION_MODE: Literal['off', 'warn', 'enforce'] = Field(
-        'warn',
+        'enforce',
         description=(
             'What the request validation layer does with input which does '
             'not match an endpoint\'s published parameter declarations. '
-            '"warn" logs what it would have rejected and changes nothing, '
-            'which is phase 3 of PLAN-api-input-validation; "enforce" '
-            'answers 400 (except for missing-required findings, which are '
-            'recorded and never enforced); "off" disables the layer '
-            'entirely, as a safety valve against unexpected log volume. '
-            'Leave this at "warn" until the warn log is understood -- see '
+            '"enforce" -- the default since phase 4 of '
+            'PLAN-api-input-validation -- answers 400 in the API error '
+            'shape, naming the offending parameter (except for '
+            'missing-required findings, which are recorded and never '
+            'enforced); "warn" logs what it would have rejected and '
+            'changes nothing; "off" disables the layer entirely. "warn" '
+            'and "off" are the rollback for an operator whose callers '
+            'send input the published declarations do not describe -- see '
             'docs/developer_guide/writing_an_endpoint.md.'
         )
     )

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_api_validation.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_api_validation.py
@@ -1,3 +1,5 @@
+# Copyright 2019 Michael Still and contributors
+
 import json
 
 from testtools import content
@@ -11,6 +13,15 @@ from shakenfist_client import apiclient
 # with something like "AuthEndpoint.post() got an unexpected keyword
 # argument 'zzz'" -- issue #3612 in its purest form. The enforced shape is
 # {"error": "<name>: not declared by this endpoint", "status": 400} instead.
+#
+# This is a subset of INTERPRETER_TEXT in
+# shakenfist/tests/external_api/test_request_validation.py, which asserts
+# the same property against the same responses in the unit suite. The list
+# is repeated rather than imported because this suite runs from an
+# installed shakenfist_ci package against a remote cluster and cannot
+# import the server's test tree; the entries dropped here are the ones
+# which describe a Python source layout the client cannot see anyway. Add
+# a marker to both, or the two will drift.
 _INTERPRETER_TEXT_MARKERS = (
     'got an unexpected keyword argument',
     'Traceback',
@@ -25,6 +36,10 @@ class TestUndeclaredParameterRefused(base.BaseNamespacedTestCase):
     on webargs' unknown=RAISE for a body key no declaration names: the
     request is refused with a 400 rather than reaching a handler that
     would raise a TypeError of its own.
+
+    Namespaced rather than admin on purpose: the refusal has to hold for
+    an ordinary caller, which is the one that would otherwise have been
+    handed a class and method name it has no other way to learn.
     """
 
     def __init__(self, *args, **kwargs):
@@ -35,6 +50,12 @@ class TestUndeclaredParameterRefused(base.BaseNamespacedTestCase):
         # GET /instances declares exactly one body parameter, "all". An
         # additional, undeclared key must be refused before the handler
         # is ever called.
+        #
+        # _request_url is private, and used deliberately: no public
+        # client method sends a key the API does not declare, which is
+        # the whole point of the property under test. A client refactor
+        # which renames it must update this test rather than assume
+        # nothing depends on it.
         try:
             self.test_client._request_url(
                 'GET', '/instances',

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_api_validation.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_api_validation.py
@@ -1,0 +1,119 @@
+import json
+
+from testtools import content
+
+from shakenfist_ci import base
+from shakenfist_client import apiclient
+
+
+# Text that must never appear in a validation refusal body. Before D14's
+# unknown=RAISE, an undeclared body key which reached its handler answered
+# with something like "AuthEndpoint.post() got an unexpected keyword
+# argument 'zzz'" -- issue #3612 in its purest form. The enforced shape is
+# {"error": "<name>: not declared by this endpoint", "status": 400} instead.
+_INTERPRETER_TEXT_MARKERS = (
+    'got an unexpected keyword argument',
+    'Traceback',
+    'TypeError',
+)
+
+
+class TestUndeclaredParameterRefused(base.BaseNamespacedTestCase):
+    """PLAN-api-input-validation-phase-04-enforce.md step 6, test 1.
+
+    API_VALIDATION_MODE defaults to 'enforce' (decision D16). D14 settled
+    on webargs' unknown=RAISE for a body key no declaration names: the
+    request is refused with a 400 rather than reaching a handler that
+    would raise a TypeError of its own.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs['namespace_prefix'] = 'apivalidation'
+        super().__init__(*args, **kwargs)
+
+    def test_undeclared_body_key_refused(self):
+        # GET /instances declares exactly one body parameter, "all". An
+        # additional, undeclared key must be refused before the handler
+        # is ever called.
+        try:
+            self.test_client._request_url(
+                'GET', '/instances',
+                data={'all': False, 'no_such_parameter': 'zzz'})
+            self.fail('Undeclared body parameter was not refused')
+        except apiclient.RequestMalformedException as e:
+            self.addDetail(
+                'response', content.text_content(str(e.text)))
+            self.assertEqual(400, e.status_code)
+
+            body = json.loads(e.text)
+            self.assertEqual(
+                {'error': 'no_such_parameter: not declared by this endpoint',
+                 'status': 400},
+                body)
+
+            for marker in _INTERPRETER_TEXT_MARKERS:
+                self.assertNotIn(
+                    marker, e.text,
+                    'Validation refusal leaked interpreter text: %s' % e.text)
+
+
+class TestNamespaceBodyParameterStillWorks(base.BaseNamespacedTestCase):
+    """PLAN-api-input-validation-phase-04-enforce.md step 6, test 2.
+
+    Regression test for issue #3739. Before step 1 of this phase declared
+    a `namespace` body parameter on every handler behind
+    `arg_is_instance_ref` / `arg_is_network_ref`, turning on D14's
+    unknown=RAISE would have refused the shipped client's own
+    cross-namespace lookups: `get_instance`, `delete_instance`,
+    `get_network` and `delete_network` all send `{'namespace': ...}` in
+    the request body once the server advertises the
+    `get-instance-namespace` / `get-network-namespace` capability tokens
+    (both unconditional in app.py's API_CAPABILITIES). This is the more
+    important of the two tests in step 6 -- it is what would have caught
+    #3739 before the warn window did.
+
+    `get_artifact` is not exercised here: unlike `get_instance` and
+    `get_network`, it takes no `namespace=` argument and sends no body at
+    all (see `TestArtifactLookupByName.test_artifact_system_creds_namespace_scoped`
+    in test_artifacts.py, which drives the artifact endpoint's namespace
+    body parameter directly via `_request_url` for that reason), so it
+    cannot regress this way.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs['namespace_prefix'] = 'apivalidationns'
+        super().__init__(*args, **kwargs)
+
+    def test_get_instance_with_namespace_body_parameter(self):
+        minimal_disk = [{'size': 1, 'type': 'disk'}]
+        inst = self.test_client.create_instance(
+            'namespace-body-param', 1, 128, None, minimal_disk, None, None,
+            namespace=self.namespace)
+        self.addDetail(
+            'inst',
+            content.text_content(json.dumps(inst, indent=4, sort_keys=True)))
+
+        # The shipped client's get_instance() sends {'namespace': ...} in
+        # the request body -- exactly the call #3739 broke.
+        found = self.system_client.get_instance(
+            inst['uuid'], namespace=self.namespace)
+        self.addDetail(
+            'found',
+            content.text_content(json.dumps(found, indent=4, sort_keys=True)))
+        self.assertEqual(inst['uuid'], found['uuid'])
+
+    def test_get_network_with_namespace_body_parameter(self):
+        net = self.test_client.allocate_network(
+            '192.168.250.0/24', True, True, 'namespace-body-param-net')
+        self.addDetail(
+            'net',
+            content.text_content(json.dumps(net, indent=4, sort_keys=True)))
+
+        # The shipped client's get_network() sends {'namespace': ...} in
+        # the request body -- exactly the call #3739 broke.
+        found = self.system_client.get_network(
+            net['uuid'], namespace=self.namespace)
+        self.addDetail(
+            'found',
+            content.text_content(json.dumps(found, indent=4, sort_keys=True)))
+        self.assertEqual(net['uuid'], found['uuid'])

--- a/shakenfist/external_api/app.py
+++ b/shakenfist/external_api/app.py
@@ -191,6 +191,15 @@ def _is_health_probe():
 # instead of redacted, is documented on api_base.handles_credentials.
 # It lives in base.py because base.py's log_request needs the same
 # answer, and two copies of this predicate would eventually disagree.
+#
+# Two redactions hang off this one predicate, and since phase 4 of
+# PLAN-api-input-validation they hold each other up. A validation
+# refusal puts the offending parameter's *name* -- which a buggy
+# caller can put secret-bearing material into, which is why
+# log_validation_findings redacts it on these routes -- verbatim into
+# the response body. The name stays out of the log stream only because
+# log_response_info below drops the whole body on the same predicate.
+# Narrowing either redaction without the other reopens the leak.
 _handles_credentials = api_base.handles_credentials
 REDACTED_BODY = api_base.REDACTED_BODY
 
@@ -689,7 +698,7 @@ def log_validation_findings(response):
     for finding in findings:
         fields = finding.fields()
         if redact:
-            fields['validation-parameter'] = '*****'
+            fields['validation-parameter'] = api_base.REDACTED_PARAMETER
         fields.update({
             'request-id': flask.request.environ.get(
                 'FLASK_REQUEST_ID', 'none'),

--- a/shakenfist/external_api/artifact.py
+++ b/shakenfist/external_api/artifact.py
@@ -1003,7 +1003,7 @@ class ArtifactMetadataEndpoint(api_base.Resource):
     @arg_is_artifact_ref
     @requires_artifact_ownership
     @api_base.log_token_use
-    def delete(self, artifact_ref=None, key=None, value=None, artifact_from_db=None):
+    def delete(self, artifact_ref=None, key=None, artifact_from_db=None):
         if not key:
             return sf_api.error(400, 'no key specified')
         artifact_from_db.add_event(

--- a/shakenfist/external_api/auth.py
+++ b/shakenfist/external_api/auth.py
@@ -722,7 +722,7 @@ class AuthMetadataEndpoint(api_base.Resource):
     @requires_namespace_ownership
     @arg_is_namespace
     @api_base.log_token_use
-    def delete(self, namespace=None, key=None, value=None, namespace_from_db=None):
+    def delete(self, namespace=None, key=None, namespace_from_db=None):
         if not key:
             return sf_api.error(400, 'no key specified')
         namespace_from_db.add_event(

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -1677,13 +1677,15 @@ def _enforce_scope(func, resource_class, override):
 def validate_request(func):
     """Check a request against its published parameter declarations.
 
-    Phase 3 of PLAN-api-input-validation. While API_VALIDATION_MODE is
-    'warn' -- the default, and what phase 3 ships -- this changes
-    nothing about any request: it records what it would have refused
-    and calls through. app.py emits those records once the response
-    status is known, because whether a finding represents a rejection
-    enforcement would *introduce* or a status code it would merely
-    *change* depends on what the request returned anyway.
+    PLAN-api-input-validation. While API_VALIDATION_MODE is 'enforce'
+    -- the default since phase 4 -- a finding other than
+    missing-required answers 400 in the API error shape, naming the
+    parameter. 'warn' is the operator's rollback and changes nothing
+    about any request: it records what it would have refused and calls
+    through. app.py emits those records once the response status is
+    known in both modes, because whether a finding represents a
+    rejection enforcement *introduced* or a status code it merely
+    *changed* depends on what the request returned anyway.
 
     First in Resource.method_decorators and so innermost, which puts it
     after authentication (an unauthenticated caller cannot probe the

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -65,6 +65,15 @@ HEALTH_PROBE_PATHS = ('/', '/livez', '/readyz', '/healthz')
 
 REDACTED_BODY = '...body not logged as this route handles credentials...'
 
+# What a validation finding's parameter name is replaced with on a
+# credential-carrying route. The name is client supplied, so a buggy
+# caller can put secret-bearing material in a key position; the reason
+# code is what a reader of either the log or the namespace's events
+# actually needs. app.py's log_validation_findings and
+# _record_refused_token_use below both use it, so the two records of
+# one refusal cannot disagree about what is safe to say.
+REDACTED_PARAMETER = '*****'
+
 
 # Request and response bodies are logged verbatim by app.py, and the
 # parsed body is logged again as kwargs by log_request below. That is
@@ -888,6 +897,25 @@ def verify_token(func):
     return wrapper
 
 
+def _token_use_event(ns, keyname: str, message: str,
+                     extra: Optional[dict[str, Any]] = None) -> None:
+    """Record a use of a token against the namespace which owns it.
+
+    NOTE(mikal): the presented token must never appear in the event.
+    The key name identifies which credential was used, which is what
+    an audit reader actually needs; the token itself would be
+    replayable by anyone who can read the namespace's events.
+    """
+    fields = {
+        'keyname': keyname,
+        'method': flask.request.environ['REQUEST_METHOD'],
+        'path': flask.request.environ['PATH_INFO'],
+        'remote-address': flask.request.remote_addr
+    }
+    fields.update(extra or {})
+    ns.add_event(EVENT_TYPE_AUDIT, message, extra=fields)
+
+
 def log_token_use(func):
     def wrapper(*args, **kwargs):
         namespace, keyname = parse_jwt_identity()
@@ -896,22 +924,70 @@ def log_token_use(func):
         if not ns:
             return sf_api.error(401, 'authenticated namespace not known')
 
-        # NOTE(mikal): the presented token must never appear in the
-        # event. The key name identifies which credential was used,
-        # which is what an audit reader actually needs; the token
-        # itself would be replayable by anyone who can read the
-        # namespace's events.
-        ns.add_event(
-            EVENT_TYPE_AUDIT, 'token used to authenticate request',
-            extra={
-                'keyname': keyname,
-                'method': flask.request.environ['REQUEST_METHOD'],
-                'path': flask.request.environ['PATH_INFO'],
-                'remote-address': flask.request.remote_addr
-            })
-
+        _token_use_event(ns, keyname, 'token used to authenticate request')
         return func(*args, **kwargs)
     return wrapper
+
+
+def _record_refused_token_use(finding) -> None:
+    """Audit a request validation refused, since no handler will.
+
+    log_token_use is the innermost per-method decorator, so a refusal
+    returned from validate_request -- which sits outside all of them --
+    means the namespace never sees the 'token used to authenticate
+    request' event it would have seen had the request been well formed.
+    Without this an authenticated caller could send malformed requests
+    indefinitely and leave no trace in the namespace's own audit trail,
+    only in sf-api's log stream, which carries neither the key name nor
+    the remote address. Preserving event coverage is a standing goal of
+    this project, and enforcement is not a licence to lose it.
+
+    The event names the refusal rather than borrowing log_token_use's
+    message, because the two are different facts: this request did not
+    reach a handler. It is recorded on every refusal, including for the
+    handlers which carry no log_token_use of their own -- what the
+    reader needs is that the credential was used, and a decorator the
+    request never reached cannot tell them.
+
+    The parameter name is redacted on a credential-carrying route, for
+    the reason handles_credentials() gives and app.py's
+    log_validation_findings already acts on: the name is client
+    supplied, a buggy caller can put secret-bearing material in a key
+    position, and a namespace event is readable by anyone who can read
+    the namespace. The reason code carries what an audit reader needs.
+
+    Nothing here may turn a 400 into anything else, so every failure is
+    swallowed. An unauthenticated caller (a @public endpoint has no JWT
+    to parse) is the ordinary case rather than an error, and the
+    database being unavailable must not upgrade a malformed request
+    into a 503.
+    """
+    try:
+        namespace, keyname = parse_jwt_identity()
+    except Exception:
+        # No JWT to attribute this to: a @public endpoint, which
+        # _authenticate_unless_public let through without one.
+        return
+
+    try:
+        ns = Namespace.from_db(namespace)
+        if not ns:
+            return
+        _token_use_event(
+            ns, keyname, 'request refused by input validation',
+            extra={
+                'validation-reason': finding.reason,
+                'validation-parameter': (
+                    REDACTED_PARAMETER if handles_credentials()
+                    else finding.parameter)
+            })
+    except Exception:
+        # Logged rather than swallowed silently: an audit event which
+        # cannot be written is worth knowing about, and this is the
+        # only remaining record that the request happened at all.
+        LOG.with_fields({
+            'namespace': namespace
+        }).exception('Failed to record audit event for a refused request')
 
 
 # The four descriptions of the `namespace` body parameter which the ref
@@ -1687,6 +1763,19 @@ def validate_request(func):
     rejection enforcement *introduced* or a status code it merely
     *changed* depends on what the request returned anyway.
 
+    A refusal names the **first** enforceable finding only, so a
+    request with several problems is fixed one round trip at a time.
+    Every finding is emitted to the log either way, so an operator sees
+    the whole picture even when the caller does not. Answering with all
+    of them would mean deciding on a wire format for a list of errors,
+    which is a change to the API's error shape rather than to this
+    layer; phase 6 can have that argument if callers ask for it.
+
+    A refused request never reaches a per-method decorator, and
+    log_token_use is one of those, so the namespace audit event that a
+    well formed request would have written is recorded here instead --
+    see _record_refused_token_use.
+
     First in Resource.method_decorators and so innermost, which puts it
     after authentication (an unauthenticated caller cannot probe the
     schema) and before every per-method decorator. That ordering is
@@ -1760,6 +1849,7 @@ def validate_request(func):
                            if f.reason != validation.MISSING_REQUIRED]
             if enforceable:
                 first = enforceable[0]
+                _record_refused_token_use(first)
                 return sf_api.error(
                     400, '%s: %s' % (first.parameter, first.detail))
 

--- a/shakenfist/external_api/blob.py
+++ b/shakenfist/external_api/blob.py
@@ -458,7 +458,7 @@ class BlobMetadataEndpoint(api_base.Resource):
         requires_admin=True))
     @arg_is_blob_uuid
     @api_base.log_token_use
-    def delete(self, blob_uuid=None, key=None, value=None, blob_from_db=None):
+    def delete(self, blob_uuid=None, key=None, blob_from_db=None):
         if not key:
             return sf_api.error(400, 'no key specified')
         blob_from_db.add_event(

--- a/shakenfist/external_api/interface.py
+++ b/shakenfist/external_api/interface.py
@@ -212,7 +212,7 @@ class InterfaceMetadataEndpoint(api_base.Resource):
          (404, 'Interface not found.', None)],
         requires_admin=True))
     @api_base.log_token_use
-    def delete(self, interface_uuid=None, key=None, value=None):
+    def delete(self, interface_uuid=None, key=None):
         ni, n, err = api_util.safe_get_network_interface(interface_uuid)
         if err:
             return err

--- a/shakenfist/external_api/node.py
+++ b/shakenfist/external_api/node.py
@@ -286,7 +286,7 @@ class NodeMetadataEndpoint(api_base.Resource):
         requires_admin=True))
     @api_base.caller_is_admin
     @api_base.log_token_use
-    def delete(self, node=None, key=None, value=None):
+    def delete(self, node=None, key=None):
         if not key:
             return sf_api.error(400, 'no key specified')
         n = Node.from_db(node, suppress_failure_audit=True)

--- a/shakenfist/external_api/validation.py
+++ b/shakenfist/external_api/validation.py
@@ -301,14 +301,15 @@ def build_registry(app: Any) -> dict[tuple[str, str], CompiledEndpoint]:
 
 
 # ---------------------------------------------------------------------
-# Warn-only checking.
+# Checking.
 #
-# Nothing below rejects anything while API_VALIDATION_MODE is 'warn',
-# which is the default and is what phase 3 ships. The findings are
-# recorded on flask.g and emitted once the response status is known,
-# because "what did this request return anyway" is what separates a
-# rejection enforcement would introduce from a status code it would
-# merely change -- and at validation time that is not yet known.
+# Nothing below rejects anything: check() is pure and returns findings,
+# and validate_request in base.py is the only place which decides what
+# to do with them. The findings are recorded on flask.g and emitted
+# once the response status is known, because "what did this request
+# return anyway" is what separates a rejection enforcement introduced
+# from a status code it merely changed -- and at validation time that
+# is not yet known.
 
 # The request-scoped hand-offs, named like base.py's
 # _RECORDED_EXCEPTION_FIELDS because they are the same pattern.

--- a/shakenfist/external_api/validation.py
+++ b/shakenfist/external_api/validation.py
@@ -377,6 +377,38 @@ class Finding:
         }
 
 
+def _flatten_messages(parameter: str, messages: Any) -> list[tuple[str, str]]:
+    """Flatten marshmallow's error structure into (name, detail) leaves.
+
+    validate() answers a list of strings when a field itself is wrong,
+    but a dict keyed by index or sub-field when a *container's elements*
+    are wrong -- `{0: ['Not a valid mapping type.']}` for a bad entry in
+    an arrayofdict. Rendering that with str() puts a Python dict repr in
+    the detail, which the enforce flip of phase 4 turned from a log line
+    into the caller's error message: `disk: {0: ['Not a valid mapping
+    type.']}`. Naming the offending element instead gives
+    `disk[0]: Not a valid mapping type.`
+
+    Integer keys index a sequence and render as `name[0]`; anything else
+    is a sub-field and renders as `name.key`. The recursion terminates
+    because marshmallow's leaves are always lists of strings, and the
+    non-list, non-dict branch keeps a malformed leaf from raising inside
+    the validator -- which _schema_findings' caller must never do.
+    """
+    if isinstance(messages, dict):
+        flattened = []
+        for key, nested in sorted(messages.items(), key=lambda kv: str(kv[0])):
+            if isinstance(key, int):
+                name = '%s[%d]' % (parameter, key)
+            else:
+                name = '%s.%s' % (parameter, key)
+            flattened.extend(_flatten_messages(name, nested))
+        return flattened
+    if isinstance(messages, list):
+        return [(parameter, '; '.join(str(m) for m in messages))]
+    return [(parameter, str(messages))]
+
+
 def _schema_findings(schema: Optional[marshmallow.Schema],
                      supplied: dict[str, Any]) -> list[Finding]:
     if schema is None:
@@ -398,11 +430,9 @@ def _schema_findings(schema: Optional[marshmallow.Schema],
             'Request validation raised internally; no findings reported')
         return []
     for parameter, messages in mismatches.items():
-        findings.append(Finding(
-            TYPE_MISMATCH, str(parameter),
-            '; '.join(messages) if isinstance(messages, list)
-            else str(messages),
-            known.get(parameter)))
+        for name, detail in _flatten_messages(str(parameter), messages):
+            findings.append(Finding(
+                TYPE_MISMATCH, name, detail, known.get(parameter)))
     return findings
 
 

--- a/shakenfist/external_api/validation.py
+++ b/shakenfist/external_api/validation.py
@@ -343,6 +343,18 @@ MAX_PARAMETER_NAME = 64
 # count, so the measurement still learns the request happened.
 MAX_UNKNOWN_PARAMETER_FINDINGS = 20
 
+# The most type-mismatch findings one schema check can produce. A
+# container's elements are each reported separately (see
+# _flatten_messages), so a single declared parameter carrying a large
+# enough array puts one log line per bad element into centralised
+# logging -- exactly the property MAX_UNKNOWN_PARAMETER_FINDINGS exists
+# to bound, arriving by a different route once phase 4 taught the
+# flattener to name elements. Nothing bounds a request body's size, so
+# a thousand-element disk list is a thousand findings without this.
+# The overflow is summarised in one finding carrying the count, in the
+# same shape as the unknown-parameter overflow above.
+MAX_TYPE_MISMATCH_FINDINGS = 20
+
 
 class Finding:
     """One thing validation would have refused.
@@ -377,8 +389,26 @@ class Finding:
         }
 
 
-def _flatten_messages(parameter: str, messages: Any) -> list[tuple[str, str]]:
-    """Flatten marshmallow's error structure into (name, detail) leaves.
+def _sort_key(key: Any) -> tuple[int, int, str]:
+    """Order marshmallow's error keys the way a caller reads them.
+
+    Sequence indices are integers and must stay in numeric order:
+    sorting them as strings gives 0, 1, 10, 11, 2, and since
+    enforcement answers with the first finding only, a caller whose
+    third and eleventh disk specifications are both malformed would be
+    told about `disk[10]`. Integers sort ahead of sub-field names,
+    which cannot collide with them because marshmallow keys a mapping
+    error by field name and a sequence error by index.
+    """
+    if isinstance(key, int):
+        return (0, key, '')
+    return (1, 0, str(key))
+
+
+def _flatten_messages(parameter: str, messages: Any,
+                      path: tuple[Any, ...] = ()
+                      ) -> list[tuple[str, str, tuple[Any, ...]]]:
+    """Flatten marshmallow's error structure into (name, detail, path) leaves.
 
     validate() answers a list of strings when a field itself is wrong,
     but a dict keyed by index or sub-field when a *container's elements*
@@ -394,19 +424,51 @@ def _flatten_messages(parameter: str, messages: Any) -> list[tuple[str, str]]:
     because marshmallow's leaves are always lists of strings, and the
     non-list, non-dict branch keeps a malformed leaf from raising inside
     the validator -- which _schema_findings' caller must never do.
+
+    Each leaf also carries the sequence of keys walked to reach it, so
+    the caller can index back into the supplied value and report the
+    *element's* type rather than the container's. That path is the
+    only reason a finding built from a leaf can say anything true
+    about the value at all, since the parameter name has by then been
+    rewritten into a display form which cannot be looked up.
     """
     if isinstance(messages, dict):
         flattened = []
-        for key, nested in sorted(messages.items(), key=lambda kv: str(kv[0])):
+        for key, nested in sorted(messages.items(),
+                                  key=lambda kv: _sort_key(kv[0])):
             if isinstance(key, int):
                 name = '%s[%d]' % (parameter, key)
             else:
                 name = '%s.%s' % (parameter, key)
-            flattened.extend(_flatten_messages(name, nested))
+            flattened.extend(_flatten_messages(name, nested, path + (key,)))
         return flattened
     if isinstance(messages, list):
-        return [(parameter, '; '.join(str(m) for m in messages))]
-    return [(parameter, str(messages))]
+        return [(parameter, '; '.join(str(m) for m in messages), path)]
+    return [(parameter, str(messages), path)]
+
+
+def _element_value(container: Any, path: tuple[Any, ...]) -> Any:
+    """The value at `path` inside `container`, or the container itself.
+
+    A finding carries the offending value's type and never its value
+    (decision D5), so this exists purely to make that type describe
+    what actually failed: `disk[0]` reported as a `list` -- the type of
+    the whole array -- is the telemetry being confidently wrong about
+    the one case element naming was added for.
+
+    Falls back to the container when the path does not resolve, which
+    is the honest answer rather than None: marshmallow can key an error
+    by a name the supplied value has no entry for (a required sub-field
+    that is absent), and "the container's type" is still true of
+    something the caller sent.
+    """
+    value = container
+    for key in path:
+        try:
+            value = value[key]
+        except (TypeError, KeyError, IndexError):
+            return container
+    return value
 
 
 def _schema_findings(schema: Optional[marshmallow.Schema],
@@ -415,7 +477,6 @@ def _schema_findings(schema: Optional[marshmallow.Schema],
         return []
     known = {name: value for name, value in supplied.items()
              if name in schema.fields}
-    findings = []
     try:
         mismatches = schema.validate(known)
     except Exception:
@@ -429,10 +490,26 @@ def _schema_findings(schema: Optional[marshmallow.Schema],
             'parameters': sorted(known)}).exception(
             'Request validation raised internally; no findings reported')
         return []
+    leaves = []
     for parameter, messages in mismatches.items():
-        for name, detail in _flatten_messages(str(parameter), messages):
-            findings.append(Finding(
-                TYPE_MISMATCH, name, detail, known.get(parameter)))
+        for name, detail, path in _flatten_messages(str(parameter), messages):
+            leaves.append((name, detail, parameter, path))
+
+    # Sliced before the values are resolved, so the elements past the
+    # bound cost a tuple each and nothing more. marshmallow has already
+    # built its own entry per bad element by this point, so the leaves
+    # add no order of magnitude to what a large body costs; what the
+    # bound is protecting is the log stream, where each finding is a
+    # line.
+    findings = [Finding(TYPE_MISMATCH, name, detail,
+                        _element_value(known.get(parameter), path))
+                for name, detail, parameter, path
+                in leaves[:MAX_TYPE_MISMATCH_FINDINGS]]
+    if len(leaves) > MAX_TYPE_MISMATCH_FINDINGS:
+        findings.append(Finding(
+            TYPE_MISMATCH, '(overflow)',
+            '%d further mismatching values not reported individually'
+            % (len(leaves) - MAX_TYPE_MISMATCH_FINDINGS)))
     return findings
 
 

--- a/shakenfist/tests/base.py
+++ b/shakenfist/tests/base.py
@@ -5,6 +5,8 @@ from unittest import mock
 from pydantic import SecretStr
 import testtools
 
+from shakenfist.config import config
+
 
 class ShakenFistTestCase(testtools.TestCase):
     def _reject_secret_operand(self, needle, haystack, method):
@@ -81,6 +83,26 @@ class ShakenFistTestCase(testtools.TestCase):
             return_value=None)
         self.mock_record_exception = self.mock_record_exception_patcher.start()
         self.addCleanup(self.mock_record_exception_patcher.stop)
+
+    def set_validation_mode(self, mode):
+        """Run the rest of this test with API_VALIDATION_MODE at `mode`.
+
+        The mode defaults to 'enforce' since phase 4 of
+        PLAN-api-input-validation, which means several handlers' own
+        input guards are no longer reachable in the default
+        configuration -- request validation answers ahead of them. They
+        are still what answers when an operator rolls back to 'warn',
+        so the tests which assert their messages say which mode they
+        are about rather than depending on a default. A rollback path
+        asserted only in prose is a rollback path that rots.
+
+        Restored on cleanup: config is a process-wide singleton, so a
+        test which leaves it changed changes every test that runs
+        after it in the same worker.
+        """
+        saved = config.API_VALIDATION_MODE
+        self.addCleanup(setattr, config, 'API_VALIDATION_MODE', saved)
+        config.API_VALIDATION_MODE = mode
 
 
 class SpoolRootMixin:

--- a/shakenfist/tests/external_api/test_agent_operation_parameters.py
+++ b/shakenfist/tests/external_api/test_agent_operation_parameters.py
@@ -166,6 +166,19 @@ class AgentOperationParametersTestCase(base.ShakenFistTestCase):
             resp.get_json()['error'])
         new.assert_not_called()
 
+    def test_the_ceiling_is_enforced_by_the_handler_in_warn_mode(self):
+        # The rollback path: with validation warning rather than
+        # enforcing, the handler's own guard is what refuses this, and
+        # it names the configuration option an operator has to change.
+        self.set_validation_mode('warn')
+
+        resp, new = self._execute(
+            deadline_seconds=config.AGENT_OPERATION_MAX_DEADLINE + 1)
+        self.assertEqual(400, resp.status_code, resp.get_json())
+        self.assertIn(
+            'AGENT_OPERATION_MAX_DEADLINE', resp.get_json()['error'])
+        new.assert_not_called()
+
     def test_an_unparsable_deadline_is_a_400_not_a_500(self):
         for value in ('soon', ['60'], {'seconds': 60}, True):
             with self.subTest(value=value):

--- a/shakenfist/tests/external_api/test_agent_operation_parameters.py
+++ b/shakenfist/tests/external_api/test_agent_operation_parameters.py
@@ -151,12 +151,19 @@ class AgentOperationParametersTestCase(base.ShakenFistTestCase):
 
     def test_a_deadline_above_the_operator_ceiling_is_refused(self):
         # Issue #4074: the ceiling published as the parameter's maximum
-        # is backed by a 400 from the handler, like the minimum.
+        # is backed by a 400, like the minimum. Since phase 4 of
+        # PLAN-api-input-validation that 400 comes from the published
+        # bound itself rather than from the handler's guard, which is
+        # the stronger version of the same property -- the two can no
+        # longer disagree. The handler's guard remains and answers when
+        # API_VALIDATION_MODE is not 'enforce'.
         resp, new = self._execute(
             deadline_seconds=config.AGENT_OPERATION_MAX_DEADLINE + 1)
         self.assertEqual(400, resp.status_code, resp.get_json())
         self.assertIn(
-            'AGENT_OPERATION_MAX_DEADLINE', resp.get_json()['error'])
+            'deadline_seconds: Must be greater than or equal to 0 and less '
+            'than or equal to %d' % config.AGENT_OPERATION_MAX_DEADLINE,
+            resp.get_json()['error'])
         new.assert_not_called()
 
     def test_an_unparsable_deadline_is_a_400_not_a_500(self):
@@ -167,12 +174,17 @@ class AgentOperationParametersTestCase(base.ShakenFistTestCase):
                 new.assert_not_called()
 
     def test_execute_does_not_accept_a_progress_timeout(self):
-        # Pins decision 4 in code rather than in prose. An undeclared
-        # body key becomes an unexpected keyword argument in the kwargs
-        # merge, which is a 400 -- so this asserts the parameter is
-        # genuinely absent, not merely undocumented.
+        # Pins decision 4 in code rather than in prose. Since phase 4 of
+        # PLAN-api-input-validation an undeclared body key is refused by
+        # name before the handler runs -- so this asserts the parameter
+        # is genuinely absent, not merely undocumented, and that the
+        # refusal says so in the API's own words rather than the
+        # interpreter's.
         resp, new = self._execute(progress_timeout_seconds=30)
         self.assertEqual(400, resp.status_code, resp.get_json())
+        self.assertEqual(
+            'progress_timeout_seconds: not declared by this endpoint',
+            resp.get_json()['error'])
         new.assert_not_called()
 
     def test_get_accepts_both_parameters(self):

--- a/shakenfist/tests/external_api/test_auth.py
+++ b/shakenfist/tests/external_api/test_auth.py
@@ -78,6 +78,22 @@ class AuthTestCase(base.ShakenFistTestCase):
             '/auth', data=json.dumps({'namespace': 'banana', 'keyyy': 'pwd'}))
         self.assertEqual(400, resp.status_code)
 
+    def test_post_auth_key_non_string_in_warn_mode(self):
+        # The handler's guard is what answers on the rollback path, so
+        # it is asserted at the mode where it is reachable rather than
+        # only described in a comment.
+        self.set_validation_mode('warn')
+
+        resp = self.client.post(
+            '/auth', data=json.dumps({'namespace': 'banana', 'key': 1234}))
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual(
+            {
+                'error': 'key is not a string',
+                'status': 400
+            },
+            resp.get_json())
+
     def test_post_auth_key_non_string(self):
         # Phase 4 of PLAN-api-input-validation: the declared type is
         # what refuses this now, so the wording is the validator's
@@ -576,6 +592,17 @@ class AuthKeysTestCase(base.ShakenFistTestCase):
         self.assertEqual(400, resp.status_code)
         self.assertEqual('expiry: Not a valid number.',
                          resp.get_json()['error'])
+
+    def test_add_key_rejects_a_non_numeric_expiry_in_warn_mode(self):
+        # The handler's own guard, which is what answers once an
+        # operator rolls back. Enforcement hides it, so without this
+        # test nothing exercises the rollback path at all.
+        self.set_validation_mode('warn')
+
+        resp = self._add_key('bogus', 'sekrit', expiry='tomorrow')
+
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual('expiry is not a number', resp.get_json()['error'])
 
     def test_add_key_rejects_a_boolean_expiry(self):
         # bool is a subclass of int, so "expiry": true would otherwise

--- a/shakenfist/tests/external_api/test_auth.py
+++ b/shakenfist/tests/external_api/test_auth.py
@@ -79,12 +79,17 @@ class AuthTestCase(base.ShakenFistTestCase):
         self.assertEqual(400, resp.status_code)
 
     def test_post_auth_key_non_string(self):
+        # Phase 4 of PLAN-api-input-validation: the declared type is
+        # what refuses this now, so the wording is the validator's
+        # rather than the handler's. The handler's own guard is still
+        # there and still answers when API_VALIDATION_MODE is not
+        # 'enforce'.
         resp = self.client.post(
             '/auth', data=json.dumps({'namespace': 'banana', 'key': 1234}))
         self.assertEqual(400, resp.status_code)
         self.assertEqual(
             {
-                'error': 'key is not a string',
+                'error': 'key: Not a valid string.',
                 'status': 400
             },
             resp.get_json())
@@ -563,10 +568,14 @@ class AuthKeysTestCase(base.ShakenFistTestCase):
                          resp.get_json()['error'])
 
     def test_add_key_rejects_a_non_numeric_expiry(self):
+        # The declared type refuses this ahead of the handler's own
+        # guard now that validation enforces, so the message is the
+        # validator's. Both still say 400 and both still name expiry.
         resp = self._add_key('bogus', 'sekrit', expiry='tomorrow')
 
         self.assertEqual(400, resp.status_code)
-        self.assertEqual('expiry is not a number', resp.get_json()['error'])
+        self.assertEqual('expiry: Not a valid number.',
+                         resp.get_json()['error'])
 
     def test_add_key_rejects_a_boolean_expiry(self):
         # bool is a subclass of int, so "expiry": true would otherwise
@@ -574,7 +583,8 @@ class AuthKeysTestCase(base.ShakenFistTestCase):
         resp = self._add_key('boolean', 'sekrit', expiry=True)
 
         self.assertEqual(400, resp.status_code)
-        self.assertEqual('expiry is not a number', resp.get_json()['error'])
+        self.assertEqual('expiry: Not a valid number.',
+                         resp.get_json()['error'])
 
     # The key update endpoint had two bugs which meant it never worked:
     # it tested membership against the wrong level of the keys dict, and
@@ -784,10 +794,13 @@ class ExternalApiTestCase(base.ShakenFistTestCase):
 
     @mock.patch('shakenfist.locks.ClusterLock')
     def test_put_namespace_metadata(self, mock_get_lock):
+        # The key rides in the URL. Sending it in the body as well is
+        # a body-path collision, which decision D18 of
+        # PLAN-api-input-validation refuses; shakenfist_client's
+        # _set_metadata sends {'value': ...} and nothing else.
         resp = self.client.put('/auth/namespaces/system/metadata/foo',
                                headers={'Authorization': self.auth_token},
                                data=json.dumps({
-                                   'key': 'foo',
                                    'value': 'bar'
                                }))
         self.assertEqual(None, resp.get_json())

--- a/shakenfist/tests/external_api/test_claims.py
+++ b/shakenfist/tests/external_api/test_claims.py
@@ -163,6 +163,30 @@ class ClaimCreateTestCase(ClaimEndpointTestCase):
                 'expires_in_seconds: Must be greater than or equal to 1',
                 resp.get_json()['error'])
 
+    def test_the_handlers_own_guards_answer_in_warn_mode(self):
+        """The rollback path for the three refusals above.
+
+        Enforcement answers ahead of these guards, so in the default
+        configuration their messages are unreachable and nothing else
+        in the tree asserts them (the 'cannot be negative' hits in
+        test_mariadb_capacity_claims.py are the database layer's own
+        guard, not this one). An operator who sets 'warn' gets these
+        answers back, so they are pinned at that mode.
+        """
+        self.set_validation_mode('warn')
+
+        resp = self._create(limit_cpus=-1)
+        self.assertEqual(400, resp.status_code)
+        self.assertIn('cannot be negative', resp.get_json()['error'])
+
+        resp = self._create(limit_cpus=True)
+        self.assertEqual(400, resp.status_code)
+        self.assertIn('not an integer', resp.get_json()['error'])
+
+        resp = self._create(expires_in_seconds=0)
+        self.assertEqual(400, resp.status_code)
+        self.assertIn('must be positive', resp.get_json()['error'])
+
     def test_an_unknown_namespace_is_not_found(self):
         resp = self._create(namespace='nosuchnamespace')
         self.assertEqual(404, resp.status_code)

--- a/shakenfist/tests/external_api/test_claims.py
+++ b/shakenfist/tests/external_api/test_claims.py
@@ -131,17 +131,26 @@ class ClaimCreateTestCase(ClaimEndpointTestCase):
             self.assertEqual(400, resp.status_code, field)
             self.assertIn(field, resp.get_json()['error'])
 
+    # The three refusals below are now made by the published parameter
+    # declarations rather than by the handler's own guards, because
+    # phase 4 of PLAN-api-input-validation runs validation ahead of
+    # every per-method decorator. The guards remain and still answer
+    # when API_VALIDATION_MODE is not 'enforce', so what is asserted
+    # here is the bound rather than either wording.
+
     def test_a_negative_limit_is_refused(self):
         resp = self._create(limit_cpus=-1)
         self.assertEqual(400, resp.status_code)
-        self.assertIn('cannot be negative', resp.get_json()['error'])
+        self.assertIn('limit_cpus: Must be greater than or equal to 0',
+                      resp.get_json()['error'])
 
     def test_a_boolean_limit_is_refused(self):
         # bool is an int in Python, so "limit_cpus": true would
         # otherwise quietly claim one cpu.
         resp = self._create(limit_cpus=True)
         self.assertEqual(400, resp.status_code)
-        self.assertIn('not an integer', resp.get_json()['error'])
+        self.assertIn('limit_cpus: Not a valid integer',
+                      resp.get_json()['error'])
 
     def test_a_non_positive_expiry_is_refused(self):
         # A claim that is expired the moment it exists holds capacity
@@ -150,7 +159,9 @@ class ClaimCreateTestCase(ClaimEndpointTestCase):
         for value in [0, -60]:
             resp = self._create(expires_in_seconds=value)
             self.assertEqual(400, resp.status_code, value)
-            self.assertIn('must be positive', resp.get_json()['error'])
+            self.assertIn(
+                'expires_in_seconds: Must be greater than or equal to 1',
+                resp.get_json()['error'])
 
     def test_an_unknown_namespace_is_not_found(self):
         resp = self._create(namespace='nosuchnamespace')

--- a/shakenfist/tests/external_api/test_parameter_declarations.py
+++ b/shakenfist/tests/external_api/test_parameter_declarations.py
@@ -26,19 +26,22 @@ REPO_ROOT = os.path.abspath(os.path.join(
 
 # Handler kwargs which are deliberately not part of the published API.
 #
-# The metadata delete endpoints accept `value` and none of them read it.
-# It should be removed from the signatures rather than documented, but not
-# until phase 4 of PLAN-api-input-validation: today, removing it means a
-# caller who sends it gets `delete() got an unexpected keyword argument`
-# as a 400, which is the leak that plan exists to remove. Once the schema
-# layer rejects unknown parameters cleanly, this list should be empty.
-UNDECLARED_BY_DESIGN = {
-    ('ArtifactMetadataEndpoint', 'delete', 'value'),
-    ('AuthMetadataEndpoint', 'delete', 'value'),
-    ('BlobMetadataEndpoint', 'delete', 'value'),
-    ('InterfaceMetadataEndpoint', 'delete', 'value'),
-    ('NodeMetadataEndpoint', 'delete', 'value'),
-}
+# Empty, and phase 4 of PLAN-api-input-validation is what emptied it.
+# Its five entries were the `value` kwarg the metadata delete handlers
+# accepted and none of them read. Removing them could not be done while
+# validation was warn-only, because a caller who sent `value` on a
+# metadata delete would then have received `delete() got an unexpected
+# keyword argument` as a 400 -- the exact leak that plan exists to
+# remove. With enforcement on, decision D14 answers `value: not
+# declared by this endpoint` before the handler either way, so the
+# signatures were cleaned up in the same commit as the flip.
+#
+# An entry here is a kwarg a handler's signature names and the handler
+# ignores. It is not an escape hatch for a parameter a caller can
+# actually use: a kwarg a decorator pops has no opt-out at all, which
+# test_accepted_parameters_are_declared explains where it enforces it.
+# Keep this empty if you can.
+UNDECLARED_BY_DESIGN: set[tuple[str, str, str]] = set()
 
 # Not deferred to phase 4 after all, though it long said it was:
 # InstanceSnapshotEndpoint.post treats an explicit `thin: false` as

--- a/shakenfist/tests/external_api/test_request_validation.py
+++ b/shakenfist/tests/external_api/test_request_validation.py
@@ -1,11 +1,15 @@
 # Copyright 2019 Michael Still and contributors
 
-"""Warn-only request validation.
+"""Request validation, in both of its modes.
 
-Phase 3 PR 3. The property that matters most here is a negative one:
-with API_VALIDATION_MODE at its default of 'warn', no request behaves
-differently than it did before this layer existed. The findings are
-recorded and logged; nothing acts on them until phase 4.
+Phase 3 built the layer and rejected nothing; phase 4 flipped
+API_VALIDATION_MODE's default to 'enforce', which is what the
+EnforcedValidationTestCase class at the bottom of this file pins.
+The warn-mode properties above it are still worth keeping -- 'warn'
+is the operator's rollback, and its promise is that no request behaves
+differently than it did before the layer existed -- so each of those
+tests now sets the mode it is about rather than relying on a default
+which has moved.
 """
 
 import json
@@ -66,14 +70,17 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
         return response, findings
 
     def test_warn_mode_changes_no_response(self):
-        """The whole point of the phase.
+        """The promise 'warn' still makes, now that it is the rollback.
 
         A body carrying an undeclared key produces a finding, and the
         response is byte for byte what it was before validation
         existed: the 400 log_request's merge has always produced, with
-        the interpreter's own text. Phase 4 replaces that message; phase
-        3 must not.
+        the interpreter's own text. That interpreter text is the defect
+        this plan exists to remove, so an operator who rolls back to
+        'warn' gets the old behaviour back in full, warts included.
         """
+        config.API_VALIDATION_MODE = 'warn'
+
         response, findings = self._post_auth(
             {'namespace': 'sys', 'key': 'k', 'zzz': 1})
 
@@ -109,6 +116,8 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
             [(f.reason, f.parameter) for f in findings])
 
     def test_a_wrong_type_is_reported(self):
+        config.API_VALIDATION_MODE = 'warn'
+
         response, findings = self._post_auth(
             {'namespace': 'sys', 'key': 5})
 
@@ -440,6 +449,8 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
         carrying what the request returned anyway is what separates a
         rejection enforcement would introduce from a status code it
         would merely change."""
+        config.API_VALIDATION_MODE = 'warn'
+
         with mock.patch.object(external_api, 'LOG') as log:
             response, findings = self._post_auth(
                 {'namespace': 'sys', 'key': 'k', 'zzz': 1})
@@ -516,21 +527,32 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
         self.assertEqual([], emitted)
 
 
-class AuthenticatedValidationTestCase(base.ShakenFistTestCase):
-    """Request-level properties which need the full decorator stack.
+class AuthenticatedStackTestCase(base.ShakenFistTestCase):
+    """A real authenticated client against the whole decorator stack.
 
-    The first review round found the deployed behaviour and the
-    behaviour of a handler tested in isolation were different answers:
-    _webargs_error built a perfect 400 which
-    suppress_exceptions_to_client then swallowed into a 500. Everything
-    here therefore drives a real authenticated request end to end and
-    asserts only what a client sees or what actually reached a spy.
+    The first review round of phase 3 found the deployed behaviour and
+    the behaviour of a handler tested in isolation were different
+    answers: _webargs_error built a perfect 400 which
+    suppress_exceptions_to_client then swallowed into a 500. Phase 4's
+    step 4 brief repeats the rule for the enforcement tests, so both
+    subclasses below drive a real request end to end and assert only
+    what a client sees or what actually reached a spy.
+
+    Carries no tests of its own: the two subclasses are the same
+    fixture at the two modes that do something.
     """
+
+    #: The mode this class's requests run in.
+    mode = 'warn'
 
     def setUp(self):
         super().setUp()
         external_api.TESTING = True
         external_api.app.testing = True
+
+        self.saved_mode = config.API_VALIDATION_MODE
+        self.addCleanup(self._restore_mode)
+        config.API_VALIDATION_MODE = self.mode
 
         self.mock_mariadb = MockMariaDB(self, node_count=1)
         self.mock_mariadb.setup()
@@ -542,6 +564,29 @@ class AuthenticatedValidationTestCase(base.ShakenFistTestCase):
             data=json.dumps({'namespace': 'system', 'key': 'bar'}))
         self.assertEqual(200, resp.status_code)
         self.token = 'Bearer %s' % resp.get_json()['access_token']
+
+    def _restore_mode(self):
+        config.API_VALIDATION_MODE = self.saved_mode
+
+    def _spy_on_check(self):
+        """Collect the findings check() produced, without changing them."""
+        findings = []
+        real = validation.check
+
+        def spy(*args, **kwargs):
+            out = real(*args, **kwargs)
+            findings.extend(out)
+            return out
+
+        return findings, mock.patch.object(validation, 'check', spy)
+
+
+class AuthenticatedValidationTestCase(AuthenticatedStackTestCase):
+    """The properties 'warn' still promises, now that it is the
+    rollback rather than the default: a finding changes nothing about
+    the response."""
+
+    mode = 'warn'
 
     def test_a_webargs_failure_answers_400_through_the_real_stack(self):
         """The whole journey: use_kwargs raises, _webargs_error aborts
@@ -591,20 +636,18 @@ class AuthenticatedValidationTestCase(base.ShakenFistTestCase):
         finding by construction and a no-op by construction, so the
         response must be byte for byte the response of the same
         request without the body.
-        """
-        findings = []
-        real = validation.check
 
-        def spy(*args, **kwargs):
-            out = real(*args, **kwargs)
-            findings.extend(out)
-            return out
+        EnforcedValidationTestCase runs the same request the other way
+        up: in 'enforce' this is the population that starts being
+        refused, which is the whole contract change.
+        """
+        findings, patcher = self._spy_on_check()
 
         headers = {'Authorization': self.token}
         clean = self.client.get('/auth/namespaces/system', headers=headers)
         self.assertEqual(200, clean.status_code)
 
-        with mock.patch.object(validation, 'check', spy):
+        with patcher:
             response = self.client.get(
                 '/auth/namespaces/system',
                 data=json.dumps({'namespace': 'system'}),
@@ -622,15 +665,9 @@ class AuthenticatedValidationTestCase(base.ShakenFistTestCase):
         CompiledEndpoint: a body key shadowing a path parameter is
         recorded where the overwrite happens and reported by the
         validator which runs after it."""
-        findings = []
-        real = validation.check
+        findings, patcher = self._spy_on_check()
 
-        def spy(*args, **kwargs):
-            out = real(*args, **kwargs)
-            findings.extend(out)
-            return out
-
-        with mock.patch.object(validation, 'check', spy):
+        with patcher:
             response = self.client.delete(
                 '/instances/nosuchinstance',
                 data=json.dumps({'instance_ref': 'adifferentinstance'}),
@@ -642,3 +679,193 @@ class AuthenticatedValidationTestCase(base.ShakenFistTestCase):
             [(f.reason, f.parameter) for f in findings])
         # And warn mode changed nothing: the handler's own 404 answered.
         self.assertEqual(404, response.status_code)
+
+
+# Text which can only have come from the Python interpreter rather than
+# from this API's own vocabulary. The motivating defect of
+# PLAN-api-input-validation is
+# `{"error": "InstancesEndpoint.get() got an unexpected keyword argument
+# 'banana'", "status": 400}` -- a caller learning a class name, a method
+# name and the fact that kwargs are merged into a call. Asserted as an
+# explicit list rather than by reading the message, because "I looked at
+# it and it seemed fine" is not a check that survives a refactor, and
+# the leak this closes has now been re-read as acceptable twice.
+#
+# Each entry names a distinct kind of leak: the TypeError text itself,
+# a stack, an exception class, an endpoint class name, a repr, and a
+# source path.
+INTERPRETER_TEXT = [
+    'got an unexpected keyword argument',
+    'unexpected keyword',
+    'positional argument',
+    'Traceback',
+    'TypeError',
+    'Endpoint',
+    'object at 0x',
+    '.py',
+    'shakenfist/',
+]
+
+
+class EnforcedValidationTestCase(AuthenticatedStackTestCase):
+    """What enforcement means, at request level.
+
+    Decision D16 made 'enforce' the default, so this is the behaviour
+    every deployment gets. Every test here drives a real authenticated
+    request through the whole decorator stack for the reason the parent
+    class documents: phase 3's review found two defects which unit
+    tests missed because they exercised components in isolation.
+    """
+
+    mode = 'enforce'
+
+    def assertNoInterpreterText(self, response):
+        """The absence, asserted positively.
+
+        Against the whole response body rather than the error string,
+        so a leak into any other field is caught too.
+        """
+        body = response.get_data(as_text=True)
+        for fragment in INTERPRETER_TEXT:
+            self.assertNotIn(
+                fragment, body,
+                'the refusal leaked interpreter text: %s' % body)
+
+    def test_an_undeclared_body_key_is_refused_by_name(self):
+        """Decision D14, and the defect the whole plan exists to close.
+
+        This is the exact request the confirmatory reading of D22 sent
+        to sfcbr on 2026-09-08, which answered
+        `InstancesEndpoint.get() got an unexpected keyword argument
+        'banana'`. The response asserted here is what replaces it.
+        """
+        findings, patcher = self._spy_on_check()
+
+        with patcher:
+            response = self.client.get(
+                '/instances',
+                data=json.dumps({'banana': 'yellow'}),
+                content_type='application/json',
+                headers={'Authorization': self.token})
+
+        self.assertEqual(
+            [(validation.UNKNOWN_PARAMETER, 'banana')],
+            [(f.reason, f.parameter) for f in findings])
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            {'error': 'banana: not declared by this endpoint', 'status': 400},
+            response.get_json())
+        self.assertNoInterpreterText(response)
+
+    def test_an_omitted_required_parameter_still_reaches_the_handler(self):
+        """Decision D17, and the one filter in the enforce branch.
+
+        `shared` on POST /artifacts is declared required and has always
+        been optional in fact -- the handler's signature defaults it to
+        False. Enforcing required-ness is phase 6's decision and would
+        break working callers, so a missing-required finding is
+        telemetry and never grounds for rejection.
+
+        The finding is asserted as well as the 200: without it this
+        test would pass just as happily if `shared` stopped being
+        declared required, which would make it a check of nothing.
+        """
+        findings, patcher = self._spy_on_check()
+
+        with patcher:
+            response = self.client.post(
+                '/artifacts',
+                data=json.dumps({'url': 'http://example.com/image.qcow2'}),
+                content_type='application/json',
+                headers={'Authorization': self.token})
+
+        self.assertEqual(
+            [(validation.MISSING_REQUIRED, 'shared')],
+            [(f.reason, f.parameter) for f in findings])
+        self.assertEqual(200, response.status_code, response.get_json())
+        # And the handler really ran, rather than something upstream
+        # answering 200 for it.
+        self.assertEqual(
+            'http://example.com/image.qcow2',
+            response.get_json()['source_url'])
+
+    def test_a_body_key_colliding_with_a_path_parameter_is_refused(self):
+        """Decision D18. The window observed none of these, so this is
+        the one piece of enforcement switched on without a population
+        behind it -- which makes a test the only evidence it works.
+
+        In 'warn' this same request reaches the handler and answers the
+        404 that AuthenticatedValidationTestCase pins. Enforcement
+        answers first, which is the status code change the release note
+        has to state.
+        """
+        findings, patcher = self._spy_on_check()
+
+        with patcher:
+            response = self.client.delete(
+                '/instances/nosuchinstance',
+                data=json.dumps({'instance_ref': 'adifferentinstance'}),
+                content_type='application/json',
+                headers={'Authorization': self.token})
+
+        self.assertIn(
+            (validation.BODY_PATH_COLLISION, 'instance_ref'),
+            [(f.reason, f.parameter) for f in findings])
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            {'error': 'instance_ref: a body key of this name overwrote the '
+                      'URL path parameter',
+             'status': 400},
+            response.get_json())
+        self.assertNoInterpreterText(response)
+
+    def test_a_finding_on_a_request_which_would_have_succeeded_refuses_it(self):
+        """The contract change, pinned on a 2xx.
+
+        Its warn-mode twin above proves this exact request answers 200
+        with the body unchanged, so the clean 200 asserted first is not
+        an assumption -- it is the same request without the offending
+        body key, taken in the same fixture.
+        """
+        headers = {'Authorization': self.token}
+        clean = self.client.get('/auth/namespaces/system', headers=headers)
+        self.assertEqual(200, clean.status_code)
+
+        findings, patcher = self._spy_on_check()
+        with patcher:
+            response = self.client.get(
+                '/auth/namespaces/system',
+                data=json.dumps({'namespace': 'system'}),
+                content_type='application/json', headers=headers)
+
+        self.assertEqual(
+            [(validation.BODY_PATH_COLLISION, 'namespace')],
+            [(f.reason, f.parameter) for f in findings])
+        self.assertEqual(400, response.status_code)
+        self.assertNotEqual(clean.get_data(), response.get_data())
+        self.assertNoInterpreterText(response)
+
+    def test_a_request_with_no_findings_is_untouched(self):
+        """The other half of the promise: enforcement must be invisible
+        to a well formed request.
+
+        Byte for byte against the same request with the layer switched
+        off, so this cannot pass by the layer having quietly rewritten
+        every response in some harmless-looking way.
+        """
+        headers = {'Authorization': self.token}
+
+        findings, patcher = self._spy_on_check()
+        with patcher:
+            enforced = self.client.get('/auth/namespaces/system',
+                                       headers=headers)
+
+        self.assertEqual([], findings)
+        self.assertEqual(200, enforced.status_code)
+
+        config.API_VALIDATION_MODE = 'off'
+        unvalidated = self.client.get('/auth/namespaces/system',
+                                      headers=headers)
+
+        self.assertEqual(unvalidated.status_code, enforced.status_code)
+        self.assertEqual(unvalidated.get_data(), enforced.get_data())

--- a/shakenfist/tests/external_api/test_request_validation.py
+++ b/shakenfist/tests/external_api/test_request_validation.py
@@ -77,7 +77,14 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
         existed: the 400 log_request's merge has always produced, with
         the interpreter's own text. That interpreter text is the defect
         this plan exists to remove, so an operator who rolls back to
-        'warn' gets the old behaviour back in full, warts included.
+        'warn' gets the old behaviour back, warts included.
+
+        With one exception, which the release note states: the five
+        metadata delete handlers no longer accept the `value` kwarg
+        they used to ignore, in any mode, so a caller which sends one
+        gets a TypeError-shaped 400 in 'warn' where enforcement would
+        have named the parameter. That was UNDECLARED_BY_DESIGN's last
+        entry, and removing it is what emptied the set.
         """
         config.API_VALIDATION_MODE = 'warn'
 
@@ -694,6 +701,11 @@ class AuthenticatedValidationTestCase(AuthenticatedStackTestCase):
 # Each entry names a distinct kind of leak: the TypeError text itself,
 # a stack, an exception class, an endpoint class name, a repr, and a
 # source path.
+#
+# shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_api_validation.py
+# asserts the same property against a real cluster and carries a subset
+# of this list, because that suite runs from an installed package and
+# cannot import this one. A marker added here belongs there too.
 INTERPRETER_TEXT = [
     'got an unexpected keyword argument',
     'unexpected keyword',
@@ -869,3 +881,187 @@ class EnforcedValidationTestCase(AuthenticatedStackTestCase):
 
         self.assertEqual(unvalidated.status_code, enforced.status_code)
         self.assertEqual(unvalidated.get_data(), enforced.get_data())
+
+    def test_a_raw_body_endpoint_is_not_validated(self):
+        """The upload path must stay out of the validator's way.
+
+        A raw body is bytes of arbitrary size and structure, so
+        CompiledEndpoint marks the route raw_body and check() skips
+        both the unknown-parameter scan and the schema. Nothing pinned
+        that under the new default, and enforcement is exactly where
+        getting it wrong would break the API's bulk transfer route.
+
+        The 404 is the proof: it comes from arg_is_upload_uuid, which
+        is a per-method decorator and therefore only reachable when
+        validation has let the request through.
+
+        The body is JSON an ordinary route would refuse outright --
+        `banana` is declared nowhere -- and is sent with a JSON content
+        type, because bytes which cannot be parsed as a body would make
+        this test pass whether the route was skipped or merely
+        unparseable. Uploads really do carry arbitrary bytes; what is
+        being pinned is that the route is skipped, so the body has to
+        be one the scan could otherwise see.
+        """
+        findings, patcher = self._spy_on_check()
+
+        with patcher, mock.patch(
+                'shakenfist.external_api.base.Upload.from_db',
+                return_value=None):
+            response = self.client.post(
+                '/upload/6a9b0f4e-0b2f-4a5e-bd0e-000000000000',
+                data=json.dumps({'banana': 'yellow'}),
+                content_type='application/json',
+                headers={'Authorization': self.token})
+
+        self.assertEqual([], findings)
+        self.assertEqual(404, response.status_code, response.get_json())
+        self.assertEqual({'error': 'upload not found', 'status': 404},
+                         response.get_json())
+
+    def test_more_undeclared_keys_than_the_bound_refuse_a_real_one(self):
+        """The overflow finding must never be what a caller is told.
+
+        check() bounds unknown-parameter findings and summarises the
+        rest in one '(overflow)' finding. That finding names no
+        parameter the caller sent, so if it were ever the first
+        enforceable one the refusal would be useless to them.
+        """
+        body = {'key%03d' % index: 1 for index in
+                range(validation.MAX_UNKNOWN_PARAMETER_FINDINGS + 5)}
+        findings, patcher = self._spy_on_check()
+
+        with patcher:
+            response = self.client.get(
+                '/instances', data=json.dumps(body),
+                content_type='application/json',
+                headers={'Authorization': self.token})
+
+        self.assertEqual(
+            validation.MAX_UNKNOWN_PARAMETER_FINDINGS + 1, len(findings))
+        self.assertEqual('(overflow)', findings[-1].parameter)
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            {'error': 'key000: not declared by this endpoint', 'status': 400},
+            response.get_json())
+        self.assertNoInterpreterText(response)
+
+    def test_a_metadata_delete_with_no_body_still_works(self):
+        """The five metadata delete handlers lost their `value` kwarg.
+
+        It was accepted and ignored, and UNDECLARED_BY_DESIGN carried
+        it until enforcement could refuse it instead. The shipped
+        client sends no body at all on a metadata delete, so this is
+        that caller.
+        """
+        response = self.client.delete(
+            '/auth/namespaces/system/metadata/foo',
+            headers={'Authorization': self.token})
+
+        self.assertEqual(200, response.status_code, response.get_json())
+
+    def test_a_metadata_delete_carrying_a_value_is_refused_by_name(self):
+        """And the caller which does send one is told which key it is.
+
+        In 'warn' or 'off' this same request is a TypeError in the
+        kwargs merge, because the kwarg is gone from the handler
+        whatever the mode -- which the release note states, since it is
+        the one thing the rollback does not undo.
+        """
+        response = self.client.delete(
+            '/auth/namespaces/system/metadata/foo',
+            data=json.dumps({'value': 'bar'}),
+            content_type='application/json',
+            headers={'Authorization': self.token})
+
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            {'error': 'value: not declared by this endpoint', 'status': 400},
+            response.get_json())
+        self.assertNoInterpreterText(response)
+
+    def test_a_refusal_is_audited_against_the_namespace(self):
+        """Enforcement must not cost the namespace its audit trail.
+
+        A refusal is returned from outside every per-method decorator,
+        so log_token_use never runs and the namespace would otherwise
+        see nothing at all -- an authenticated caller could send
+        malformed requests indefinitely and appear in sf-api's log
+        alone, which carries neither the key name nor the remote
+        address.
+        """
+        events = []
+        with mock.patch('shakenfist.eventlog.add_event',
+                        side_effect=lambda event_type, object_type, object_uuid,
+                        message, duration=None, extra=None, **kwargs:
+                        events.append((message, extra or {}))):
+            response = self.client.get(
+                '/instances',
+                data=json.dumps({'banana': 'yellow'}),
+                content_type='application/json',
+                headers={'Authorization': self.token})
+
+        self.assertEqual(400, response.status_code)
+        refusals = [extra for message, extra in events
+                    if message == 'request refused by input validation']
+        self.assertEqual(1, len(refusals), events)
+        self.assertEqual('key1', refusals[0]['keyname'])
+        self.assertEqual('GET', refusals[0]['method'])
+        self.assertEqual('/instances', refusals[0]['path'])
+        self.assertEqual(validation.UNKNOWN_PARAMETER,
+                         refusals[0]['validation-reason'])
+        self.assertEqual('banana', refusals[0]['validation-parameter'])
+        # And the credential itself is not in the event, in any field.
+        self.assertNotIn(self.token, json.dumps(refusals[0]))
+
+    def test_a_refusal_on_a_credential_route_redacts_the_parameter(self):
+        """The audit event obeys the same redaction the log does.
+
+        A parameter name is client supplied, so a buggy caller can put
+        secret-bearing material in a key position -- which is why
+        log_validation_findings replaces it on /auth routes. A
+        namespace event is readable by anyone who can read the
+        namespace, so a second record of the same refusal must not be
+        the one that says it.
+        """
+        events = []
+        with mock.patch('shakenfist.eventlog.add_event',
+                        side_effect=lambda event_type, object_type, object_uuid,
+                        message, duration=None, extra=None, **kwargs:
+                        events.append((message, extra or {}))):
+            response = self.client.post(
+                '/auth/namespaces/system/keys',
+                data=json.dumps({'sekrit-looking-key-name': 'x'}),
+                content_type='application/json',
+                headers={'Authorization': self.token})
+
+        self.assertEqual(400, response.status_code)
+        refusals = [extra for message, extra in events
+                    if message == 'request refused by input validation']
+        self.assertEqual(1, len(refusals), events)
+        self.assertEqual(api_base.REDACTED_PARAMETER,
+                         refusals[0]['validation-parameter'])
+        self.assertNotIn('sekrit-looking-key-name', json.dumps(refusals[0]))
+        # The reason survives, which is what an audit reader needs.
+        self.assertEqual(validation.UNKNOWN_PARAMETER,
+                         refusals[0]['validation-reason'])
+
+    def test_a_refusal_of_an_unauthenticated_request_is_still_a_refusal(self):
+        """The audit event has no token to attribute a @public
+        endpoint's refusal to, and must not turn the 400 into anything
+        else while discovering that."""
+        events = []
+        with mock.patch('shakenfist.eventlog.add_event',
+                        side_effect=lambda *args, **kwargs:
+                        events.append(args[3])):
+            response = self.client.post(
+                '/auth',
+                data=json.dumps({'namespace': 'system', 'key': 'key1',
+                                 'banana': 'yellow'}),
+                content_type='application/json')
+
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            {'error': 'banana: not declared by this endpoint', 'status': 400},
+            response.get_json())
+        self.assertNotIn('request refused by input validation', events)

--- a/shakenfist/tests/external_api/test_validation_compiler.py
+++ b/shakenfist/tests/external_api/test_validation_compiler.py
@@ -343,3 +343,58 @@ class ValidationCompilerTestCase(base.ShakenFistTestCase):
 
         self.assertEqual([], list(length.validators))
         self.assertEqual(-1, length.deserialize(-1))
+
+
+class NestedMessageFlatteningTestCase(base.ShakenFistTestCase):
+    """A container's element errors must name the element, not a dict.
+
+    marshmallow answers validate() with a list of strings when a field
+    is wrong and a dict keyed by index when a container's *elements*
+    are wrong. Phase 4's enforce flip turned the finding detail from a
+    log line into the caller's error message, so rendering that dict
+    with str() would answer `disk: {0: ['Not a valid mapping type.']}`.
+    """
+
+    class _Schema(marshmallow.Schema):
+        disk = fields.List(fields.Dict())
+        tags = fields.List(fields.String())
+        name = fields.String()
+
+    def _findings(self, supplied):
+        schema = self._Schema(unknown=marshmallow.EXCLUDE)
+        return [(f.parameter, f.detail)
+                for f in validation._schema_findings(schema, supplied)]
+
+    def test_a_bad_element_names_its_index(self):
+        self.assertEqual(
+            [('disk[0]', 'Not a valid mapping type.')],
+            self._findings({'disk': ['not a dict']}))
+
+    def test_every_bad_element_is_reported_in_order(self):
+        self.assertEqual(
+            [('disk[0]', 'Not a valid mapping type.'),
+             ('disk[1]', 'Not a valid mapping type.')],
+            self._findings({'disk': ['one', 'two']}))
+
+    def test_a_scalar_field_is_unchanged(self):
+        # The flattening must not disturb the shape the rest of the
+        # phase's tests pin, which is the common case by far.
+        self.assertEqual(
+            [('name', 'Not a valid string.')], self._findings({'name': 5}))
+
+    def test_a_whole_container_of_the_wrong_type_is_unchanged(self):
+        # marshmallow answers a plain list here, not a dict, so this
+        # never went through the nested path at all.
+        self.assertEqual(
+            [('disk', 'Not a valid list.')],
+            self._findings({'disk': 'not a list'}))
+
+    def test_no_detail_renders_a_python_repr(self):
+        # The property the fix exists for, stated directly: whatever
+        # marshmallow nests, no finding may carry a dict or list repr
+        # into the caller's error message.
+        for supplied in ({'disk': ['x']}, {'tags': [{'a': 1}]},
+                         {'disk': ['x', 'y']}, {'name': 5}):
+            for parameter, detail in self._findings(supplied):
+                self.assertNotIn('{', detail, parameter)
+                self.assertNotIn('[', detail, parameter)

--- a/shakenfist/tests/external_api/test_validation_compiler.py
+++ b/shakenfist/tests/external_api/test_validation_compiler.py
@@ -376,6 +376,67 @@ class NestedMessageFlatteningTestCase(base.ShakenFistTestCase):
              ('disk[1]', 'Not a valid mapping type.')],
             self._findings({'disk': ['one', 'two']}))
 
+    def test_indices_are_ordered_numerically_not_lexically(self):
+        """Eleven elements, because two cannot tell the difference.
+
+        marshmallow keys a sequence error by integer index, and
+        sorting those as strings gives 0, 1, 10, 2 -- so a caller whose
+        third and eleventh disks are both malformed would be told about
+        `disk[10]`, since enforcement answers with the first finding
+        only. The count here is deliberately past ten.
+        """
+        self.assertEqual(
+            ['disk[%d]' % index for index in range(12)],
+            [parameter for parameter, _ in
+             self._findings({'disk': ['x'] * 12})])
+
+    def test_the_findings_one_container_can_produce_are_bounded(self):
+        """Nothing bounds a request body, so something must bound this.
+
+        Each finding is a log line shipped to centralised logging, and
+        naming elements individually is precisely what turns one bad
+        parameter into one line per element. The unknown-parameter scan
+        has had this bound since phase 3 for the same reason; element
+        naming gave type mismatches the same unbounded property.
+        """
+        findings = self._findings(
+            {'disk': ['x'] * (validation.MAX_TYPE_MISMATCH_FINDINGS + 500)})
+
+        self.assertEqual(
+            validation.MAX_TYPE_MISMATCH_FINDINGS + 1, len(findings))
+        self.assertEqual(
+            ('(overflow)',
+             '500 further mismatching values not reported individually'),
+            findings[-1])
+        # The bound is on findings, not on which ones: the reported
+        # elements are still the first ones, in order.
+        self.assertEqual(
+            ['disk[%d]' % index
+             for index in range(validation.MAX_TYPE_MISMATCH_FINDINGS)],
+            [parameter for parameter, _ in findings[:-1]])
+
+    def test_a_finding_carries_the_element_type_not_the_containers(self):
+        """Decision D5 makes the type the only thing a finding says
+        about a value, so it must be the type of the value that failed.
+        `disk[0]` reported as a list describes the array around it."""
+        schema = self._Schema(unknown=marshmallow.EXCLUDE)
+        findings = validation._schema_findings(
+            schema, {'disk': ['a string'], 'tags': [{'a': 1}]})
+
+        self.assertEqual(
+            [('disk[0]', 'str'), ('tags[0]', 'dict')],
+            sorted((f.parameter, f.value_type) for f in findings))
+
+    def test_an_unresolvable_path_falls_back_to_the_container(self):
+        # marshmallow can key an error by something the supplied value
+        # has no entry for. The container's type is still true of what
+        # the caller sent, which beats reporting nothing.
+        self.assertEqual(
+            'list',
+            validation.Finding(
+                validation.TYPE_MISMATCH, 'disk[3]', 'nope',
+                validation._element_value(['only one'], (3,))).value_type)
+
     def test_a_scalar_field_is_unchanged(self):
         # The flattening must not disturb the shape the rest of the
         # phase's tests pin, which is the common case by far.

--- a/shakenfist/tests/test_config.py
+++ b/shakenfist/tests/test_config.py
@@ -45,20 +45,39 @@ class ConfigTestCase(base.ShakenFistTestCase):
     def test_bogus_override(self):
         self.assertRaises(ValueError, SFConfig)
 
+    @mock.patch.dict('os.environ')
+    def test_validation_mode_defaults_to_enforce(self):
+        # Decision D16 of PLAN-api-input-validation: enforcement is the
+        # default rather than an operator opt-in, because leaving it at
+        # 'warn' would mean the defect class stays open in every
+        # deployment while the machinery to close it sits unused.
+        # Asserted here rather than only in the plan, so a well meant
+        # revert to the safer looking value has to argue with a test.
+        #
+        # The override is removed first: this asserts the default, and
+        # a developer who happens to run the suite with the setting
+        # exported would otherwise be testing their shell.
+        os.environ.pop('SHAKENFIST_API_VALIDATION_MODE', None)
+
+        self.assertEqual('enforce', SFConfig().API_VALIDATION_MODE)
+
     @mock.patch.dict('os.environ',
                      {'SHAKENFIST_API_VALIDATION_MODE': 'enforced'})
     def test_bogus_validation_mode_fails_at_load(self):
-        # The setting exists to be flipped to 'enforce' in phase 4 of
-        # PLAN-api-input-validation. A typo silently meaning warn is no
-        # validation and no signal anything is wrong, so anything other
-        # than the two literals must refuse to load.
+        # A typo silently meaning something other than what the
+        # operator wrote is no signal anything is wrong, so anything
+        # other than the three literals must refuse to load. This is
+        # the rollback path's safety net: an operator reaching for
+        # 'warn' in an incident must not get enforcement because they
+        # typed 'Warn'.
         self.assertRaises(ValueError, SFConfig)
 
     @mock.patch.dict('os.environ',
-                     {'SHAKENFIST_API_VALIDATION_MODE': 'enforce'})
+                     {'SHAKENFIST_API_VALIDATION_MODE': 'warn'})
     def test_valid_validation_mode_loads(self):
-        conf = SFConfig()
-        self.assertEqual('enforce', conf.API_VALIDATION_MODE)
+        # 'warn' rather than 'enforce', so this cannot pass by
+        # accidentally reading the default back.
+        self.assertEqual('warn', SFConfig().API_VALIDATION_MODE)
 
 
 class AgentOperationAttemptCapTestCase(base.ShakenFistTestCase):

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -586,7 +586,7 @@ class ExternalApiInstanceTestCase(ExternalApiTestCase):
         # refuses this ahead of the handler's own guard, which remains
         # and answers when API_VALIDATION_MODE is not 'enforce'.
         self.assertEqual(
-            {'error': "disk: {0: ['Not a valid mapping type.']}", 'status': 400},
+            {'error': 'disk[0]: Not a valid mapping type.', 'status': 400},
             resp.get_json())
         self.assertEqual(400, resp.status_code)
 
@@ -608,7 +608,7 @@ class ExternalApiInstanceTestCase(ExternalApiTestCase):
                                 }))
         # As above: the declared arrayofdict answers first now.
         self.assertEqual(
-            {'error': "network: {0: ['Not a valid mapping type.']}", 'status': 400},
+            {'error': 'network[0]: Not a valid mapping type.', 'status': 400},
             resp.get_json())
         self.assertEqual(400, resp.status_code)
 

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -319,11 +319,14 @@ class ExternalApiGeneralTestCase(ExternalApiTestCase):
 
     def test_put_instance_metadata(self):
         self.mock_mariadb.create_instance('banana')
+        # The key rides in the URL. Sending it in the body as well is
+        # a body-path collision, which decision D18 of
+        # PLAN-api-input-validation refuses; shakenfist_client's
+        # _set_metadata sends {'value': ...} and nothing else.
         resp = self.client.put(
             '/instances/12345678-1234-4321-8234-000000000001/metadata/foo',
             headers={'Authorization': self.auth_token},
             data=json.dumps({
-                'key': 'foo',
                 'value': 'bar'
             }))
         self.assertEqual(None, resp.get_json())
@@ -399,11 +402,13 @@ class ExternalApiGeneralTestCase(ExternalApiTestCase):
 
     def test_put_network_metadata(self):
         self.mock_mariadb.create_network('banana', namespace='foo')
+        # As with the instance metadata test above: the key rides in
+        # the URL, and repeating it in the body is a body-path
+        # collision decision D18 refuses.
         resp = self.client.put(
             '/networks/12345678-1234-4321-8234-000000000001/metadata/foo',
             headers={'Authorization': self.auth_token},
             data=json.dumps({
-                'key': 'foo',
                 'value': 'bar'
             }))
         self.assertEqual(None, resp.get_json())
@@ -577,8 +582,11 @@ class ExternalApiInstanceTestCase(ExternalApiTestCase):
                                     'placed_on': None,
                                     'namespace': None,
                                 }))
+        # Phase 4 of PLAN-api-input-validation: the declared arrayofdict
+        # refuses this ahead of the handler's own guard, which remains
+        # and answers when API_VALIDATION_MODE is not 'enforce'.
         self.assertEqual(
-            {'error': 'disk specification should contain JSON objects', 'status': 400},
+            {'error': "disk: {0: ['Not a valid mapping type.']}", 'status': 400},
             resp.get_json())
         self.assertEqual(400, resp.status_code)
 
@@ -598,8 +606,9 @@ class ExternalApiInstanceTestCase(ExternalApiTestCase):
                                     'placed_on': None,
                                     'namespace': None,
                                 }))
+        # As above: the declared arrayofdict answers first now.
         self.assertEqual(
-            {'error': 'network specification should contain JSON objects', 'status': 400},
+            {'error': "network: {0: ['Not a valid mapping type.']}", 'status': 400},
             resp.get_json())
         self.assertEqual(400, resp.status_code)
 

--- a/shakenfist/tests/test_external_api.py
+++ b/shakenfist/tests/test_external_api.py
@@ -590,6 +590,58 @@ class ExternalApiInstanceTestCase(ExternalApiTestCase):
             resp.get_json())
         self.assertEqual(400, resp.status_code)
 
+    def test_post_instance_invalid_disk_in_warn_mode(self):
+        # The handler's own guard, which is what answers on the
+        # rollback path. Enforcement hides it in the default
+        # configuration, and a guard nothing exercises is a guard that
+        # rots between here and the next operator who sets 'warn'.
+        self.set_validation_mode('warn')
+
+        resp = self.client.post('/instances',
+                                headers={'Authorization': self.auth_token},
+                                data=json.dumps({
+                                    'name': 'test-instance',
+                                    'cpus': 1,
+                                    'memory': 1024,
+                                    'network': [],
+                                    'disk': ['8@cirros'],
+                                    'ssh_key': None,
+                                    'user_data': None,
+                                    'placed_on': None,
+                                    'namespace': None,
+                                }))
+        self.assertEqual(
+            {'error': 'disk specification should contain JSON objects',
+             'status': 400},
+            resp.get_json())
+        self.assertEqual(400, resp.status_code)
+
+    @mock.patch('shakenfist.artifact.Artifact.from_url')
+    def test_post_instance_invalid_network_in_warn_mode(
+            self, mock_get_artifact):
+        # As above, for the network specification's guard.
+        self.set_validation_mode('warn')
+
+        resp = self.client.post('/instances',
+                                headers={'Authorization': self.auth_token},
+                                data=json.dumps({
+                                    'name': 'test-instance',
+                                    'cpus': 1,
+                                    'memory': 1024,
+                                    'network': ['87c15186-5f73-4947-a9fb-2183c4951efc'],
+                                    'disk': [{'size': 8,
+                                              'base': 'cirros'}],
+                                    'ssh_key': None,
+                                    'user_data': None,
+                                    'placed_on': None,
+                                    'namespace': None,
+                                }))
+        self.assertEqual(
+            {'error': 'network specification should contain JSON objects',
+             'status': 400},
+            resp.get_json())
+        self.assertEqual(400, resp.status_code)
+
     @mock.patch('shakenfist.artifact.Artifact.from_url')
     def test_post_instance_invalid_network(self, mock_get_artifact):
         resp = self.client.post('/instances',


### PR DESCRIPTION
Phase 4 of [PLAN-api-input-validation](docs/plans/PLAN-api-input-validation-phase-04-enforce.md), completing steps 4, 5 and 6. Steps 1-3 landed earlier in #4101.

`API_VALIDATION_MODE` now defaults to `enforce`, so input which does not match an endpoint's published parameter declarations is refused with `{"error": "<parameter>: <reason>", "status": 400}` rather than reaching a handler which raises `TypeError` and hands the caller the interpreter's own words. That leak is #3612 in its purest form.

## The confirmatory reading which unlocked the flip

Decision D22 said the switch could not be thrown until the two declaration bugs the warn window found were shown to be fixed. Both readings are now in the plan's measurement log:

* **Functional CI: nine to zero.** The `merge_group` run of #4101, the first full suite over the merged code, produced **zero** `unknown-parameter namespace` findings against the nine of 2026-08-13. The other three signatures are unchanged at 21, 6 and 6 — all intended rejections. Both of phase 3's guards against a false negative were re-run rather than assumed: the registry compiled line appears in all six bundles at 139 handlers, and the two cluster CI tests which drive a namespace-scoped lookup both ran and passed.
* **Metadata `value`: probed, not waited out.** D22 asked for 72 hours of absence "during which the k3s orchestration traffic has actually run", but that named the wrong thing — the traffic is `client-python-k3s` exercised by hand, not a running cluster, and it last ran 35 hours *before* the fix deployed. Since the declaration is per route, any JSON-valued metadata write exercises the same schema. A dict-valued and a list-valued write against sfcbr produced no finding, alongside a deliberate undeclared body key in the same second which did. That is positive evidence rather than a quiet channel, which is what the wait could not have given us.

Widening the reading to the whole 30-day warn window also bounds the blast radius: **all 294 findings on requests which actually succeeded are the metadata bug, now fixed. The remaining 63 already answer 400 and answer 400 after the flip.** The enforceable surface on sfcbr is empty.

## Caller-visible changes the plan did not anticipate

Both are documented in the release note rather than left to be discovered:

* **Eleven refusals which already answered 400 now carry validation's wording** instead of the handler's, because validation answers first — `key is not a string` becomes `key: Not a valid string.` The handler guards are untouched and still answer whenever the mode is not `enforce`.
* **A body key which repeats a path parameter is now refused** as a body/path collision (D18). The shipped client never sends one; three of our own tests did, which is how it surfaced.

## One commit which is not a plan step

`5a5847259` is not in the step list. Enforcing turned a finding's detail from a log line into the caller's error message, which exposed a rendering bug warn mode had kept private: marshmallow answers with a dict keyed by index when a *container's elements* are wrong, and the `str()` fallback put a Python dict repr in the response — `disk: {0: ['Not a valid mapping type.']}`. It reaches seven declarations. The fix names the element instead: `disk[0]: Not a valid mapping type.` A phase whose purpose is to stop the API answering in the interpreter's words should not ship a new way for it to answer in marshmallow's.

## Verification

* Every assertion in step 4 was mutation tested — ten mutations, each caught, each by the test which names the property. The three added for `5a5847259` likewise.
* `tools/check-api-declaration-guards.sh`: all 34 mutations caught.
* Full unit suite: 4555 tests, 0 failures. `pre-commit run --all-files` clean.
* `UNDECLARED_BY_DESIGN` is now empty, and the five metadata delete handlers no longer accept a `value` kwarg none of them read.
* All 13 Definition of done items met.

The `missing-required` filter is deliberately untouched (D17): several parameters are declared required while omitting them has always worked, so enforcing that is phase 6's decision. A request-level test pins that `enforce` plus an omitted required parameter still reaches its handler.

Operators whose callers break can set `API_VALIDATION_MODE=warn` or `off` as the rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019M9kQBiC4WxmX6w2NPjrBe
