### PR TITLE
Record phase 10 merges in the VDI tokens plan.

### DIFF
--- a/docs/plans/PLAN-kerbside-vdi-tokens.md
+++ b/docs/plans/PLAN-kerbside-vdi-tokens.md
@@ -399,11 +399,27 @@ and is the authoritative list of what this plan actually merged:
 | shakenfist | 11 (#4009) | #4016 | `5ef83c065` |
 | shakenfist | 11 (#4003) | #4018 | `913411586` |
 | shakenfist | 11 (#4004) | #4024 | `f2df423d8` |
+| shakenfist | 10 (audit, its three medium fixes, the `.vv` functional test) | #4099 | `2d585cd1a` |
+| shakenfist | 10 closeout (docs) | #4137 | `ccc1b5ff2` |
 | client-python | 4 | #350 | `b426e1f` |
 | kerbside | 5, 6, 7, 8 (kerbside half) | #167 | `f50ea59` |
 | kerbside | 9 (SF end-to-end lane) | #194 | `115416c` |
 | kerbside | post-phase-9 scrape fix | #201 | `7803368` |
+| kerbside | 10 (F-B1 part 1: a key fetch no longer errors the source) | #412 | `e2a493ea6` |
+| kerbside | 10 (F-B1 part 2: cleanup narrowed to enumerated sources) | #413 | `29323fb85` |
 | ryll | 3 | #190 | `fa7ee21` |
+| ryll | 10 (F8: SPICE TLS trust anchors) | #358 | `aac25cf3c` |
+| ryll | 10 follow-up (redundant `app.js` test assertion removed) | #366 | `0113f0ff7` |
+
+Rows are grouped by repository and ordered by merge within each, which
+is why phase 10 trails phase 11 in the Shaken Fist block: the
+post-completion defects were fixed before the audit ran. Phase 10
+appears six times because the audit did not merge as one change. Its
+findings were fixed in whichever repository owned them, and the
+blocking one took two attempts. The fourteen advisory findings are
+deliberately *not* rows here -- they were filed as issues in their own
+repositories and land on their own schedule, so a list would go stale.
+Follow those from the disposition table in phase 10's plan.
 
 ### Phase 0: Decisions and token format
 


### PR DESCRIPTION
Closes the one definition-of-done gap left by the Kerbside VDI console
tokens push audit (#4137).

## Why

The plan carries a table of what it actually merged. Phase 10 added
that table because the phase status table names *plan files* rather
than pull requests, so the audit had to reconstruct the merge history
from `git log` in four working copies before it could audit anything.
Its definition of done then required the table record a reference for
every phase, "so decision 1's reconstruction does not have to happen
again".

Phase 10 never added its own rows. The closeout updated the statuses
and the narrative and stopped, which left the one phase whose work
spanned all four repositories as the only phase a reader has to
reconstruct from prose — exactly the cost the criterion existed to
prevent.

## What changed

Six rows, one file, docs only:

| Repo | Phase 10 work | PR | Merge |
|---|---|---|---|
| shakenfist | audit, its three medium fixes, the `.vv` functional test | #4099 | `2d585cd1a` |
| shakenfist | closeout (docs) | #4137 | `ccc1b5ff2` |
| kerbside | F-B1 part 1: a key fetch no longer errors the source | #412 | `e2a493ea6` |
| kerbside | F-B1 part 2: cleanup narrowed to enumerated sources | #413 | `29323fb85` |
| ryll | F8: SPICE TLS trust anchors | #358 | `aac25cf3c` |
| ryll | follow-up, redundant `app.js` test assertion removed | #366 | `0113f0ff7` |

Plus a note explaining two things a reader would otherwise trip over:
why phase 10 sorts after phase 11 in the shakenfist block (rows are
grouped by repo and ordered by merge, and the post-completion defects
were fixed before the audit ran), and why the fourteen advisory
findings are deliberately *not* rows — they land on their own schedule,
so a list here would go stale. They stay traceable from the disposition
table in phase 10's plan.

## Verification

Every merge reference was checked against its own repository rather
than copied from the surrounding prose — the two shakenfist SHAs with
`git merge-base --is-ancestor` against `develop`, the four foreign ones
against `gh pr view --json mergeCommit`. All six resolve and match.

`pre-commit run --all-files` passes, including
`tools/check-plan-status.py` ("Plan statuses, index arithmetic and
phase links agree").

This makes no claim about the plan's status: all twelve phases were
already Complete in both the master plan and `docs/plans/index.md`
before this change, and remain so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbYd92imhYufuWps6ZfEyF
