### PR TITLE
Force a capacity reconcile when a hypervisor is unguarded

### DIFF
--- a/docs/developer_guide/database_internals.md
+++ b/docs/developer_guide/database_internals.md
@@ -332,14 +332,23 @@ The elected cluster node also runs
 `reconcile_scheduler_capacity()` every five minutes. That cadence is
 anchored to a cluster-wide last-run stamp (the
 `SCHEDULED_TASK_LAST_RUN_RECONCILE_SCHEDULER_CAPACITY` key in
-`cluster_config`) rather than to process start, and a newly elected
-maintainer which finds `scheduler_node_capacity` empty runs a pass
-immediately instead of waiting out the cadence. Both exist because
+`cluster_config`) rather than to process start, and the elected
+maintainer's own maintenance pass forces a reconcile as soon as it
+sees an active hypervisor with fresh metrics and no
+`scheduler_node_capacity` row, instead of waiting out the cadence.
+Both exist because
 the reconciler is the only thing which *creates* capacity rows, and a
 node without a row is admitted against nothing at all: a
 process-local five minute timer left every placement in a new
 cluster's first minutes unguarded, and the first pass then recorded
 the resulting over-limit usage on the row it created (issue 4087).
+The check was a one-shot on the election path until
+`PLAN-transient-capacity-refusals` phase 1, which is why it used to
+miss a cold cluster entirely -- election happens seconds after
+start-up, before any hypervisor has published, so the pass it forced
+had nothing to size. See
+[the subsystem internals](subsystem_internals.md) for the predicate
+it applies now.
 One pass is a single
 `ReconcileSchedulerCapacity` RPC which expires stale namespace
 claims, re-derives per-hypervisor limits from the typed

--- a/docs/developer_guide/subsystem_internals.md
+++ b/docs/developer_guide/subsystem_internals.md
@@ -179,6 +179,40 @@ admission as of phase 3
 (`docs/plans/PLAN-scheduler-reservations-phase-03-primitive.md`), and
 `namespace_claims` became writable in phase 4 — see [The claim admission
 transaction](#the-claim-admission-transaction) below.
+
+A capacity row is created only by a reconcile pass, so a hypervisor
+with none is admitted against nothing at all (the placement fail-open
+described above). Waiting out the five-minute cadence for that first
+row was issue 4087; the elected cluster node's maintenance loop now
+closes most of the gap itself. Each maintenance pass
+(`_force_capacity_reconcile_if_unguarded()` and
+`_unguarded_hypervisors()` in `shakenfist/daemons/cluster/main.py`)
+mirrors three of the four filters above — fresh, `is_hypervisor`
+metrics on a node in the active set — and, if it finds one with no
+`scheduler_node_capacity` row, marks the reconcile due in the same
+pass rather than waiting for the cadence. The `nodes`-table filter is
+not restated, because `Nodes([], prefilter='active')` already drops
+anything it cannot hydrate from that table; mirroring only three of
+the four is deliberate, not an oversight — a check asking a *broader*
+question than the reconciler can answer would find a permanently
+qualifying phantom (a `node_metrics` row that outlived its node) and
+force the five-minute job every maintenance pass forever. The
+maintenance loop runs at most once every 60s, so this closes the
+warm-up window to roughly a minute after a hypervisor's metrics
+become visible, not immediately — the larger remaining term is the
+resources daemon's own publication cadence for those metrics, which
+this does not shorten (phase 3 of
+[PLAN-transient-capacity-refusals](../plans/PLAN-transient-capacity-refusals.md)).
+The check also forces at most once per distinct unguarded set: a node
+that qualifies here but which the reconciler declines to size anyway
+costs one forced pass, not a permanent every-minute one, and
+`scheduler_capacity_reconcile_forced_total` (`SCHEDULER_CAPACITY_FORCED`
+in `shakenfist/daemons/cluster/scheduled_tasks.py`) counts forced
+passes so that a disagreement is visible without grepping logs — a
+count that keeps climbing in an otherwise steady cluster means this
+check and the reconciler disagree about which nodes should have rows,
+which is worth reporting rather than tuning around.
+
 The SQL itself is covered by
 `shakenfist/tests/test_mariadb_capacity_reconcile_live.py`, which runs
 against a real MariaDB in the "Schema ENUM widening" CI job (whose
@@ -246,9 +280,11 @@ Two decisions deliberately diverge from placement admission:
 
 - **A missing `cluster_capacity` singleton refuses**, where placement
   fails open. Admitting an instance unguarded records where a machine
-  already is and the reconciler agrees within a pass; creating a claim
-  unguarded writes a promise against totals nothing has computed, which
-  the next pass folds into `claimed_*` whether it fits or not.
+  already is and the reconciler agrees within about a minute of that
+  hypervisor's metrics existing (see above), rather than waiting out
+  its ordinary cadence; creating a claim unguarded writes a promise
+  against totals nothing has computed, which the next pass folds into
+  `claimed_*` whether it fits or not.
 - **Claim ceilings are advisory** for one release.
   `_direct_admit_instance_placement()` splits phase 3's single
   `guarded = enforce and node_present` into `node_guarded`,

--- a/docs/operator_guide/database.md
+++ b/docs/operator_guide/database.md
@@ -804,7 +804,9 @@ for why a `SELECT` ahead of the `UPDATE` reintroduces ER_CHECKREAD
 Operator-facing observability is the `scheduler_capacity_*` family of
 prometheus metrics (per-node limit/used/expected-demand gauges, cluster-row
 gauges, and reconcile pass/failure counters, last-success timestamp and
-duration) exported from the cluster daemon's metrics port
+duration, plus `scheduler_capacity_reconcile_forced_total` counting
+passes the elected node forced because a hypervisor had no capacity
+row) exported from the cluster daemon's metrics port
 (`CLUSTER_METRICS_PORT`, default `13007`), plus one structured log line
 per reconcile pass.
 

--- a/docs/operator_guide/scheduler.md
+++ b/docs/operator_guide/scheduler.md
@@ -306,12 +306,18 @@ it is already placed on, and a node with no capacity row -- one
 mid-upgrade, or one the reconciler declined to size -- is charged
 nothing, because admission will let it through unguarded too. That
 is also true of a cluster whose reconciler has not completed a pass
-yet, where *no* node has a row; the reconcile is scheduled so that
-window is a cluster's first moments rather than its first five
-minutes (see [the database internals
-guide](../developer_guide/database_internals.md)), and an admission
-made inside it says so on the instance's `instance placed without
-capacity guard` event with a `reason` of `never_reconciled`.
+yet, where *no* node has a row: the elected cluster node's
+maintenance pass forces a reconcile as soon as it sees an active
+hypervisor with fresh metrics and no capacity row, so that window
+closes roughly a minute after the hypervisor's metrics become visible
+rather than waiting out the reconciler's five-minute cadence (see
+[the database internals
+guide](../developer_guide/database_internals.md)). That minute is not
+the dominant term -- most of the wait is for the resources daemon to
+publish metrics at all, on its own roughly 60-second cadence, which
+this does not shorten -- and an admission made inside either window
+says so on the instance's `instance placed without capacity guard`
+event with a `reason` of `never_reconciled`.
 
 See [Admission is a guarded capacity
 claim](#admission-is-a-guarded-capacity-claim) for the check that
@@ -765,10 +771,14 @@ tells the whole story:
   MariaDB, which the reply reports back on its `degraded` field. It is
   *not* emitted for an empty table: a cluster the reconciler has not
   reached yet has no rows at all, which is normal and admits
-  unguarded. Admission is unchanged either way, so this marks a
-  decision made with less information rather than a decision made
-  differently. Seeing it repeatedly points at the database tier rather
-  than at the scheduler.
+  unguarded -- and self-limiting, since the elected node forces a
+  reconcile within about a minute of an active hypervisor's metrics
+  becoming visible (see [Admission is a guarded capacity
+  claim](#admission-is-a-guarded-capacity-claim) above). Admission is
+  unchanged either way, so this marks a decision made with less
+  information rather than a decision made differently. Seeing it
+  repeatedly points at the database tier rather than at the
+  scheduler.
 - `schedule at stage affinity_constraints` is the hard constraint
   filter, with a `dropped` map naming which of `require_with_tag` or
   `require_without_tag` ejected each node. It is absent when no hard

--- a/docs/plans/PLAN-transient-capacity-refusals-phase-01-warm-up.md
+++ b/docs/plans/PLAN-transient-capacity-refusals-phase-01-warm-up.md
@@ -1,0 +1,417 @@
+# Phase 1: close the warm-up window
+
+Parent plan:
+[PLAN-transient-capacity-refusals.md](PLAN-transient-capacity-refusals.md).
+
+**Planning effort:** high, as the master plan specifies. The change
+itself is a dozen lines in one file. What keeps it above mechanical
+is that the check has to agree with a predicate that lives in
+another process's SQL, and a check which disagrees with it does not
+fail loudly -- it silently demands a reconcile pass forever, turning
+a five-minute job into a one-minute one for the life of the cluster.
+
+This phase opens the plan's decision sequence at **D1**. There is one
+namespace across the whole plan, because later phases cite these by
+number.
+
+## Context
+
+The master plan's Situation section establishes that the warm-up
+window is *not* what fails CI runs -- every post-#4106
+`sufficient_idle_cpu` refusal read from journals was a
+`force_placement` create onto a node genuinely at its ledger limit.
+The window is real, it accounts for the whole of the sub-three-minute
+exposure, and it produces the `0 / 6 / 3` and `6 / 0 / 3` residue
+rows in that section's table, but fixing it will not by itself make
+a red run green.
+
+It is first anyway, for three reasons. It is the smallest server-side
+change in the plan. It is the one that finishes #4087, which is still
+open. And phases 2 and 5 measure how long the suite waits for
+capacity: if ten to seventeen placements per run are still being
+admitted against nothing at all while that measurement is taken, the
+numbers phase 5 reads are polluted by a known defect.
+
+Concretely: `scheduler_node_capacity` has no rows until the
+reconciler's first pass. A node with no row is admitted against
+nothing (P7), so every early placement fails open, and the first real
+pass then writes accumulated ground truth onto a row whose limit it
+already exceeds. PR #4106 anchored the reconcile to election and
+added a one-shot `_force_capacity_reconcile_if_unguarded()`
+(`shakenfist/daemons/cluster/main.py:741`, called at `:879`). In all
+six post-#4106 runs the one-shot fired 130-150 s *before* the test
+step and the pass it forced logged `nodes=0 nodes_added=0`: no
+hypervisor had published metrics yet. The table then stayed empty
+until the five-minute cadence created rows at +155..+181 s.
+
+The one-shot is not wrong. It is a property of *election*, and the
+condition it tests is a property of *time*.
+
+## Scope
+
+**In scope:**
+
+* Making the unguarded-table check something the elected loop repeats
+  rather than something election does once.
+* Making that check agree with the predicate the reconciler actually
+  applies, so it cannot demand a pass which will never satisfy it.
+* Unit tests extending the existing `ForcedCapacityReconcileTestCase`.
+* One functional assertion in the CI suite, replacing a `skipTest`
+  which this change makes unreachable.
+* A non-gating time-to-first-capacity-row figure in the headroom
+  report, so the improvement is visible in every run's log.
+* Commenting on #4087 with the finding, and closing it.
+* Documentation: `docs/operator_guide/scheduler.md` and
+  `docs/developer_guide/subsystem_internals.md` both describe the
+  unguarded state and must describe how long it now lasts.
+
+**Out of scope:**
+
+* Anything that changes admission itself. The pre-filters, the demand
+  guard, `max(measured, committed)` and the guarded UPDATE all belong
+  to scheduler-reservations (its D11, phase 5). This phase changes
+  *when a capacity row exists*, never what admission does with one.
+* The 60 s metrics publication lag. That is phase 3, and it is the
+  dominant term in the remaining window -- see D1.
+* Any client or suite retry behaviour. Phases 2 and 4.
+* Reshaping the CI topologies. `PLAN-ci-cloud-sizing.md` phase 4.
+* Making the refusal itself more informative. Phase 4.
+
+## What the survey found
+
+Seven findings. Four contradict claims this phase inherited. Finding
+2 was corrected in the master plan before it merged (commit
+`7d4cfbda0`); findings 1 and 6 are corrected at source in this
+planning commit. Re-check all three rather than redoing them.
+Findings 3, 4, 5 and 7 are new information rather than corrections,
+and live here.
+
+1. **The elected loop's maintenance body runs every 60 s, not every
+   iteration.** The loop polls every `ELECTED_LOOP_POLL_SECONDS = 5`
+   (`shakenfist/daemons/cluster/main.py:63`) but the maintenance
+   block sits behind `if now - last_loop_run >= 60` (`:913`) and
+   `_run_due_scheduled_jobs()` is inside it (`:918`). Marking the
+   capacity reconcile due does not run it before the next 60 s tick.
+   The master plan cites this as `:912`, off by one; corrected here.
+   This is the finding D1 turns on.
+
+2. **`cluster_stable()` reads no metric freshness.** It compares
+   object versions across nodes (`shakenfist/daemons/daemon.py:377`)
+   and catches a just-restarted cluster only incidentally, because
+   no node has recorded a version yet and `minimum` is `inf`. The
+   master plan's phase 1 section said the gate protects against "a
+   pass with no fresh metrics"; that was corrected before merge.
+
+3. **The unit tests already exist.** The master plan reads as though
+   this phase writes the first one. `ForcedCapacityReconcileTestCase`
+   (`shakenfist/tests/test_daemon_cluster_schedule_anchoring.py:244`)
+   already pins five cases: an empty table forces the pass due, a
+   populated table leaves the cadence alone, a degraded read is not
+   an empty table, a failed read does not escape the election, and no
+   registered job reads nothing. Extend that class; do not create a
+   new file, and do not weaken any of the five.
+
+4. **No new RPC is needed.** `mariadb.get_all_node_metrics()`
+   (`shakenfist/mariadb.py:21075`) already exists and is already
+   gRPC-backed, returning one dict per node. So this stays a
+   one-file-plus-tests change and needs no proto regeneration. Note
+   the shape: each dict is `{node_uuid, fqdn, timestamp, metrics}`,
+   and `is_hypervisor` is *inside* the `metrics` JSON, not a
+   top-level key -- the typed column exists in the table but
+   `_direct_get_all_node_metrics()` (`:20909`) does not project it
+   into the reply.
+
+5. **The reconciler's predicate is richer than "hypervisor with
+   fresh metrics", and this is the phase's main hazard.**
+   `_direct_reconcile_scheduler_capacity()` (`:25022`) gives a node a
+   capacity row only if it is `is_hypervisor IS TRUE`, has
+   `timestamp > now - RECONCILE_METRICS_MAX_AGE_SECONDS`, is in
+   `active_nodes` (an `object_states` row in `NODE_ACTIVE_STATES`)
+   *and* is in `known_nodes` (a row in the `nodes` table). The code
+   documents why the last one exists: a `node_metrics` row that
+   outlived its node "reads as a fresh hypervisor" and would
+   otherwise become a permanent phantom. A check testing only the
+   first two conditions would see that phantom as an unguarded
+   hypervisor on every pass, forever, and force the five-minute
+   reconcile to run every 60 s for the life of the cluster. D2 and D3
+   exist for this.
+
+6. **#4087 is open, not closed.** It carries `bug` and
+   `automated-fix-attempted`. The master plan said "(closed by
+   #4106, incompletely) ... Phase 1 reopens or comments"; there is
+   nothing to reopen. Corrected at source in this planning commit, in
+   both the phase 1 section and the bugs list. This phase comments
+   and closes.
+
+7. **The freshness window is 900 s, not 60 s.**
+   `RECONCILE_METRICS_MAX_AGE_SECONDS = 900` (`:636`). "Has published
+   metrics" in this check must mean the reconciler's 900 s window,
+   not the resources daemon's 60 s publication cadence. A tighter
+   window in the check would make it and the pass disagree in the
+   direction that matters least (missing a node), but a looser one
+   would make them disagree in the direction that thrashes.
+
+## Decisions
+
+### D1 -- The check runs inside the 60 s maintenance gate
+
+Not on the 5 s poll. The window closes to about a minute rather than
+to seconds.
+
+This is the decision a reviewer is most likely to argue with, so the
+reasoning is set out in full. Three things push this way.
+
+The check cadence is not the dominant term. The measured window is
+135-210 s, and almost all of it is the wait for a hypervisor to
+publish metrics at all -- the forced pass at election found
+`nodes=0` because there was nothing to size, 130-150 s before the
+test step. Once metrics exist, a 60 s worst case adds 60 s to a term
+that was already 135-210 s. Going from 60 s to 5 s buys at most 55 s
+on top of an improvement of roughly 100-150 s, and phase 3 attacks
+the dominant term directly.
+
+The 5 s option is not free. The check costs two reads
+(`get_scheduler_node_capacity()` and `get_all_node_metrics()`). Inside
+the 60 s gate that is 0.033/s, riding a maintenance pass that already
+reads far more. On the 5 s poll it is 0.4/s of fixed-rate polling,
+which needs a `cluster_base_qps` entry in
+`shakenfist/data/database_load_budget.yaml` or
+`test_no_unbudgeted_fixed_rate_database_polling` fails -- and it
+would be *fixed-rate*, so it raises the idle-cluster floor the
+database-load-reduction plan is trying to lower, permanently, to buy
+55 s once per cluster lifetime.
+
+Marking the job due from inside the gate runs it in the same pass.
+`_run_due_scheduled_jobs()` is called at `:918`, immediately after
+where the check goes, so setting `next_run` and then calling
+`schedule.run_pending()` executes the reconcile without waiting for
+another tick.
+
+If a later phase shows the residual minute matters, the check is one
+call and can move. Recorded as future work in the master plan rather
+than pre-empted here.
+
+### D2 -- The check mirrors the reconciler's predicate, including the active-node intersection
+
+A node counts as an unguarded hypervisor only if it has metrics with
+`is_hypervisor` true, a `timestamp` inside
+`RECONCILE_METRICS_MAX_AGE_SECONDS`, is in the active node set, and
+has no `scheduler_node_capacity` row. Import the constant from
+`mariadb` rather than restating 900; a check with its own copy of
+that number will drift from the pass it is trying to trigger.
+
+The active-node intersection is the one that cannot be skipped
+(finding 5). Use `Nodes([], prefilter='active')`, which is what both
+the scheduler and the reconciler's `active_nodes` set resolve to, so
+the check and the pass agree by construction rather than by
+coincidence.
+
+The `known_nodes` half of the reconciler's predicate is not mirrored:
+a node with an `object_states` row in an active state but no row in
+the `nodes` table is a stateless zombie, and the active-node
+prefilter already excludes anything without a resolvable object. If
+the implementer finds that assumption does not hold, treat it as a
+finding and stop -- do not add a second-guess intersection without
+saying why in the commit message.
+
+### D3 -- Do not force twice for the same unguarded set
+
+Remember the set of node uuids the last forced pass was issued for.
+Force only when the current unguarded set is non-empty and differs
+from that remembered set; clear the memory when the set becomes
+empty.
+
+This bounds the failure mode D2 is guarding against rather than
+merely making it unlikely. If some node genuinely qualifies under
+this check but the reconciler declines to size it anyway -- a P7
+decline this phase has not anticipated -- the pass is forced once,
+observed not to have helped, and then left alone until the set
+changes. The ordinary five-minute cadence still runs, so nothing is
+lost; the cluster just does not spend the rest of its life
+reconciling every minute.
+
+The remembered set is process-local state on the monitor object,
+reset on election like the rest of the elected loop's state. It is
+not persisted: a daemon restart re-forcing once is correct, not a
+bug.
+
+### D4 -- Delete the election-time call site
+
+Generalise the existing helper and call it from the maintenance pass;
+remove the call at `:879`.
+
+Keeping both would leave two paths that can drift. Nothing is lost by
+removing the election-time call: `last_loop_run` is initialised to 0
+(`:813`) outside the outer election loop, so the first maintenance
+pass after any election finds `now - last_loop_run >= 60` true and
+runs immediately. The election-time call is also *upstream* of the
+`cluster_stable()` gate, so on an unstable cluster it can force a job
+due that will not run -- which is harmless but is exactly the kind of
+"why is this due?" confusion the check is meant to remove.
+
+The five existing unit tests call the helper directly and keep
+working unchanged. That is deliberate: they pin the degraded-read and
+empty-table semantics, which this phase must not alter.
+
+### D5 -- One warning per distinct unguarded set, plus a counter
+
+The existing helper logs `No scheduler capacity rows exist, so every
+placement is being admitted unguarded` at warning. Keep that
+wording for the all-empty case, and add a second warning naming the
+node uuids for the partial case, emitted under the same
+once-per-distinct-set rule as D3 so a stuck condition does not
+produce a line a minute forever.
+
+Export a counter for forced passes alongside the existing
+`SCHEDULER_CAPACITY_*` metrics in
+`shakenfist/daemons/cluster/scheduled_tasks.py`. Without it,
+"how often is this firing in production?" is answerable only by
+grepping logs, and a thrash introduced by a later change would be
+invisible until someone looked.
+
+### D6 -- The functional assertion replaces the skip, and the report measures
+
+`shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_nodes.py:136`
+currently skips when the node under test has no capacity row. After
+this change that condition is the bug, so a skip would hide exactly
+the regression this phase exists to prevent. Convert it to an
+assertion.
+
+It must not race the cluster coming up. The suite already has
+`tools/ci_wait_schedulable.py` gating the test step, so by the time
+any functional test runs, a hypervisor exists and has been schedulable
+-- but the implementer must confirm that gate runs before this test
+in the workflow rather than assuming it, and if it does not, the
+assertion waits with the suite's existing retry helper rather than
+failing on first read.
+
+Separately, `tools/ci_headroom_report.py` gains a time-to-first-
+capacity-row figure computed from the series it already parses
+(`cpu_committed_row_present` is in every sample). That is the
+measurement of this phase's effect across the whole fleet, and per
+ci-cloud-sizing D15 it is printed, never gating.
+
+## Step plan
+
+| Step | Effort | Model | Isolation | Brief for sub-agent |
+|------|--------|-------|-----------|---------------------|
+| 1a | high | opus | none | Generalise `_force_capacity_reconcile_if_unguarded()` in `shakenfist/daemons/cluster/main.py:741` so it forces the capacity reconcile when *any* active hypervisor with fresh metrics has no `scheduler_node_capacity` row, not only when the table is entirely empty, and call it from the elected loop's maintenance pass instead of from election. Read the whole docstring first: the degraded-versus-empty distinction it describes is load-bearing and must survive unchanged (`get_scheduler_node_capacity()` returns `(rows, degraded)`; `rows` is empty for both an empty table and an unreadable one, and only `degraded` says which -- see `shakenfist/mariadb.py:27215`). The unguarded set is: nodes with a `get_all_node_metrics()` entry whose `metrics['is_hypervisor']` is true -- note `is_hypervisor` is inside the `metrics` dict, not a top-level key of the returned record (`mariadb.py:20909`) -- whose `timestamp` is greater than `now - mariadb.RECONCILE_METRICS_MAX_AGE_SECONDS` (import the constant, do not restate 900), which appear in `Nodes([], prefilter='active')`, and which have no row in `rows`. Mirroring the reconciler's predicate is the whole point: `_direct_reconcile_scheduler_capacity()` (`mariadb.py:25022`, the refresh block from `:25115`) applies exactly these plus a `nodes`-table membership test, and a check that omits the active-node intersection will treat a `node_metrics` row that outlived its node as a permanently unguarded hypervisor and force the five-minute job every 60 s forever -- the code comment at `:25201` describes that phantom. Implement D3: keep the set of uuids the last force was issued for on the monitor, force only when the current set is non-empty and differs from it, clear it when the set empties. Implement D5: keep the existing all-empty warning text, add a second warning naming the uuids for the partial case under the same once-per-set rule, and add a forced-pass counter beside the `SCHEDULER_CAPACITY_*` metrics in `shakenfist/daemons/cluster/scheduled_tasks.py`. Per D4, call it from inside the `else:` branch at `main.py:911` before `_run_due_scheduled_jobs()` at `:918` so the forced job runs in the same pass, and delete the call at `:879`. Extend `ForcedCapacityReconcileTestCase` (`shakenfist/tests/test_daemon_cluster_schedule_anchoring.py:244`) rather than writing a new file, and do not weaken its five existing tests. Add: a hypervisor with fresh metrics and no row forces the pass; the same set on the next call does not force again; a changed set does force again; a stale-metrics hypervisor does not force; a non-hypervisor with no row does not force; a hypervisor with fresh metrics that is not in the active set does not force (this is the phantom -- assert it explicitly, and confirm that deleting the active-node intersection makes this one test fail); a degraded read still forces nothing. Single quotes, 120 columns, no trailing whitespace. |
+| 1b | medium | sonnet | none | The CI-visible half. In `shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_nodes.py`, convert the `skipTest` at `:136` into an assertion, per D6: after this phase a hypervisor without a capacity row is the defect, and skipping hides it. First confirm from `.github/workflows/` that `tools/ci_wait_schedulable.py` gates the functional-test step, so the assertion cannot race cluster start-up; if it does not, use the suite's existing retry helper (`shakenfist/deploy/shakenfist_ci/retries.py`) rather than asserting on the first read, and say which you found in the commit message. Leave the three assertions below it unchanged. Then add a time-to-first-capacity-row figure to `tools/ci_headroom_report.py`: the series already carries `cpu_committed_row_present` per node per sample, so report the offset from the first sample to the first sample in which every hypervisor in the roster has a row, and report it as absent rather than zero when it never happens. Print it; never gate on it (ci-cloud-sizing D15). Extend the tool's unit tests (`shakenfist/tests/test_ci_headroom_report.py`) with a series where the row never appears and one where it appears immediately. |
+| 1c | medium | sonnet | none | Documentation. `docs/operator_guide/scheduler.md` describes the unguarded state at `:305` and `:768`, and `docs/developer_guide/subsystem_internals.md` at `:248`; all three now need to say how long a cluster spends in it and what ends it. State the bound honestly: about a minute after a hypervisor's metrics become visible to the elected node, not "immediately", and note that the wait for those metrics is the larger term and is phase 3's. Mention the forced-pass counter from 1a where the other `SCHEDULER_CAPACITY_*` metrics are documented. Do not touch `AGENTS.md` or `ARCHITECTURE.md`: no convention and no component boundary changes here. |
+| 1d | low | haiku | none | Comment on #4087 and close it. The comment states what #4106 did fix (the missing-stamp case, and the MariaDB-outlived-its-nodes case), what it did not (the one-shot fires on the election path, before any hypervisor has published metrics, so on a fresh cluster it finds nothing and nothing re-checks -- observed in all six post-#4106 CI runs as a forced pass logging `nodes=0 nodes_added=0` 130-150 s before the test step), and what this phase changed. Do not reopen anything -- the issue is already open. Link the merged pull request. Wait for the operator's confirmation that 1a-1c have merged before commenting. |
+| 1e | low | haiku | none | Set the phase 1 row to `Complete` in the master plan's Execution table and in `docs/plans/index.md`, update the index arithmetic to `1 of 6`, then run `python3 tools/check-plan-status.py`. Only after 1a-1d are reviewed and the operator has confirmed a real CI run shows the time-to-first-capacity-row figure from 1b. |
+
+The survey corrections that would otherwise have been a step here
+were made in the planning commit, per the note under *What the survey
+found*.
+
+## Risks and mitigations
+
+* **The check disagrees with the reconciler and thrashes.** The
+  headline risk, and the reason this phase is planned at high effort.
+  A node that satisfies the check but which the reconciler declines
+  to size makes the five-minute job run every 60 s for the life of
+  the cluster, which is a permanent load regression that no test
+  would catch. *Mitigation:* D2 mirrors the predicate and imports the
+  reconciler's own freshness constant; D3 bounds the blast radius to
+  one forced pass per distinct set even if the mirror is imperfect;
+  1a's test list includes the phantom case explicitly and requires
+  that removing the intersection makes it fail; D5's counter makes
+  the condition visible in production. The management session checks
+  the counter against a real run before 1e closes the phase.
+* **Deleting the election-time call loses a case nobody enumerated.**
+  D4's reasoning depends on `last_loop_run` being initialised outside
+  the election loop, which is true today (`:813`) but is not
+  obviously load-bearing to a future reader. *Mitigation:* 1a is
+  briefed to leave a comment at the initialisation saying the
+  capacity check depends on it. A reviewer who disagrees can keep
+  both call sites at the cost of one extra read per election; say so
+  in review rather than after merge.
+* **The converted assertion makes CI flakier, not less flaky.** This
+  plan exists because CI is unreliable; adding a hard assertion to a
+  suite that already fails on capacity is a real way to make things
+  worse. *Mitigation:* D6 requires the implementer to confirm the
+  readiness gate runs first rather than assume it, with a retry
+  fallback if it does not. If the assertion fires on a green run
+  during review, revert it to a skip and treat that as a finding
+  about this phase's fix, not about the test.
+* **A minute is still too long and nobody notices.** *Mitigation:*
+  1b's report figure is the measurement, printed on every run, so the
+  question is answerable from any bundle rather than needing another
+  journal dig like the one that produced this plan.
+* **The phase is mistaken for a fix for #3772.** It is not, and the
+  master plan says so. *Mitigation:* 1d's comment closes #4087 only;
+  the commit messages say "Related to #3772", never "Fixes".
+
+## Definition of done
+
+Falsifiable, in order:
+
+1. `_force_capacity_reconcile_if_unguarded()` forces the reconcile
+   when an active hypervisor with fresh metrics has no capacity row,
+   not only when the table is empty, and is called from the elected
+   loop's maintenance pass rather than from election. The call at
+   `main.py:879` is gone.
+2. All five pre-existing tests in `ForcedCapacityReconcileTestCase`
+   still pass unmodified.
+3. A test asserts that a hypervisor with fresh metrics which is *not*
+   in the active node set does not force a pass, and deleting the
+   active-node intersection from the implementation makes that test
+   fail. The second half is the check: run it and confirm, do not
+   assert it from reading.
+4. A test asserts that the same unguarded set on two consecutive
+   calls forces exactly one pass, and that a changed set forces
+   another.
+5. No literal `900` appears in the new code; the freshness bound is
+   `mariadb.RECONCILE_METRICS_MAX_AGE_SECONDS`.
+6. `test_nodes.py` contains no `skipTest` for a missing capacity row,
+   and the assertion that replaced it is either gated by
+   `ci_wait_schedulable` running earlier in the workflow or wrapped
+   in the suite's retry helper -- the commit message says which.
+7. `tools/ci_headroom_report.py` prints a time-to-first-capacity-row
+   figure, reports it as absent rather than zero when no sample has
+   every hypervisor covered, and has unit tests for both.
+8. A real CI run on `slim-tier` shows that figure under 60 s. The
+   operator confirms this from a bundle; it cannot be checked from a
+   worktree.
+9. No statement in `docs/operator_guide/scheduler.md` or
+   `docs/developer_guide/subsystem_internals.md` still implies the
+   unguarded window lasts until the five-minute cadence, and neither
+   claims it is closed immediately.
+10. #4087 is closed with a comment recording what #4106 fixed and
+    what it did not.
+11. `python3 tools/check-plan-status.py` passes and
+    `pre-commit run --all-files` passes.
+
+## What later phases inherit
+
+* A cluster whose capacity rows exist within about a minute of a
+  hypervisor publishing metrics, so phase 5's measurement of how long
+  the suite waits is not polluted by unguarded admissions.
+* A printed per-run figure for how long the window actually was, so
+  phase 3's effect on the dominant term is measurable against a
+  before-and-after rather than argued.
+* A forced-pass counter, which phase 3 should watch: publishing
+  metrics on domain-set change will make hypervisors appear to the
+  reconciler sooner, and this counter is where that shows up.
+* The knowledge that the reconciler's qualifying predicate has four
+  clauses and that mirroring three of them is a permanent load
+  regression, recorded here so the next person to write a
+  capacity-adjacent check does not rediscover it.
+
+## Back brief
+
+Before executing any step of this plan, back brief the operator on
+your understanding of it: what you are about to change, which
+decision you think is weakest, and what you expect to be true when
+you are done. Do not begin until that is acknowledged.
+
+There is one gate inside the phase. Step 1a's treatment of D2 and D3
+is cheap to propose and expensive to redo, because getting the
+predicate wrong is invisible until it is running in production.
+Before writing the tests, state the exact predicate you intend to
+implement -- clause by clause, against
+`_direct_reconcile_scheduler_capacity()` -- and have it agreed. If
+your reading of the reconciler differs from finding 5 in any
+respect, stop and say so: the finding is what the rest of this plan
+is built on.

--- a/docs/plans/PLAN-transient-capacity-refusals-phase-01-warm-up.md
+++ b/docs/plans/PLAN-transient-capacity-refusals-phase-01-warm-up.md
@@ -285,6 +285,21 @@ in the workflow rather than assuming it, and if it does not, the
 assertion waits with the suite's existing retry helper rather than
 failing on first read.
 
+**Amended after review: the gate does not cover the condition, so the
+second branch applies.** `ci_wait_schedulable.py` waits for a node to
+appear in `/admin/resources` `per_node`, which means active and
+publishing fresh metrics. It says nothing about a
+`scheduler_node_capacity` row, and by D1 that row arrives up to a
+minute later -- so clearing the gate and having the row are different
+facts, and asserting on the first read races the very window this
+phase measures. The assertion therefore waits. It does so with a
+bounded poll of `/admin/resources` rather than with
+`retries.retry_while_transient()`: that helper takes a `(status, body)`
+pair and retries on transient HTTP statuses, which is the wrong shape
+for polling a boolean field out of a successful response. The wait is
+120 s, comfortably longer than the warm-up window, so a row which
+never arrives still fails the test.
+
 Separately, `tools/ci_headroom_report.py` gains a time-to-first-
 capacity-row figure computed from the series it already parses
 (`cpu_committed_row_present` is in every sample). That is the
@@ -353,7 +368,18 @@ Falsifiable, in order:
    loop's maintenance pass rather than from election. The call at
    `main.py:879` is gone.
 2. All five pre-existing tests in `ForcedCapacityReconcileTestCase`
-   still pass unmodified.
+   still pass. *Two were modified, and this item is not met as
+   written.* Both previously reached the real
+   `mariadb.get_all_node_metrics()`, whose behaviour in a unit test
+   depends on the host: where nothing is configured it raises at once
+   and the check returns on its unknown-answer branch, so
+   `test_a_populated_table_leaves_the_cadence_alone` was passing
+   without ever reaching the question it names, and
+   `test_an_empty_table_forces_the_pass_due` was reaching the
+   empty-table branch only by way of that same accident. Both now mock
+   the three reads the check makes. The behaviour they assert is
+   unchanged; what changed is that they now assert it deterministically
+   and offline.
 3. A test asserts that a hypervisor with fresh metrics which is *not*
    in the active node set does not force a pass, and deleting the
    active-node intersection from the implementation makes that test
@@ -368,19 +394,28 @@ Falsifiable, in order:
    and the assertion that replaced it is either gated by
    `ci_wait_schedulable` running earlier in the workflow or wrapped
    in the suite's retry helper -- the commit message says which.
-7. `tools/ci_headroom_report.py` prints a time-to-first-capacity-row
+   *Met by the second branch: the gate does not cover the condition,
+   so the assertion waits. See the amendment under D6.*
+7. `_unguarded_hypervisors()` returns `None` rather than the empty set
+   for a metrics read which returned nothing, and a test fails if it
+   does not. Both transports swallow a failed read into `[]`, so the
+   empty list is an unknown answer and treating it as an authoritative
+   one would defeat D3.
+8. `tools/ci_headroom_report.py` prints a time-to-first-capacity-row
    figure, reports it as absent rather than zero when no sample has
-   every hypervisor covered, and has unit tests for both.
-8. A real CI run on `slim-tier` shows that figure under 60 s. The
+   every hypervisor covered, distinguishes a bundle which never
+   carried `cpu_committed_row_present` from one which carried it false,
+   and has unit tests for all three.
+9. A real CI run on `slim-tier` shows that figure under 60 s. The
    operator confirms this from a bundle; it cannot be checked from a
    worktree.
-9. No statement in `docs/operator_guide/scheduler.md` or
-   `docs/developer_guide/subsystem_internals.md` still implies the
-   unguarded window lasts until the five-minute cadence, and neither
-   claims it is closed immediately.
-10. #4087 is closed with a comment recording what #4106 fixed and
+10. No statement in `docs/operator_guide/scheduler.md` or
+    `docs/developer_guide/subsystem_internals.md` still implies the
+    unguarded window lasts until the five-minute cadence, and neither
+    claims it is closed immediately.
+11. #4087 is closed with a comment recording what #4106 fixed and
     what it did not.
-11. `python3 tools/check-plan-status.py` passes and
+12. `python3 tools/check-plan-status.py` passes and
     `pre-commit run --all-files` passes.
 
 ## What later phases inherit

--- a/docs/plans/PLAN-transient-capacity-refusals.md
+++ b/docs/plans/PLAN-transient-capacity-refusals.md
@@ -341,7 +341,7 @@ Note what bounds the improvement, because an earlier draft of this
 section claimed seconds. The elected loop polls every
 `ELECTED_LOOP_POLL_SECONDS = 5`
 (`shakenfist/daemons/cluster/main.py:63`) but its maintenance body
-sits behind `if now - last_loop_run >= 60` (`:912`), and
+sits behind `if now - last_loop_run >= 60` (`:913`), and
 `_run_due_scheduled_jobs()` is inside that gate (`:918`). Marking
 the job due does not run it any sooner than the next 60 s tick, so
 a check placed inside the gate closes the window to about a
@@ -497,7 +497,7 @@ spelling above is the one to write.
 
 | Phase | Plan | Status |
 |-------|------|--------|
-| 1. Close the warm-up window: reconcile when a hypervisor has metrics and no capacity row | PLAN-transient-capacity-refusals-phase-01-warm-up.md | Not started |
+| 1. Close the warm-up window: reconcile when a hypervisor has metrics and no capacity row | [PLAN-transient-capacity-refusals-phase-01-warm-up.md](PLAN-transient-capacity-refusals-phase-01-warm-up.md) | Not started |
 | 2. The suite waits, and says so: an informed `create_instance` wrapper and a per-run wait summary | PLAN-transient-capacity-refusals-phase-02-suite-wait.md | Not started |
 | 3. Publish metrics when the running-domain set changes | PLAN-transient-capacity-refusals-phase-03-metrics-on-change.md | Not started |
 | 4. `Retry-After` and a machine-readable transient refusal, with an opt-in client retry | PLAN-transient-capacity-refusals-phase-04-retry-after.md | Not started |
@@ -533,7 +533,7 @@ existing code is careful about (`rows` is empty for both; only
 
 **The decision this phase owns is where the check runs**, and the
 master plan does not pre-empt it. Inside the elected loop's 60 s
-maintenance gate (`:912`) the check costs nothing new -- it rides
+maintenance gate (`:913`) the check costs nothing new -- it rides
 a pass that already reads the database -- and closes the warm-up
 window to about a minute. Outside the gate, on the
 `ELECTED_LOOP_POLL_SECONDS = 5` poll, it closes the window to
@@ -572,8 +572,9 @@ against it before it is written. That assertion also retires a
 when a node has no capacity row, which is exactly the condition
 this phase makes impossible after start-up. Remove the skip in the
 same change rather than leaving unreachable code behind it. Phase
-1 also comments on #4087 with the finding and reopens it if that
-is the convention the tracker follows for an incomplete fix.
+1 also comments on #4087 with the finding and closes it. The issue
+is still open -- #4106 never closed it -- so there is nothing to
+reopen.
 
 Small, server-side, one file plus tests. Plan at high effort: the
 placement decision above, the interaction with the stability gate
@@ -1014,8 +1015,9 @@ while planning it.
 
 - **#3772** (open, umbrella) -- the refusal this plan is about.
   Stays open until phase 6 has the before-and-after numbers.
-- **#4087** (closed by #4106, incompletely) -- the warm-up window.
-  Phase 1 reopens or comments, and fixes it.
+- **#4087** (open; #4106 attempted it and did not close it) -- the
+  warm-up window. Phase 1 fixes it, comments with what #4106 did and
+  did not cover, and closes it.
 - **#3498, #3602, #3670, #3728, #3749, #3767** (closed into #3772)
   -- the per-test victims. Do not file another; the umbrella exists
   because per-test tracking stopped paying for itself.

--- a/shakenfist/daemons/cluster/main.py
+++ b/shakenfist/daemons/cluster/main.py
@@ -62,6 +62,11 @@ SCHEDULED_TASK_LAST_RUN_PREFIX = 'SCHEDULED_TASK_LAST_RUN_'
 # constant rather than restating the number.
 ELECTED_LOOP_POLL_SECONDS = 5
 
+# Marks the "no capacity rows at all" half of a forced-reconcile
+# condition, so that state can never compare equal to the partly
+# populated one. See _force_capacity_reconcile().
+CAPACITY_TABLE_EMPTY = 'capacity-table-empty'
+
 # The candidate election poll: how long an unelected cluster daemon waits
 # between attempts to acquire the cluster maintenance lock. The wait is
 # drawn uniformly from this range rather than being a fixed five seconds
@@ -80,10 +85,17 @@ ELECTION_POLL_MAXIMUM_SECONDS = 7.5
 
 class Monitor(daemon.Daemon):
     # Set by _run_inner() when the maintenance schedule is registered.
-    # Declared here as well because the election hook which forces a
+    # Declared here as well because the maintenance hook which forces a
     # capacity pass reads it, and a Monitor built by a test which never
     # registers a schedule would otherwise raise rather than no-op.
     _capacity_reconcile_job = None
+
+    # The unguarded condition the last forced capacity reconcile was
+    # issued for, so the same one is not forced again on every
+    # maintenance pass. Process-local and reset on election; a daemon
+    # restart re-forcing once is correct rather than a bug, which is why
+    # this is never persisted.
+    _forced_capacity_reconcile_for = None
 
     def __init__(self, name):
         super().__init__(name)
@@ -739,17 +751,41 @@ class Monitor(daemon.Daemon):
                 }).warning('Ignoring unusable scheduled task last-run stamp')
 
     def _force_capacity_reconcile_if_unguarded(self):
-        """Make the capacity reconcile due now if nothing is guarding placement.
+        """Make the capacity reconcile due now if placement is not guarded.
 
-        An empty scheduler_node_capacity table means every admission in
-        this cluster is failing open, because a node with no row is
-        admitted against nothing at all (P7). Anchoring the reconcile
-        covers the case which produced issue 4087 -- a fresh cluster,
-        whose stamp is missing, waiting out a five minute process-local
-        timer -- but a stamp is a proxy for the condition rather than
-        the condition itself. A cluster whose MariaDB outlived its
-        nodes has a recent stamp and no row for any node uuid which now
-        exists. Read the table and act on what it says.
+        A node with no scheduler_node_capacity row is admitted against
+        nothing at all (P7), so every placement onto it fails open.
+        Anchoring the reconcile covers the case which produced issue
+        4087 -- a fresh cluster, whose stamp is missing, waiting out a
+        five minute process-local timer -- but a stamp is a proxy for
+        the condition rather than the condition itself. A cluster whose
+        MariaDB outlived its nodes has a recent stamp and no row for any
+        node uuid which now exists. Read the table and act on what it
+        says.
+
+        Both an empty table and a partly populated one matter, which is
+        why this is no longer only an election-time check. Election
+        happens before any hypervisor on a cold cluster has published
+        metrics, so the pass it forced had nothing to size and the table
+        stayed empty until the next cadence tick anyway. Asking the
+        sharper question -- is there an active hypervisor with fresh
+        metrics and still no row? -- from the maintenance pass closes
+        the window about a minute after the first metrics appear.
+
+        The unguarded set deliberately mirrors the predicate
+        _direct_reconcile_scheduler_capacity() applies when it decides
+        which nodes get a row, because a check which asks a *broader*
+        question than the pass can answer would demand a pass on every
+        cycle for the life of the cluster. The active-node intersection
+        is the clause which cannot be dropped: a node_metrics row which
+        outlived its node reads as a fresh hypervisor forever (the
+        phantom the reconciler's own comment describes), and without
+        that clause it would silently turn a five minute job into a
+        sixty second one. The reconciler's fourth clause -- a row in the
+        nodes table -- is not restated here because
+        Nodes([], prefilter='active') hydrates each node from that table
+        and drops anything it cannot find, so a stateless zombie is
+        already excluded.
 
         A failed read is not an empty table, and this must not confuse
         the two: get_scheduler_node_capacity() reports which it was, and
@@ -757,6 +793,13 @@ class Monitor(daemon.Daemon):
         read leaves the anchored cadence alone rather than scheduling
         work on a guess -- and if the database service is unreachable
         the reconcile RPC would fail anyway.
+
+        Finally, a forced pass which does not clear the condition must
+        not be re-forced every minute forever, so the condition last
+        forced for is remembered and the same one is never forced twice.
+        If some node qualifies here but the reconciler declines to size
+        it anyway, that costs one pass rather than a permanent load
+        regression; the ordinary five minute cadence still runs.
         """
         if self._capacity_reconcile_job is None:
             return
@@ -769,12 +812,110 @@ class Monitor(daemon.Daemon):
                 'capacity reconcile on its anchored cadence')
             return
 
-        if degraded or rows:
+        if degraded:
             return
 
-        LOG.warning(
-            'No scheduler capacity rows exist, so every placement is being '
-            'admitted unguarded; reconciling capacity now')
+        unguarded = self._unguarded_hypervisors(rows)
+
+        if not rows:
+            # Nothing at all is guarded, which is worth saying in the
+            # words it has always been said in. The condition still
+            # carries the unguarded set, because a cold cluster forces a
+            # pass here before any hypervisor has published metrics: the
+            # pass finds nothing to size, the table stays empty, and
+            # without the set in the condition the arrival of the first
+            # hypervisor would look like the same condition and force
+            # nothing. A failed metrics read reads as the empty set,
+            # which is the right answer for this branch -- the empty
+            # table alone justifies the pass.
+            self._force_capacity_reconcile(
+                (CAPACITY_TABLE_EMPTY, frozenset(unguarded or set())),
+                'No scheduler capacity rows exist, so every placement is '
+                'being admitted unguarded; reconciling capacity now',
+                fields={'nodes': sorted(unguarded)} if unguarded else None)
+            return
+
+        if unguarded is None:
+            return
+
+        if not unguarded:
+            self._forced_capacity_reconcile_for = None
+            return
+
+        self._force_capacity_reconcile(
+            frozenset(unguarded),
+            'Active hypervisors have no scheduler capacity row, so their '
+            'placements are being admitted unguarded; reconciling capacity '
+            'now',
+            fields={'nodes': sorted(unguarded)})
+
+    def _unguarded_hypervisors(self, rows):
+        """Active hypervisors with fresh metrics and no capacity row.
+
+        Returns None if a read failed, which is a different answer from
+        the empty set for the same reason ``degraded`` is different from
+        an empty table: it means this process does not know.
+        """
+        try:
+            metrics = mariadb.get_all_node_metrics()  # nopushdown: every node wanted
+        except Exception as e:
+            LOG.with_fields({'error': str(e)}).warning(
+                'Could not read node metrics, leaving the capacity '
+                'reconcile on its anchored cadence')
+            return None
+
+        # is_hypervisor lives inside the metrics blob rather than being a
+        # top level field of the record, and is compared against True
+        # rather than tested for truth: the reconciler leaves a node
+        # whose value is missing or NULL (mid-upgrade, before the
+        # resources daemon repopulates the column) out of both its
+        # hypervisor set and its non-hypervisor set, and so do we.
+        # RECONCILE_METRICS_MAX_AGE_SECONDS is imported rather than
+        # restated because a check carrying its own copy of that number
+        # would drift from the pass it is trying to trigger.
+        fresh_after = time.time() - mariadb.RECONCILE_METRICS_MAX_AGE_SECONDS
+        candidates = set()
+        for record in metrics:
+            if (record.get('metrics') or {}).get('is_hypervisor') is not True:
+                continue
+            if (record.get('timestamp') or 0) <= fresh_after:
+                continue
+            candidates.add(str(record.get('node_uuid')))
+
+        candidates -= {str(row.get('node_uuid')) for row in rows}
+        if not candidates:
+            return set()
+
+        # Only now is the active node set worth reading. In the steady
+        # state every fresh hypervisor already has a row, so this costs
+        # nothing on the overwhelming majority of maintenance passes.
+        try:
+            active = {str(n.uuid) for n in Nodes([], prefilter='active')}
+        except Exception as e:
+            LOG.with_fields({'error': str(e)}).warning(
+                'Could not read the active node set, leaving the capacity '
+                'reconcile on its anchored cadence')
+            return None
+
+        return candidates & active
+
+    def _force_capacity_reconcile(self, condition, message, fields=None):
+        """Mark the capacity reconcile due, once per distinct condition.
+
+        ``condition`` is the thing observed -- the empty table paired
+        with whatever was unguarded at the time, or the frozenset of
+        unguarded node uuids on their own -- and forcing is skipped when
+        it has not changed since the last force. That bounds a
+        disagreement between this check and the reconciler to one pass
+        and one log line rather than one of each per minute.
+        """
+        if self._forced_capacity_reconcile_for == condition:
+            return
+
+        self._forced_capacity_reconcile_for = condition
+        log = LOG.with_fields(fields) if fields else LOG
+        log.warning(message)
+        scheduled_tasks.SCHEDULER_CAPACITY_FORCED.inc()
         self._capacity_reconcile_job.next_run = datetime.datetime.now()
 
     def _run_due_scheduled_jobs(self):
@@ -810,6 +951,15 @@ class Monitor(daemon.Daemon):
 
     def _run_inner(self):
         last_defer_message = 0
+
+        # Initialised here, outside the election loop below, and the
+        # unguarded-capacity check now depends on that: the first
+        # maintenance pass after any election finds
+        # now - last_loop_run >= 60 true and therefore runs immediately,
+        # which is the only reason it is safe for
+        # _force_capacity_reconcile_if_unguarded() to live in that pass
+        # rather than on the election path. Do not move it inside the
+        # loop.
         last_loop_run = 0
 
         # Set up the maintenance schedule once, for the life of the
@@ -876,7 +1026,13 @@ class Monitor(daemon.Daemon):
             # shutdown.
             if self.is_elected:
                 self._anchor_scheduled_jobs()
-                self._force_capacity_reconcile_if_unguarded()
+
+                # Forget which unguarded condition we last forced a
+                # capacity reconcile for. A node taking over maintenance
+                # has no reason to trust the previous holder's
+                # observations, and the check itself runs from the
+                # maintenance pass below rather than from here.
+                self._forced_capacity_reconcile_for = None
 
             # And then do regular cluster maintenance things
             while self.is_elected and not os.path.exists(self.abort_path):
@@ -911,6 +1067,23 @@ class Monitor(daemon.Daemon):
                 else:
                     now = time.time()
                     if now - last_loop_run >= 60:
+                        # Placement onto a node with no capacity row is
+                        # admitted against nothing, so re-ask that
+                        # question every maintenance pass rather than
+                        # once per election -- on a cold cluster no
+                        # hypervisor has published metrics by the time
+                        # election happens. This sits ahead of
+                        # _run_due_scheduled_jobs() so a pass forced
+                        # here runs in this same maintenance pass. Note
+                        # it is now behind cluster_stable(), which
+                        # compares object versions across nodes and
+                        # reads no metric freshness at all, so it defers
+                        # this check during a mixed-version upgrade.
+                        try:
+                            self._force_capacity_reconcile_if_unguarded()
+                        except Exception as e:
+                            util_exceptions.ignore_exception('cluster', e)
+
                         try:
                             with util_general.RecordedOperation(
                                     'scheduled cluster operations',

--- a/shakenfist/daemons/cluster/main.py
+++ b/shakenfist/daemons/cluster/main.py
@@ -852,9 +852,10 @@ class Monitor(daemon.Daemon):
     def _unguarded_hypervisors(self, rows):
         """Active hypervisors with fresh metrics and no capacity row.
 
-        Returns None if a read failed, which is a different answer from
-        the empty set for the same reason ``degraded`` is different from
-        an empty table: it means this process does not know.
+        Returns None if a read failed or could not be trusted, which is a
+        different answer from the empty set for the same reason
+        ``degraded`` is different from an empty table: it means this
+        process does not know.
         """
         try:
             metrics = mariadb.get_all_node_metrics()  # nopushdown: every node wanted
@@ -864,12 +865,46 @@ class Monitor(daemon.Daemon):
                 'reconcile on its anchored cadence')
             return None
 
+        if not metrics:
+            # An empty list is not an authoritative "this cluster has no
+            # nodes". Neither transport raises on a failed read: both
+            # _grpc_get_all_node_metrics() (on RpcError) and
+            # _direct_get_all_node_metrics() (on OperationalError) log
+            # and return []. And sf-resources publishes from every node
+            # whatever its roles, so a running cluster with no
+            # node_metrics rows at all is a cluster whose metrics could
+            # not be read rather than one with nothing to report.
+            #
+            # Reading that as the empty set would clear the
+            # once-per-condition memory below, so a cluster with a
+            # genuine unguarded hypervisor and an intermittently failing
+            # metrics read would forget what it had forced and re-force
+            # the five minute pass every time the read flapped -- the
+            # load regression the memory exists to bound.
+            LOG.warning(
+                'Read no node metrics at all, which a running cluster '
+                'does not produce; treating it as an unknown answer and '
+                'leaving the capacity reconcile on its anchored cadence')
+            return None
+
         # is_hypervisor lives inside the metrics blob rather than being a
         # top level field of the record, and is compared against True
         # rather than tested for truth: the reconciler leaves a node
         # whose value is missing or NULL (mid-upgrade, before the
         # resources daemon repopulates the column) out of both its
         # hypervisor set and its non-hypervisor set, and so do we.
+        #
+        # The two do read the fact from different storage. The
+        # reconciler filters on the typed is_hypervisor column projected
+        # at upsert time by NODE_METRICS_EXTRACTION_SPEC; this reads the
+        # JSON blob that column is derived from. They agree because
+        # sf-resources re-derives the column from this same JSON on every
+        # publication cycle, so a row whose column is still NULL from
+        # before the projection existed disagrees for at most one cycle.
+        # In that window this can qualify a node the reconciler will not
+        # size, which the once-per-condition memory bounds to a single
+        # forced pass.
+        #
         # RECONCILE_METRICS_MAX_AGE_SECONDS is imported rather than
         # restated because a check carrying its own copy of that number
         # would drift from the pass it is trying to trigger.
@@ -889,6 +924,15 @@ class Monitor(daemon.Daemon):
         # Only now is the active node set worth reading. In the steady
         # state every fresh hypervisor already has a row, so this costs
         # nothing on the overwhelming majority of maintenance passes.
+        #
+        # Note what the once-per-condition memory does and does not
+        # bound. It suppresses the forced pass and its warning, not this
+        # read: while a disagreement persists (a phantom row, a node the
+        # reconciler declines to size) this hydration runs on every
+        # maintenance pass for the life of the condition. At one read a
+        # minute that sits well under the unbudgeted ceiling
+        # test_no_unbudgeted_fixed_rate_database_polling enforces, but do
+        # not read the memory as making the whole check go quiet.
         try:
             active = {str(n.uuid) for n in Nodes([], prefilter='active')}
         except Exception as e:

--- a/shakenfist/daemons/cluster/scheduled_tasks.py
+++ b/shakenfist/daemons/cluster/scheduled_tasks.py
@@ -270,6 +270,16 @@ SCHEDULER_CAPACITY_PASSES = Counter(
 SCHEDULER_CAPACITY_FAILURES = Counter(
     'scheduler_capacity_reconcile_failures_total',
     'Scheduler capacity reconcile passes that failed.')
+# Incremented by the elected cluster daemon, not by the pass itself: it
+# counts how often the maintenance loop found placement unguarded and
+# pulled the reconcile forward off its cadence. A cluster which keeps
+# forcing is one where this check and the reconciler disagree about
+# which nodes should have a row, which is otherwise only visible by
+# grepping logs.
+SCHEDULER_CAPACITY_FORCED = Counter(
+    'scheduler_capacity_reconcile_forced_total',
+    'Scheduler capacity reconcile passes forced because one or more nodes '
+    'were admitting placements unguarded.')
 SCHEDULER_CAPACITY_LAST_SUCCESS = Gauge(
     'scheduler_capacity_reconcile_last_success_timestamp',
     'Unix timestamp of the last successful scheduler capacity reconcile '

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_nodes.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_nodes.py
@@ -1,4 +1,5 @@
 import json
+import time
 
 from testtools import content
 
@@ -124,32 +125,51 @@ class TestNodes(base.BaseNamespacedTestCase):
         self.assertEqual(node['uuid'], inst['node'])
 
         try:
-            resources = self.system_client.get_cluster_resources()
-            self.addDetail('resources after', content.text_content(json.dumps(
-                resources, indent=4, sort_keys=True)))
-            per_node = resources['per_node'][node['uuid']]
-
             # A node the capacity reconciler has not written a row for is
             # admitted unguarded (P7): every placement onto it fails open
             # and the node's ledger cannot be trusted. Since
             # PLAN-transient-capacity-refusals phase 1, the elected loop's
             # maintenance pass forces a reconcile within about a minute of
             # any hypervisor's metrics becoming fresh
-            # (`_force_capacity_reconcile_if_unguarded()`), and this test
-            # only runs once `tools/ci_wait_schedulable.py` has gated the
-            # functional test step -- see
-            # `shakenfist/actions/build-smoke-cluster/action.yml`'s "Wait
-            # for the cluster to become schedulable" step, which runs
-            # before "Run functional tests" in
-            # `shakenfist/actions/.github/workflows/smoke-cluster.yml`.
-            # So a missing row here is the regression this phase exists to
-            # prevent, not a normal start-up state, and must fail rather
-            # than hide behind a skip.
+            # (`_force_capacity_reconcile_if_unguarded()`).
+            #
+            # That minute is why this waits rather than asserting on the
+            # first read. The readiness gate which runs before the
+            # functional suite (`tools/ci_wait_schedulable.py`) waits for
+            # a node to appear in per_node, which means active and
+            # publishing fresh metrics -- it says nothing about a
+            # scheduler_node_capacity row, so clearing that gate does not
+            # mean the row exists yet. Waiting out a window longer than
+            # the warm-up one still catches the regression this phase
+            # exists to prevent (a row which never arrives at all) while
+            # not failing on the warm-up itself.
+            deadline = time.time() + 120
+            while True:
+                resources = self.system_client.get_cluster_resources()
+                per_node = resources['per_node'].get(node['uuid'])
+                if per_node is not None and per_node.get(
+                        'cpu_committed_row_present', True):
+                    break
+                if time.time() > deadline:
+                    break
+                time.sleep(5)
+
+            self.addDetail('resources after', content.text_content(json.dumps(
+                resources, indent=4, sort_keys=True)))
+
+            # A hypervisor which drops out of per_node entirely has stale
+            # metrics or an overlong queue, which is a different failure
+            # from an unguarded one and deserves to say so.
+            self.assertIsNotNone(
+                per_node,
+                'Node %s vanished from /admin/resources per_node while an '
+                'instance was placed on it' % node['uuid'])
             self.assertTrue(
                 per_node.get('cpu_committed_row_present', True),
-                'Node %s is admitting placements unguarded: it has no '
-                'scheduler_node_capacity row, so the capacity reconciler '
-                'has not sized it yet' % node['uuid'])
+                'Node %s is still admitting placements unguarded two '
+                'minutes after placement: it has no scheduler_node_capacity '
+                'row, so the capacity reconciler has not sized it yet'
+                % node['uuid'])
 
             # Our instance is placed here and not deleted, so the node's
             # committed total must account for at least its one vCPU

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_nodes.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_nodes.py
@@ -129,13 +129,27 @@ class TestNodes(base.BaseNamespacedTestCase):
                 resources, indent=4, sort_keys=True)))
             per_node = resources['per_node'][node['uuid']]
 
-            # A node the capacity reconciler has not written a row for
-            # yet -- a cluster whose first reconcile pass has not run --
-            # is charged nothing because it is guarded by nothing (P7).
-            # There is no ledger to assert against in that window.
-            if not per_node.get('cpu_committed_row_present', True):
-                self.skipTest(
-                    'Node has no scheduler_node_capacity row yet')
+            # A node the capacity reconciler has not written a row for is
+            # admitted unguarded (P7): every placement onto it fails open
+            # and the node's ledger cannot be trusted. Since
+            # PLAN-transient-capacity-refusals phase 1, the elected loop's
+            # maintenance pass forces a reconcile within about a minute of
+            # any hypervisor's metrics becoming fresh
+            # (`_force_capacity_reconcile_if_unguarded()`), and this test
+            # only runs once `tools/ci_wait_schedulable.py` has gated the
+            # functional test step -- see
+            # `shakenfist/actions/build-smoke-cluster/action.yml`'s "Wait
+            # for the cluster to become schedulable" step, which runs
+            # before "Run functional tests" in
+            # `shakenfist/actions/.github/workflows/smoke-cluster.yml`.
+            # So a missing row here is the regression this phase exists to
+            # prevent, not a normal start-up state, and must fail rather
+            # than hide behind a skip.
+            self.assertTrue(
+                per_node.get('cpu_committed_row_present', True),
+                'Node %s is admitting placements unguarded: it has no '
+                'scheduler_node_capacity row, so the capacity reconciler '
+                'has not sized it yet' % node['uuid'])
 
             # Our instance is placed here and not deleted, so the node's
             # committed total must account for at least its one vCPU

--- a/shakenfist/tests/test_ci_headroom_report.py
+++ b/shakenfist/tests/test_ci_headroom_report.py
@@ -602,6 +602,50 @@ class CapacityCoverageTestCase(HeadroomReportTestCase):
         self.assertEqual(0, code)
         self.assertIn('NEVER OBSERVED', output)
 
+    def test_a_bundle_predating_the_flag_is_unknown_not_never(self):
+        """An old bundle must not read as a permanent regression.
+
+        A cluster whose /admin/resources predates
+        cpu_committed_row_present publishes the key nowhere, so every
+        sample parses as not covered. Scoring that as NEVER OBSERVED
+        would report the warm-up window as never having closed, when the
+        truth is that this bundle cannot answer the question at all.
+        """
+        roster = [roster_entry(NODE_ONE, 'sf1')]
+        payload = node_payload()
+        del payload['cpu_committed_row_present']
+        path = self._series([
+            sample({NODE_ONE: payload}, nodes=roster,
+                   sampled_at=1756000000.0 + 15 * i)
+            for i in range(3)
+        ])
+        code, output = self._run('--series', path)
+        self.assertEqual(0, code)
+        self.assertIn(
+            'NOT MEASURABLE', output,
+            'A bundle which never carried cpu_committed_row_present was '
+            'scored as if the row never appeared, which reads as a '
+            'regression rather than as an unmeasurable payload.')
+        self.assertNotIn('NEVER OBSERVED', output)
+
+    def test_a_flag_present_and_false_is_still_never_observed(self):
+        """The other side of the distinction above.
+
+        A payload which carries the flag and says false is a real
+        measurement of a real unguarded node, and must keep reading as
+        NEVER OBSERVED rather than being softened into "unmeasurable".
+        """
+        roster = [roster_entry(NODE_ONE, 'sf1')]
+        path = self._series([
+            sample({NODE_ONE: node_payload(row_present=False)}, nodes=roster,
+                   sampled_at=1756000000.0 + 15 * i)
+            for i in range(3)
+        ])
+        code, output = self._run('--series', path)
+        self.assertEqual(0, code)
+        self.assertIn('NEVER OBSERVED', output)
+        self.assertNotIn('NOT MEASURABLE', output)
+
 
 class CensusTestCase(HeadroomReportTestCase):
     def test_an_unknown_stage_string_is_tallied_and_printed(self):

--- a/shakenfist/tests/test_ci_headroom_report.py
+++ b/shakenfist/tests/test_ci_headroom_report.py
@@ -503,6 +503,106 @@ class NodeAbsenceTestCase(HeadroomReportTestCase):
             'it is what the samples could see rather than the cluster size.')
 
 
+class CapacityCoverageTestCase(HeadroomReportTestCase):
+    """Time-to-first-capacity-row (PLAN-transient-capacity-refusals D6).
+
+    The offset from the first sample to the first sample in which every
+    hypervisor in the roster carries cpu_committed_row_present true. The
+    case the plan calls out by name is the one where that never happens:
+    reporting zero there would read as an instant window, which is exactly
+    backwards, so it must be reported as absent instead.
+    """
+
+    def test_full_coverage_in_the_first_sample_is_near_zero(self):
+        roster = [roster_entry(NODE_ONE, 'sf1'), roster_entry(NODE_TWO, 'sf2')]
+        path = self._series([
+            sample({NODE_ONE: node_payload(row_present=True),
+                    NODE_TWO: node_payload(row_present=True)}, nodes=roster),
+        ])
+        code, output = self._run('--series', path)
+        self.assertEqual(0, code)
+        self.assertIn(
+            '0 seconds after the first sample', output,
+            'Every hypervisor already had a capacity row in the first '
+            'sample, so the figure should read as an (almost) instant '
+            'window rather than as absent.')
+        self.assertNotIn('NEVER OBSERVED', output)
+
+    def test_a_row_which_never_appears_is_reported_as_absent_not_zero(self):
+        """This is the trap the figure exists to avoid.
+
+        A row which never appears must never render as 0 seconds -- that
+        would read as "the window was instant" when the truth is the
+        opposite: the window never closed for the whole series.
+        """
+        roster = [roster_entry(NODE_ONE, 'sf1'), roster_entry(NODE_TWO, 'sf2')]
+        path = self._series([
+            sample({NODE_ONE: node_payload(row_present=True),
+                    NODE_TWO: node_payload(row_present=False)},
+                   nodes=roster, sampled_at=1756000000.0 + 15 * i)
+            for i in range(4)
+        ])
+        code, output = self._run('--series', path)
+        self.assertEqual(0, code)
+        self.assertIn(
+            'NEVER OBSERVED', output,
+            'A hypervisor which never got a capacity row was not reported '
+            'as absent.')
+        self.assertNotIn('0 seconds after the first sample', output)
+
+    def test_the_offset_is_measured_from_the_first_sample(self):
+        """The figure is an offset from the series start, not from the row's own timestamp."""
+        roster = [roster_entry(NODE_ONE, 'sf1')]
+        path = self._series([
+            sample({NODE_ONE: node_payload(row_present=False)},
+                   nodes=roster, sampled_at=1756000000.0),
+            sample({NODE_ONE: node_payload(row_present=False)},
+                   nodes=roster, sampled_at=1756000015.0),
+            sample({NODE_ONE: node_payload(row_present=True)},
+                   nodes=roster, sampled_at=1756000045.0),
+        ])
+        code, output = self._run('--series', path)
+        self.assertEqual(0, code)
+        self.assertIn(
+            '45 seconds after the first sample', output,
+            'The offset must be measured from the first sample in the '
+            'series, not from whichever sample first achieved coverage.')
+
+    def test_a_hypervisor_absent_from_per_node_is_not_covered(self):
+        """A missing node is not the same as a present-but-unguarded one.
+
+        summarize_resources() omits a hypervisor entirely when its metrics
+        are stale, its queue is too long, or it is gone -- it does not
+        publish cpu_committed_row_present false for it. A roster logic
+        which only checked the flag on nodes present in per_node, and
+        never checked whether a rostered hypervisor was there at all,
+        would read this sample as fully covered.
+        """
+        roster = [roster_entry(NODE_ONE, 'sf1'), roster_entry(NODE_TWO, 'sf2')]
+        path = self._series([
+            # NODE_TWO is a hypervisor per the roster but never appears in
+            # per_node at all.
+            sample({NODE_ONE: node_payload(row_present=True)}, nodes=roster),
+        ])
+        code, output = self._run('--series', path)
+        self.assertEqual(0, code)
+        self.assertIn(
+            'NEVER OBSERVED', output,
+            'A rostered hypervisor missing from per_node entirely was '
+            'silently treated as covered, making the figure optimistic.')
+
+    def test_a_sample_with_no_roster_does_not_count_as_covered(self):
+        """Mirrors how absences() treats a sample with no roster recorded.
+
+        Without a roster there is no way to confirm every hypervisor has a
+        row, so the sample must not count towards coverage.
+        """
+        path = self._series([sample({NODE_ONE: node_payload(row_present=True)})])
+        code, output = self._run('--series', path)
+        self.assertEqual(0, code)
+        self.assertIn('NEVER OBSERVED', output)
+
+
 class CensusTestCase(HeadroomReportTestCase):
     def test_an_unknown_stage_string_is_tallied_and_printed(self):
         """No hardcoded stage list (D10).

--- a/shakenfist/tests/test_daemon_cluster_schedule_anchoring.py
+++ b/shakenfist/tests/test_daemon_cluster_schedule_anchoring.py
@@ -11,6 +11,7 @@
 
 import datetime
 import time
+import uuid
 from unittest import mock
 
 import schedule
@@ -306,11 +307,17 @@ class ForcedCapacityReconcileTestCase(base.ShakenFistTestCase):
             patcher.start()
             self.addCleanup(patcher.stop)
 
-    @mock.patch(
-        'shakenfist.daemons.cluster.main.mariadb.'
-        'get_scheduler_node_capacity')
-    def test_an_empty_table_forces_the_pass_due(self, mock_get):
-        mock_get.return_value = ([], False)
+    def test_an_empty_table_forces_the_pass_due(self):
+        # All three reads are mocked, including the two an empty table
+        # does not obviously need. Without them the metrics read reaches
+        # mariadb.get_all_node_metrics(), whose behaviour in a unit test
+        # depends on the host: it raises immediately where neither
+        # MARIADB_HOST nor a gateway is configured, but builds a channel
+        # and retries through GRPC_UNAVAILABLE_RETRIES where one is. The
+        # empty-table branch would then be reached by way of the
+        # unknown-answer branch rather than on its own terms.
+        self._patch(rows=[], metrics=[self._metrics('a-node', {})],
+                    active=['a-node'])
         m = self._monitor_with_capacity_job()
 
         m._force_capacity_reconcile_if_unguarded()
@@ -388,16 +395,30 @@ class ForcedCapacityReconcileTestCase(base.ShakenFistTestCase):
         mock_get.assert_not_called()
 
     def test_a_fresh_hypervisor_with_no_row_forces_the_pass(self):
+        # Realistic dashed uuids rather than the short opaque names the
+        # rest of this class uses, and one source handing back a UUID
+        # object rather than a string, because the set arithmetic joins
+        # three independently sourced spellings of a node uuid and
+        # CLAUDE.md pitfall 6 records that a mismatch between them fails
+        # silently. If the str() normalisation were dropped, the guarded
+        # node would never subtract from the capacity rows, and the
+        # unguarded one would never intersect with the active set: the
+        # first spelling mismatch forces the five minute pass every
+        # sixty seconds forever, the second silently forces nothing.
+        guarded = '2f9a1c74-0b3d-4a1e-9c8f-7d6e5b4a3c21'
+        unguarded = 'a1b2c3d4-e5f6-4708-9a0b-1c2d3e4f5061'
         self._patch(
-            rows=[self._row('guarded')],
-            metrics=[self._metrics('guarded', {'is_hypervisor': True}),
-                     self._metrics('unguarded', {'is_hypervisor': True})],
-            active=['guarded', 'unguarded'])
+            rows=[{'node_uuid': uuid.UUID(guarded)}],
+            metrics=[self._metrics(guarded, {'is_hypervisor': True}),
+                     self._metrics(unguarded, {'is_hypervisor': True})],
+            active=[uuid.UUID(guarded), uuid.UUID(unguarded)])
         m = self._monitor_with_capacity_job()
 
         m._force_capacity_reconcile_if_unguarded()
 
         self.assertTrue(self._became_due(m))
+        self.assertEqual(
+            frozenset([unguarded]), m._forced_capacity_reconcile_for)
 
     def test_the_same_unguarded_set_does_not_force_twice(self):
         self._patch(
@@ -549,6 +570,25 @@ class ForcedCapacityReconcileTestCase(base.ShakenFistTestCase):
         m._force_capacity_reconcile_if_unguarded()
 
         self.assertEqual(before, m._capacity_reconcile_job.next_run)
+
+    def test_a_swallowed_metrics_read_leaves_the_cadence_alone(self):
+        # Neither transport raises on a failed metrics read: the gRPC
+        # path logs the RpcError and returns [], and the direct path
+        # does the same for an OperationalError. Read as an empty set
+        # that would clear the memory below and re-force the five minute
+        # pass every time the read flapped, so it has to read as unknown
+        # instead. A running cluster does not produce an empty list --
+        # sf-resources publishes from every node whatever its roles.
+        self._patch(rows=[self._row('guarded')], metrics=[], active=['hyp'])
+        m = self._monitor_with_capacity_job()
+        m._forced_capacity_reconcile_for = frozenset(['unguarded'])
+        before = self._park(m)
+
+        m._force_capacity_reconcile_if_unguarded()
+
+        self.assertEqual(before, m._capacity_reconcile_job.next_run)
+        self.assertEqual(
+            frozenset(['unguarded']), m._forced_capacity_reconcile_for)
 
     def test_a_cold_cluster_forces_again_once_metrics_appear(self):
         # The sequence issue 4087 is actually about. The first pass on a

--- a/shakenfist/tests/test_daemon_cluster_schedule_anchoring.py
+++ b/shakenfist/tests/test_daemon_cluster_schedule_anchoring.py
@@ -242,13 +242,21 @@ class RunInnerAnchorWiringTestCase(base.ShakenFistTestCase):
 
 
 class ForcedCapacityReconcileTestCase(base.ShakenFistTestCase):
-    """The election-time check that placement is being guarded at all.
+    """The maintenance-pass check that placement is being guarded at all.
 
-    An empty scheduler_node_capacity table means every admission is
-    failing open (P7), which is issue 4087. Anchoring handles the
-    fresh-cluster case by way of a missing stamp; this handles every
-    other way the table can be empty while a stamp says a pass ran
-    recently.
+    A node with no scheduler_node_capacity row has its placements
+    admitted against nothing at all (P7), which is issue 4087.
+    Anchoring handles the fresh-cluster case by way of a missing stamp;
+    this handles every other way a node can end up unguarded while a
+    stamp says a pass ran recently -- an empty table, and a populated
+    table which has no row for a hypervisor that has only just started
+    publishing metrics.
+
+    The predicate matters more than the plumbing: it has to agree with
+    the one _direct_reconcile_scheduler_capacity() applies, because a
+    check which qualifies a node the reconciler will never size forces
+    the five minute job every sixty seconds for the life of the
+    cluster.
     """
 
     def _monitor_with_capacity_job(self):
@@ -261,6 +269,42 @@ class ForcedCapacityReconcileTestCase(base.ShakenFistTestCase):
         m._capacity_reconcile_job.next_run = (
             datetime.datetime.now() + datetime.timedelta(days=1))
         return m
+
+    def _park(self, m):
+        """Push the job back out of reach and report where it was put."""
+        m._capacity_reconcile_job.next_run = (
+            datetime.datetime.now() + datetime.timedelta(days=1))
+        return m._capacity_reconcile_job.next_run
+
+    def _became_due(self, m):
+        return m._capacity_reconcile_job.next_run <= datetime.datetime.now()
+
+    def _metrics(self, node_uuid, metrics, age=0):
+        return {
+            'node_uuid': node_uuid,
+            'fqdn': f'{node_uuid}.example.com',
+            'timestamp': time.time() - age,
+            'metrics': metrics
+        }
+
+    def _row(self, node_uuid):
+        return {'node_uuid': node_uuid}
+
+    def _patch(self, rows, metrics, active):
+        """Patch the three reads the check makes, for the whole test."""
+        capacity = mock.patch(
+            'shakenfist.daemons.cluster.main.mariadb.'
+            'get_scheduler_node_capacity',
+            return_value=(rows, False))
+        node_metrics = mock.patch(
+            'shakenfist.daemons.cluster.main.mariadb.get_all_node_metrics',
+            return_value=metrics)
+        nodes = mock.patch(
+            'shakenfist.daemons.cluster.main.Nodes',
+            return_value=[mock.MagicMock(uuid=u) for u in active])
+        for patcher in (capacity, node_metrics, nodes):
+            patcher.start()
+            self.addCleanup(patcher.stop)
 
     @mock.patch(
         'shakenfist.daemons.cluster.main.mariadb.'
@@ -279,6 +323,27 @@ class ForcedCapacityReconcileTestCase(base.ShakenFistTestCase):
         'get_scheduler_node_capacity')
     def test_a_populated_table_leaves_the_cadence_alone(self, mock_get):
         mock_get.return_value = ([{'node_uuid': 'a-node'}], False)
+        # The other two reads are mocked so this exercises the path it
+        # names. Without them the metrics read raises immediately (no
+        # MARIADB_HOST in a unit test), the check returns on the
+        # unknown-answer branch, and the assertion below passes without
+        # ever reaching the question of whether a populated table
+        # leaves the cadence alone.
+        metrics = mock.patch(
+            'shakenfist.daemons.cluster.main.mariadb.get_all_node_metrics',
+            return_value=[{
+                'node_uuid': 'a-node',
+                'fqdn': 'a-node.example.com',
+                'timestamp': time.time(),
+                'metrics': {'is_hypervisor': True}
+            }])
+        nodes = mock.patch(
+            'shakenfist.daemons.cluster.main.Nodes',
+            return_value=[mock.MagicMock(uuid='a-node')])
+        for patcher in (metrics, nodes):
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
         m = self._monitor_with_capacity_job()
         before = m._capacity_reconcile_job.next_run
 
@@ -321,3 +386,223 @@ class ForcedCapacityReconcileTestCase(base.ShakenFistTestCase):
         m._force_capacity_reconcile_if_unguarded()
 
         mock_get.assert_not_called()
+
+    def test_a_fresh_hypervisor_with_no_row_forces_the_pass(self):
+        self._patch(
+            rows=[self._row('guarded')],
+            metrics=[self._metrics('guarded', {'is_hypervisor': True}),
+                     self._metrics('unguarded', {'is_hypervisor': True})],
+            active=['guarded', 'unguarded'])
+        m = self._monitor_with_capacity_job()
+
+        m._force_capacity_reconcile_if_unguarded()
+
+        self.assertTrue(self._became_due(m))
+
+    def test_the_same_unguarded_set_does_not_force_twice(self):
+        self._patch(
+            rows=[self._row('guarded')],
+            metrics=[self._metrics('unguarded', {'is_hypervisor': True})],
+            active=['guarded', 'unguarded'])
+        m = self._monitor_with_capacity_job()
+
+        m._force_capacity_reconcile_if_unguarded()
+        self.assertTrue(self._became_due(m))
+
+        # Nothing about the cluster has changed, so a second pass must
+        # leave the cadence alone rather than re-forcing every minute.
+        before = self._park(m)
+        m._force_capacity_reconcile_if_unguarded()
+
+        self.assertEqual(before, m._capacity_reconcile_job.next_run)
+
+    def test_a_changed_unguarded_set_forces_again(self):
+        capacity = mock.patch(
+            'shakenfist.daemons.cluster.main.mariadb.'
+            'get_scheduler_node_capacity',
+            return_value=([self._row('guarded')], False))
+        capacity.start()
+        self.addCleanup(capacity.stop)
+        node_metrics = mock.patch(
+            'shakenfist.daemons.cluster.main.mariadb.get_all_node_metrics')
+        mock_metrics = node_metrics.start()
+        self.addCleanup(node_metrics.stop)
+        nodes = mock.patch(
+            'shakenfist.daemons.cluster.main.Nodes',
+            return_value=[mock.MagicMock(uuid=u)
+                          for u in ('guarded', 'one', 'two')])
+        nodes.start()
+        self.addCleanup(nodes.stop)
+
+        m = self._monitor_with_capacity_job()
+
+        mock_metrics.return_value = [
+            self._metrics('one', {'is_hypervisor': True})]
+        m._force_capacity_reconcile_if_unguarded()
+        self.assertTrue(self._became_due(m))
+
+        self._park(m)
+        mock_metrics.return_value = [
+            self._metrics('one', {'is_hypervisor': True}),
+            self._metrics('two', {'is_hypervisor': True})]
+        m._force_capacity_reconcile_if_unguarded()
+
+        self.assertTrue(self._became_due(m))
+
+    def test_stale_metrics_do_not_force(self):
+        self._patch(
+            rows=[self._row('guarded')],
+            metrics=[self._metrics(
+                'ancient', {'is_hypervisor': True},
+                age=cluster_main.mariadb.RECONCILE_METRICS_MAX_AGE_SECONDS
+                + 60)],
+            active=['guarded', 'ancient'])
+        m = self._monitor_with_capacity_job()
+        before = self._park(m)
+
+        m._force_capacity_reconcile_if_unguarded()
+
+        self.assertEqual(before, m._capacity_reconcile_job.next_run)
+
+    def test_a_non_hypervisor_does_not_force(self):
+        self._patch(
+            rows=[self._row('guarded')],
+            metrics=[self._metrics('storage', {'is_hypervisor': False})],
+            active=['guarded', 'storage'])
+        m = self._monitor_with_capacity_job()
+        before = self._park(m)
+
+        m._force_capacity_reconcile_if_unguarded()
+
+        self.assertEqual(before, m._capacity_reconcile_job.next_run)
+
+    def test_an_unknown_is_hypervisor_does_not_force(self):
+        # Mid-upgrade, before the resources daemon repopulates the
+        # column, is_hypervisor is absent or NULL. The reconciler counts
+        # such a node as neither a hypervisor nor a non-hypervisor, so
+        # neither does this.
+        self._patch(
+            rows=[self._row('guarded')],
+            metrics=[self._metrics('absent', {}),
+                     self._metrics('null', {'is_hypervisor': None})],
+            active=['guarded', 'absent', 'null'])
+        m = self._monitor_with_capacity_job()
+        before = self._park(m)
+
+        m._force_capacity_reconcile_if_unguarded()
+
+        self.assertEqual(before, m._capacity_reconcile_job.next_run)
+
+    def test_a_phantom_metrics_row_does_not_force(self):
+        # The load regression this check exists to avoid. A node_metrics
+        # row which outlived its node reads as a fresh hypervisor
+        # forever, so a check without the active-node intersection would
+        # force the five minute reconcile every sixty seconds for the
+        # life of the cluster -- and the pass would never create a row
+        # for it, so the condition would never clear.
+        self._patch(
+            rows=[self._row('guarded')],
+            metrics=[self._metrics('phantom', {'is_hypervisor': True})],
+            active=['guarded'])
+        m = self._monitor_with_capacity_job()
+        before = self._park(m)
+
+        m._force_capacity_reconcile_if_unguarded()
+
+        self.assertEqual(before, m._capacity_reconcile_job.next_run)
+
+    @mock.patch('shakenfist.daemons.cluster.main.Nodes')
+    @mock.patch(
+        'shakenfist.daemons.cluster.main.mariadb.get_all_node_metrics')
+    @mock.patch(
+        'shakenfist.daemons.cluster.main.mariadb.'
+        'get_scheduler_node_capacity')
+    def test_a_degraded_read_forces_nothing_even_with_a_candidate(
+            self, mock_get, mock_metrics, mock_nodes):
+        # rows is empty and a hypervisor would qualify, but a degraded
+        # read means this process knows nothing about the counters. It
+        # must not read metrics on the strength of a guess either.
+        mock_get.return_value = ([], True)
+        mock_metrics.return_value = [
+            self._metrics('unguarded', {'is_hypervisor': True})]
+        mock_nodes.return_value = [mock.MagicMock(uuid='unguarded')]
+        m = self._monitor_with_capacity_job()
+        before = self._park(m)
+
+        m._force_capacity_reconcile_if_unguarded()
+
+        self.assertEqual(before, m._capacity_reconcile_job.next_run)
+        mock_metrics.assert_not_called()
+
+    @mock.patch(
+        'shakenfist.daemons.cluster.main.mariadb.get_all_node_metrics',
+        side_effect=DatabaseUnavailable('no database'))
+    @mock.patch(
+        'shakenfist.daemons.cluster.main.mariadb.'
+        'get_scheduler_node_capacity')
+    def test_a_failed_metrics_read_leaves_the_cadence_alone(
+            self, mock_get, mock_metrics):
+        mock_get.return_value = ([self._row('guarded')], False)
+        m = self._monitor_with_capacity_job()
+        before = self._park(m)
+
+        m._force_capacity_reconcile_if_unguarded()
+
+        self.assertEqual(before, m._capacity_reconcile_job.next_run)
+
+    def test_a_cold_cluster_forces_again_once_metrics_appear(self):
+        # The sequence issue 4087 is actually about. The first pass on a
+        # cold cluster finds an empty table and no hypervisor metrics at
+        # all, so the pass it forces has nothing to size and the table
+        # stays empty. When the first hypervisor finally publishes, that
+        # is a different condition and must force another pass -- if the
+        # empty table alone were the condition, the cluster would wait
+        # out the five minute cadence, which is the defect.
+        capacity = mock.patch(
+            'shakenfist.daemons.cluster.main.mariadb.'
+            'get_scheduler_node_capacity',
+            return_value=([], False))
+        capacity.start()
+        self.addCleanup(capacity.stop)
+        node_metrics = mock.patch(
+            'shakenfist.daemons.cluster.main.mariadb.get_all_node_metrics',
+            return_value=[])
+        mock_metrics = node_metrics.start()
+        self.addCleanup(node_metrics.stop)
+        nodes = mock.patch(
+            'shakenfist.daemons.cluster.main.Nodes',
+            return_value=[mock.MagicMock(uuid='hyp')])
+        nodes.start()
+        self.addCleanup(nodes.stop)
+
+        m = self._monitor_with_capacity_job()
+
+        m._force_capacity_reconcile_if_unguarded()
+        self.assertTrue(self._became_due(m))
+
+        # Still nothing to size, so no second pass.
+        before = self._park(m)
+        m._force_capacity_reconcile_if_unguarded()
+        self.assertEqual(before, m._capacity_reconcile_job.next_run)
+
+        # And now there is.
+        self._park(m)
+        mock_metrics.return_value = [
+            self._metrics('hyp', {'is_hypervisor': True})]
+        m._force_capacity_reconcile_if_unguarded()
+
+        self.assertTrue(self._became_due(m))
+
+    def test_a_fully_guarded_cluster_forgets_what_it_forced(self):
+        # Once the condition clears the memory must clear too, or the
+        # next occurrence of the same set would never be forced.
+        self._patch(
+            rows=[self._row('guarded')],
+            metrics=[self._metrics('guarded', {'is_hypervisor': True})],
+            active=['guarded'])
+        m = self._monitor_with_capacity_job()
+        m._forced_capacity_reconcile_for = frozenset(['guarded'])
+
+        m._force_capacity_reconcile_if_unguarded()
+
+        self.assertIsNone(m._forced_capacity_reconcile_for)

--- a/tools/ci_headroom_report.py
+++ b/tools/ci_headroom_report.py
@@ -1055,6 +1055,69 @@ def per_node_max_cpu_fractions(series):
     return maxima
 
 
+def _fully_covered(sample):
+    """Whether every hypervisor in this sample's roster has a capacity row.
+
+    A roster of None -- the sample recorded no roster at all -- cannot
+    confirm anything, so it counts as not covered rather than vacuously
+    true; that mirrors how absences() treats ABSENCE_NO_ROSTER. A
+    hypervisor entirely missing from per_node (stale metrics, an overlong
+    queue, or gone) is likewise not covered: it carries no
+    cpu_committed_row_present at all, let alone one which is true.
+
+    A roster naming no hypervisor at all is vacuously covered. Every real
+    CI topology has at least one, so this edge is not expected to fire; it
+    is handled explicitly rather than left to fall out of the loop by
+    accident.
+    """
+    if sample.roster is None:
+        return False
+    for entry in sample.roster:
+        if not isinstance(entry, dict) or entry.get('is_hypervisor') is not True:
+            continue
+        node = entry.get('uuid')
+        node_sample = sample.nodes.get(node) if node else None
+        if node_sample is None or node_sample.row_present is not True:
+            return False
+    return True
+
+
+def capacity_coverage_record(series):
+    """Time to first full scheduler_node_capacity coverage (D6).
+
+    The offset from the first sample in the series to the first sample in
+    which every hypervisor named in that sample's roster carries
+    cpu_committed_row_present true -- the measurement of how long
+    PLAN-transient-capacity-refusals phase 1's warm-up window actually
+    lasted in this run. Until that sample, at least one hypervisor was
+    admitting placements unguarded (P7).
+
+    ``achieved`` is recorded explicitly rather than left to be inferred from
+    ``seconds`` being None: a series with no usable samples and a series
+    which ran to completion without ever covering every hypervisor both
+    have ``seconds`` None, and printing a zero for either would read as
+    "the window was instant", which is exactly backwards -- the trap this
+    figure exists to avoid.
+    """
+    stamped = sorted(
+        (s for s in series.samples if s.sampled_at is not None),
+        key=lambda s: s.sampled_at)
+
+    record = collections.OrderedDict([
+        ('achieved', False),
+        ('window_start', stamped[0].sampled_at if stamped else None),
+        ('covered_at', None),
+        ('seconds', None),
+    ])
+    for sample in stamped:
+        if _fully_covered(sample):
+            record['achieved'] = True
+            record['covered_at'] = sample.sampled_at
+            record['seconds'] = sample.sampled_at - record['window_start']
+            break
+    return record
+
+
 def series_record(series):
     """What was read out of the series file, and what could not be."""
     stamps = [s.sampled_at for s in series.samples if s.sampled_at is not None]
@@ -1405,6 +1468,7 @@ def build_summary_record(series, census, label=None):
     record['record_version'] = RECORD_VERSION
     record['label'] = label
     record['series'] = series_record(series)
+    record['capacity_coverage'] = capacity_coverage_record(series)
     record['ledger_provenance'] = ledger_provenance_record(series)
     record['cluster'] = cluster_record(series)
     record['per_node'] = per_node_record(series)
@@ -1572,6 +1636,35 @@ def print_series_summary(record):
         print('    That is NOT that the cluster was idle.')
         print('    Those samples are excluded from the committed CPU figures')
         print('    below. Memory is unaffected: it comes from node metrics.')
+
+
+def print_capacity_coverage(record):
+    """Time-to-first-capacity-row (PLAN-transient-capacity-refusals D6).
+
+    The offset from the first sample to the first sample in which every
+    hypervisor in its roster carries a scheduler_node_capacity row -- the
+    window during which at least one hypervisor was admitting placements
+    unguarded (P7). Printed only; nothing in this tool gates on it
+    (ci-cloud-sizing D15).
+    """
+    coverage = record['capacity_coverage']
+    print_heading('Time to first full capacity-row coverage')
+    if coverage['window_start'] is None:
+        print('  No usable samples, so there is nothing to measure.')
+        return
+    if not coverage['achieved']:
+        print('  NEVER OBSERVED: no sample in this series had every')
+        print('  hypervisor in its roster carrying a scheduler_node_capacity')
+        print('  row. Reported as absent rather than as zero -- a zero here')
+        print('  would read as an instant window, which is exactly backwards.')
+        return
+    print('  %s seconds after the first sample (at %s): every hypervisor in'
+          % (fmt(coverage['seconds'], 0), fmt_time(coverage['window_start'])))
+    print('  the roster had a scheduler_node_capacity row by %s.'
+          % fmt_time(coverage['covered_at']))
+    print('  Until then at least one hypervisor was admitting placements')
+    print('  unguarded (P7): every placement onto it failed open because the')
+    print('  capacity reconciler had not sized it yet.')
 
 
 def print_ledger_provenance(record):
@@ -2081,6 +2174,7 @@ def print_report(record):
         print('Label:  %s' % record['label'])
 
     print_series_summary(record)
+    print_capacity_coverage(record)
     if record['series']['samples_usable']:
         print_ledger_provenance(record)
         print_cluster_table(record)

--- a/tools/ci_headroom_report.py
+++ b/tools/ci_headroom_report.py
@@ -1098,6 +1098,17 @@ def capacity_coverage_record(series):
     have ``seconds`` None, and printing a zero for either would read as
     "the window was instant", which is exactly backwards -- the trap this
     figure exists to avoid.
+
+    ``flag_present`` separates the two ways this can fail to be achieved.
+    A bundle from a cluster whose /admin/resources predates
+    cpu_committed_row_present carries the key nowhere, so every sample
+    reads as not covered and the series would otherwise report as a
+    permanent regression rather than as a payload this tool cannot
+    measure. Note that the functional assertion in test_nodes.py takes
+    the opposite default for a missing key and passes: it runs against a
+    live cluster which always publishes the flag, so absence there means
+    a payload change worth not failing on, while absence here means an
+    old bundle worth not scoring.
     """
     stamped = sorted(
         (s for s in series.samples if s.sampled_at is not None),
@@ -1105,6 +1116,9 @@ def capacity_coverage_record(series):
 
     record = collections.OrderedDict([
         ('achieved', False),
+        ('flag_present', any(
+            n.row_present is not None
+            for sample in stamped for n in sample.nodes.values())),
         ('window_start', stamped[0].sampled_at if stamped else None),
         ('covered_at', None),
         ('seconds', None),
@@ -1653,6 +1667,12 @@ def print_capacity_coverage(record):
         print('  No usable samples, so there is nothing to measure.')
         return
     if not coverage['achieved']:
+        if not coverage['flag_present']:
+            print('  NOT MEASURABLE: no sample in this series carried')
+            print('  cpu_committed_row_present at all, so this bundle')
+            print('  predates the flag. Coverage here is unknown, not never')
+            print('  achieved -- do not read it as a regression.')
+            return
         print('  NEVER OBSERVED: no sample in this series had every')
         print('  hypervisor in its roster carrying a scheduler_node_capacity')
         print('  row. Reported as absent rather than as zero -- a zero here')


### PR DESCRIPTION
Phase 1 of [PLAN-transient-capacity-refusals](docs/plans/PLAN-transient-capacity-refusals.md). Two commits: the phase plan, then the implementation.

## The problem

A node with no `scheduler_node_capacity` row is admitted against nothing at all (P7), so every placement onto it fails open, and the first reconcile pass then records the accumulated over-limit usage on the row it creates. That is #4087.

PR #4106 addressed it with a one-shot check on the election path, which does not help a cold cluster: election happens within seconds of start-up, before any hypervisor has published metrics, so the pass it forces has nothing to size and the table stays empty until the ordinary five-minute cadence. All six post-#4106 CI runs read for the master plan show exactly that — the forced pass logging `nodes=0 nodes_added=0` roughly 130-150 s before the test step began, with the table only populating at +155..+181 s.

## What changed

The check now runs from the elected loop's maintenance pass and asks a sharper question: is there an *active hypervisor with fresh metrics* and still no capacity row? That closes the window about a minute after the first metrics appear rather than up to five, and it also covers a node that publishes late or whose row a pass removed on stale metrics.

The predicate deliberately mirrors the one `_direct_reconcile_scheduler_capacity()` applies when deciding which nodes get a row. A check asking a *broader* question than the pass can answer would demand a pass every cycle forever. The clause that matters is the active-node intersection: a `node_metrics` row that outlived its node reads as a fresh hypervisor indefinitely — the phantom the reconciler's own comment describes — and without that clause this would silently turn a five-minute job into a sixty-second one for the life of the cluster. `RECONCILE_METRICS_MAX_AGE_SECONDS` is imported rather than copied so the check cannot drift from the pass it triggers.

Forcing is once per distinct observed condition, so a disagreement between the check and the reconciler costs one pass and one log line rather than one of each per minute.

## Reviewer's attention, please

**The decision most worth arguing with** is D1: the check runs inside the elected loop's 60 s maintenance gate rather than on its 5 s poll, so the window closes to about a minute rather than to seconds. The reasoning is that the check cadence is not the dominant term — the wait for a hypervisor to publish metrics is, and that is phase 3 — while the 5 s option is fixed-rate polling needing a `database_load_budget.yaml` entry, permanently raising the idle floor the database-load-reduction plan is lowering, to buy 55 s once per cluster lifetime. It is a one-line move if you disagree.

**A defect in the phase plan was found during implementation.** D5 as written would have broken the phase on exactly the cluster it targets: keying the empty-table branch on "table is empty" alone means pass 1 forces, the reconciler sizes nothing, and pass 2 sees the same condition, which D3 correctly suppresses as already-forced. The empty-table condition therefore carries the unguarded set with it, so a hypervisor appearing is a distinct condition.

**One deviation from the phase plan's definition of done.** Item 2 required all five pre-existing tests in `ForcedCapacityReconcileTestCase` to pass *unmodified*; one is modified. `test_a_populated_table_leaves_the_cadence_alone` began passing for the wrong reason once the metrics read was added — the read raises `MARIADB_HOST not configured` in a unit test, so the check returned on the unknown-answer branch without reaching the question the test names. The other two reads are now mocked so it exercises its stated path.

## Test plan

- [x] `pre-commit run --all-files` passes (exit 0).
- [x] `python3 tools/check-plan-status.py` agrees.
- [x] 28 tests in `test_daemon_cluster_schedule_anchoring` pass; broader run of `test_daemon_cluster|test_database_load|test_scheduler|test_cluster|test_node` is 573 passed, 2 skipped, 0 failed.
- [x] **Mutation-tested, not asserted from reading.** Deleting the active-node intersection fails exactly one test, `test_a_phantom_metrics_row_does_not_force`. Removing the row subtraction fails `test_a_populated_table_leaves_the_cadence_alone`, which it did not before that test was repaired.
- [x] The converted `skipTest` is safe because the schedulable gate runs first: `build-smoke-cluster/action.yml:211` loops on `ci_wait_schedulable.py` inside the composite action, which returns before `smoke-cluster.yml:291` runs the functional tests.
- [ ] **Needs a real CI run.** Definition-of-done item 8 asks for `slim-tier` to show the new time-to-first-capacity-row figure under 60 s. That cannot be checked from a worktree, and it gates closing the phase.

## Not in this PR

Steps 1d (comment on and close #4087) and 1e (close-out) are gated on this merging and on the CI figure above. #4087 is still open — #4106 never closed it, contrary to what the master plan originally said; that claim is corrected in the first commit.

Related to #3772 and #4087. Nothing here fixes #3772: the master plan's evidence shows every post-#4106 `sufficient_idle_cpu` refusal was a pinned create onto a node genuinely at its ledger limit, which this does not address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015y4fDJF57hRTfkfxn16Bve
