### PR TITLE
API input validation phase 5: narrow the handlers

### DIFF
--- a/docs/developer_guide/writing_an_endpoint.md
+++ b/docs/developer_guide/writing_an_endpoint.md
@@ -317,6 +317,18 @@ have been refused and changes no response — and `off` disables the
 layer entirely, as a further safety valve against unexpected log
 volume.
 
+Neither rollback restores the handler-facing behaviour from before
+enforcement existed, and an undeclared body key is where that shows.
+Under `warn` or `off` the key still reaches the handler, which raises
+`TypeError` on the unexpected keyword argument, and that now answers
+`500` — recorded like any other server exception, with nothing about
+it in the response body — rather than the `400` carrying the
+interpreter's own message it used to answer. An operator choosing the
+rollback gets requests that were working kept working, not a tidier
+answer for the ones that were not; see the [v0.7 to v0.8 release
+notes](../release_notes/v07-v08.md) for the caller-visible shape of
+it.
+
 Because a refusal is answered from outside every per-method decorator,
 `log_token_use` never runs for one. The refusal writes its own
 `request refused by input validation` audit event against the caller's

--- a/docs/developer_guide/writing_an_endpoint.md
+++ b/docs/developer_guide/writing_an_endpoint.md
@@ -329,6 +329,17 @@ answer for the ones that were not; see the [v0.7 to v0.8 release
 notes](../release_notes/v07-v08.md) for the caller-visible shape of
 it.
 
+Budget for the operator-visible shape too. A refusal under `enforce`
+is an audit event; a `TypeError` under `warn` or `off` is a server
+fault, so it writes an exception record under
+`/srv/shakenfist/exceptions/` and logs at ERROR. `record_exception`
+keys those records by a hash of the traceback and the `TypeError`
+message embeds the caller's own key name, so a client sending varying
+undeclared keys writes one record per distinct key and one ERROR line
+per request — which is client input driving disk usage and quite
+possibly alerting. It is a reason to treat the rollback as temporary
+rather than a resting state.
+
 Because a refusal is answered from outside every per-method decorator,
 `log_token_use` never runs for one. The refusal writes its own
 `request refused by input validation` audit event against the caller's

--- a/docs/plans/PLAN-api-input-validation-phase-05-narrow.md
+++ b/docs/plans/PLAN-api-input-validation-phase-05-narrow.md
@@ -67,6 +67,9 @@ the *request* was malformed.
   phase 4 recorded and did not file (F8).
 * Document what the `warn`/`off` rollback now does, since this phase
   changes it.
+* Stop `suppress_exceptions_to_client` putting `repr(e)` in the
+  caller's error body. Added to the phase after step 2 found it — see
+  F11 and D31.
 
 **Out:**
 
@@ -256,7 +259,7 @@ non-existent namespace gets `instance not found` (404) instead of
 removing the dead call acknowledges the ref decorator already covers
 the case. See D29.
 
-### F9. Two more 500 classes on the proxy path, recorded not fixed
+### F9. Two more 500 classes on the proxy path — mostly already fixed
 
 The full 30-day sample is 266 `Server error` records, and the five
 `KeyError`s of F6 are the small half of it:
@@ -267,11 +270,47 @@ The full 30-day sample is 266 `Server error` records, and the five
 | 5 | `KeyError` | `util/general.py` in `get_user_agent` |
 | 1 | `ConnectionRefusedError` | `util/concurrency.py:329` in `_node_lock_request` |
 
-A node being unreachable is answered as a 500 with an exception repr,
-260 times in a month. That is a genuine error-contract defect of the
-same family as this plan's, and it is a different mechanism with a
-different right answer (502 or 503, and a decision about retries). To
-be filed rather than absorbed — see D28.
+**This finding was substantially wrong, and step 5 caught it.** The
+correction is recorded here rather than only in Progress, because a
+stale finding left standing is how the next reader inherits the error.
+
+The claim above — "a node being unreachable is answered as a 500, 260
+times in a month" — reads a 30-day aggregate as a rate. It is not one.
+Split by day, every `ConnectionError` in the sample falls between
+2026-08-12 and 2026-08-19, and **252 of the 260 are a single burst on
+08-19**. There are none afterwards, because
+[`2ac50193b`](https://github.com/shakenfist/shakenfist/commit/2ac50193b)
+— *Surface unreachable proxy peers as a 503*, issue #3743 — landed
+2026-08-21 and already fixed that path. `proxy_request_to_node` now
+catches `requests.exceptions.RequestException` and answers 503.
+
+So the headline defect was fixed a week into the window this plan
+measured, and the survey did not notice because it never asked whether
+the distribution was uniform. That is the same mistake as F5's first
+cut: a derived number nobody checked against a second axis.
+
+What is actually left, verified by step 5 against the current tree and
+current Loki data:
+
+* **The `ConnectionRefusedError` is live.** It recurred 2026-08-26,
+  *after* the proxy fix, on `POST /instances/<uuid>/poweroff`. It is a
+  different mechanism — `_node_lock_request` speaks to a local Unix
+  socket belonging to the node's own nodelock daemon, not to a peer —
+  so `2ac50193b` never covered it.
+* **Two more unguarded proxy call sites the survey missed**, neither
+  behind `proxy_request_to_node` and so neither fixed by `2ac50193b`:
+  `shakenfist/external_api/blob.py:71` (`_read_remote`) and the
+  `upload_uuid` branch of `POST /artifacts`
+  (`shakenfist/external_api/artifact.py:588`). Both call
+  `requests.request()` with no exception handling.
+
+Filed as
+[#4161](https://github.com/shakenfist/shakenfist/issues/4161), scoped
+to what is still true rather than to the table above. D28's reasoning
+for not fixing it here survives the correction: it still needs a
+status-code decision, a retry decision and a caller audit, which is a
+phase and not a step. D31 raises its value, since a caller can no
+longer see which exception it was.
 
 ### F10. The arm has fired once in the only window that can be counted
 
@@ -296,6 +335,41 @@ records, not a caller. Five days is a short window and it is the only
 one there is; the honest statement is that nothing is known about the
 arm's rate before 2026-09-05, and that in the days since, no real
 caller has reached it.
+
+### F11. The deletion relabels the leak rather than removing it
+
+**Found by step 2, after this plan was written and committed.** It is
+recorded here rather than silently fixed because it falsifies
+something the plan assumed.
+
+`suppress_exceptions_to_client` builds every 500 body as
+`'server error: %s' % repr(e)` (`base.py:1684`). So after the arm is
+deleted, an undeclared body key under `warn` or `off` answers:
+
+```
+500 {"error": "server error: TypeError(\"AuthEndpoint.post() got an
+unexpected keyword argument 'zzz'\")", "status": 500}
+```
+
+which is #3612's motivating string — endpoint class, method name, and
+the fact that kwargs are merged into the call — wearing a 500 instead
+of a 400. The plan assumed the generic 500 body was clean. It is not,
+and the assumption is load-bearing for D25 and for definition of done
+item 4.
+
+It is a second and independent leak site, common to every exception
+class rather than specific to this one. It is also what puts
+`KeyError('arch_string_raw')` (F6) and the 260 `ConnectionError`
+reprs (F9) into caller-visible bodies. `base.py:1684` is the only
+production site; `grep` finds no other.
+
+Step 2 did not fix it, correctly: cleaning that body changes the shape
+of every 500 the API emits, which is an error-contract decision of the
+same size as D25. Instead it asserted what is true — every
+`INTERPRETER_TEXT` marker absent *except* the exception class name,
+with the exemption named and justified in the test docstring so that
+tightening it is a one-line change. That is the right shape for a
+finding that outruns its plan.
 
 ### Nothing else in the master plan's phase 5 section was wrong
 
@@ -422,6 +496,32 @@ Without it, the property "the API never answers a `TypeError` in the
 interpreter's words" is asserted nowhere and could be undone by
 someone restoring the arm.
 
+### D31. The generic 500 body stops carrying `repr(e)`
+
+Taken by the operator after step 2 surfaced F11, and added to the
+phase rather than filed.
+
+`base.py:1684` becomes `sf_api.error(500, 'server error')`. The detail
+does not disappear: `suppress_exceptions_to_client` already logs one
+`Server error` line carrying `exception_class`, the full `traceback`,
+`method`, `path` and the correlation fields for the on-disk record
+under `/srv/shakenfist/exceptions/`, all of which say more than
+`repr(e)` in a response body ever did.
+
+Two things argued for doing it here rather than deferring it. It is
+what makes the phase's own claim true — a phase whose purpose is to
+stop the API answering in the interpreter's words should not ship a
+version that only changes which status code the words arrive under.
+And it closes the same leak for the classes F6 and F9 found in
+production, which are two orders of magnitude more frequent than the
+`TypeError` this phase started with.
+
+The cost, stated plainly: a caller debugging from a response body
+alone loses the exception detail, and gets `server error` with nothing
+else. That is deliberate — the caller is not who the detail is for,
+and an operator has both the log line and the exception record. It
+goes in the release note for the same reason D25 does.
+
 ## Step plan
 
 | Step | Effort | Model | Isolation | Brief for sub-agent |
@@ -430,11 +530,17 @@ someone restoring the arm.
 | 2 | high | opus | none | **Delete the `except TypeError` arm.** In `shakenfist/external_api/base.py`, `handle_authorization_exceptions` (line 1500) catches `TypeError` and answers `400 str(e)`. Delete that arm and leave the three JWT arms — `DecodeError`, `ExpiredSignatureError` and the eight-class tuple — untouched. Rewrite the `NOTE(mikal)` comment above the wrapper so it says what the function now catches and why (authorization conditions only; see decision D23 in this plan). Then fix the fallout, which the plan has already enumerated: `test_warn_mode_changes_no_response` (`test_request_validation.py:98`) and `test_off_mode_disables_the_layer` (`:198`) both assert `unexpected keyword argument` appears in the response body; under `warn` and `off` an undeclared body key now answers 500 (decision D25), so rewrite both to assert the new behaviour *and* to assert the response carries no interpreter text. Add the D30 test: a handler which raises `TypeError` internally answers 500, the body contains no Python message, and `util.exceptions.record_exception` was called. Reuse the `INTERPRETER_TEXT` list (`test_request_validation.py:709`) rather than writing a new one; note its comment says a marker added there belongs in `shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_api_validation.py` too. Before finishing, enumerate every remaining source of `TypeError` reachable from a request: grep the whole tree for `raise TypeError` (step 1 removed the only one in `external_api/`), and check the `@use_kwargs`/webargs sites and `flasgger`. Report what you found even if the answer is nothing. Commit subject: `Stop answering a TypeError as a bad request.` |
 | 3 | medium | sonnet | none | **Fix #3523.** `shakenfist/util/general.py:87` `get_user_agent()` indexes `cpuinfo.get_cpu_info()` for `arch_string_raw` and `vendor_id_raw` without guarding. `py-cpuinfo` returns whatever its probes collected, so both keys can be absent, and the resulting `KeyError` reaches a caller as a 500 on `GET /instances/<uuid>/consoledata` via `proxy_request_to_node`. Use `.get()` with a sensible literal for each (`'unknown'` reads correctly in a user agent string). Add a unit test in `shakenfist/tests/` that patches `cpuinfo.get_cpu_info` to return `{}` and asserts `get_user_agent()` returns a string containing the version — mutation test it by restoring one of the bare lookups and confirming the test fails. Do not change the user agent's format for the case where both keys are present; a test should pin that too. Commit subject: `Survive a partial cpuinfo probe.` |
 | 4 | low | sonnet | none | **Remove two dead decorator uses.** `@api_base.requires_namespace_exist_if_specified` is applied *below* `@api_base.arg_is_instance_ref` on `InstanceEndpoint.delete` (`shakenfist/external_api/instance.py:268`) and below `@api_base.arg_is_network_ref` on `NetworkEndpoint.delete` (`shakenfist/external_api/network.py:165`). The ref decorator wraps it and opens with `kwargs.pop('namespace', None)` (`base.py:1052`), so its `kwargs.get('namespace')` is always `None` and it can never fire. Delete both applications. Do not reorder them, and do not touch the other ten uses, which are on creation and collection routes and work (decision D29). Confirm no test asserts `namespace not found` on either route before deleting. Add a short comment to `requires_namespace_exist_if_specified` in `base.py` recording that it must be applied *above* any ref decorator, so the next use does not repeat this. Commit subject: `Drop two guards that could never fire.` |
+| 6 | medium | sonnet | none | **Stop the 500 body carrying `repr(e)`.** Per D31 and F11. In `shakenfist/external_api/base.py`, `suppress_exceptions_to_client` (line ~1629) ends with `return sf_api.error(500, 'server error: %s' % repr(e), suppress_traceback=True)` at line 1684. Change the message to a bare `'server error'`. Do not touch the `LOG.with_fields(fields).exception('Server error')` line above it or the fields it builds — that line and the on-disk record under `/srv/shakenfist/exceptions/` are where the detail goes, and they already carry more than the body did. Add a comment saying why the body is deliberately opaque: the caller is not who the detail is for, and `repr(e)` in an error field is the same defect as the interpreter text this phase deleted (issue #3612, decision D31). Then find what depended on the old shape: `test_a_handler_internal_type_error_is_a_recorded_500` in `shakenfist/tests/external_api/test_request_validation.py` skips the `'TypeError'` marker in its `INTERPRETER_TEXT` sweep and says in its docstring why — **remove the exemption and the paragraph justifying it**, so the sweep runs whole. Check `shakenfist/tests/external_api/test_server_error_logging.py`, `shakenfist/tests/test_federation.py` (line ~780) and `shakenfist/external_api/label.py` (line ~59) for assertions or comments naming the old body; a comment which now describes something untrue should be corrected, not left. Finally grep `shakenfist/deploy/shakenfist_ci/` for anything reading a 500's error text. Report everything you found. Commit subject: `Stop telling callers what exception broke.` |
 | 5 | medium | sonnet | none | **Documentation and close-out.** (a) `docs/developer_guide/writing_an_endpoint.md:308-316` already describes `API_VALIDATION_MODE` and calls `warn` the operator's rollback; extend that passage to say what `warn` and `off` now do with an undeclared body key (500, recorded exception). Do not add a new section. (b) `docs/release_notes/v07-v08.md:188-220` is phase 4's enforcement entry, including the `API_VALIDATION_MODE=warn` rollback sentence at line 210; extend that entry, do not start a second one, noting that the rollback modes no longer answer 400 for input the handler cannot accept. (c) File the F9 issue: the proxy path answers an unreachable node with a 500, with the Loki evidence from this plan's F9 and links to `proxy_request_to_node` and `util/concurrency.py:329`. (d) Update this plan's Progress section, the master plan's Execution table row for phase 5, and the `docs/plans/index.md` phase arithmetic. Commit subject: `Document what narrowing changed.` |
 
-Steps 1 and 2 are strictly ordered. Steps 3 and 4 are independent of
-both and of each other. Step 5 runs last. Step 2 carries a conditional
+Steps 1 and 2 are strictly ordered, and step 6 follows step 2. Steps 3
+and 4 are independent of both and of each other. Step 5 runs last,
+because it documents what the others did. Step 2 carries a conditional
 gate — see the Back brief.
+
+Step 6 was added after the plan was committed, when step 2 found F11.
+It is numbered 6 and sequenced fifth so that the earlier numbers keep
+pointing at the commits that already reference them.
 
 ## Risks and mitigations
 
@@ -478,27 +584,48 @@ gate — see the Back brief.
    unchanged, for all four payloads, after both step 1 and step 2.
 4. A test proves a handler which raises `TypeError` internally answers
    500, that the body carries none of the shapes in `INTERPRETER_TEXT`
-   (`test_request_validation.py:709`), and that an exception was
-   recorded. The test has been mutation-tested by restoring the
-   deleted arm, and fails when it is restored.
-5. No test in the suite asserts that a response body contains
+   (`test_request_validation.py:709`) **with no exemptions**, and that
+   an exception was recorded. The test has been mutation-tested by
+   restoring the deleted arm, and fails when it is restored. Step 2
+   met this with one exemption because of F11; step 6 removes it, and
+   the item is not met until the sweep runs whole.
+5. The **generic** 500 path carries no exception detail: the body
+   `suppress_exceptions_to_client` returns is a fixed string, and the
+   item 4 sweep runs unexempted against it. Deliberate `str(e)` on a
+   caught exception elsewhere is untouched and stays — nineteen
+   handlers answer a Shaken Fist exception class that way, and there
+   the message is the API's own vocabulary rather than the
+   interpreter's. D31 is about what escapes uncaught, not about
+   whether an exception may ever be quoted.
+
+   *This item took two attempts to state, both recorded rather than
+   quietly replaced. It first said `grep -n "repr(e)"
+   shakenfist/external_api/base.py` returns nothing; step 5 reported
+   that as not met, correctly, because step 6's own comment explains
+   in prose why the body is opaque and so contains the string. The
+   rewrite then over-corrected to "no `sf_api.error()` call
+   interpolates an exception", which those nineteen deliberate sites
+   falsify. A criterion a comment can break, and a criterion that
+   condemns correct code, are both the wrong test — and this plan has
+   now produced one of each.*
+6. No test in the suite asserts that a response body contains
    `unexpected keyword argument` or `missing 1 required positional
    argument`.
-6. `get_user_agent()` returns a string when `cpuinfo.get_cpu_info()`
+7. `get_user_agent()` returns a string when `cpuinfo.get_cpu_info()`
    returns `{}`, pinned by a test which fails if either guarded lookup
    is restored to a bare index.
-7. #3523 is closed, and the closing comment names
+8. #3523 is closed, and the closing comment names
    `util/general.py:get_user_agent` and `KeyError: 'arch_string_raw'`
    as the raising frame the issue asked for.
-8. `requires_namespace_exist_if_specified` is applied above every ref
+9. `requires_namespace_exist_if_specified` is applied above every ref
    decorator that uses it, or not at all; the two applications named
    in F8 are gone and the other ten are untouched.
-9. An issue exists for F9, linked from the master plan's Future work.
-10. What `warn` and `off` do with an undeclared body key is stated the
+10. An issue exists for F9, linked from the master plan's Future work.
+11. What `warn` and `off` do with an undeclared body key is stated the
     same way in `docs/developer_guide/writing_an_endpoint.md`, the
     v07-v08 release note, and this plan.
-11. `pre-commit run --all-files` is clean.
-12. The master plan's Execution table, its status line, and the
+12. `pre-commit run --all-files` is clean.
+13. The master plan's Execution table, its status line, and the
     `docs/plans/index.md` row all say phase 5 is complete and agree on
     the phase arithmetic.
 
@@ -516,4 +643,249 @@ session rather than in the step.
 
 ## Progress
 
-Planned 2026-09-10. No steps executed.
+Executed 2026-09-10. Steps 1-4 and 6 landed as five commits, in
+execution order below; step 6 was added mid-phase, after step 2
+found the problem it fixes (F11). This section is step 5, and it
+runs last as the step plan says it should.
+
+### Step 1, `efc0ca6eb` — Answer a non-object body directly
+
+`log_request`'s non-object body guard stopped depending on the catch
+step 2 was about to delete: it now returns `sf_api.error(400, 'the
+request body must be a JSON object')` itself instead of raising
+`TypeError` for `handle_authorization_exceptions` to catch. No
+behaviour change — `test_a_non_object_body_is_still_a_400` passes
+with its four-payload assertions unchanged both before and after,
+which is why this is its own commit ahead of the deletion (D24).
+
+### Step 2, `6220496df` — Stop answering a TypeError as a bad request
+
+The `except TypeError` arm in `handle_authorization_exceptions` is
+deleted (D23); the three JWT arms are untouched. The `NOTE(mikal)`
+comment above the wrapper was rewritten to say what it now catches —
+ten JWT exception classes across three arms, nothing else — and why.
+Under `enforce`, the default since phase 4, nothing changes for a
+caller: an undeclared body key is refused by name before a handler is
+reached. Under `warn` and `off` such a key now reaches the handler,
+raises `TypeError`, and answers 500 rather than the
+400-with-interpreter-text it used to (D25) — the phase's one intended
+behaviour change.
+
+The enumeration D25 rests on was re-run rather than taken on trust
+from the plan, and is recorded in the commit message: no production
+code raises `TypeError` outside a handler-signature mismatch, no
+handler has a parameter without a default, the four `use_kwargs`
+schemas filter unknown keys before the call, `_webargs_error` ends in
+an `HTTPException`, and `check()` itself cannot raise.
+
+Two tests asserted the deleted arm's behaviour without being named in
+the plan's step brief: `test_findings_are_emitted_with_the_response_status`
+asserted 400 twice, and `test_type_error_400_is_attributable` was a
+whole test for the arm; both were rewritten rather than deleted, the
+second becoming a test that a `TypeError` escapes the wrapper unlogged.
+The D30 test, `test_a_handler_internal_type_error_is_a_recorded_500`
+(`shakenfist/tests/external_api/test_request_validation.py:815`), was
+added here.
+
+**Found while implementing, not fixed here: F11.**
+`suppress_exceptions_to_client` builds every 500 body as
+`'server error: %s' % repr(e)`, so deleting the arm relabelled the
+leak instead of removing it: an undeclared body key under `warn`/`off`
+went on carrying interpreter text, now under a 500 instead of a 400.
+This falsified the plan's assumption that the generic 500 body was
+already clean, so step 2's own test had to carry an exemption for the
+exception-class marker, with the exemption's reason written into its
+docstring rather than silently worked around. The operator was asked
+whether to clean the body here or file it, and chose to clean it —
+which is step 6.
+
+### Step 3, `dc6019d6a` — Survive a partial cpuinfo probe
+
+Fixes [#3523](https://github.com/shakenfist/shakenfist/issues/3523).
+`get_user_agent()` (`shakenfist/util/general.py`) now uses `.get()`
+with a literal default for both `arch_string_raw` and `vendor_id_raw`
+instead of indexing `cpuinfo.get_cpu_info()` directly. Three tests —
+both keys present, an empty probe, and one key present without the
+other, the third pinning that the two lookups fall back
+independently — mutation-tested by restoring one bare index, which
+fails with the production `KeyError: 'arch_string_raw'` signature.
+#3523 is closed, with a comment naming the raising frame and this
+commit.
+
+### Step 4, `aeb318519` — Drop two guards that could never fire
+
+Per F8. `@api_base.requires_namespace_exist_if_specified` is removed
+from `InstanceEndpoint.delete` and `NetworkEndpoint.delete`, where it
+sat below a ref-resolving decorator that had already popped
+`namespace` out of `kwargs` before this decorator ever saw it — dead
+since phase 4 found it and recorded it without filing an issue. All
+twelve uses of the decorator were surveyed, not just the two; the
+other ten are on creation and collection routes with no ref decorator
+above them and are live. The decorator itself now carries a comment
+naming the ordering constraint and the two routes it went wrong on,
+so the next use does not repeat the mistake.
+
+### Step 6, `92fc4bb6b` — Stop telling callers what exception broke
+
+Added to the phase after step 2 found F11, above. Sequenced fifth in
+execution order — after step 4, before this step 5 — while keeping the
+number 6, so the earlier step numbers keep pointing at the commits
+that already cite them (per the plan's own note above). The prompt
+that authorised it: Michael was asked whether the phase should clean
+the generic 500 body or file it, and chose to clean it here.
+
+`suppress_exceptions_to_client`'s 500 body is now the bare string
+`'server error'`. The `LOG.with_fields(fields).exception('Server
+error')` line immediately above it, and the on-disk record under
+`/srv/shakenfist/exceptions/`, are unchanged and carry the detail
+instead — `exception_class`, the full traceback, method, path, and the
+correlation fields. `test_a_handler_internal_type_error_is_a_recorded_500`
+now runs the whole `INTERPRETER_TEXT` sweep with no exemption, and the
+docstring paragraph justifying the exemption is gone with it.
+
+Four comments and two assertions described the old body and were
+corrected rather than left. Two are about the present and were
+rewritten because they had become false: `test_server_error_logging`
+asserted the exception class appears in the response, and now asserts
+it must not; a comment in `shakenfist/external_api/auth.py` explaining
+a guard around a damaged federation rule said the generic 500 handler
+"answers with `repr(e)`", which is no longer true, and was rewritten
+to say what the guard is for now (a categorised, evented refusal
+rather than an unevented 500) instead of deleting the guard, since its
+reason changed but it is not dead. Two are history and were left
+alone except for a note: `shakenfist/external_api/label.py` and
+`shakenfist/tests/test_federation.py` record what a caller saw before
+each was independently fixed, and keep the string they quote because
+it was true when it happened, with a note added that a 500 no longer
+names anything at all.
+
+### Step 5, this edit — Documentation and close-out
+
+(a) `docs/developer_guide/writing_an_endpoint.md` now says what `warn`
+and `off` do with an undeclared body key, in the same passage that
+already described the rollback rather than in a new section. (b) The
+`API_VALIDATION_MODE` entry in `docs/release_notes/v07-v08.md` is
+extended, not duplicated, with both behaviour changes: the rollback no
+longer answers 400 for input a handler cannot accept, and every 500
+body is now the bare string `server error` for every cause, not only
+this phase's. (c) An issue was filed for F9 — see the next section,
+because filing it required re-verifying the finding first, and the
+finding had partly gone stale. (d) This Progress section, the
+Definition of done walk below, the master plan's phase 5 row and its
+*Where the tracked issues stand* section, and `docs/plans/index.md`'s
+phase count.
+
+### F9 was re-verified before filing, and the picture had changed
+
+The plan's F9 table — 30 days of sfcbr `Server error` records: 260
+`ConnectionError` via `proxy_request_to_node`, 5 `KeyError` via
+`get_user_agent`, 1 `ConnectionRefusedError` via `_node_lock_request`
+— was measured before this phase started executing. Filing it
+required re-running the query, which found the table no longer said
+the whole truth:
+
+* **The 260 `ConnectionError` records are not live any more, for that
+  call site.** Re-running `{job="shakenfist"} |= "Server error" |=
+  "ConnectionError"` over the same 30-day window: all 260 timestamps
+  fall between 2026-08-12 and 2026-08-19.
+  [#3743](https://github.com/shakenfist/shakenfist/issues/3743)
+  (`2ac50193b`, PR
+  [#3833](https://github.com/shakenfist/shakenfist/pull/3833), merged
+  2026-08-21) made `proxy_request_to_node` answer 503 for exactly this
+  condition, and there have been zero occurrences since. The five
+  `KeyError`s are fixed by step 3, above.
+* **Two more unguarded proxy call sites exist**, found by one grep
+  pass and absent from the plan's survey:
+  `shakenfist/external_api/blob.py:71` (`_read_remote`, proxying
+  `GET /blobs/<uuid>/data` to whichever node holds the blob) and
+  `shakenfist/external_api/artifact.py:588` (the `upload_uuid` branch
+  of `POST /artifacts`, proxying to the node an upload landed on).
+  Neither is covered by the #3743 fix, and neither has log evidence,
+  because nobody has hit the failure window in the last 30 days.
+
+The 1-occurrence `ConnectionRefusedError` is still live: it recurred
+on 2026-08-26, five days after the #3743 fix landed, on
+`POST /instances/<uuid>/poweroff`, while releasing the instance lock.
+It is a different mechanism from the other two — a local Unix socket
+to the node's own nodelock daemon refusing a connection, not a peer
+node being unreachable — which the #3743 fix does not touch and could
+not have.
+
+Filed as [#4161](https://github.com/shakenfist/shakenfist/issues/4161),
+scoped to what re-verification found still true rather than to the
+table as originally surveyed, with the correction recorded in the
+issue itself so a future reader does not have to reconcile these two
+sources disagreeing.
+
+### Definition of done, item by item
+
+1. **Met.** `grep -n "except TypeError" shakenfist/external_api/base.py`
+   returns nothing.
+2. **Met.** `grep -rn "raise TypeError" shakenfist/external_api/`
+   returns two comments in `validation.py` (explaining webargs' own
+   behaviour) and no executable statement, which is exactly what the
+   item excepts.
+3. **Met.** `test_a_non_object_body_is_still_a_400` passes with its
+   four-payload assertions unchanged; step 1's commit message records
+   running it before and after both step 1 and step 2.
+4. **Met, as of step 6.**
+   `test_a_handler_internal_type_error_is_a_recorded_500`
+   (`test_request_validation.py:815`) asserts 500, every
+   `INTERPRETER_TEXT` marker absent with no exemption, and that
+   `record_exception` was called once, and it is mutation-tested by
+   restoring the deleted arm. Step 2 met an earlier version of this
+   item with one exemption, which F11 required; step 6 removed the
+   exemption, so this item is met by step 6's commit, not step 2's —
+   exactly the distinction the plan's own text under item 4 called
+   for.
+5. **Met, with a literal caveat worth recording rather than hiding.**
+   `grep -n "repr(e)" shakenfist/external_api/base.py` does not return
+   nothing — it returns two hits, both inside the comment step 6 added
+   directly above the fix, explaining in prose why the body no longer
+   carries `repr(e)`. No *code* builds a response body from it any
+   more, and the substantive claim the item is actually checking for —
+   that no response body contains an exception class name, a repr, a
+   traceback or a source path — is what
+   `test_a_handler_internal_type_error_is_a_recorded_500` proves with
+   its unexempted sweep. The item's own verification command, read
+   literally, does not pass; its intent does.
+6. **Met.** No test asserts either fragment appears in a response
+   body. The surviving text hits are `test_request_validation.py:185`,
+   which asserts the *absence* of `unexpected keyword argument`; the
+   `INTERPRETER_TEXT` list itself and a docstring quoting the old
+   response as history; and an unrelated comment in
+   `test_clusteroperations.py` about a different code path.
+7. **Met.** Pinned by the three tests step 3 added, mutation-tested by
+   restoring a bare index.
+8. **Met.** #3523 is closed, with a comment naming
+   `util/general.py:get_user_agent` and `KeyError: 'arch_string_raw'`
+   as the raising frame and linking `dc6019d6a`.
+9. **Met.** The two dead applications are gone (step 4); `grep -rn
+   "requires_namespace_exist_if_specified" shakenfist/external_api/*.py`
+   shows the other ten, untouched.
+10. **Met.** [#4161](https://github.com/shakenfist/shakenfist/issues/4161)
+    filed and linked from the master plan's *Where the tracked issues
+    stand* section. Scoped to what re-verification found still true
+    rather than to the plan's original table — see the F9 section
+    above for why that is not the same thing as the table as surveyed.
+11. **Met.** The same two facts — the rollback answers 500 instead of
+    400 for an undeclared body key, and every 500 body is now the bare
+    string `server error` — are stated in
+    `docs/developer_guide/writing_an_endpoint.md`, the v07-v08 release
+    note, and this plan (D25, D31, F4, F11).
+12. **Met.** `pre-commit run --all-files` is clean: 4552 tests passed,
+    121 skipped, 0 failed, and every other hook (flake8, the four
+    `external_api` guard checks, `check-plan-status.py`, mypy) passed.
+    Recorded honestly: the first run reported the `py3` hook itself as
+    `Failed` with `files were modified by this hook`, while its own
+    `stestr` totals inside that same run already showed 0 failures and
+    `git status`/`git diff` showed no tracked file changed beyond this
+    edit's own doc changes. A second, unmodified rerun passed the `py3`
+    hook cleanly with no such report, so this was a one-off (most
+    likely a first-run artefact of `tox` reinstalling the package into
+    a fresh environment) rather than a reproducible problem, and it is
+    noted here rather than quietly rerun-until-green.
+13. **Met by this edit.** The master plan's Execution table row, its
+    status line, and the `docs/plans/index.md` row all say phase 5 is
+    complete and agree on the arithmetic (6 of 8), checked by
+    `tools/check-plan-status.py`.

--- a/docs/plans/PLAN-api-input-validation-phase-05-narrow.md
+++ b/docs/plans/PLAN-api-input-validation-phase-05-narrow.md
@@ -1,0 +1,519 @@
+# Phase 5: Narrow the handlers
+
+Phase 5 of [`PLAN-api-input-validation.md`](PLAN-api-input-validation.md),
+following [phase 4](PLAN-api-input-validation-phase-04-enforce.md).
+
+Phase 4 made the validation layer reject. This phase removes the thing
+it was built to replace: the `except TypeError` arm in
+`handle_authorization_exceptions`, which has been handing callers the
+interpreter's own words as a 400 since 2021 (`ffecee9f9`, *Refactor API
+to be more tractable*). That catch is the second
+half of the mechanism issue
+[#3612](https://github.com/shakenfist/shakenfist/issues/3612)
+describes, and it could not be removed earlier because it was absorbing
+the malformed input phase 4 now refuses.
+
+**Planning effort:** high. The change is four lines of deletion, and
+every difficulty in it is in establishing what those four lines are
+still load-bearing for. The survey found one deliberate `raise
+TypeError` that depends on them and one documented rollback path whose
+behaviour they define.
+
+**Review effort:** high, for the same reason. A reviewer's job here is
+to find the TypeError source the survey missed.
+
+## Context
+
+The catch lives at `shakenfist/external_api/base.py:1509`:
+
+```python
+except TypeError as e:
+    _authorization_failure_log(e).info('API request rejected as malformed')
+    return sf_api.error(400, str(e), suppress_traceback=False)
+```
+
+It sits inside `handle_authorization_exceptions`, alongside three
+further `except` arms covering ten JWT exception classes. That is a category error: a `TypeError` is not an
+authorization condition, and nothing in `flask_jwt_extended` or `PyJWT`
+signals one with it. The arm is there because a handler called with a
+body key it does not accept raises `TypeError`, and answering 400 was
+better than answering 500 — a workaround for the absence of the
+validation layer this plan spent four phases building.
+
+With `API_VALIDATION_MODE` defaulting to `enforce`, decision D14
+answers an undeclared body key with `<name>: not declared by this
+endpoint` *before* the handler is reached. The arm's original purpose
+is therefore already served on the default path, and what remains
+behind it is the thing it was never meant to catch: a genuine
+`TypeError` from inside a handler, currently reported to the caller as
+a 400 with a Python message and to the operator as an INFO line saying
+the *request* was malformed.
+
+## Scope
+
+**In:**
+
+* Delete the `except TypeError` arm from
+  `handle_authorization_exceptions`, so a handler-internal `TypeError`
+  becomes a recorded 500 like every other unexpected exception.
+* Replace `log_request`'s deliberate `raise TypeError` with an explicit
+  400 return first, in its own commit, because the deletion depends on
+  it.
+* Fix [#3523](https://github.com/shakenfist/shakenfist/issues/3523),
+  whose raising frame this survey identified (see F6).
+* Update the two unit tests which currently assert interpreter text as
+  the expected response under `warn` and `off`.
+* Remove the two dead `requires_namespace_exist_if_specified` uses
+  phase 4 recorded and did not file (F8).
+* Document what the `warn`/`off` rollback now does, since this phase
+  changes it.
+
+**Out:**
+
+* [#2094](https://github.com/shakenfist/shakenfist/issues/2094) — the
+  bare 403 on deleting an already-unrouted address. It is response
+  *semantics* for one endpoint, not the error contract of the chain;
+  phase 6 owns it. See D27.
+* Enforcing `required`, and semantic validation of the prose formats.
+  Phase 6.
+* The proxy path answering an unreachable node with a 500 (F9). Real,
+  and a status-code contract change of its own. Filed, not fixed.
+* Response validation. Ruled out in phase 0 (D7).
+
+## What the survey found
+
+The master plan's phase 5 section is stale in one important way and
+correct in the rest. Corrections have been made at source in
+`PLAN-api-input-validation.md` and `docs/plans/index.md` as part of the
+planning commit, so this section is the record of *why* they changed
+rather than a second copy of the claims.
+
+### F1. Three of the four attribution issues are now closed, not two
+
+The master plan says "#3615 landed 2026-08-10, #3606 is in flight as
+PR #3714, leaving #3523 and #3371". As of this survey:
+
+| Issue | State | Note |
+|---|---|---|
+| [#3615](https://github.com/shakenfist/shakenfist/issues/3615) | Closed | As recorded |
+| [#3606](https://github.com/shakenfist/shakenfist/issues/3606) | Closed | PR #3714 merged 2026-08-12 |
+| [#3371](https://github.com/shakenfist/shakenfist/issues/3371) | Closed | Closed since the master plan was written |
+| [#3523](https://github.com/shakenfist/shakenfist/issues/3523) | Open | The only one left |
+
+So the master plan's prediction — that by the time phases 3 and 4
+landed, phase 5 would be "likely to be the single item that actually
+depends on them" — is now the fact rather than the forecast. Phase 5
+is the `except TypeError` narrowing, plus one issue.
+
+### F2. The catch is still broad, and phases 3 and 4 did not touch it
+
+`base.py:1509`, unchanged by phases 3 and 4. Phase 3's plan said
+explicitly that it does not narrow it and that doing so before
+enforcement "would turn 400s into 500s". Enforcement has landed, so
+that gate is open.
+
+### F3. One deliberate `raise TypeError` depends on the catch
+
+`log_request` raises it on purpose (`base.py:1378`):
+
+```python
+if not isinstance(j, dict):
+    raise TypeError('the request body must be a JSON object')
+```
+
+with a comment saying the per-key merge it replaced raised `TypeError`
+for a non-object body and that this guard "keeps it that way". The
+400 it produces comes entirely from the arm being deleted. It is
+pinned by `test_a_non_object_body_is_still_a_400`
+(`shakenfist/tests/external_api/test_request_validation.py:432`),
+which drives four payloads — `['a', 'b']`, `'abc'`, `['ab', 'cd']` and
+`5` — through the real stack.
+
+Deleting the arm without changing this first turns every non-object
+JSON body into a 500. This is why step 1 exists and why it is a
+separate commit.
+
+`grep -rn "raise TypeError" shakenfist/ --include=*.py` outside tests
+returns exactly this one site; the two other matches are comments in
+`validation.py`.
+
+### F4. The rollback modes are what the deletion actually changes
+
+In `enforce` — the default since phase 4 — an undeclared body key
+never reaches the handler, so the arm is unreachable for that input.
+In `warn` and `off` it is reachable, and two unit tests assert the
+interpreter text as the expected response:
+
+* `test_warn_mode_changes_no_response`
+  (`test_request_validation.py:98`) asserts `unexpected keyword
+  argument` appears in the response body.
+* `test_off_mode_disables_the_layer` (`:198`) asserts the same.
+
+Both are correct today and both describe a leak. After this phase
+those inputs answer 500. That is the substantive behaviour change of
+the phase, and it lands on the path an operator uses when they have
+rolled enforcement back — see D25, which is the decision most likely
+to be argued with.
+
+### F5. No handler can raise `TypeError` from a *missing* parameter
+
+Worth checking because D17 deliberately leaves `missing-required`
+unenforced, which looks like it should leave a live path from an
+omitted parameter to `TypeError: missing 1 required positional
+argument` to a 400 carrying interpreter text.
+
+It does not. Every endpoint handler in the tree gives every non-path
+parameter a default. Verified with the repository's own AST
+machinery rather than by reading:
+
+```python
+# tools/... (written into step 2's brief; run from the repo root)
+from shakenfist.external_api import declarations as d
+
+for path, tree, cls, fn in d.handlers():
+    allpos = list(fn.args.posonlyargs) + list(fn.args.args)
+    nd = len(fn.args.defaults)
+    nodefault = [a.arg for a in (allpos[:len(allpos) - nd] if nd else allpos)]
+    nodefault += [a.arg for a, dv in zip(fn.args.kwonlyargs, fn.args.kw_defaults)
+                  if dv is None]
+    ...
+```
+
+The count is **zero**. Recorded with a caution: the first cut of that
+script sliced the defaults against a list it had already filtered
+`self` and the `*_from_db` injected parameters out of, and reported
+**22** handlers. The number was wrong in the direction that would have
+made this phase look gated on phase 6. It was caught by driving one of
+the 22 through the real stack — `POST /auth` without `namespace`
+answers `missing namespace in request` from the handler's own guard,
+not a `TypeError` — which is the check that should have been run
+first. A derived number that nobody drove through the stack is exactly
+the sort of assertion this plan's own review rounds keep catching.
+
+### F6. #3523's raising frame, found
+
+The issue asks for "a live Loki drill-down for the untruncated
+traceback to identify the raising frame (single event, so it may take
+a recurrence)". It has recurred, and the drill-down is done. Thirty
+days of `{job="shakenfist"} |= "Server error"` on the `sfcbr` tenant:
+
+```
+KeyError: 'arch_string_raw'
+  File ".../shakenfist/external_api/base.py", line 933, in proxy_request_to_node
+  File ".../shakenfist/util/general.py", line 93, in get_user_agent
+```
+
+on `GET /instances/<uuid>/consoledata`, five occurrences in thirty
+days. The code is `shakenfist/util/general.py:87-96`:
+
+```python
+def get_user_agent() -> str:
+    architecture = cpuinfo.get_cpu_info()
+    return ('Mozilla/5.0 (%(distribution)s; %(vendor)s %(architecture)s) '
+            ...
+                'architecture': architecture['arch_string_raw'],
+                'vendor': architecture['vendor_id_raw'],
+```
+
+`py-cpuinfo` is not guaranteed to populate either key — it probes
+through several mechanisms and returns what it managed to collect —
+so when the probe comes back partial the API answers an opaque 500 to
+a caller asking for console data. The fix is two guarded lookups in
+`util/general.py`, and it is not in the API at all.
+
+### F7. #3523's logging half is already fixed
+
+The issue's second complaint — a traceback showing only wrapper frames,
+plus a content-free `Recorded new exception` WARNING 195µs away — was
+resolved by the #3433 and #3590 work now visible in
+`record_exception` (`already_logged=True`, correlation fields stashed
+on `flask.g`) and `suppress_exceptions_to_client` (one line carrying
+`exception_class`, the full `traceback`, `method` and `path`). The
+Loki records in F6 are the proof: the traceback reaches `get_user_agent`,
+which is what the issue said it could not do. So #3523 reduces to F6.
+
+### F8. A defect phase 4 recorded and never filed
+
+Phase 4's plan records, under *Found while implementing, recorded
+rather than fixed*, that `requires_namespace_exist_if_specified` is
+dead on `InstanceEndpoint.delete` and `NetworkEndpoint.delete` because
+the ref decorator above it has already popped `namespace`. Verified:
+`instance.py:266-270` applies `@arg_is_instance_ref` above
+`@api_base.requires_namespace_exist_if_specified`, so the ref
+decorator wraps it and runs first, and `arg_is_instance_ref:1052`
+opens with `kwargs.pop('namespace', None)`.
+
+**No issue was filed.** `gh issue list --state all --search
+requires_namespace_exist_if_specified` returns nothing, so the record
+exists only in a phase plan nobody has reason to read again. That is
+the silent-disappearance failure mode, caught here rather than lost.
+
+The observable effect is small, which is why removal rather than
+reordering is the right fix: `arg_is_instance_ref` already resolves
+the namespace itself and answers its own errors, so a caller naming a
+non-existent namespace gets `instance not found` (404) instead of
+`namespace not found` (404). Reordering would change that message;
+removing the dead call acknowledges the ref decorator already covers
+the case. See D29.
+
+### F9. Two more 500 classes on the proxy path, recorded not fixed
+
+The full 30-day sample is 266 `Server error` records, and the five
+`KeyError`s of F6 are the small half of it:
+
+| n | class | deepest frame |
+|---|---|---|
+| 260 | `ConnectionError` | `requests/adapters.py` in `send` |
+| 5 | `KeyError` | `util/general.py` in `get_user_agent` |
+| 1 | `ConnectionRefusedError` | `util/concurrency.py:329` in `_node_lock_request` |
+
+A node being unreachable is answered as a 500 with an exception repr,
+260 times in a month. That is a genuine error-contract defect of the
+same family as this plan's, and it is a different mechanism with a
+different right answer (502 or 503, and a decision about retries). To
+be filed rather than absorbed — see D28.
+
+### F10. The arm has fired once in the only window that can be counted
+
+`handle_authorization_exceptions` logged **nothing** on the `TypeError`
+path until 2026-09-05, when `804b165d8` added
+`_authorization_failure_log` and the line `API request rejected as
+malformed`. Before that the arm returned a silent 400: the leak this
+phase closes has had no operator-side record for its whole life, which
+is its own small argument for closing it.
+
+Since that line exists, sfcbr has fired the arm exactly **once**, on
+2026-09-08:
+
+```
+"error-class": "TypeError",
+"error": "InstancesEndpoint.get() got an unexpected keyword argument 'banana'",
+"method": "GET", "path": "/instances"
+```
+
+which is phase 4's own hand probe — the control its measurement log
+records, not a caller. Five days is a short window and it is the only
+one there is; the honest statement is that nothing is known about the
+arm's rate before 2026-09-05, and that in the days since, no real
+caller has reached it.
+
+### Nothing else in the master plan's phase 5 section was wrong
+
+The description of what the narrowing *is*, and the reasoning about
+why nobody picks it up incidentally, both hold.
+
+## Decisions
+
+### D23. The arm is deleted, not narrowed to a subset
+
+"Narrow `except TypeError` to JWT errors" reads two ways. It means
+delete the `TypeError` arm and leave the three JWT arms, not keep a
+`TypeError` arm that tries to distinguish JWT-originated ones: nothing
+in `flask_jwt_extended` or `PyJWT` raises `TypeError` to signal an
+authorization failure, and there is no attribute on a `TypeError` that
+would let the handler tell where it came from. A conditional there
+could only work by matching the message text, which is the technique
+this plan exists to remove.
+
+### D24. `log_request` stops raising, in its own commit
+
+The non-object body guard becomes an explicit `return sf_api.error(400,
+'the request body must be a JSON object')`. Two reasons it is a
+separate commit ahead of the deletion: the deletion is otherwise a
+behaviour change bundled with a regression fix and cannot be bisected
+apart, and `test_a_non_object_body_is_still_a_400` should pass
+unchanged across both commits, which is only meaningful if they are
+separate.
+
+`log_request` is a decorator wrapper and already returns responses on
+other paths, so this is a return, not a new mechanism.
+
+### D25. Under `warn` and `off`, an undeclared body key becomes a 500
+
+**This is the decision most likely to be argued with.** The
+documented rollback for enforcement is `API_VALIDATION_MODE=warn` or
+`off`. Today, rolling back restores the old 400-with-interpreter-text
+answer for an undeclared body key. After this phase, rolling back
+gives a 500 with a recorded server exception instead.
+
+The argument against: a rollback should restore the previous
+behaviour, and this makes the rollback strictly worse for the caller
+who triggered it.
+
+The argument for, which wins:
+
+* The 400 it restores is the defect. `str(TypeError)` in a caller's
+  error field is #3612, and preserving it in a mode reachable by an
+  operator flag preserves the leak that four phases were spent
+  closing. An operator rolling back is buying "requests that were
+  working keep working", not "malformed requests get a tidier error".
+* A request whose kwargs do not match its handler's signature *is* a
+  server-side surprise once a validation layer exists and is switched
+  off. 500 with a recorded exception is the honest answer; the
+  operator gets a file in `/srv/shakenfist/exceptions/` and a log line
+  carrying the class, traceback, method and path, which is more than
+  the INFO line said.
+* The population is small and known. Thirty days of sfcbr warn data
+  (phase 4's measurement log, *What thirty days of sfcbr says about
+  the flip's blast radius*) contains exactly **one**
+  `unknown-parameter` finding — a hand probe on 2026-08-13 which
+  already answered 400. No real caller in that window sent a body key
+  its handler could not accept. The callers who would meet the new
+  500 are callers who are already being refused. F10 says the same
+  thing from the other side: the arm itself has fired once since it
+  started logging, on a hand probe.
+
+The alternative considered and rejected: keep a `TypeError` arm gated
+on `config.API_VALIDATION_MODE != 'enforce'`. It preserves the
+rollback exactly, and it makes the response to a malformed request
+depend on a mode flag in two places instead of one, leaving the leak
+in the tree with a longer justification attached. Recorded here so
+the option is visible rather than absent.
+
+Documented in the release note and in
+`docs/developer_guide/writing_an_endpoint.md`, because a rollback
+whose behaviour changed is a thing an operator finds out at the worst
+possible moment otherwise.
+
+### D26. #3523 is fixed in `util/general.py`, not in the API
+
+Per F6 and F7 the issue's logging half is done and its remaining half
+is an unguarded dict lookup in a utility function. The fix belongs
+where the bug is. `get_user_agent()` gets a default for each key it
+reads, and returns a user agent string naming what it does know.
+
+It is in this phase rather than filed separately because #3523 is one
+of the four issues the master plan assigns to phase 5, and because it
+is a live 500 on a user-facing endpoint.
+
+### D27. #2094 stays out
+
+`DELETE .../route/<addr>` on an already-unrouted address returns a bare
+403. Making it idempotent is a decision about what the endpoint means,
+not about how the chain reports errors, and it needs the same
+judgement phase 6 will be making about `required`. It is not blocked
+by anything this phase does.
+
+### D28. F9 is filed, not fixed
+
+An unreachable node answering 500 is a real defect, and fixing it means
+choosing a status code, deciding whether the proxy retries, and
+auditing every caller of `proxy_request_to_node` and
+`_node_lock_request`. That is a phase, not a step. File it with the
+Loki evidence and link it from the master plan's Future work.
+
+### D29. The dead decorator uses are removed, not reordered
+
+Per F8. Removal is behaviour-neutral because the call cannot fire;
+reordering would change a 404's message text on two delete routes and
+would need its own justification. The four now-redundant
+`namespace=None` signature parameters phase 4 also recorded are left
+alone: they are populated by the body merge and read by nothing, and
+removing them is a signature change to four handlers for no observable
+gain. Recorded so the next phase does not rediscover them.
+
+### D30. A test that a handler-internal `TypeError` is a 500
+
+The deletion is a removal, and a removal is exactly the change a test
+suite is least likely to notice. The phase adds a test that mounts a
+handler which raises `TypeError` and asserts the caller gets 500 with
+no interpreter text in the body, and that an exception was recorded.
+Without it, the property "the API never answers a `TypeError` in the
+interpreter's words" is asserted nowhere and could be undone by
+someone restoring the arm.
+
+## Step plan
+
+| Step | Effort | Model | Isolation | Brief for sub-agent |
+|------|--------|-------|-----------|---------------------|
+| 1 | medium | sonnet | none | **`log_request` returns a 400 instead of raising.** In `shakenfist/external_api/base.py`, `log_request`'s wrapper raises `TypeError('the request body must be a JSON object')` at line 1378 when the parsed JSON body is not a dict. Replace it with `return sf_api.error(400, 'the request body must be a JSON object')`. Keep the surrounding comment but rewrite it: it currently explains that the raise reproduces the old per-key merge's `TypeError`, and after this change the point is that the guard answers directly rather than depending on a catch two decorators out. Do not change anything else in `log_request`. `test_a_non_object_body_is_still_a_400` (`shakenfist/tests/external_api/test_request_validation.py:432`) must pass **unchanged** — all four payloads, same status, same message. Verify by running it before and after. Commit subject: `Answer a non-object body directly.` |
+| 2 | high | opus | none | **Delete the `except TypeError` arm.** In `shakenfist/external_api/base.py`, `handle_authorization_exceptions` (line 1500) catches `TypeError` and answers `400 str(e)`. Delete that arm and leave the three JWT arms — `DecodeError`, `ExpiredSignatureError` and the eight-class tuple — untouched. Rewrite the `NOTE(mikal)` comment above the wrapper so it says what the function now catches and why (authorization conditions only; see decision D23 in this plan). Then fix the fallout, which the plan has already enumerated: `test_warn_mode_changes_no_response` (`test_request_validation.py:98`) and `test_off_mode_disables_the_layer` (`:198`) both assert `unexpected keyword argument` appears in the response body; under `warn` and `off` an undeclared body key now answers 500 (decision D25), so rewrite both to assert the new behaviour *and* to assert the response carries no interpreter text. Add the D30 test: a handler which raises `TypeError` internally answers 500, the body contains no Python message, and `util.exceptions.record_exception` was called. Reuse the `INTERPRETER_TEXT` list (`test_request_validation.py:709`) rather than writing a new one; note its comment says a marker added there belongs in `shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_api_validation.py` too. Before finishing, enumerate every remaining source of `TypeError` reachable from a request: grep the whole tree for `raise TypeError` (step 1 removed the only one in `external_api/`), and check the `@use_kwargs`/webargs sites and `flasgger`. Report what you found even if the answer is nothing. Commit subject: `Stop answering a TypeError as a bad request.` |
+| 3 | medium | sonnet | none | **Fix #3523.** `shakenfist/util/general.py:87` `get_user_agent()` indexes `cpuinfo.get_cpu_info()` for `arch_string_raw` and `vendor_id_raw` without guarding. `py-cpuinfo` returns whatever its probes collected, so both keys can be absent, and the resulting `KeyError` reaches a caller as a 500 on `GET /instances/<uuid>/consoledata` via `proxy_request_to_node`. Use `.get()` with a sensible literal for each (`'unknown'` reads correctly in a user agent string). Add a unit test in `shakenfist/tests/` that patches `cpuinfo.get_cpu_info` to return `{}` and asserts `get_user_agent()` returns a string containing the version — mutation test it by restoring one of the bare lookups and confirming the test fails. Do not change the user agent's format for the case where both keys are present; a test should pin that too. Commit subject: `Survive a partial cpuinfo probe.` |
+| 4 | low | sonnet | none | **Remove two dead decorator uses.** `@api_base.requires_namespace_exist_if_specified` is applied *below* `@api_base.arg_is_instance_ref` on `InstanceEndpoint.delete` (`shakenfist/external_api/instance.py:268`) and below `@api_base.arg_is_network_ref` on `NetworkEndpoint.delete` (`shakenfist/external_api/network.py:165`). The ref decorator wraps it and opens with `kwargs.pop('namespace', None)` (`base.py:1052`), so its `kwargs.get('namespace')` is always `None` and it can never fire. Delete both applications. Do not reorder them, and do not touch the other ten uses, which are on creation and collection routes and work (decision D29). Confirm no test asserts `namespace not found` on either route before deleting. Add a short comment to `requires_namespace_exist_if_specified` in `base.py` recording that it must be applied *above* any ref decorator, so the next use does not repeat this. Commit subject: `Drop two guards that could never fire.` |
+| 5 | medium | sonnet | none | **Documentation and close-out.** (a) `docs/developer_guide/writing_an_endpoint.md:308-316` already describes `API_VALIDATION_MODE` and calls `warn` the operator's rollback; extend that passage to say what `warn` and `off` now do with an undeclared body key (500, recorded exception). Do not add a new section. (b) `docs/release_notes/v07-v08.md:188-220` is phase 4's enforcement entry, including the `API_VALIDATION_MODE=warn` rollback sentence at line 210; extend that entry, do not start a second one, noting that the rollback modes no longer answer 400 for input the handler cannot accept. (c) File the F9 issue: the proxy path answers an unreachable node with a 500, with the Loki evidence from this plan's F9 and links to `proxy_request_to_node` and `util/concurrency.py:329`. (d) Update this plan's Progress section, the master plan's Execution table row for phase 5, and the `docs/plans/index.md` phase arithmetic. Commit subject: `Document what narrowing changed.` |
+
+Steps 1 and 2 are strictly ordered. Steps 3 and 4 are independent of
+both and of each other. Step 5 runs last. Step 2 carries a conditional
+gate — see the Back brief.
+
+## Risks and mitigations
+
+* **A `TypeError` source the survey missed becomes a 500.** The
+  survey enumerated `raise TypeError` across the tree and reasoned
+  about the handler-signature paths, but a library on a code path with
+  no test could raise one. *Mitigation:* step 2's brief makes the
+  enumeration an explicit deliverable and asks for a report even when
+  it is empty; the reviewer's job is named as finding the one that was
+  missed. Note what the production sample can and cannot say: the
+  `Server error` records in F6/F9 carry no `TypeError` *by
+  construction*, because the arm catches it before the outer wrapper
+  sees it, so that sample is not evidence. F10 is — the arm's own log
+  line, which has fired once since it started existing on 2026-09-05,
+  on a hand probe.
+* **The rollback becomes worse and an operator finds out during an
+  incident.** *Mitigation:* D25 is documented in both the developer
+  guide and the release note by step 5, and the release note entry
+  sits with the enforcement entry an operator reading about the
+  rollback would already be looking at.
+* **Step 4 removes a guard that is not actually dead.** *Mitigation:*
+  the claim was verified by reading the decorator application order
+  and `arg_is_instance_ref`'s first statement, and the brief requires
+  confirming no test asserts `namespace not found` on those routes
+  before deleting. If either check fails, the step stops rather than
+  proceeding.
+* **The phase looks trivial and is reviewed as though it were.** Four
+  lines of deletion is the whole change, and the plan's value is in
+  what the deletion is load-bearing for. *Mitigation:* the review
+  effort is stated as high above, and D30's test makes the property
+  the phase establishes assertable rather than argued.
+
+## Definition of done
+
+1. `handle_authorization_exceptions` contains no `except TypeError`,
+   and `grep -n "except TypeError" shakenfist/external_api/base.py`
+   returns nothing.
+2. `grep -rn "raise TypeError" shakenfist/external_api/` returns no
+   executable statement (comments in `validation.py` excepted).
+3. `test_a_non_object_body_is_still_a_400` passes with its assertions
+   unchanged, for all four payloads, after both step 1 and step 2.
+4. A test proves a handler which raises `TypeError` internally answers
+   500, that the body carries none of the shapes in `INTERPRETER_TEXT`
+   (`test_request_validation.py:709`), and that an exception was
+   recorded. The test has been mutation-tested by restoring the
+   deleted arm, and fails when it is restored.
+5. No test in the suite asserts that a response body contains
+   `unexpected keyword argument` or `missing 1 required positional
+   argument`.
+6. `get_user_agent()` returns a string when `cpuinfo.get_cpu_info()`
+   returns `{}`, pinned by a test which fails if either guarded lookup
+   is restored to a bare index.
+7. #3523 is closed, and the closing comment names
+   `util/general.py:get_user_agent` and `KeyError: 'arch_string_raw'`
+   as the raising frame the issue asked for.
+8. `requires_namespace_exist_if_specified` is applied above every ref
+   decorator that uses it, or not at all; the two applications named
+   in F8 are gone and the other ten are untouched.
+9. An issue exists for F9, linked from the master plan's Future work.
+10. What `warn` and `off` do with an undeclared body key is stated the
+    same way in `docs/developer_guide/writing_an_endpoint.md`, the
+    v07-v08 release note, and this plan.
+11. `pre-commit run --all-files` is clean.
+12. The master plan's Execution table, its status line, and the
+    `docs/plans/index.md` row all say phase 5 is complete and agree on
+    the phase arithmetic.
+
+## Back brief
+
+Before executing any step, back brief the operator on the plan and how
+the intended work aligns with it.
+
+One gate: **step 2 stops and reports before committing** if its
+enumeration of remaining `TypeError` sources finds anything beyond the
+two the survey already knows about (`log_request`'s, removed by step
+1, and handler-internal ones). A third source changes what D25 says
+about the rollback, and that is a decision to take in the management
+session rather than in the step.
+
+## Progress
+
+Planned 2026-09-10. No steps executed.

--- a/docs/plans/PLAN-api-input-validation-phase-05-narrow.md
+++ b/docs/plans/PLAN-api-input-validation-phase-05-narrow.md
@@ -182,7 +182,11 @@ for path, tree, cls, fn in d.handlers():
     ...
 ```
 
-The count is **zero**. Recorded with a caution: the first cut of that
+The count is **zero** — and it answers a narrower question than the
+one that mattered, which the review of #4162 later caught. Read the
+correction at the end of this finding before relying on it.
+
+Recorded with a caution: the first cut of that
 script sliced the defaults against a list it had already filtered
 `self` and the `*_from_db` injected parameters out of, and reported
 **22** handlers. The number was wrong in the direction that would have
@@ -192,6 +196,50 @@ answers `missing namespace in request` from the handler's own guard,
 not a `TypeError` — which is the check that should have been run
 first. A derived number that nobody drove through the stack is exactly
 the sort of assertion this plan's own review rounds keep catching.
+
+**The corrected number was still answering the wrong question.** The
+review of [#4162](https://github.com/shakenfist/shakenfist/pull/4162)
+found that the hazard is not a parameter *without* a default. It is a
+parameter *with* a `None` default which a handler then dereferences
+without a type guard. Every declared parameter compiles to a field
+with `allow_none=True`, and D17 leaves `required` unenforced, so
+`None` reaches handlers routinely on the **default** `enforce` path —
+which an AST check for missing defaults cannot see at all.
+
+`InstancesEndpoint.post` is the proven instance. It defaults
+`name=None`; `validators.hostname(None, ...)` returns a falsy
+`ValidationError` rather than raising, so execution reaches
+`contains_domain = '.' in name`, which raises `TypeError: argument of
+type 'NoneType' is not iterable`. Before this phase that answered 400
+with interpreter text. After step 2 it answers a recorded 500, on the
+default path, for `POST /instances {}`. Fixed here, with tests.
+
+So F5's zero covers non-defaulted parameters only, and D25's
+blast-radius argument covers undeclared body keys under `warn`/`off`
+only. Neither covered a plain caller mistake against a declared but
+nullable parameter. `POST /networks` next door escapes only by
+accident, because `ipaddress.ip_network(None)` raises `ValueError`
+rather than `TypeError`.
+
+The class as a whole is unswept, and sweeping it belongs to phase 6,
+which already owns `required` and semantic validation. Filed as
+[#4167](https://github.com/shakenfist/shakenfist/issues/4167), which
+also carries three further latent 500s the fix's author found in the
+same handler while probing its other fifteen parameters — `cpus` and
+`memory` as null, `disk[].base` as a non-string, and
+`network[].network_uuid` as a non-string. **None of the three is a
+regression from this phase**: they raise pydantic `ValidationError` or
+`AttributeError`, which the deleted arm never caught, so they answered
+a 500 before it too. The last two share a structural cause worth phase
+6's attention on its own — an `arrayofdict` compiles to
+`fields.List(fields.Dict())` with no value schema, so every nested key
+in `disk` and `network` is unvalidated by construction, in every
+mode. The lesson
+worth carrying is not that the script had a bug — it is that the
+script was mechanically correct on the second attempt and still aimed
+at the wrong property. This phase's own risk register named "a
+TypeError source the survey missed becomes a 500" and the survey
+still missed one.
 
 ### F6. #3523's raising frame, found
 

--- a/docs/plans/PLAN-api-input-validation.md
+++ b/docs/plans/PLAN-api-input-validation.md
@@ -32,7 +32,7 @@ appended.
 I prefer one commit per logical change, and at minimum one
 commit per phase. Each commit should be self-contained.
 
-**Status: phases 0 to 4 planned; 0, 1, 2 and 3 complete.**
+**Status: phases 0 to 5 planned; 0, 1, 2, 3 and 4 complete.**
 The open questions at the bottom are answered in the Decisions
 section; see
 [`PLAN-api-input-validation-phase-00-decisions.md`](PLAN-api-input-validation-phase-00-decisions.md)
@@ -45,8 +45,11 @@ recorded, and
 [`PLAN-api-input-validation-phase-03-compile-and-warn.md`](PLAN-api-input-validation-phase-03-compile-and-warn.md)
 for the measurement that closed it, and
 [`PLAN-api-input-validation-phase-04-enforce.md`](PLAN-api-input-validation-phase-04-enforce.md)
-for the phase now ready to start. Phases 5 onward are not yet cut
-into per-phase files.
+for the reading that unlocked the flip and what the flip changed for
+callers, and
+[`PLAN-api-input-validation-phase-05-narrow.md`](PLAN-api-input-validation-phase-05-narrow.md)
+for the phase now ready to start. Phases 6 and 7 are not yet cut into
+per-phase files.
 
 ## Situation
 
@@ -297,8 +300,8 @@ declarations are good enough to compile.
 | 1: Declaration audit | Complete | Correct 116 path-parameter locations from the route table, 2 invalid location tokens, 5 wrong names (incl. `sshkey`/`userdata` in the published OpenAPI) and 20 undeclared parameters; make `swagger_helper()` reject unknown locations; add a test that keeps declarations honest. A precondition for phase 3, and a documentation-correctness fix worth landing on its own merits. See [phase 1](PLAN-api-input-validation-phase-01-declaration-audit.md) |
 | 2: Type vocabulary | Complete | The specification-validation test (#3626) plus `schemes`/`securityDefinitions` template fixes; one schema-carrying body parameter per operation, taking the validation error count from 129 to zero; `unsignedinteger`/`macaddr`/`base64`/`netblock` tokens and the optional constraints element, rendered into the published OpenAPI so bounds like the events `limit` cap are visible to callers. See [phase 2](PLAN-api-input-validation-phase-02-type-vocabulary.md) |
 | 3: Compile and warn | Complete | Code landed 2026-08-13 via #3726: declarations compiled to schemas, warn-only validation ahead of the handlers; four further decisions (D10-D13) recorded in the phase plan, including that an undeclared body key is *already* a 400 carrying interpreter text. The measurement window opened the same day and closed 2026-08-21 with every finding explained: 33 intended rejections, and two declaration bugs — the undeclared `namespace` of #3739 and fourteen metadata `value` declarations narrower than their handlers — which phase 4 fixes before it enforces. See [phase 3](PLAN-api-input-validation-phase-03-compile-and-warn.md) |
-| 4: Enforce | In progress | Fix the two declaration bugs the warn window found (#3739's undeclared `namespace` on 55 handlers, and fourteen metadata `value` declarations), teach the derivation to see decorator-consumed kwargs so that class cannot recur, then turn on rejection with one malformed-input response shape that never contains interpreter text. The `get_args` fold moves to Future work: read as "delete the four `@use_kwargs` decorators" it is a bug, because the compiled path is check-only and `@use_kwargs` is the only thing that gets a query parameter to a handler. See [phase 4](PLAN-api-input-validation-phase-04-enforce.md) |
-| 5: Narrow the handlers | Not started | Narrow `except TypeError` to JWT errors — still owned by this plan, and still gated on phase 4. The attribution issues are being closed independently: #3615 landed 2026-08-10, #3606 is in flight as PR #3714, leaving #3523 and #3371. See the note below |
+| 4: Enforce | Complete | Landed 2026-09-09 via [#4141](https://github.com/shakenfist/shakenfist/pull/4141). Fixed the two declaration bugs the warn window found (#3739's undeclared `namespace` on 55 handlers, and fourteen metadata `value` declarations), taught the derivation to see decorator-consumed kwargs so that class cannot recur, and turned on rejection with one malformed-input response shape that never contains interpreter text. The `get_args` fold moved to Future work as [#4098](https://github.com/shakenfist/shakenfist/issues/4098): read as "delete the four `@use_kwargs` decorators" it is a bug, because the compiled path is check-only and `@use_kwargs` is the only thing that gets a query parameter to a handler. See [phase 4](PLAN-api-input-validation-phase-04-enforce.md) |
+| 5: Narrow the handlers | In progress | Delete the `except TypeError` arm from `handle_authorization_exceptions`, which is the second half of the #3612 mechanism and could not be removed until phase 4 was refusing the input it absorbed. Three of the four attribution issues closed independently while phases 3 and 4 ran (#3615, #3606 via PR #3714, #3371), so the phase is the narrowing plus #3523 — whose raising frame the phase 5 survey identified as an unguarded `cpuinfo` lookup in `util/general.py`. See [phase 5](PLAN-api-input-validation-phase-05-narrow.md) |
 | 6: Required and semantics | Not started | Enforce `required` — or decide not to, since it is the change most likely to break working clients; semantic validators for #534, #3269, #323, #936 |
 | 7: Push audit | Not started | Runs `PUSH-AUDIT.md` over the accumulated diff of every phase in this plan against `develop`, not the last phase's diff alone. Findings land as their own pull request, and the plan is not complete until each is resolved or declined in writing here; if the audit finds nothing, that is recorded in one sentence |
 
@@ -312,9 +315,10 @@ the plan was scoped against.
 2026-08-07), #3626 (specification validation in CI), #3616
 (`base.py` under mypy), #3642 (variadic handlers in the audit),
 #3629 (body-supplied `all`, see D6 below), #3615 (`log_request`
-discarding headers). #3739 (the ref decorators' undeclared
-`namespace`) is fixed by phase 4 and closes when that branch
-merges.
+discarding headers), #3739 (the ref decorators' undeclared
+`namespace`, closed when phase 4 merged 2026-09-09), #3606 (JWT
+rejection attribution, PR #3714, merged 2026-08-12) and #3371
+(`record_exception` tracebacks only at DEBUG).
 
 **Filed by phase 4, and deliberately not fixed by it:** #4098 (the
 `get_args` fold, see the carried section below) and #4100 (an
@@ -324,21 +328,21 @@ injects, so no phase of this plan unblocks it; it needs a client
 release which omits the key).
 
 **Still open and still owned by this plan:** #528 (parent), #3612
-(the mechanism), #936, #534, #3269, #323, #3523, #3371, #2094;
-#3606 is in flight as PR #3714.
+(the mechanism), #936, #534, #3269, #323, #3523, #2094.
 
-**Phase 5 is being overtaken from outside.** Two of its four
-attribution issues have been picked up by the automated issue
-fixer rather than by this plan. That is fine — they are genuinely
-independent of phases 3 and 4, which is why they were grouped
-rather than sequenced. It is recorded because it changes what
-phase 5 *is*: by the time phases 3 and 4 land, phase 5 is likely
-to be the single item that actually depends on them — narrowing
+**Phase 5 was overtaken from outside, as predicted.** Three of
+its four attribution issues were picked up by the automated issue
+fixer rather than by this plan — #3615, #3606 and #3371, leaving
+only #3523. That is fine: they were genuinely independent of
+phases 3 and 4, which is why they were grouped rather than
+sequenced. It is recorded because it changed what phase 5 *is*.
+The forecast written here was that phase 5 would reduce to the
+single item which actually depends on phases 3 and 4 — narrowing
 `except TypeError` to JWT errors, which cannot happen until a
 validation layer is rejecting the malformed input that broad
-catch currently absorbs. Nobody picks that up incidentally,
-because on its own it looks like a regression risk with no
-visible benefit.
+catch absorbs. That is now the fact rather than the forecast.
+Nobody picks that item up incidentally, because on its own it
+looks like a regression risk with no visible benefit.
 
 ### Carried into phase 2 from phase 1
 

--- a/docs/plans/PLAN-api-input-validation.md
+++ b/docs/plans/PLAN-api-input-validation.md
@@ -32,7 +32,7 @@ appended.
 I prefer one commit per logical change, and at minimum one
 commit per phase. Each commit should be self-contained.
 
-**Status: phases 0 to 5 planned; 0, 1, 2, 3 and 4 complete.**
+**Status: phases 0 to 5 planned; 0, 1, 2, 3, 4 and 5 complete.**
 The open questions at the bottom are answered in the Decisions
 section; see
 [`PLAN-api-input-validation-phase-00-decisions.md`](PLAN-api-input-validation-phase-00-decisions.md)
@@ -301,7 +301,7 @@ declarations are good enough to compile.
 | 2: Type vocabulary | Complete | The specification-validation test (#3626) plus `schemes`/`securityDefinitions` template fixes; one schema-carrying body parameter per operation, taking the validation error count from 129 to zero; `unsignedinteger`/`macaddr`/`base64`/`netblock` tokens and the optional constraints element, rendered into the published OpenAPI so bounds like the events `limit` cap are visible to callers. See [phase 2](PLAN-api-input-validation-phase-02-type-vocabulary.md) |
 | 3: Compile and warn | Complete | Code landed 2026-08-13 via #3726: declarations compiled to schemas, warn-only validation ahead of the handlers; four further decisions (D10-D13) recorded in the phase plan, including that an undeclared body key is *already* a 400 carrying interpreter text. The measurement window opened the same day and closed 2026-08-21 with every finding explained: 33 intended rejections, and two declaration bugs — the undeclared `namespace` of #3739 and fourteen metadata `value` declarations narrower than their handlers — which phase 4 fixes before it enforces. See [phase 3](PLAN-api-input-validation-phase-03-compile-and-warn.md) |
 | 4: Enforce | Complete | Landed 2026-09-09 via [#4141](https://github.com/shakenfist/shakenfist/pull/4141). Fixed the two declaration bugs the warn window found (#3739's undeclared `namespace` on 55 handlers, and fourteen metadata `value` declarations), taught the derivation to see decorator-consumed kwargs so that class cannot recur, and turned on rejection with one malformed-input response shape that never contains interpreter text. The `get_args` fold moved to Future work as [#4098](https://github.com/shakenfist/shakenfist/issues/4098): read as "delete the four `@use_kwargs` decorators" it is a bug, because the compiled path is check-only and `@use_kwargs` is the only thing that gets a query parameter to a handler. See [phase 4](PLAN-api-input-validation-phase-04-enforce.md) |
-| 5: Narrow the handlers | In progress | Delete the `except TypeError` arm from `handle_authorization_exceptions`, which is the second half of the #3612 mechanism and could not be removed until phase 4 was refusing the input it absorbed. Three of the four attribution issues closed independently while phases 3 and 4 ran (#3615, #3606 via PR #3714, #3371), so the phase is the narrowing plus #3523 — whose raising frame the phase 5 survey identified as an unguarded `cpuinfo` lookup in `util/general.py`. See [phase 5](PLAN-api-input-validation-phase-05-narrow.md) |
+| 5: Narrow the handlers | Complete | Deleted the `except TypeError` arm from `handle_authorization_exceptions` (D23): a handler-internal `TypeError` is now a recorded 500 like any other server fault, and under the `warn`/`off` rollback an undeclared body key gets that same 500 instead of the 400-with-interpreter-text it used to (D25). Fixed [#3523](https://github.com/shakenfist/shakenfist/issues/3523) (a partial `cpuinfo` probe raising `KeyError` in `get_user_agent`) and removed two `requires_namespace_exist_if_specified` applications phase 4 found dead and never filed (F8). Grew a sixth step mid-phase, after step 2 found the generic 500 body still carried `repr(e)` (F11): every 500 response now answers a bare `server error` with no exception detail at all, for any cause (D31). Filed [#4161](https://github.com/shakenfist/shakenfist/issues/4161) for the proxy path answering an unreachable node with a 500 (F9) — re-verifying the finding before filing found that an unrelated fix ([#3743](https://github.com/shakenfist/shakenfist/issues/3743)) had already closed its largest instance, so the issue is scoped to what is still true rather than to the table as originally surveyed. See [phase 5](PLAN-api-input-validation-phase-05-narrow.md) |
 | 6: Required and semantics | Not started | Enforce `required` — or decide not to, since it is the change most likely to break working clients; semantic validators for #534, #3269, #323, #936 |
 | 7: Push audit | Not started | Runs `PUSH-AUDIT.md` over the accumulated diff of every phase in this plan against `develop`, not the last phase's diff alone. Findings land as their own pull request, and the plan is not complete until each is resolved or declined in writing here; if the audit finds nothing, that is recorded in one sentence |
 
@@ -317,8 +317,10 @@ the plan was scoped against.
 #3629 (body-supplied `all`, see D6 below), #3615 (`log_request`
 discarding headers), #3739 (the ref decorators' undeclared
 `namespace`, closed when phase 4 merged 2026-09-09), #3606 (JWT
-rejection attribution, PR #3714, merged 2026-08-12) and #3371
-(`record_exception` tracebacks only at DEBUG).
+rejection attribution, PR #3714, merged 2026-08-12), #3371
+(`record_exception` tracebacks only at DEBUG) and #3523 (a
+partial `cpuinfo` probe raising `KeyError` in `get_user_agent`,
+closed when phase 5 landed `dc6019d6a`).
 
 **Filed by phase 4, and deliberately not fixed by it:** #4098 (the
 `get_args` fold, see the carried section below) and #4100 (an
@@ -327,8 +329,18 @@ in the tree wrongly blamed on this plan — the compiled path never
 injects, so no phase of this plan unblocks it; it needs a client
 release which omits the key).
 
+**Filed by phase 5, and deliberately not fixed by it:** #4161 (the
+proxy path answering an unreachable node — or the local nodelock
+socket refusing a connection — with an unqualified 500, see F9 in
+[phase 5](PLAN-api-input-validation-phase-05-narrow.md)). Filing
+it required re-verifying the finding first: an unrelated fix
+(#3743, merged 2026-08-21) had already closed the largest of the
+three classes the phase 5 survey recorded, so the issue is scoped
+to the two proxy call sites and the local-socket case that fix
+does not cover, not to the survey's original table.
+
 **Still open and still owned by this plan:** #528 (parent), #3612
-(the mechanism), #936, #534, #3269, #323, #3523, #2094.
+(the mechanism), #936, #534, #3269, #323, #2094.
 
 **Phase 5 was overtaken from outside, as predicted.** Three of
 its four attribution issues were picked up by the automated issue

--- a/docs/plans/PLAN-api-input-validation.md
+++ b/docs/plans/PLAN-api-input-validation.md
@@ -48,8 +48,9 @@ for the measurement that closed it, and
 for the reading that unlocked the flip and what the flip changed for
 callers, and
 [`PLAN-api-input-validation-phase-05-narrow.md`](PLAN-api-input-validation-phase-05-narrow.md)
-for the phase now ready to start. Phases 6 and 7 are not yet cut into
-per-phase files.
+for the narrowing and the two leaks it closed. Phase 6 is the next
+phase to start, and neither it nor phase 7 is yet cut into a per-phase
+file.
 
 ## Situation
 

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -108,7 +108,7 @@ checker's blind spot, and the only numbers here it cannot recompute.
 | 2026-07-19 | [Node resource health](PLAN-node-resource-health.md) | Declarative dependency checks driving node state, so a dead disk stops scheduling | Complete | 5 of 5 |
 | 2026-07-21 | [Per-host resource reservations](PLAN-per-host-resource-reservations.md) | Per-node RAM, CPU and disk reservation overrides | Complete | 4 of 4 |
 | 2026-07-28 | [sf-netserv](PLAN-netserv.md) | Replace dnsmasq with a Rust per-network service plane | Proposed | — |
-| 2026-08-03 | [API input validation](PLAN-api-input-validation.md) | Declarative request validation and a consistent error contract for the REST API | In progress | 5 of 8 |
+| 2026-08-03 | [API input validation](PLAN-api-input-validation.md) | Declarative request validation and a consistent error contract for the REST API | In progress | 6 of 8 |
 | 2026-08-14 | [Agent operation deadlines](PLAN-agent-operation-deadlines.md) | Client-propagated deadlines and per-command progress timeouts for agent operations; audited, and the one defect of its own making the audit found ([#4074](https://github.com/shakenfist/shakenfist/issues/4074)) was fixed hours later by #4080 -- see Known defects in the plan for the two which remain open | Complete | 9 of 9 |
 | 2026-08-14 | [Dependency-aware agent operations](PLAN-agent-operation-dependencies.md) | `depends_on` and `runs_after` for agent operations, including cross-instance edges | Blocked | — |
 | 2026-08-16 | [Bound gRPC reply sizes](PLAN-grpc-bounded-replies.md) | Make `DatabaseService` replies bounded by construction rather than by the message size limit | Not started | 0 of 7 |

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -108,7 +108,7 @@ checker's blind spot, and the only numbers here it cannot recompute.
 | 2026-07-19 | [Node resource health](PLAN-node-resource-health.md) | Declarative dependency checks driving node state, so a dead disk stops scheduling | Complete | 5 of 5 |
 | 2026-07-21 | [Per-host resource reservations](PLAN-per-host-resource-reservations.md) | Per-node RAM, CPU and disk reservation overrides | Complete | 4 of 4 |
 | 2026-07-28 | [sf-netserv](PLAN-netserv.md) | Replace dnsmasq with a Rust per-network service plane | Proposed | — |
-| 2026-08-03 | [API input validation](PLAN-api-input-validation.md) | Declarative request validation and a consistent error contract for the REST API | In progress | 4 of 8 |
+| 2026-08-03 | [API input validation](PLAN-api-input-validation.md) | Declarative request validation and a consistent error contract for the REST API | In progress | 5 of 8 |
 | 2026-08-14 | [Agent operation deadlines](PLAN-agent-operation-deadlines.md) | Client-propagated deadlines and per-command progress timeouts for agent operations; audited, and the one defect of its own making the audit found ([#4074](https://github.com/shakenfist/shakenfist/issues/4074)) was fixed hours later by #4080 -- see Known defects in the plan for the two which remain open | Complete | 9 of 9 |
 | 2026-08-14 | [Dependency-aware agent operations](PLAN-agent-operation-dependencies.md) | `depends_on` and `runs_after` for agent operations, including cross-instance edges | Blocked | — |
 | 2026-08-16 | [Bound gRPC reply sizes](PLAN-grpc-bounded-replies.md) | Make `DatabaseService` replies bounded by construction rather than by the message size limit | Not started | 0 of 7 |

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -234,6 +234,27 @@
   carrying the same key name, method, path and remote address, plus
   the reason and the parameter the refusal named (the parameter name
   is redacted on the `/auth` routes, as it already is in the log).
+  A later change in the same release narrows the rollback further.
+  Under `warn` or `off`, a body key your handler does not accept used
+  to reach the handler, raise `TypeError`, and come back as a 400
+  carrying the interpreter's own message -- for example
+  `AuthEndpoint.post() got an unexpected keyword argument 'zzz'`.
+  That answer is gone in every mode: the same `TypeError` now answers
+  500, recorded like any other server exception, so a request outside
+  the endpoint's declared shape is no longer distinguishable in the
+  response from an internal error. And separately from validation
+  altogether: every 500 response body the API returns is now the bare
+  string `server error`, with no exception class, `repr`, traceback or
+  source path in it, on any endpoint, for any cause. It previously
+  answered `server error: <repr of the exception>`, which put
+  interpreter text -- a `KeyError`, an unreachable node's
+  `ConnectionError` -- directly in a caller's response. You can no
+  longer tell which exception occurred from the response body alone.
+  The detail is not gone, only moved: `sf-api`'s `Server error` log
+  line carries `exception_class`, the full traceback, and the request
+  method and path, and the on-disk record under
+  `/srv/shakenfist/exceptions/` on the node that handled the request
+  carries the same correlation fields. Look there instead.
 * Malformed values inside the reserved `affinity` instance metadata key
   are now refused with a 400 instead of returning a 500. A list, a
   dictionary, `null` or `Infinity` used as the *value* of an affinity

--- a/docs/release_notes/v07-v08.md
+++ b/docs/release_notes/v07-v08.md
@@ -242,10 +242,22 @@
   That answer is gone in every mode: the same `TypeError` now answers
   500, recorded like any other server exception, so a request outside
   the endpoint's declared shape is no longer distinguishable in the
-  response from an internal error. And separately from validation
-  altogether: every 500 response body the API returns is now the bare
-  string `server error`, with no exception class, `repr`, traceback or
-  source path in it, on any endpoint, for any cause. It previously
+  response from an internal error. Recorded is meant literally, and is
+  worth planning for before you roll back: each such request writes an
+  exception record under `/srv/shakenfist/exceptions/` and logs at
+  ERROR. The record is keyed by a hash of the traceback, and the
+  message embeds the key the caller sent, so a client cycling through
+  undeclared key names produces a new record per name and an ERROR
+  line per request. Under the `enforce` default none of that happens,
+  because the request never reaches a handler. And separately from validation
+  altogether: a 500 raised while handling a request -- by the handler
+  or by any of its decorators, which is where all but a handful come
+  from -- is now the bare string `server error`, with no exception
+  class, `repr`, traceback or source path in it. (The exception is a
+  failure to serialise a response the handler already returned, such
+  as issue 3657: that happens after the handler is done, so
+  flask-restful's own error path answers it and its body is
+  unchanged.) It previously
   answered `server error: <repr of the exception>`, which put
   interpreter text -- a `KeyError`, an unreachable node's
   `ConnectionError` -- directly in a caller's response. You can no

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_api_validation.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_api_validation.py
@@ -29,6 +29,20 @@ _INTERPRETER_TEXT_MARKERS = (
 )
 
 
+# This suite intentionally pins only the enforced 400 shape above, not the
+# opaque {"error": "server error", "status": 500} shape decision D31
+# settled on for a genuine handler-internal fault. The 400 is reachable on
+# purpose -- an ordinary caller sends an undeclared parameter every day --
+# but there is no known way to drive a real endpoint into an internal
+# TypeError from this namespaced CI client without either white-box
+# mocking (unavailable against a remote cluster, which is the whole point
+# of this suite) or actually exploiting a live bug, and deliberately
+# breaking a running cluster to exercise a failure path is out of bounds
+# for this suite. The 500 shape is pinned instead in the unit suite --
+# test_a_handler_internal_type_error_is_a_recorded_500 and the
+# warn/off-mode tests in shakenfist/tests/external_api/
+# test_request_validation.py -- where a handler can be safely mocked into
+# raising. This absence is a decision, not an oversight.
 class TestUndeclaredParameterRefused(base.BaseNamespacedTestCase):
     """PLAN-api-input-validation-phase-04-enforce.md step 6, test 1.
 

--- a/shakenfist/external_api/auth.py
+++ b/shakenfist/external_api/auth.py
@@ -1897,11 +1897,13 @@ class AuthFederatedEndpoint(api_base.Resource):
                 namespace=namespace)
 
         #    Read the whole policy in one go, and refuse a damaged row
-        #    rather than let it escape as an exception. The generic 500
-        #    handler answers with repr(e), and CorruptMappingRule names
-        #    the rule's UUID -- which on the one endpoint anybody may
-        #    call would hand a stranger an identifier they should not
-        #    have.
+        #    rather than let it escape as an exception. Decision D31
+        #    stopped the generic 500 handler putting repr(e) in the
+        #    body, so CorruptMappingRule's rule UUID no longer reaches
+        #    a caller that way either -- but going through this guard
+        #    still turns an internal fault into a categorised refusal
+        #    evented against the rule's owner via _federated_refusal,
+        #    rather than an unevented 500 nobody but the log sees.
         #
         #    The guard belongs here and not around the lookup above.
         #    from_db_by_name reads the static row and the object state,

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -1500,17 +1500,30 @@ def _authorization_failure_log(e: Exception):
 
 
 def handle_authorization_exceptions(func):
-    # NOTE(mikal): like _reject_token, these are logged at INFO. Every
-    # rejection here is caused by the credential the client presented,
-    # which is an expected client condition and not a cluster fault, so
-    # none of them should be paging anyone (issue 3606).
+    # NOTE(mikal): this wrapper catches authorization conditions and
+    # nothing else -- the ten JWT exception classes below, covering a
+    # token which cannot be decoded, one which has expired, and the
+    # assorted ways flask_jwt_extended reports a token which is
+    # structurally fine but not acceptable. Like _reject_token, they
+    # are all logged at INFO: every rejection here is caused by the
+    # credential the client presented, which is an expected client
+    # condition and not a cluster fault, so none of them should be
+    # paging anyone (issue 3606).
+    #
+    # TypeError used to be caught here too, and answered as a 400
+    # carrying str(e). It is not an authorization condition, and
+    # nothing in flask_jwt_extended or PyJWT signals one with it: the
+    # arm existed because a handler called with a body key it does not
+    # accept raises TypeError, and a 400 was a better answer than a
+    # 500 in the absence of a validation layer. Phases 1 to 4 of
+    # PLAN-api-input-validation built that layer, so an undeclared body
+    # key is now refused by name before the handler is reached, and the
+    # workaround has been deleted (decision D23). What is left behind
+    # it is a genuine handler-internal TypeError, which is a server
+    # fault and is now recorded and answered as one.
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-
-        except TypeError as e:
-            _authorization_failure_log(e).info('API request rejected as malformed')
-            return sf_api.error(400, str(e), suppress_traceback=False)
 
         except DecodeError as e:
             # Send a more informative message than 'Not enough segments'. If this

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -1391,7 +1391,19 @@ def log_request(func):
             # decorator chain catches, and would silently merge a list
             # of two-character strings as key value pairs.
             if not isinstance(j, dict):
-                return sf_api.error(400, 'the request body must be a JSON object')
+                # This used to be a raised TypeError, caught by
+                # handle_authorization_exceptions and logged through
+                # _authorization_failure_log(e) -- the attributed line
+                # issue 4069 added so a rejection can be joined to the
+                # 'API request parsed' and audit records by request-id.
+                # Answering directly (decision D23) dropped that unless
+                # it is emitted here instead; suppress_traceback=True
+                # because there is no exception in flight to log a
+                # traceback for.
+                _request_rejection_log().info('API request rejected as malformed')
+                return sf_api.error(
+                    400, 'the request body must be a JSON object',
+                    suppress_traceback=True)
 
             # A body key with the same name as a URL path parameter
             # overwrites it. Recorded here rather than in the validator
@@ -1493,24 +1505,37 @@ def redirect_to_root_clearing_jwt() -> flask.Response:
     return resp
 
 
-def _authorization_failure_log(e: Exception):
+def _request_rejection_log(fields=None):
     """A logger carrying the attribution a rejected request needs.
 
     The record emitted here is the only one saying *why* a request was
     rejected, and without the request-id it cannot be joined to the
     'API request parsed' and audit records which say *which* request it
-    was (issue 4069). The exception class travels as its own field so
-    an expired token, an unparseable one and a revoked one are
-    distinguishable in a query rather than only by message text.
+    was (issue 4069). This is the common attribution every rejection
+    site needs; _authorization_failure_log below layers an exception's
+    class and message on top of it, and a site with no exception in
+    flight -- log_request's non-object-body 400 -- calls this directly.
     """
-    return LOG.with_fields({
+    base_fields = {
         'request-id': flask.request.environ.get('FLASK_REQUEST_ID', 'none'),
         'method': flask.request.method,
         'path': flask.request.path,
         'remote-address': flask.request.remote_addr,
-        'error-class': type(e).__name__,
-        'error': str(e)
-    })
+    }
+    if fields:
+        base_fields.update(fields)
+    return LOG.with_fields(base_fields)
+
+
+def _authorization_failure_log(e: Exception):
+    """A logger carrying the attribution a rejected request needs.
+
+    The exception class travels as its own field so an expired token,
+    an unparseable one and a revoked one are distinguishable in a query
+    rather than only by message text.
+    """
+    return _request_rejection_log(
+        {'error-class': type(e).__name__, 'error': str(e)})
 
 
 def handle_authorization_exceptions(func):

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -1368,14 +1368,16 @@ def log_request(func):
         if j:
             # Only a JSON object can merge into kwargs. Any other JSON
             # document -- a list, a string, a number -- has always been
-            # refused as a 400 (previously by the per-key merge raising
-            # TypeError on the lookup), and this guard keeps it that
-            # way: dict.update would raise ValueError for most of them,
-            # which nothing in the decorator chain catches, and would
-            # silently merge a list of two-character strings as key
-            # value pairs.
+            # refused as a 400 and still is, but it is refused here
+            # directly rather than by raising a TypeError and depending
+            # on a catch two decorators further out. That catch is gone
+            # as of phase 5 of PLAN-api-input-validation, and this guard
+            # had to stop leaning on it first: dict.update would
+            # raise ValueError for most of them, which nothing in the
+            # decorator chain catches, and would silently merge a list
+            # of two-character strings as key value pairs.
             if not isinstance(j, dict):
-                raise TypeError('the request body must be a JSON object')
+                return sf_api.error(400, 'the request body must be a JSON object')
 
             # A body key with the same name as a URL path parameter
             # overwrites it. Recorded here rather than in the validator

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -1695,8 +1695,18 @@ def suppress_exceptions_to_client(func):
             fields.update(getattr(flask.g, _RECORDED_EXCEPTION_FIELDS, {}))
 
             LOG.with_fields(fields).exception('Server error')
-            return sf_api.error(500, 'server error: %s' % repr(e),
-                                suppress_traceback=True)
+
+            # The body is deliberately opaque. A repr(e) here -- exception
+            # class, message, both -- is the same defect as the interpreter
+            # text this phase deleted from handle_authorization_exceptions
+            # (issue 3612, decision D31): it answers a caller in the
+            # implementation's words instead of the API's. The caller is
+            # not who the detail is for, and loses nothing that mattered --
+            # the log line above and the on-disk record under
+            # /srv/shakenfist/exceptions/ both already carry exception_class,
+            # the full traceback and the correlation fields, which is more
+            # than repr(e) ever put in the response.
+            return sf_api.error(500, 'server error', suppress_traceback=True)
 
     return wrapper
 

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -1295,6 +1295,20 @@ def requires_network_active(func):
 
 
 def requires_namespace_exist_if_specified(func):
+    # Apply this above any ref-resolving decorator (`arg_is_instance_ref`,
+    # `arg_is_network_ref`, and friends), never below one. Those decorators
+    # each open with `kwargs.pop('namespace', None)` so they can resolve and
+    # authorise the namespace themselves before calling inward; applied below
+    # one, this decorator's `kwargs.get('namespace')` always sees `None` and
+    # the check is silently dead code. That happened: phase 4 of
+    # PLAN-api-input-validation found it on `InstanceEndpoint.delete` and
+    # `NetworkEndpoint.delete` and recorded it without filing an issue (F8 of
+    # PLAN-api-input-validation-phase-05-narrow), and phase 5 removed both
+    # uses rather than reordering them, because the ref decorator already
+    # resolves the namespace and answers its own 404 -- reordering instead
+    # would have changed those routes' 404 message text for no benefit (D29
+    # of the same plan). If you are adding a new use of this decorator next
+    # to a ref decorator, put it above.
     def wrapper(*args, **kwargs):
         if kwargs.get('namespace'):
             if not Namespace.from_db(kwargs['namespace']):

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -265,7 +265,6 @@ class InstanceEndpoint(api_base.Resource):
          (404, 'Instance not found.', None)]))
     @api_base.arg_is_instance_ref
     @api_base.requires_instance_ownership
-    @api_base.requires_namespace_exist_if_specified
     @api_base.log_token_use
     def delete(self, instance_ref=None, instance_from_db=None, namespace=None):
         # Check if instance has already been deleted

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -588,6 +588,31 @@ class InstancesEndpoint(api_base.Resource):
         if not namespace_is_trusted(namespace, request_namespace()):
             return sf_api.error(404, 'namespace not found')
 
+        # A name has to be a string before anything can ask whether it is a
+        # good one. `name` is declared required, but required-ness is
+        # deliberately not enforced (decision D17 of
+        # PLAN-api-input-validation), and the compiled field is nullable, so
+        # an omitted name and an explicit JSON null both arrive here as None.
+        # validators.hostname() *returns* a falsy ValidationError for None
+        # rather than raising, so without this guard execution reaches
+        # `'.' in name` and the interpreter raises TypeError -- which until
+        # this phase was answered as a 400 by the arm
+        # handle_authorization_exceptions no longer carries, and is otherwise
+        # a recorded 500 for a plain caller mistake.
+        #
+        # Two messages rather than one, because these are two different
+        # mistakes. The refusal below explains the permitted character set,
+        # which is the right answer for a name that is a string and a bad
+        # one, and says nothing a caller who sent no name at all can act on.
+        # The isinstance arm is unreachable while API_VALIDATION_MODE is
+        # 'enforce' -- a non-string name is refused as a type mismatch before
+        # the handler is entered -- but 'warn' and 'off' are the operator's
+        # rollback and hand the handler whatever the caller sent.
+        if name is None:
+            return sf_api.error(400, 'instance name must be specified')
+        if not isinstance(name, str):
+            return sf_api.error(400, 'instance name must be a string')
+
         # Check that the instance name is safe for use as a DNS host name
         valid_hostname = validators.hostname(
             name, skip_ipv4_addr=True, skip_ipv6_addr=True, may_have_port=False)

--- a/shakenfist/external_api/label.py
+++ b/shakenfist/external_api/label.py
@@ -59,7 +59,11 @@ def _label_url_or_error(label_name):
     that answered ``server error: LabelHierarchyTooDeep()`` -- the
     third way this endpoint had of returning 500, alongside the two
     fixed in get() and delete(). It is the caller's mistake rather than
-    ours, so it is a 400, and it says which mistake.
+    ours, so it is a 400, and it says which mistake. (A 500 no longer
+    names the exception at all: decision D31 of
+    PLAN-api-input-validation-phase-05-narrow made that body opaque.
+    The reason this is a 400 is unchanged -- an opaque 500 is still the
+    wrong answer to a caller's own mistake.)
     """
     try:
         namespace, label_url = _label_url(label_name)

--- a/shakenfist/external_api/network.py
+++ b/shakenfist/external_api/network.py
@@ -162,7 +162,6 @@ class NetworkEndpoint(api_base.Resource):
          (404, 'Network not found.', None)]))
     @api_base.arg_is_network_ref
     @api_base.requires_network_ownership
-    @api_base.requires_namespace_exist_if_specified
     @api_base.log_token_use
     def delete(self, network_ref=None, network_from_db=None, namespace=None):
         if network_ref == str(FLOATING_NETWORK_UUID):

--- a/shakenfist/external_api/validation.py
+++ b/shakenfist/external_api/validation.py
@@ -534,10 +534,13 @@ def check(compiled: CompiledEndpoint, body: Any,
 
     # An undeclared body key is already fatal when the request reaches
     # its handler -- log_request merges every key into kwargs and no
-    # handler is variadic, so Python raises TypeError and the broad
-    # except in handle_authorization_exceptions returns it as a 400
-    # carrying interpreter text. Counting these is how phase 4 chooses
-    # between webargs' EXCLUDE and RAISE (decision D10).
+    # handler is variadic, so Python raises TypeError. Counting these
+    # is how phase 4 chose between webargs' EXCLUDE and RAISE
+    # (decision D10). Until phase 5 that TypeError was caught by a
+    # broad except in handle_authorization_exceptions and returned as
+    # a 400 carrying interpreter text; that arm is gone (decision
+    # D23), so in 'warn' and 'off' -- the only modes where such a key
+    # still reaches a handler -- it is now a recorded 500 (D25).
     if not compiled.raw_body:
         unknown = [name for name in body if name not in compiled.names]
         for name in unknown[:MAX_UNKNOWN_PARAMETER_FINDINGS]:

--- a/shakenfist/tests/external_api/test_authorization_failure_logging.py
+++ b/shakenfist/tests/external_api/test_authorization_failure_logging.py
@@ -1,5 +1,4 @@
 # Copyright 2019 Michael Still and contributors
-import json
 import logging
 
 import flask
@@ -142,17 +141,37 @@ class AuthorizationFailureLoggingTestCase(base.ShakenFistTestCase):
             'API request rejected, JWT authorization failed')
         self._assert_attribution(record, 'NoAuthorizationError')
 
-    def test_type_error_400_is_attributable(self):
-        resp = self._raise_through_handler(
-            TypeError("'<=' not supported between instances of "
-                      "'str' and 'int'"),
-            'application/json')
-        self.assertEqual(400, resp.status_code)
-        body = json.loads(resp.get_data(as_text=True))
-        self.assertIn('not supported', body['error'])
+    def test_a_type_error_is_not_an_authorization_failure(self):
+        """Phase 5 of PLAN-api-input-validation, decision D23.
 
-        record = self._sole_record('API request rejected as malformed')
-        self._assert_attribution(record, 'TypeError')
+        A TypeError used to be caught here and answered as a 400
+        carrying str(e) -- the second half of the mechanism issue 3612
+        describes, and a workaround for the absence of the validation
+        layer phases 1 to 4 built. It is not an authorization
+        condition: nothing in flask_jwt_extended or PyJWT signals one
+        with it, and there is no attribute on a TypeError that would
+        let this wrapper tell where it came from. So it must now travel
+        straight through, to be recorded and answered as the server
+        fault it is by the decorators outside this one.
+
+        Asserted in this frame as well as at request level (see
+        test_request_validation's
+        test_a_handler_internal_type_error_is_a_recorded_500), because
+        this is the frame the arm lived in: restoring it fails this
+        test on the exception which no longer escapes, however the
+        response is shaped further out.
+        """
+        with self.assertRaises(TypeError):
+            self._raise_through_handler(
+                TypeError("'<=' not supported between instances of "
+                          "'str' and 'int'"),
+                'application/json')
+
+        # And this wrapper said nothing about it. An INFO line here
+        # claiming the *request* was malformed would be a second and
+        # wrong attribution of a server side fault, on top of the one
+        # suppress_exceptions_to_client correctly emits.
+        self.assertEqual([], self.capture.records)
 
     def test_success_path_logs_nothing(self):
         @api_base.handle_authorization_exceptions

--- a/shakenfist/tests/external_api/test_federated_exchange.py
+++ b/shakenfist/tests/external_api/test_federated_exchange.py
@@ -373,7 +373,7 @@ class ExchangeAuditTestCase(FederatedExchangeTestCase):
         # the audit trail along with the credential.
         self.assertIn('/auth/federated', logged)
 
-    def test_a_damaged_rule_does_not_leak_its_uuid(self):
+    def test_a_damaged_rule_is_refused_rather_than_erroring(self):
         # CorruptMappingRule names the rule, and decision D31 stopped
         # putting repr(e) in the generic 500 body but did not remove
         # the dedicated guard around this read -- that guard is what
@@ -381,6 +381,15 @@ class ExchangeAuditTestCase(FederatedExchangeTestCase):
         # anybody may call, would still answer a bare 500 rather than a
         # categorised 401, and the fault would go unevented against the
         # rule's owner.
+        #
+        # The uuid-leak assertion below is no longer load-bearing on
+        # its own: decision D31 made every 500 body the same opaque
+        # 'server error' string, so the uuid would be absent from the
+        # response whether or not this guard exists. The status code
+        # is what actually distinguishes them -- without the guard this
+        # becomes an uncategorised 500 rather than a 401 -- which is
+        # why the test still fails if the guard is removed, and why it
+        # is named for that property rather than the uuid.
         #
         # The exception is raised where the policy is decoded, not
         # where the rule is looked up: from_db_by_name reads the static

--- a/shakenfist/tests/external_api/test_federated_exchange.py
+++ b/shakenfist/tests/external_api/test_federated_exchange.py
@@ -374,10 +374,13 @@ class ExchangeAuditTestCase(FederatedExchangeTestCase):
         self.assertIn('/auth/federated', logged)
 
     def test_a_damaged_rule_does_not_leak_its_uuid(self):
-        # The generic 500 handler answers with repr(e), and
-        # CorruptMappingRule names the rule. /auth/federated is the one
-        # endpoint anybody may call, so that repr would hand a stranger
-        # an identifier they have no business holding.
+        # CorruptMappingRule names the rule, and decision D31 stopped
+        # putting repr(e) in the generic 500 body but did not remove
+        # the dedicated guard around this read -- that guard is what
+        # this test pins. Without it, /auth/federated, the one endpoint
+        # anybody may call, would still answer a bare 500 rather than a
+        # categorised 401, and the fault would go unevented against the
+        # rule's owner.
         #
         # The exception is raised where the policy is decoded, not
         # where the rule is looked up: from_db_by_name reads the static

--- a/shakenfist/tests/external_api/test_instance_create_validation.py
+++ b/shakenfist/tests/external_api/test_instance_create_validation.py
@@ -1,0 +1,252 @@
+# Copyright 2019 Michael Still and contributors
+
+"""What POST /instances answers for a name it cannot use.
+
+Phase 5 of PLAN-api-input-validation deleted the `except TypeError` arm
+from handle_authorization_exceptions (decision D23), which had been
+answering every handler-internal TypeError as a 400 carrying the
+interpreter's own words. That arm was load bearing for one input on the
+default path: `name` is declared required, required-ness is deliberately
+not enforced (decision D17) and the compiled field is nullable, so both
+an omitted name and an explicit JSON null reach the handler as None.
+`validators.hostname(None, ...)` *returns* a falsy ValidationError
+rather than raising, so execution used to reach `'.' in name`, raise
+TypeError, and be answered as a 400 by the arm that is now gone --
+turning a plain caller mistake into a recorded 500 with a file under
+/srv/shakenfist/exceptions/ and an ERROR `Server error` log line.
+
+These drive real authenticated requests through the whole decorator
+stack, for the reason AuthenticatedStackTestCase documents: phase 3's
+review found a handler tested in isolation and the deployed behaviour
+giving different answers, because suppress_exceptions_to_client sits
+outside everything a unit test sees.
+"""
+
+import json
+from unittest import mock
+
+from shakenfist.external_api import base as api_base
+from shakenfist.external_api import instance as instance_api
+from shakenfist.tests.external_api.test_request_validation import (
+    AuthenticatedStackTestCase)
+from shakenfist.tests.external_api.test_request_validation import (
+    INTERPRETER_TEXT)
+
+
+# Enough of a body to get past every guard which precedes the name
+# check, so a test about `name` fails for the reason it says it does.
+# `disk` in particular is refused before the instance object exists, and
+# a body without it would answer 400 whatever the name was.
+VALID_REMAINDER = {
+    'cpus': 1,
+    'memory': 1024,
+    'disk': [{'size': 8}]
+}
+
+
+class InstanceCreateNameTestCase(AuthenticatedStackTestCase):
+    """The name guard, at both validation modes that reach the handler."""
+
+    mode = 'enforce'
+
+    def _post(self, body):
+        """POST /instances, with exception recording spied on rather than
+        performed.
+
+        The spy is the point rather than incidental: a 500 here writes a
+        file under /srv/shakenfist/exceptions/ for what is a caller's
+        mistake, and "no record was written" is the half of this defect
+        which a status code assertion alone would not catch.
+
+        InstancesEndpoint.post caches its Scheduler in a module global
+        and only builds one if that global is falsy, so a request which
+        reaches placement leaves a real Scheduler behind for every
+        later test in the same worker process -- including the ones in
+        test_external_api.py which patch shakenfist.scheduler.Scheduler
+        with a fake in setUp and then never get asked for it, and so
+        fail with the scheduler refusal of whatever cluster this
+        fixture built. patch.object restores the attribute it saved
+        even though the handler reassigns it, which is exactly the
+        containment wanted here.
+        """
+        with mock.patch.object(instance_api, 'SCHEDULER', None), \
+                mock.patch.object(
+                    api_base.util_exceptions, 'record_exception',
+                    return_value={'exception-record': 'test'}) as recorded:
+            response = self.client.post(
+                '/instances', data=json.dumps(body),
+                content_type='application/json',
+                headers={'Authorization': self.token})
+        return response, recorded
+
+    def assertNoInterpreterText(self, response):
+        """The absence, asserted positively.
+
+        Against the whole response body rather than the error string, so
+        a leak into any other field is caught too. INTERPRETER_TEXT is
+        imported rather than restated because a marker added there must
+        apply here as well.
+        """
+        body = response.get_data(as_text=True)
+        for fragment in INTERPRETER_TEXT:
+            self.assertNotIn(
+                fragment, body,
+                'the refusal leaked interpreter text: %s' % body)
+
+    def test_an_omitted_name_is_a_bad_request(self):
+        """The default path, and the regression phase 5 introduced.
+
+        `name` is declared required and D17 says the validation layer
+        does not enforce that, so this body produces a
+        missing-required finding, is not refused for it, and reaches
+        the handler with name=None. Before the guard this was the
+        TypeError described in the module docstring; the property
+        pinned here is that a caller who forgot a name is told so
+        rather than being told the cluster broke.
+        """
+        response, recorded = self._post(dict(VALID_REMAINDER))
+
+        self.assertEqual(400, response.status_code, response.get_json())
+        self.assertEqual(
+            {'error': 'instance name must be specified', 'status': 400},
+            response.get_json())
+        self.assertNoInterpreterText(response)
+        recorded.assert_not_called()
+
+    def test_an_explicitly_null_name_is_a_bad_request(self):
+        """The same defect by the other route.
+
+        The compiled field is allow_none=True (see validation._field:
+        a JSON null reaches the handler as None today and several
+        handlers read that as "not supplied"), so an explicit null is
+        not a type mismatch and is not refused by the layer either. It
+        is worth its own test because it arrives through a different
+        branch of the compiler than an omitted key does, and a guard
+        keyed on falsiness rather than on None would pass one of these
+        two and not the other.
+        """
+        body = dict(VALID_REMAINDER)
+        body['name'] = None
+        response, recorded = self._post(body)
+
+        self.assertEqual(400, response.status_code, response.get_json())
+        self.assertEqual(
+            {'error': 'instance name must be specified', 'status': 400},
+            response.get_json())
+        self.assertNoInterpreterText(response)
+        recorded.assert_not_called()
+
+    def test_a_non_string_name_is_refused_by_the_validation_layer(self):
+        """Enforcement answers first, and its message is unchanged.
+
+        The handler's isinstance guard exists for the rollback modes,
+        not for this one. Pinning which of the two answers here means a
+        later change that moved the refusal from the layer into the
+        handler would be visible rather than silent -- the two produce
+        different messages and the published behaviour is the layer's.
+        """
+        body = dict(VALID_REMAINDER)
+        body['name'] = 5
+        response, recorded = self._post(body)
+
+        self.assertEqual(400, response.status_code, response.get_json())
+        self.assertEqual(
+            {'error': 'name: Not a valid string.', 'status': 400},
+            response.get_json())
+        self.assertNoInterpreterText(response)
+        recorded.assert_not_called()
+
+    def test_a_valid_name_gets_past_the_guard(self):
+        """The guard refuses nothing that used to work.
+
+        A single node cluster with no hypervisor cannot place an
+        instance, so the request lands on the scheduler's 507. That is
+        the point: the name check is behind it, so a 507 is proof the
+        request reached the placement stage rather than being turned
+        away by a guard which is too eager. Asserting the 507 rather
+        than a 200 keeps this from needing a whole fake hypervisor to
+        make an assertion about a name.
+        """
+        body = dict(VALID_REMAINDER)
+        body['name'] = 'validname'
+        response, recorded = self._post(body)
+
+        self.assertEqual(507, response.status_code, response.get_json())
+        recorded.assert_not_called()
+
+    def test_a_name_containing_a_dot_still_gets_the_host_name_refusal(self):
+        """The existing 400, unchanged.
+
+        A dotted name is a string, so it falls through both new arms to
+        the DNS host name explanation it has always received. The
+        message is asserted in full because the whole shape of the fix
+        is "add two arms above this one and change nothing about it",
+        and a paraphrase would not detect the guard swallowing this
+        case.
+        """
+        body = dict(VALID_REMAINDER)
+        body['name'] = 'not.a.hostname'
+        response, recorded = self._post(body)
+
+        self.assertEqual(400, response.status_code, response.get_json())
+        self.assertEqual(
+            {'error': 'instance name not.a.hostname is not useable as a DNS '
+                      'and Linux host name. That is, less than 63 characters '
+                      'and in the character set: a-z, A-Z, 0-9, or hyphen '
+                      '(-).',
+             'status': 400},
+            response.get_json())
+        recorded.assert_not_called()
+
+    def test_an_over_long_name_still_gets_the_host_name_refusal(self):
+        """The other pre-existing 400, for the same reason.
+
+        64 characters is one past the 63 the handler allows, so this
+        exercises the `len(name) > 63` clause specifically -- the one
+        arm of the original condition that a None would have reached
+        only if the two before it had somehow passed.
+        """
+        body = dict(VALID_REMAINDER)
+        body['name'] = 'a' * 64
+        response, recorded = self._post(body)
+
+        self.assertEqual(400, response.status_code, response.get_json())
+        self.assertIn(
+            'is not useable as a DNS and Linux host name',
+            response.get_json()['error'])
+        recorded.assert_not_called()
+
+
+class InstanceCreateNameRollbackTestCase(InstanceCreateNameTestCase):
+    """The same properties with enforcement rolled back to 'warn'.
+
+    'warn' promises that no request behaves differently than it does
+    with the layer switched off, so it is the mode in which a
+    non-string name actually reaches the handler -- which is the only
+    mode where the isinstance arm of the guard is reachable at all. An
+    arm no test can reach is an arm that rots, and this class is what
+    stops the rollback path being the one where a caller's mistake is
+    still a recorded 500.
+    """
+
+    mode = 'warn'
+
+    def test_a_non_string_name_is_refused_by_the_validation_layer(self):
+        """Overridden: in 'warn' the layer stands aside and the
+        handler's own guard is what answers, with its own message.
+
+        This is the arm the enforce-mode test above cannot reach. It
+        matters because the whole purpose of 'warn' is to be an
+        operator's escape hatch from enforcement, and an escape hatch
+        which turns a bad request into a 500 is not one.
+        """
+        body = dict(VALID_REMAINDER)
+        body['name'] = 5
+        response, recorded = self._post(body)
+
+        self.assertEqual(400, response.status_code, response.get_json())
+        self.assertEqual(
+            {'error': 'instance name must be a string', 'status': 400},
+            response.get_json())
+        self.assertNoInterpreterText(response)
+        recorded.assert_not_called()

--- a/shakenfist/tests/external_api/test_request_validation.py
+++ b/shakenfist/tests/external_api/test_request_validation.py
@@ -120,6 +120,18 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
         # observed and stood aside" from "warn rejected" -- which a
         # status code on its own cannot say.
         self.assertNotIn('not declared by this endpoint', body['error'])
+        # The body is the opaque one every 500 carries (decision D31),
+        # not merely "not the 400 that used to be here". Warn is
+        # precisely the mode where a handler-raised TypeError still
+        # happens, so it is where a regression in
+        # suppress_exceptions_to_client leaking interpreter text back
+        # into the response would first show up.
+        self.assertEqual('server error', body['error'])
+        raw = response.get_data(as_text=True)
+        for fragment in INTERPRETER_TEXT:
+            self.assertNotIn(
+                fragment, raw,
+                'the server error leaked interpreter text: %s' % raw)
 
     def test_a_clean_request_produces_no_findings(self):
         """Otherwise every request is a finding and the log says nothing."""
@@ -231,6 +243,16 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
         self.assertEqual(500, body['status'])
         # Nothing from the layer reached the caller, in either mode.
         self.assertNotIn('not declared by this endpoint', body['error'])
+        # Off means check() never runs at all, so this is the mode
+        # least likely to be caught by the EnforcedValidationTestCase
+        # sweep if suppress_exceptions_to_client ever regressed back to
+        # leaking repr(e). Assert the same opaque shape as warn's.
+        self.assertEqual('server error', body['error'])
+        raw = response.get_data(as_text=True)
+        for fragment in INTERPRETER_TEXT:
+            self.assertNotIn(
+                fragment, raw,
+                'the server error leaked interpreter text: %s' % raw)
 
     def test_the_validator_does_not_refetch_the_body(self):
         """The validator reads the body log_request stashed, so it
@@ -487,6 +509,46 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
                 self.assertEqual(
                     'the request body must be a JSON object',
                     response.get_json()['error'])
+
+    def test_a_non_object_body_400_is_attributed(self):
+        """Item 3 of the phase 5 review: the 400 above must still carry
+        the attribution issue 4069 added.
+
+        Before phase 5, this path raised TypeError and
+        handle_authorization_exceptions caught it, logging
+        _authorization_failure_log(e).info('API request rejected as
+        malformed') -- a line carrying request-id, method, path and
+        remote-address so the rejection can be joined to the 'API
+        request parsed' and audit records. Answering directly (decision
+        D23) dropped that logging unless log_request emits it itself,
+        which is what this pins.
+        """
+        # The RequestID middleware sets FLASK_REQUEST_ID from an
+        # incoming X-Request-ID header (or generates one if absent), so
+        # the header rather than environ_base is what actually pins the
+        # value this test checks for -- environ_base is overwritten by
+        # the middleware before the request reaches log_request.
+        with mock.patch.object(api_base, 'LOG') as log:
+            response = self.client.post(
+                '/auth', data=json.dumps(['a', 'b']),
+                content_type='application/json',
+                headers={'X-Request-ID': 'req-non-object-400'},
+                environ_base={'REMOTE_ADDR': '192.168.9.9'})
+
+        self.assertEqual(400, response.status_code)
+
+        # Exactly one attributed line, and nothing else: the request
+        # is refused before log_request's own 'API request parsed'
+        # line, and before any decorator further out gets a chance to
+        # log anything of its own.
+        self.assertEqual(1, log.with_fields.call_count)
+        fields = log.with_fields.call_args[0][0]
+        self.assertEqual('req-non-object-400', fields['request-id'])
+        self.assertEqual('POST', fields['method'])
+        self.assertEqual('/auth', fields['path'])
+        self.assertEqual('192.168.9.9', fields['remote-address'])
+        log.with_fields.return_value.info.assert_called_once_with(
+            'API request rejected as malformed')
 
     def test_findings_are_emitted_with_the_response_status(self):
         """The after_request hook is the deliverable: a finding line

--- a/shakenfist/tests/external_api/test_request_validation.py
+++ b/shakenfist/tests/external_api/test_request_validation.py
@@ -832,14 +832,13 @@ class EnforcedValidationTestCase(AuthenticatedStackTestCase):
         actually produces.
 
         On what the body carries. Every INTERPRETER_TEXT marker is
-        asserted absent except the exception class name, which
-        suppress_exceptions_to_client still puts in the body itself via
-        `repr(e)` in its `server error: %s` message -- a separate leak
-        on the generic 500 path, common to every exception class and
-        not something the deleted arm was responsible for. What matters
-        for D23 is asserted in full: the caller learns no endpoint
-        class, no method name, no traceback and no source path, and is
-        told this was a server error rather than their bad request.
+        asserted absent, with no exemption: decision D31 stopped
+        suppress_exceptions_to_client putting `repr(e)` in the body,
+        so the generic 500 path no longer leaks the exception class
+        name either. The caller learns no endpoint class, no method
+        name, no traceback, no source path and no exception class, and
+        is told only that this was a server error rather than their
+        bad request.
         """
         findings, patcher = self._spy_on_check()
 
@@ -862,8 +861,7 @@ class EnforcedValidationTestCase(AuthenticatedStackTestCase):
         self.assertEqual(500, response.status_code, response.get_json())
         body = response.get_json()
         self.assertEqual(500, body['status'])
-        self.assertTrue(
-            body['error'].startswith('server error: '), body['error'])
+        self.assertEqual('server error', body['error'])
 
         # Recorded rather than swallowed: the operator gets a file
         # under /srv/shakenfist/exceptions/ for a fault the caller is
@@ -873,8 +871,6 @@ class EnforcedValidationTestCase(AuthenticatedStackTestCase):
 
         raw = response.get_data(as_text=True)
         for fragment in INTERPRETER_TEXT:
-            if fragment == 'TypeError':
-                continue
             self.assertNotIn(
                 fragment, raw,
                 'the server error leaked interpreter text: %s' % raw)

--- a/shakenfist/tests/external_api/test_request_validation.py
+++ b/shakenfist/tests/external_api/test_request_validation.py
@@ -432,8 +432,10 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
     def test_a_non_object_body_is_still_a_400(self):
         """A JSON body which is not an object has always been a 400.
 
-        The per-key merge this phase replaced raised TypeError for one,
-        which handle_authorization_exceptions answers as 400.
+        The per-key merge phase 3 replaced raised TypeError for one,
+        which handle_authorization_exceptions used to answer as 400.
+        Phase 5 deleted that arm, so log_request returns the 400
+        itself and this test holds across both.
         dict.update would instead raise ValueError for most of these
         (a 500, since nothing catches ValueError) -- and would silently
         merge a list of two-character strings as key/value pairs, which

--- a/shakenfist/tests/external_api/test_request_validation.py
+++ b/shakenfist/tests/external_api/test_request_validation.py
@@ -7,9 +7,15 @@ API_VALIDATION_MODE's default to 'enforce', which is what the
 EnforcedValidationTestCase class at the bottom of this file pins.
 The warn-mode properties above it are still worth keeping -- 'warn'
 is the operator's rollback, and its promise is that no request behaves
-differently than it did before the layer existed -- so each of those
-tests now sets the mode it is about rather than relying on a default
-which has moved.
+differently than it does with the layer switched off -- so each of
+those tests now sets the mode it is about rather than relying on a
+default which has moved.
+
+Phase 5 then deleted the `except TypeError` arm which used to answer a
+handler's rejected kwargs as a 400 in the interpreter's own words, so
+that promise is now kept against a 500 rather than against that 400.
+The mode did not change; what a request the mode declines to intervene
+in answers did.
 """
 
 import json
@@ -72,19 +78,32 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
     def test_warn_mode_changes_no_response(self):
         """The promise 'warn' still makes, now that it is the rollback.
 
-        A body carrying an undeclared key produces a finding, and the
-        response is byte for byte what it was before validation
-        existed: the 400 log_request's merge has always produced, with
-        the interpreter's own text. That interpreter text is the defect
-        this plan exists to remove, so an operator who rolls back to
-        'warn' gets the old behaviour back, warts included.
+        A body carrying an undeclared key produces a finding and the
+        layer then stands aside: the response is whatever the same
+        request produces with the layer switched off, which
+        test_off_mode_disables_the_layer asserts is this same 500.
+        Warn observes and never answers, and that is unchanged -- which
+        is why this test still carries the name it does.
 
-        With one exception, which the release note states: the five
-        metadata delete handlers no longer accept the `value` kwarg
-        they used to ignore, in any mode, so a caller which sends one
-        gets a TypeError-shaped 400 in 'warn' where enforcement would
-        have named the parameter. That was UNDECLARED_BY_DESIGN's last
-        entry, and removing it is what emptied the set.
+        What the underlying request answers *did* change, in phase 5.
+        Until then an undeclared key reached the handler, failed the
+        kwargs merge with a TypeError, and
+        handle_authorization_exceptions turned that into a 400 carrying
+        the interpreter's own words. That is the defect of issue 3612,
+        and leaving it in the one mode an operator can reach by rolling
+        enforcement back would have preserved it behind a flag. The arm
+        is gone (decision D23), so a request whose kwargs its handler
+        cannot accept is now answered as what it has always been
+        underneath: an unhandled server side exception, recorded on
+        disk and answered as a 500 (decision D25). An operator rolling
+        back is buying "requests that were working keep working", not a
+        tidier error for requests that were already being refused.
+
+        The five metadata delete handlers are the one thing the
+        rollback does not undo at all: they no longer accept the
+        `value` kwarg they used to ignore, in any mode. That was
+        UNDECLARED_BY_DESIGN's last entry, and removing it is what
+        emptied the set.
         """
         config.API_VALIDATION_MODE = 'warn'
 
@@ -93,9 +112,14 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
 
         self.assertEqual(
             [validation.UNKNOWN_PARAMETER], [f.reason for f in findings])
-        self.assertEqual(400, response.status_code)
-        self.assertIn(
-            'unexpected keyword argument', response.get_json()['error'])
+        self.assertEqual(500, response.status_code)
+        body = response.get_json()
+        self.assertEqual(500, body['status'])
+        # And the layer itself did not answer. Its refusal names the
+        # parameter, so the absence of that is what separates "warn
+        # observed and stood aside" from "warn rejected" -- which a
+        # status code on its own cannot say.
+        self.assertNotIn('not declared by this endpoint', body['error'])
 
     def test_a_clean_request_produces_no_findings(self):
         """Otherwise every request is a finding and the log says nothing."""
@@ -185,17 +209,28 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
         """The operator's safety valve: if the layer itself becomes the
         problem -- log volume being the foreseeable case -- it can be
         turned off without a downgrade. Off means check() never runs,
-        not merely that findings are discarded."""
+        not merely that findings are discarded.
+
+        So the response is the request's own, with nothing of the layer
+        in it. Phase 5 changed what that is: deleting the `except
+        TypeError` arm (decision D23) means a body key the handler
+        cannot accept is no longer converted into a 400 carrying the
+        interpreter's words, and is instead recorded and answered as
+        the 500 it always was underneath (decision D25). The status
+        asserted here is identical to warn's, which is the point --
+        warn observes and off does not look, and neither answers.
+        """
         config.API_VALIDATION_MODE = 'off'
 
         response, findings = self._post_auth(
             {'namespace': 'sys', 'key': 'k', 'zzz': 1})
 
         self.assertEqual([], findings)
-        # And the request itself behaved exactly as it always did.
-        self.assertEqual(400, response.status_code)
-        self.assertIn(
-            'unexpected keyword argument', response.get_json()['error'])
+        self.assertEqual(500, response.status_code)
+        body = response.get_json()
+        self.assertEqual(500, body['status'])
+        # Nothing from the layer reached the caller, in either mode.
+        self.assertNotIn('not declared by this endpoint', body['error'])
 
     def test_the_validator_does_not_refetch_the_body(self):
         """The validator reads the body log_request stashed, so it
@@ -457,14 +492,20 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
         """The after_request hook is the deliverable: a finding line
         carrying what the request returned anyway is what separates a
         rejection enforcement would introduce from a status code it
-        would merely change."""
+        would merely change.
+
+        The status recorded here is the request's own, whatever it is.
+        Since phase 5 that is a 500 for this input rather than the 400
+        the deleted `except TypeError` arm used to manufacture, which
+        is precisely the sort of movement the field exists to make
+        visible."""
         config.API_VALIDATION_MODE = 'warn'
 
         with mock.patch.object(external_api, 'LOG') as log:
             response, findings = self._post_auth(
                 {'namespace': 'sys', 'key': 'k', 'zzz': 1})
 
-        self.assertEqual(400, response.status_code)
+        self.assertEqual(500, response.status_code)
         self.assertEqual(1, len(findings))
 
         emitted = [c.args[0] for c in log.with_fields.call_args_list
@@ -472,7 +513,7 @@ class RequestValidationTestCase(base.ShakenFistTestCase):
         self.assertEqual(1, len(emitted))
         self.assertEqual(
             validation.UNKNOWN_PARAMETER, emitted[0]['validation-reason'])
-        self.assertEqual(400, emitted[0]['validation-response-status'])
+        self.assertEqual(500, emitted[0]['validation-response-status'])
         self.assertEqual('warn', emitted[0]['validation-mode'])
 
     def test_enforced_rejections_still_emit_their_findings(self):
@@ -770,6 +811,73 @@ class EnforcedValidationTestCase(AuthenticatedStackTestCase):
             {'error': 'banana: not declared by this endpoint', 'status': 400},
             response.get_json())
         self.assertNoInterpreterText(response)
+
+    def test_a_handler_internal_type_error_is_a_recorded_500(self):
+        """Decision D30: the removal, asserted.
+
+        Phase 5 deleted the `except TypeError` arm from
+        handle_authorization_exceptions (decision D23). A deletion is
+        the change a suite is least likely to notice, and restoring
+        that arm would silently reinstate the leak four phases were
+        spent closing, so the property it establishes is pinned here:
+        a TypeError raised inside a handler is a server fault, recorded
+        and answered as a 500, and never a 400 telling the caller
+        something about the call it made.
+
+        The request itself is well formed and produces no findings --
+        this is not the validation layer's path. The TypeError is a
+        real one from the interpreter rather than one constructed for
+        the test, raised where a handler's own bug would raise it, so
+        the message being asserted about is the shape a handler
+        actually produces.
+
+        On what the body carries. Every INTERPRETER_TEXT marker is
+        asserted absent except the exception class name, which
+        suppress_exceptions_to_client still puts in the body itself via
+        `repr(e)` in its `server error: %s` message -- a separate leak
+        on the generic 500 path, common to every exception class and
+        not something the deleted arm was responsible for. What matters
+        for D23 is asserted in full: the caller learns no endpoint
+        class, no method name, no traceback and no source path, and is
+        told this was a server error rather than their bad request.
+        """
+        findings, patcher = self._spy_on_check()
+
+        def raise_a_real_type_error(*args, **kwargs):
+            # Not TypeError('...') by hand: comparing incomparable
+            # types is how a handler bug actually reaches this path,
+            # and the interpreter writes the message.
+            return sorted(['a', 1])
+
+        with patcher, mock.patch(
+                'shakenfist.external_api.instance.instance.Instances',
+                side_effect=raise_a_real_type_error), \
+                mock.patch.object(
+                    api_base.util_exceptions, 'record_exception',
+                    return_value={'exception-record': 'test'}) as recorded:
+            response = self.client.get(
+                '/instances', headers={'Authorization': self.token})
+
+        self.assertEqual([], findings)
+        self.assertEqual(500, response.status_code, response.get_json())
+        body = response.get_json()
+        self.assertEqual(500, body['status'])
+        self.assertTrue(
+            body['error'].startswith('server error: '), body['error'])
+
+        # Recorded rather than swallowed: the operator gets a file
+        # under /srv/shakenfist/exceptions/ for a fault the caller is
+        # told nothing useful about, which is the trade decision D25
+        # makes.
+        self.assertEqual(1, recorded.call_count)
+
+        raw = response.get_data(as_text=True)
+        for fragment in INTERPRETER_TEXT:
+            if fragment == 'TypeError':
+                continue
+            self.assertNotIn(
+                fragment, raw,
+                'the server error leaked interpreter text: %s' % raw)
 
     def test_an_omitted_required_parameter_still_reaches_the_handler(self):
         """Decision D17, and the one filter in the enforce branch.

--- a/shakenfist/tests/external_api/test_server_error_logging.py
+++ b/shakenfist/tests/external_api/test_server_error_logging.py
@@ -68,7 +68,11 @@ class ServerErrorLoggingTestCase(base.ShakenFistTestCase):
         resp = self.client.get('/boom')
 
         self.assertEqual(500, resp.status_code)
-        self.assertIn('ValueError', resp.get_data(as_text=True))
+
+        # Decision D31: the response body is deliberately opaque. The
+        # attribution this test is about lives on the log record
+        # asserted below, not in anything the caller can read.
+        self.assertNotIn('ValueError', resp.get_data(as_text=True))
 
         records = self._server_error_records()
         self.assertEqual(1, len(records))
@@ -144,8 +148,10 @@ class ServerErrorLoggingTestCase(base.ShakenFistTestCase):
     def test_recorder_failure_does_not_misattribute(self):
         # If the on-disk exception recorder itself fails (for example
         # /srv/shakenfist/exceptions is unwritable), the 'Server error'
-        # record and the client response must still attribute the original
-        # exception, not the recorder's failure.
+        # record must still attribute the original exception, not the
+        # recorder's failure. The client response carries neither name
+        # (decision D31): it stays the same bare 'server error' whether
+        # or not the recorder worked, which is what is checked below.
         self.mock_record_exception_patcher.stop()
         try:
             with mock.patch(
@@ -157,7 +163,7 @@ class ServerErrorLoggingTestCase(base.ShakenFistTestCase):
 
         self.assertEqual(500, resp.status_code)
         body = resp.get_data(as_text=True)
-        self.assertIn('ValueError', body)
+        self.assertNotIn('ValueError', body)
         self.assertNotIn('PermissionError', body)
 
         records = self._server_error_records()

--- a/shakenfist/tests/test_federation.py
+++ b/shakenfist/tests/test_federation.py
@@ -779,7 +779,10 @@ class JWKSTrustAnchorTestCase(base.ShakenFistTestCase):
         # unauthenticated endpoint. Neither TokenValidationFailed nor
         # anything else auth.py catches, so it escaped as `server error:
         # FileNotFoundError(2, 'No such file or directory')` on every
-        # exchange from then on, naming no setting.
+        # exchange from then on, naming no setting. A 500 no longer
+        # names the exception either (decision D31), which makes the
+        # unhandled version of this strictly less diagnosable and this
+        # test more load bearing than when it was written.
         with mock.patch.object(federation.config,
                                'FEDERATION_JWKS_CA_BUNDLE',
                                '/no/such/jwks-ca.pem'):

--- a/shakenfist/tests/test_util_general.py
+++ b/shakenfist/tests/test_util_general.py
@@ -16,3 +16,25 @@ class UtilUserAgent(base.ShakenFistTestCase):
         self.assertEqual('Mozilla/5.0 (Debian GNU/Linux 10 (buster); '
                          'GenuineIntel x86_64) Shaken Fist/1.2.3',
                          ua)
+
+    @mock.patch('cpuinfo.get_cpu_info', return_value={})
+    @mock.patch('distro.name', return_value='Debian GNU/Linux 10 (buster)')
+    @mock.patch('shakenfist.util.general.get_version', return_value='1.2.3')
+    def test_user_agent_partial_cpu_info(self, mock_version, mock_distro, mock_cpuinfo):
+        # py-cpuinfo returns whatever its probes collected, so both keys can be
+        # missing (issue 3523). This must not raise a KeyError.
+        ua = util_general.get_user_agent()
+        self.assertEqual('Mozilla/5.0 (Debian GNU/Linux 10 (buster); '
+                         'unknown unknown) Shaken Fist/1.2.3',
+                         ua)
+
+    @mock.patch('cpuinfo.get_cpu_info', return_value={'arch_string_raw': 'x86_64'})
+    @mock.patch('distro.name', return_value='Debian GNU/Linux 10 (buster)')
+    @mock.patch('shakenfist.util.general.get_version', return_value='1.2.3')
+    def test_user_agent_missing_vendor_only(self, mock_version, mock_distro, mock_cpuinfo):
+        # A probe can also succeed for one key and not the other; pin that the two
+        # lookups are guarded independently rather than as a single fallback.
+        ua = util_general.get_user_agent()
+        self.assertEqual('Mozilla/5.0 (Debian GNU/Linux 10 (buster); '
+                         'unknown x86_64) Shaken Fist/1.2.3',
+                         ua)

--- a/shakenfist/tests/test_util_general.py
+++ b/shakenfist/tests/test_util_general.py
@@ -5,6 +5,15 @@ from shakenfist.util import general as util_general
 
 
 class UtilUserAgent(base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+        # get_user_agent() caches the cpuinfo probe in a module-level global so it is
+        # only paid for once per process. Reset it before and after every test so tests
+        # don't leak a cached value into each other via assertions against different
+        # cpuinfo.get_cpu_info mocks.
+        util_general.CPUINFO_CACHE = None
+        self.addCleanup(setattr, util_general, 'CPUINFO_CACHE', None)
+
     @mock.patch('cpuinfo.get_cpu_info', return_value={
         'arch_string_raw': 'x86_64',
         'vendor_id_raw': 'GenuineIntel'
@@ -38,3 +47,17 @@ class UtilUserAgent(base.ShakenFistTestCase):
         self.assertEqual('Mozilla/5.0 (Debian GNU/Linux 10 (buster); '
                          'unknown x86_64) Shaken Fist/1.2.3',
                          ua)
+
+    @mock.patch('cpuinfo.get_cpu_info', return_value={
+        'arch_string_raw': 'x86_64',
+        'vendor_id_raw': 'GenuineIntel'
+    })
+    @mock.patch('distro.name', return_value='Debian GNU/Linux 10 (buster)')
+    @mock.patch('shakenfist.util.general.get_version', return_value='1.2.3')
+    def test_user_agent_caches_cpu_probe(self, mock_version, mock_distro, mock_cpuinfo):
+        # cpuinfo.get_cpu_info() can shell out to external tools on some platforms, and
+        # get_user_agent() is called on every proxied API request and image fetch, so
+        # the probe must only run once per process.
+        util_general.get_user_agent()
+        util_general.get_user_agent()
+        self.assertEqual(1, mock_cpuinfo.call_count)

--- a/shakenfist/util/general.py
+++ b/shakenfist/util/general.py
@@ -86,12 +86,16 @@ def get_version() -> str:
 
 def get_user_agent() -> str:
     architecture = cpuinfo.get_cpu_info()
+    # py-cpuinfo probes through several mechanisms and returns whatever it managed to
+    # collect, so neither key below is guaranteed to be present. A partial probe used to
+    # raise a KeyError here, which propagated out of a request handler as an opaque 500
+    # to the API caller (issue 3523), so fall back to 'unknown' instead.
     return ('Mozilla/5.0 (%(distribution)s; %(vendor)s %(architecture)s) '
             'Shaken Fist/%(version)s'
             % {
                 'distribution': distro.name(pretty=True),
-                'architecture': architecture['arch_string_raw'],
-                'vendor': architecture['vendor_id_raw'],
+                'architecture': architecture.get('arch_string_raw', 'unknown'),
+                'vendor': architecture.get('vendor_id_raw', 'unknown'),
                 'version': get_version()
             })
 

--- a/shakenfist/util/general.py
+++ b/shakenfist/util/general.py
@@ -84,8 +84,26 @@ def get_version() -> str:
     return sf_version
 
 
+CPUINFO_CACHE: dict[str, Any] | None = None
+
+
+def _get_cpu_info() -> dict[str, Any]:
+    global CPUINFO_CACHE
+
+    # py-cpuinfo probes through several mechanisms, including subprocess invocations on
+    # some platforms, and get_user_agent() is called on every proxied API request and
+    # image fetch. The result cannot change for the lifetime of the process, so probe
+    # once and cache it -- a partial result is fine to cache now that the caller
+    # tolerates one. Compare against None rather than falsiness: an empty dict is a
+    # valid (if partial) cached probe result, not "not yet probed".
+    if CPUINFO_CACHE is None:
+        CPUINFO_CACHE = cpuinfo.get_cpu_info()
+
+    return CPUINFO_CACHE
+
+
 def get_user_agent() -> str:
-    architecture = cpuinfo.get_cpu_info()
+    architecture = _get_cpu_info()
     # py-cpuinfo probes through several mechanisms and returns whatever it managed to
     # collect, so neither key below is guaranteed to be present. A partial probe used to
     # raise a KeyError here, which propagated out of a request handler as an opaque 500


### PR DESCRIPTION
Phase 5 of [PLAN-api-input-validation](docs/plans/PLAN-api-input-validation-phase-05-narrow.md). Phase 4 landed in #4141.

Phase 4 made the validation layer reject. This phase deletes the thing it was built to replace: the `except TypeError` arm in `handle_authorization_exceptions`, which has been answering 400 in the interpreter's own words since 2021 (`ffecee9f9`) and is the second half of the mechanism #3612 describes. It could not go earlier because it was absorbing the malformed input phase 4 now refuses.

```python
        except TypeError as e:
            _authorization_failure_log(e).info('API request rejected as malformed')
            return sf_api.error(400, str(e), suppress_traceback=False)
```

A `TypeError` is not an authorization condition, and nothing in `flask_jwt_extended` or `PyJWT` signals one with it. The three JWT arms are untouched.

## The phase grew a sixth step, because deleting the arm was not enough

Step 2 found that `suppress_exceptions_to_client` builds **every** 500 body as `'server error: %s' % repr(e)`. So the deletion on its own would have relabelled the leak rather than removed it — an undeclared body key under the `warn` rollback would have answered:

```
500 server error: TypeError("AuthEndpoint.post() got an unexpected keyword argument 'zzz'")
```

which is #3612's motivating string wearing a different status code. It is a second, independent leak site common to every exception class: it is also what put `KeyError('arch_string_raw')` and unreachable-node `ConnectionError` reprs into caller-visible bodies.

**Every 500 body is now the bare string `server error`**, for any cause, on any endpoint (D31). Nothing is lost that mattered — the `Server error` log line already carries `exception_class`, the full traceback, method and path, and the on-disk record under `/srv/shakenfist/exceptions/` carries the correlation fields. What a caller loses is stated in the release note rather than left to be discovered: you can no longer tell which exception occurred from a response body alone.

The step 2 agent did not fix this itself, correctly — it asserted what was true, exempting one marker from its `INTERPRETER_TEXT` sweep with the exemption named in the test docstring, and brought the contract decision back rather than taking it. Step 6 removes the exemption.

## What callers see

* **Under `enforce`, the default: nothing changes.** An undeclared body key is refused by name before the handler is reached.
* **Under the `warn`/`off` rollback**, such a key now answers 500 with a recorded exception instead of 400 with interpreter text (D25). The rollback buys "requests that were working keep working", not a tidier answer for the ones that were not.
* **Every 500, everywhere**, loses its exception detail.

## Also in this phase

* **#3523 is fixed and closed.** It asked for a Loki drill-down to find its raising frame; thirty days of `sfcbr` named it — `KeyError: 'arch_string_raw'` in `util/general.py:get_user_agent`, via `proxy_request_to_node` on `GET /instances/<uuid>/consoledata`. `py-cpuinfo` returns whatever its probes collected. The issue's logging half was already fixed by the #3433/#3590 work, which is why the traceback reaches the raise site at all.
* **Two dead `requires_namespace_exist_if_specified` applications removed.** Phase 4 found them and filed no issue, so the record lived only in a phase plan. All twelve applications were surveyed, not just the two named.

## Two corrections this phase made to its own plan

Recorded in the plan at source rather than only in notes, because a stale finding is how the next reader inherits an error.

* **F9 was substantially wrong.** It claimed a node being unreachable answers 500 "260 times in a month". That reads a 30-day aggregate as a rate: 252 of the 260 are a single burst on 2026-08-19, there are none after, and [`2ac50193b`](../../commit/2ac50193b) (#3743) landed 2026-08-21 and had already fixed that path. What survives is the local nodelock socket — which recurred *after* that fix — and two proxy call sites the survey missed because neither goes through `proxy_request_to_node`. Filed as #4161, scoped to what is still true.
* **Definition of done item 5 took two attempts to state.** First a `grep` for `repr(e)` that step 6's own explanatory comment falsifies; then an over-correction that would have condemned the nineteen handlers deliberately answering `str(e)` for a Shaken Fist exception class, where the message is the API's vocabulary rather than the interpreter's. Both attempts stay visible — editing whichever item fails is how a falsifiable list stops being one.

## Verification

* Every new assertion mutation tested. Restoring the deleted arm fails two tests, one of them in the frame the arm lived in, so it pins the property whatever the response is shaped into further out. Restoring `repr(e)` fails the unexempted sweep.
* The `TypeError` enumeration D25 rests on was re-run independently rather than taken from the plan, including the AST check that no handler has a parameter without a default — the one number the plan got wrong on its first attempt.
* Full unit suite: 4673 tests, 0 failures. `pre-commit run --all-files` clean.
* All 13 definition-of-done items met.

Operators whose callers break can still set `API_VALIDATION_MODE=warn` or `off`, with the caveat above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019M9kQBiC4WxmX6w2NPjrBe
