### PR TITLE
The suite waits out a transient capacity refusal, and says so

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,12 @@ metrics. The headlines:
   the operator recovery path; see
   [docs/operator_guide/node_health.md](docs/operator_guide/node_health.md).
 
+- **A raw `create_instance()` call in the CI suite needs a `# raw-create:
+  <reason>` comment**, or an `ast`-based unit test fails the build; use
+  `self.create_instance()` instead unless the test must see a 507
+  directly. See
+  [docs/developer_guide/ci.md](docs/developer_guide/ci.md#creating-instances-in-the-functional-suite).
+
 - **An unlanded plan may already own the code you are changing.** A fix
   landed across a partially implemented plan has to be unpicked later,
   which is why the automated fixer reads `docs/plans/` before writing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,8 +133,9 @@ metrics. The headlines:
   the operator recovery path; see
   [docs/operator_guide/node_health.md](docs/operator_guide/node_health.md).
 
-- **A raw `create_instance()` call in the CI suite needs a `# raw-create:
-  <reason>` comment**, or an `ast`-based unit test fails the build; use
+- **A raw `create_instance()` in the CI suite needs a `# raw-create:
+  <reason>` comment**, or an `ast`-based unit test fails the build. That
+  covers a bare reference passed to `assertRaises` as well as a call; use
   `self.create_instance()` instead unless the test must see a 507
   directly. See
   [docs/developer_guide/ci.md](docs/developer_guide/ci.md#creating-instances-in-the-functional-suite).

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -128,6 +128,56 @@ that connects and then stops responding; without this the job would stall
 until the CI runner's own timeout killed it, with no indication of which test
 was to blame.
 
+## Creating instances in the functional suite
+
+Every functional test creates instances through `self.create_instance()` on
+`BaseTestCase` (`shakenfist/deploy/shakenfist_ci/base.py`), never through a
+client's `create_instance()` directly. The wrapper forwards its arguments
+unchanged and waits out a transient `InsufficientResourcesException` (a 507)
+rather than failing the test on it.
+
+The reason is that a 507 on a shared CI cluster is usually a statement about
+a moment, not about the cluster: the capacity the refusing node is holding is
+very often already being returned by a sibling test that is mid-delete.
+Failing the test on that makes a run's pass/fail a coin flip on sibling
+timing. The wrapper polls `/admin/resources` for room for up to
+`CLUSTER_HEADROOM_WAIT` -- 420 seconds, the same deadline
+`cluster_ci_tests/test_namespace_claims.py` already used for the same
+reason -- and only for a plain 507: an `AffinityConstraintUnsatisfiable` 409
+is never caught, because that refusal does not become satisfiable by
+waiting.
+
+If the deadline passes, which is what it means for a test that is genuinely
+asking for more than the cloud has, the test fails with the last refusal's
+body, the node the wrapper waited for (or "unpinned" if the create had no
+placement), and the `per_node` capacity roster from the last successful
+poll -- so the failure carries the diagnosis a reader needs rather than a
+bare 507.
+
+A raw call -- `self.test_client.create_instance(...)`, a local client,
+another test's client, anything that does not go through
+`self.create_instance()` -- skips the wait silently, and needs a
+`# raw-create: <reason>` comment immediately above it, with a non-empty
+reason. A unit test in `shakenfist/tests/` (`test_ci_raw_creates.py`) walks
+the suite's source with `ast` looking for exactly this, rather than
+importing the suite, which depends on `shakenfist_client` -- not a test
+dependency of this repository. An empty reason fails the same as no marker
+at all, so the allowlist cannot grow by copy-pasting an existing line.
+
+The marker exists for a caller that must see the 507 rather than have it
+waited out. `cluster_ci_tests/test_coalescing.py`'s mesh burst is the
+current example: it pins instances round robin across the hypervisors
+inside a `try` that tolerates and records a capacity refusal as a normal
+outcome on a shared cluster, and carries on -- wrapping that create would
+break it twice, since the wrapper's own deadline failure is a test failure
+rather than an `APIException` the `except` clause could catch, and waiting
+up to seven minutes per refusal would serialise a burst whose simultaneity
+is the thing under test. The other reserved use is the wrapper's own call
+inside `base.py`, which has to reach the client somehow. The CI cloud
+sizing plan's phase 3 saturation tests are expected to need the marker
+too, to assert that a genuinely full cluster refuses rather than have the
+refusal waited away.
+
 ## CI headroom instrumentation
 
 Phase 1 of `docs/plans/PLAN-ci-cloud-sizing.md` (see
@@ -229,6 +279,37 @@ wrong cannot be the thing that empties the last good dataset; and any
 harvest whose output is going to be committed names both ends of its
 window, because `--since` alone grows with every merge and `--limit`
 moves with the day it is run on.
+
+### A third file: the capacity-wait trace (`--waits`)
+
+A third file lands beside the other two, written by a different
+mechanism. `PLAN-transient-capacity-refusals` phase 2's
+`self.create_instance()` wrapper (see "Creating instances in the
+functional suite" above) appends one JSON line to
+`/srv/ci/traces/instance-waits.jsonl` every time a create waits out a
+transient 507. It reaches the bundle through the same "Gather logs"
+scp as `headroom.jsonl` and `headroom-census.json`, with no separate
+plumbing needed to get it there.
+
+`tools/ci_headroom_report.py --waits <file>` summarises it: total
+seconds waited, the number of waits, the longest wait and the test it
+came from, and the split between waits that were informed by a
+capacity read and waits that had to sleep blind because
+`/admin/resources` itself could not be read (`mode: degraded`).
+Because the report already runs over a downloaded bundle rather than
+only inside a live job, this summary is available from the moment the
+phase that writes the trace merges -- the evidence does not wait for
+`ci_headroom_collect.sh` to grow its own `--waits` plumbing and print
+it into the job log, which is a separate, later change.
+
+An absent or empty file reports as unknown, never as zero waits, for
+the same reason an absent or empty census reports as unknown rather
+than as zero refusals (see "Nothing here is a quality gate" below): "no
+one collected this" and "the wrapper never had to wait" are different
+findings, and the reading that looks reassuring -- zero -- is exactly
+the wrong one to print when the file was never written or never read.
+A file that was read but whose every line was malformed is reported
+the same way, for the same reason.
 
 ### The series record format
 

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -169,8 +169,19 @@ ceiling under that, and a failure that cites it says so rather than
 blaming the cluster's capacity.
 
 A retry uses a fresh name, because the refused instance holds the caller's
-name until its error delete completes. The base name is trimmed so that the
-name plus the retry suffix stays inside the server's 63 character limit.
+name until its error delete completes: the instance object is created and
+then error-deleted, and `Instance.ACTIVE_STATES` includes the error states,
+so the name still resolves while that delete is in flight. The base name is
+trimmed so that the name plus the retry suffix stays inside the server's 63
+character limit.
+
+**This means the instance's name is not always the name you asked for.** A
+test that looks an instance up by the literal it passed in will 404 after a
+wait; read the name back from the returned dict (`inst['name']`) instead,
+which is what `test_object_names.py` does. A test whose subject *is* the
+name -- one asserting that two namespaces can hold the same name -- cannot
+be renamed at all without silently asserting nothing, and so uses a
+`# raw-create:` marker rather than the wrapper.
 
 If the deadline passes, which is what it means for a test that is genuinely
 asking for more than the cloud has, the test fails with the last refusal's
@@ -333,7 +344,11 @@ capacity read and waits that had to sleep blind because
 line also carries the create's three request dimensions, the
 `binding_dimension` it was short of, and `attempt_number` -- a
 1-indexed position, not a count, so a create refused three times
-writes three lines carrying 1, 2 and 3.
+writes three lines carrying 1, 2 and 3. `node` is the placement the
+test asked for, and `roster_key` is the `per_node` entry the wait
+actually watched: `/admin/resources` keys that mapping by node UUID
+while the suite pins by node name, so the two differ and the wait has
+to resolve one to the other before it can read anything.
 Because the report already runs over a downloaded bundle rather than
 only inside a live job, this summary is available from the moment the
 phase that writes the trace merges -- the evidence does not wait for

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -141,28 +141,62 @@ a moment, not about the cluster: the capacity the refusing node is holding is
 very often already being returned by a sibling test that is mid-delete.
 Failing the test on that makes a run's pass/fail a coin flip on sibling
 timing. The wrapper polls `/admin/resources` for room for up to
-`CLUSTER_HEADROOM_WAIT` -- 420 seconds, the same deadline
-`cluster_ci_tests/test_namespace_claims.py` already used for the same
-reason -- and only for a plain 507: an `AffinityConstraintUnsatisfiable` 409
-is never caught, because that refusal does not become satisfiable by
-waiting.
+`CLUSTER_HEADROOM_WAIT` -- 420 seconds, which
+`cluster_ci_tests/test_namespace_claims.py` imports from `base.py` rather
+than keeping its own copy of -- and only for a plain 507: an
+`AffinityConstraintUnsatisfiable` 409 is never caught, because that refusal
+does not become satisfiable by waiting.
+
+"Room" means room for the whole create, on one node. The scheduler
+pre-filters a candidate on cpus, memory and disk, and refuses for whichever
+of the three binds, so the wait models all three
+(`retries.wait_for_capacity()`): a node satisfies the wait only when every
+dimension the create asks for fits on that node, and the wait record names
+the dimension it was short of. Reading just one dimension is not a smaller
+version of the same thing but a different failure -- a predicate that is
+permanently satisfied while the server is permanently refusing, which turns
+one 507 into a retry loop rather than a wait.
+
+For the same reason the loop is paced. The first wait after a refusal may
+hand control straight back, because capacity returning between the refusal
+and the poll is both common and the case the whole mechanism exists for.
+Every wait after that sleeps at least one poll interval, because a second
+refusal following a satisfied wait means the create is being refused for
+something the predicate cannot see, and an unpaced loop there re-issues as
+fast as two HTTP round trips allow until the deadline -- leaving an
+error-deleted instance behind on every turn. `MAX_CREATE_ATTEMPTS` is a
+ceiling under that, and a failure that cites it says so rather than
+blaming the cluster's capacity.
+
+A retry uses a fresh name, because the refused instance holds the caller's
+name until its error delete completes. The base name is trimmed so that the
+name plus the retry suffix stays inside the server's 63 character limit.
 
 If the deadline passes, which is what it means for a test that is genuinely
 asking for more than the cloud has, the test fails with the last refusal's
 body, the node the wrapper waited for (or "unpinned" if the create had no
 placement), and the `per_node` capacity roster from the last successful
-poll -- so the failure carries the diagnosis a reader needs rather than a
-bare 507.
+poll, plus the dimensions the waits were short of -- so the failure carries
+the diagnosis a reader needs rather than a bare 507.
 
 A raw call -- `self.test_client.create_instance(...)`, a local client,
 another test's client, anything that does not go through
 `self.create_instance()` -- skips the wait silently, and needs a
-`# raw-create: <reason>` comment immediately above it, with a non-empty
-reason. A unit test in `shakenfist/tests/` (`test_ci_raw_creates.py`) walks
-the suite's source with `ast` looking for exactly this, rather than
-importing the suite, which depends on `shakenfist_client` -- not a test
-dependency of this repository. An empty reason fails the same as no marker
-at all, so the allowlist cannot grow by copy-pasting an existing line.
+`# raw-create: <reason>` comment in the block of comment lines immediately
+above it, with a non-empty reason. A unit test in `shakenfist/tests/`
+(`test_ci_raw_creates.py`) walks the suite's source with `ast` looking for
+exactly this, rather than importing the suite, which depends on
+`shakenfist_client` -- not a test dependency of this repository. An empty
+reason fails the same as no marker at all, so the allowlist cannot grow by
+copy-pasting an existing line.
+
+A call is not the only way to reach a client's `create_instance()`.
+`assertRaises(Exc, self.test_client.create_instance, ...)` hands the bound
+method over as a reference and lets `assertRaises` do the calling, and the
+guard checks those too -- the marker goes on the line above the reference,
+inside the `assertRaises` call. Six sites in the suite use that shape, each
+asserting a 400, 404 or 409 that must not be waited out, and each carries a
+marker saying which.
 
 The marker exists for a caller that must see the 507 rather than have it
 waited out. `cluster_ci_tests/test_coalescing.py`'s mesh burst is the
@@ -295,7 +329,11 @@ plumbing needed to get it there.
 seconds waited, the number of waits, the longest wait and the test it
 came from, and the split between waits that were informed by a
 capacity read and waits that had to sleep blind because
-`/admin/resources` itself could not be read (`mode: degraded`).
+`/admin/resources` itself could not be read (`mode: degraded`). Each
+line also carries the create's three request dimensions, the
+`binding_dimension` it was short of, and `attempt_number` -- a
+1-indexed position, not a count, so a create refused three times
+writes three lines carrying 1, 2 and 3.
 Because the report already runs over a downloaded bundle rather than
 only inside a live job, this summary is available from the moment the
 phase that writes the trace merges -- the evidence does not wait for
@@ -309,7 +347,11 @@ one collected this" and "the wrapper never had to wait" are different
 findings, and the reading that looks reassuring -- zero -- is exactly
 the wrong one to print when the file was never written or never read.
 A file that was read but whose every line was malformed is reported
-the same way, for the same reason.
+the same way, for the same reason, and carries its own `state` of
+`unparseable` in the machine-readable record rather than an
+`available` file with a count of zero -- the prose and the record have
+to say the same thing, because the later phases that read this are
+consumers of the record.
 
 ### The series record format
 

--- a/docs/plans/PLAN-transient-capacity-refusals-phase-02-suite-wait.md
+++ b/docs/plans/PLAN-transient-capacity-refusals-phase-02-suite-wait.md
@@ -225,6 +225,56 @@ being wrong in this direction is bounded by the 420 s deadline; the
 cost of being wrong in the other direction is the measurement phase 5
 reads.
 
+**Corrected in review (2026-09-11).** D8 as written models one
+dimension, and the automated reviewer was right that it is the wrong
+one to model alone. The scheduler pre-filters a candidate on three --
+`_has_sufficient_cpu()`, `_has_sufficient_ram()` and
+`_has_sufficient_disk()` -- and turns any of their
+`LowResourceException`s into the same 507. CI instances are 1 vCPU but
+1-2 GB with 8 GB disks, so memory and disk bind far more often than
+cpus do. A one-dimension predicate is therefore not a rougher version
+of the right answer; it is permanently satisfied while the server is
+permanently refusing, which is a different failure with a different
+shape. The predicate now requires every dimension the create asks for
+to fit **on one node** (`retries.coverage_of()`), which is the same
+error as `total['cpu_available']` one level down: an instance is placed
+on one node and needs all three of its dimensions there.
+
+Two per-instance ceilings join the ledgers above, for the same reason:
+`cpu_max_per_instance` and `ram_max_per_instance` bound the largest
+single instance a node will take whatever its aggregate headroom, so a
+create larger than one of them is refused permanently. They differ in
+how a zero reads -- a missing `cpu_max_per_instance` metric publishes
+as 0, where `ram_max_per_instance` is legitimately 0 on a full node --
+so the cpu one is read only when non-zero and the memory one whenever
+present.
+
+The wait record now names the `binding_dimension` it was short of at
+the first poll, which is the question phase 5 actually asks of this
+data: a duration with no cause attached to it cannot be acted on.
+
+**Also corrected in review: the predicate is not the only thing that
+has to be right.** A satisfied wait hands control straight back to a
+caller which has just been refused, and `wait_for_capacity()` returns
+after one poll and zero sleeps when the predicate is already met. If
+the refusal is for anything the predicate cannot see -- a pre-filter it
+does not model, the admission guard losing a race it cannot observe --
+then satisfied is the *permanent* answer, and the wrapper re-issues as
+fast as two HTTP round trips allow for the whole 420 s, leaving an
+error-deleted instance, a trace line and an `addDetail` entry behind on
+every turn. That is the risk section's "turns one 507 into six" with
+three more orders of magnitude on it.
+
+Widening the predicate shrinks that window but cannot close it, because
+the whole point is that some refusals are invisible from
+`/admin/resources`. So the loop is paced as well: the first wait after
+a refusal may return immediately, because capacity returning between
+the refusal and the poll is the common case and the reason this phase
+exists, and every wait after that sleeps at least one poll interval
+(`minimum_sleep`). `MAX_CREATE_ATTEMPTS` is a hard ceiling under the
+derived bound, and the failure it raises says the refusal is for
+something the predicate cannot see rather than blaming the cluster.
+
 ### D9 -- A node missing from `per_node` is "not yet", not "never"
 
 The wait loop treats an absent `per_node[target]` as zero available

--- a/docs/plans/PLAN-transient-capacity-refusals-phase-02-suite-wait.md
+++ b/docs/plans/PLAN-transient-capacity-refusals-phase-02-suite-wait.md
@@ -215,6 +215,22 @@ cluster start and never recur; treating it as "the published headroom
 is all we know" is the right reading, and it is what the fallback to
 `cpu_available` alone does.
 
+*Amended by the automated review of PR #4166: the predicate was right
+about which ledger to read and wrong about how to find the row. The
+`per_node` mapping is keyed by node UUID -- `summarize_resources()`
+builds it from the metrics dict, which `get_active_node_metrics()` keys
+by `str(n.uuid)` -- while the suite pins by node name almost everywhere
+(`'sf-2'`, `node['name']`, `socket.getfqdn()`). The target was therefore
+absent from the roster on every poll for a name-pinned create, which
+`best_node()` reads as zero headroom in every dimension rather than as
+"no entry", so the wait could never be satisfied however empty the
+cluster was. One transient 507 on a name-pinned create became a
+guaranteed 420 s failure whose message said there was room everywhere.
+`BaseTestCase._placement_roster_key()` now resolves the pin to the
+roster's key space before waiting; a pin that resolves to nothing waits
+blind (`mode: degraded`) rather than reading an absent key as an empty
+node.*
+
 This is the decision a reviewer is most likely to argue with, because
 it makes the wrapper wait *longer* than the master plan's predicate
 would in exactly the case where the two ledgers disagree. That is the
@@ -340,6 +356,23 @@ delete completes asynchronously. Every retry appends
 returns the instance it finally created, so the caller never sees the
 name it did not choose except in the failure message and the wait
 record, both of which state it.
+
+*Amended by the automated review of PR #4166: D13 holds, but its stated
+mechanism was incomplete and the consequence was not carried through to
+the callers. Nothing refuses a duplicate instance name on create -- the
+only name validation is the DNS hostname check at
+`external_api/instance.py:592-600`. What actually keeps the name in use
+is resolution: `Instance.ACTIVE_STATES` (`instance.py:239-244`) includes
+the error states, so the refused instance still answers a name lookup
+until its delete finishes, and reusing the name would make that lookup
+ambiguous rather than refused. The consequence is that a retried create
+does not carry the caller's name, which breaks any test that resolves an
+instance by the literal it passed. `test_object_names.py` did, in two
+different ways, and both are fixed: the first keys on the name the
+instance actually got, and the two duplicate-name tests -- whose subject
+is the name itself, and which would have asserted nothing against a
+renamed instance -- take `# raw-create:` markers. The rename is now
+stated in `ci.md` rather than only in the wrapper's docstring.*
 
 ### D14 -- The wait record lands in the bundle without a cross-repo push
 

--- a/docs/plans/PLAN-transient-capacity-refusals-phase-02-suite-wait.md
+++ b/docs/plans/PLAN-transient-capacity-refusals-phase-02-suite-wait.md
@@ -1,0 +1,501 @@
+# Phase 2: the suite waits, and says so
+
+Parent plan:
+[PLAN-transient-capacity-refusals.md](PLAN-transient-capacity-refusals.md).
+
+**Planning effort:** high, as the master plan specifies. The wrapper
+itself is thirty lines. What keeps this above mechanical is that the
+wrapper has to decide *when to stop waiting*, and the obvious
+predicate -- the headroom figure `/admin/resources` publishes -- is
+not the quantity admission refuses on. A wrapper that waits on the
+wrong number does not fail loudly: it stops waiting early, re-issues
+a create that refuses again, and turns one 507 into six while
+reporting that it waited. The second hard part is that this phase's
+output is evidence phase 5 will make a decision from, so a summary
+which quietly loses waits is worse than no summary.
+
+This phase continues the plan's decision sequence at **D7**. There is
+one namespace across the whole plan; phase 1 used D1-D6.
+
+## Context
+
+The master plan's Situation section establishes that a capacity
+refusal in CI is usually a statement about a moment rather than about
+the cluster: the instance the refusing node is holding is often
+already being deleted by a sibling test. The suite treats every one
+of them as a hard failure, because `create_instance()` is called raw
+at every site and a 507 raises.
+
+Phase 1 removed one of the two causes. A cluster's first minutes no
+longer admit placements against nothing: the measured
+time-to-first-capacity-row went from 165 s to 0 s on the same probe
+(see phase 1's Outcome section). That matters here in a way worth
+stating, because it changes what this phase measures. Before phase 1,
+a wait early in a run could be a cold ledger. After it, a wait is
+what it appears to be -- some other test is holding the capacity --
+which is exactly the quantity phase 5 needs and could not previously
+have read cleanly.
+
+What this phase does *not* do is make refusals rarer. It makes them
+survivable, and it writes down how long survival took.
+
+## Scope
+
+**In:**
+
+* A `create_instance()` wrapper on `BaseTestCase` which waits out a
+  transient capacity refusal, and every call site in
+  `shakenfist/deploy/shakenfist_ci/` routed through it.
+* A unit test which walks the suite's source with `ast` and fails on
+  a raw call outside an explicit allowlist marker.
+* A per-wait record written where the CI bundle already collects it,
+  and a summary in `tools/ci_headroom_report.py`.
+* The load-budget declaration for the wrapper's polling.
+* Two ride-along test fixes the survey confirmed are real.
+
+**Out:**
+
+* Any change to what the server does about a refusal. `Retry-After`
+  and the machine-readable transient marker are phase 4; the wrapper
+  here reads only what `/admin/resources` already publishes.
+* Any change to the scheduler, its pre-filters, the demand guard or
+  the guarded `UPDATE`. Those are scheduler-reservations' (D11).
+* Deciding anything about a server-side placement queue. This phase
+  produces the numbers phase 5 decides from and takes no position.
+* Making the suite use less capacity. Reducing the number of pinned
+  creates is a ride-along where the survey found the pin was not
+  load-bearing, and is not a goal in itself.
+
+## What the survey found
+
+The master plan's phase 2 section was written on 2026-09-08, before
+phase 1 executed. Most of it holds. Five claims do not, and two of
+those change the design rather than the wording.
+
+**1. The call-site count is wrong, and so is the scope it names.**
+The section says "115 call sites across 39 files" in
+`cluster_ci_tests/` and `guest_ci_tests/`. Those two directories hold
+**88 calls in 32 files** today. The count that matches 115 is the one
+over all of `shakenfist/deploy/shakenfist_ci/`: **117 calls in 41
+files**. The difference is `smoke_ci_tests/` (27 calls in 7 files),
+plus one call each in `base.py:1227` (`TestDistroBoots`) and
+`database_tier.py:275`. The smoke tier is not a rounding error: it is
+the tier that runs on the smallest cloud, where a single sibling
+instance is a larger fraction of the cluster. Corrected at source in
+the master plan.
+
+**2. The published headroom figure is not what admission refuses
+on.** `summarize_resources()` computes
+`per_node[n]['cpu_available'] = cpu_hard_max - max(measured,
+committed)` (`shakenfist/scheduler.py:1086-1088`), where
+`cpu_hard_max` is the *live* overcommit arithmetic. Admission refuses
+against the capacity row's `limit_cpus`, which is the same arithmetic
+refreshed once a reconcile period. The endpoint publishes both
+deliberately and says why: the comment at `:1071-1078` is explicit
+that `cpu_limit` has no fallback precisely so a reader can see the
+two ledgers disagree. A wait predicate reading only `cpu_available`
+therefore returns "there is room" during exactly the window where the
+two differ -- which is the window this plan exists to describe. See
+D8.
+
+**3. `total['cpu_available']` is a sum, and an instance is not.**
+The same function accumulates `total['cpu_available']` by adding each
+node's headroom, flooring negatives at zero (`:1091-1093`). An
+instance must fit on one node. `total['cpu_available'] >= cpus` is
+therefore satisfied by a cluster of ten nodes with one spare thread
+each, which will refuse a two-vCPU create every time. See D8.
+
+**4. The target node can be absent from `per_node`, not merely
+short of headroom.** `per_node` skips any node whose metrics say it
+is not a hypervisor and any node over `UNREASONABLE_QUEUE_LENGTH`
+(`scheduler.py:1039-1044`), and a node with no metrics row at all
+never appears. Phase 1 hit this in `test_nodes.py` and had to assert
+`assertIsNotNone(per_node)` separately from the headroom check. A
+predicate written as `per_node[target]['cpu_available'] >= cpus`
+raises `KeyError` inside the wait loop. See D9.
+
+**5. `retry_while_transient` is a blind re-issue, and its module is
+deliberately import-free.** `shakenfist/deploy/shakenfist_ci/retries.py`
+calls `request()` every 10 s until the status stops being transient.
+Reusing it directly means issuing a *create* every 10 s, and every
+refused create builds an instance object and then
+`enqueue_delete_due_error`s it (`shakenfist/external_api/instance.py:901-906`)
+-- so a 420 s wait would leave 42 error-deleted instances behind and
+add its own load to the cluster it is waiting for. Worse, the
+module's docstring records that it imports nothing from the suite or
+from `shakenfist_client` so the unit tests can load it by path; a
+poll of `system_client.get_cluster_resources()` cannot live in it.
+See D11.
+
+**6. The bundle plumbing needs no change in the actions
+repository.** The master plan says this phase "carries the same
+operator-push obligation the sizing plan's phase 1 did". Half of that
+is true. `/srv/ci/traces` on the primary is created and chowned to
+the base-image user by `smoke-cluster.yml:212`, and the *entire*
+directory is scp'd into the 90-day artifact bundle by the "Gather
+logs" step at `:550`. The functional suite runs on the primary as
+that user. So a file the suite writes to `/srv/ci/traces` reaches the
+bundle with no change to `shakenfist/actions` at all. Only *printing*
+the summary in the job log needs one, because that happens in
+`tools/ci_headroom_collect.sh`. See D14, which splits the phase so
+the evidence does not depend on the cross-repo push.
+
+**7. Claims the survey confirmed.** `BaseTestCase`
+(`base.py:119`) has no `create_instance()`. `_uniquifier()` exists at
+`base.py:193`. `CLUSTER_HEADROOM_WAIT = 420` is at
+`test_namespace_claims.py:134`, with the existing transient-retry
+usage at `:324`. `InsufficientResourcesException` is exported by
+`shakenfist_client.apiclient` and is what a 507 raises.
+`HARNESS_DRIVEN_PAIRS` is at `load_budget.py:309`, and
+`test_the_suite_still_probes_cluster_headroom` -- which holds its
+prose up -- is at `shakenfist/tests/test_database_tier_harness.py:374`.
+The `ast` precedent is `shakenfist/tests/test_ci_claims_headroom.py`
+(`:41`, helpers at `:171-190`). `test_system_namespace.py:9`
+subclasses `base.BaseTestCase`, creates inline at `:27` and deletes
+at `:56` with no `addCleanup`. `capacity_degraded` is published on
+`total`.
+
+**8. One ride-along is already done, and the other is
+mis-described.** The master plan asks for
+`test_commandline_artifacts.py`'s second instance to target
+`inst1['node']` "only where co-location is actually load-bearing" --
+but `:182-190` already pins it to `inst1['node']`, which is the shape
+being asked for, and `inst1` at `:139` is not pinned at all. There is
+nothing to change there. `test_imagefetch.py` has **four** pinned
+creates, not one. In the first test (`:130`, `:152`) both are pinned
+to `n`, the first hypervisor in the node list; the source URL is
+deleted between them, so `inst2` must land where `inst1` did, but
+`inst1`'s pin to an arbitrary node is pure convenience. In the second
+test (`:222`, `:247`) the `first`/`second` pins are load-bearing by
+construction -- the comment says "on a node which has not seen this
+image before" -- and must stay. Net: one pin is removable and one
+becomes `inst1['node']`. See D17.
+
+Corrections 1, 6 and 8 have been made at their source in the master
+plan's phase 2 section as part of the planning commit, so a later
+step does not need to redo them.
+
+## Decisions
+
+### D7 -- The wrapper covers every call site in `shakenfist_ci`
+
+All 117, not the 88 in the two directories the master plan named.
+`smoke_ci_tests/` gets the wrapper for the same reason the others do,
+and more so: it runs on the smallest cloud. `base.py:1227` and
+`database_tier.py:275` are inside the harness rather than in a test,
+but they are creates against the same cluster and a refusal fails
+them the same way.
+
+The two harness call sites route through the wrapper by calling it as
+`self.create_instance(...)`, which is available to them because both
+are on classes descending from `BaseTestCase`. No call site outside a
+`BaseTestCase` subclass exists today; the AST guard in D15 fails if
+one appears.
+
+### D8 -- Wait on the ledger the guard reads, not the headroom published
+
+The predicate for "there is now room for this create" is, per node:
+
+```
+available = per_node[n]['cpu_available']
+if per_node[n]['cpu_limit'] is not None:
+    available = min(available,
+                    per_node[n]['cpu_limit'] - per_node[n]['cpu_committed'])
+```
+
+and the create proceeds when `available >= cpus` for the pinned
+target, or when **any** node satisfies it for an unpinned create --
+`max` over nodes, never `total['cpu_available']`, per survey finding
+3.
+
+`cpu_limit` is `None` exactly when the node has no capacity row
+(`scheduler.py:1078`), which is also when `cpu_committed_row_present`
+is false. After phase 1 that state should last about a minute at
+cluster start and never recur; treating it as "the published headroom
+is all we know" is the right reading, and it is what the fallback to
+`cpu_available` alone does.
+
+This is the decision a reviewer is most likely to argue with, because
+it makes the wrapper wait *longer* than the master plan's predicate
+would in exactly the case where the two ledgers disagree. That is the
+point. Stopping early does not avoid the wait, it converts it into
+another refused create, another error-deleted instance, and a wait
+record that understates what the run actually spent. The cost of
+being wrong in this direction is bounded by the 420 s deadline; the
+cost of being wrong in the other direction is the measurement phase 5
+reads.
+
+### D9 -- A node missing from `per_node` is "not yet", not "never"
+
+The wait loop treats an absent `per_node[target]` as zero available
+and keeps waiting, rather than raising. Survey finding 4 gives the
+three ways a node goes missing, two of which -- a queue over the
+unreasonable length, and metrics not yet published -- are transient
+and are precisely what the wrapper is waiting out. The third, a node
+that is genuinely not a hypervisor, is a test bug, and the deadline
+turns it into a failure with the `per_node` roster attached, which is
+the diagnosis a reader needs.
+
+The same treatment applies to a `get_cluster_resources()` call that
+raises: log it into the wait record and keep waiting. The endpoint
+being briefly unavailable is not evidence about capacity.
+
+### D10 -- A degraded capacity read falls back to a blind wait
+
+When `total['capacity_degraded']` is set, the capacity mapping the
+whole predicate rests on could not be read, so `cpu_limit` is `None`
+for every node for a reason that has nothing to do with capacity.
+Waiting informed on that is waiting on noise. Fall back to sleeping
+the poll interval and retrying the create at the deadline's cadence,
+and record `mode: degraded` on the wait so a reader can tell a wait
+that was informed from one that was not.
+
+This is the same distinction phase 1 drew between an empty answer and
+an unknown one (D2, D3), for the same reason.
+
+### D11 -- The informed wait is a new function, with the poll injected
+
+`retries.py` keeps its property of importing nothing from the suite.
+The new `wait_for_capacity(...)` lives beside `retry_while_transient`
+in the same module and takes the poll as a callable returning the
+resources dict, plus `clock` and `sleep` as `retry_while_transient`
+already does. The suite passes
+`self.system_client.get_cluster_resources`; the unit tests pass a
+fake returning a scripted sequence of dicts.
+
+`retry_while_transient` is *not* reused as the outer loop. Its
+contract is "re-issue the request until its status stops being
+transient", and this loop's shape is "poll a different thing, then
+re-issue once". Bending one into the other would leave a helper whose
+docstring no longer describes either caller.
+
+### D12 -- Only an insufficient-resources refusal is waited on
+
+The wrapper catches `apiclient.InsufficientResourcesException` and
+nothing else. In particular it does not catch the 409 from
+`AffinityConstraintUnsatisfiable`, which the API path deliberately
+orders *above* the 507 clause because the exception is a subclass and
+the ordering is what keeps them distinct
+(`external_api/instance.py:890-899`). An affinity constraint that
+cannot be satisfied does not become satisfiable by waiting, and a
+wrapper that retried it for 420 s would convert a clear failure into
+a slow one.
+
+### D13 -- Re-create under a fresh uniquified name
+
+The refused instance is created and then `enqueue_delete_due_error`ed
+(`external_api/instance.py:901-906`), so its name is in use until the
+delete completes asynchronously. Every retry appends
+`'-%s' % self._uniquifier()` to the caller's name. The wrapper
+returns the instance it finally created, so the caller never sees the
+name it did not choose except in the failure message and the wait
+record, both of which state it.
+
+### D14 -- The wait record lands in the bundle without a cross-repo push
+
+Each wait appends one JSON object as a line to
+`/srv/ci/traces/instance-waits.jsonl` on the machine running the
+suite, opened `'a'` per write. One line per wait, not per run, so
+concurrent stestr workers do not have to agree on anything and a
+crashed worker loses at most its own in-flight line. Per survey
+finding 6 this reaches the artifact bundle through the existing
+"Gather logs" scp with no change to `shakenfist/actions`.
+
+`tools/ci_headroom_report.py` grows a `--waits <file>` argument that
+prints total seconds waited, number of waits, the longest wait and
+its test, and the split between informed and degraded waits. The
+report already runs over a downloaded bundle -- that is how phase 1
+verified its own definition-of-done item 9 -- so **the evidence is
+available from the moment this phase merges**, whether or not the
+job log ever prints it.
+
+Printing it in the job log is a one-line addition to
+`ci_headroom_collect.sh` in `shakenfist/actions` (scp the file, pass
+the flag) and is step 2f. It is deliberately last and deliberately
+not depended on by anything else in this phase. If the directory is
+unwritable the wrapper still waits and the test still passes: nothing
+about recording a wait may fail a test, for the same reason
+`ci_headroom_collect.sh`'s header gives for never failing a job.
+
+### D15 -- The AST guard names an allowlist marker
+
+A unit test in `shakenfist/tests/` walks every `.py` file under
+`shakenfist/deploy/shakenfist_ci/` and fails on any
+`*.create_instance(` call whose line is not preceded by a
+`# raw-create:` comment giving a reason. It follows
+`test_ci_claims_headroom.py`'s pattern of parsing the suite's source
+rather than importing it, because the suite imports
+`shakenfist_client`, which is not a test dependency of this
+repository.
+
+The marker exists for callers that must see the refusal: the sizing
+plan's phase 3 saturation tests, and the wrapper's own call inside
+`base.py`. The test asserts the marker's *reason* is non-empty, so
+the allowlist cannot grow by copy-paste.
+
+### D16 -- The load-budget prose names the wrapper as a second producer
+
+`GetNodeMetrics`/`api` is already in `HARNESS_DRIVEN_PAIRS`
+(`load_budget.py:309`), but the prose there names the headroom probe
+as the producer, and
+`test_the_suite_still_probes_cluster_headroom`
+(`test_database_tier_harness.py:374`) holds that prose up. Extend the
+comment to name the wrapper as a second, activity-coupled producer --
+it polls only while a create is being retried, so it adds nothing to
+an idle cluster and adds load in proportion to how full the cluster
+already is.
+
+Not a new budget entry: the pair is already exempt, and adding a
+second entry for the same pair would make the exemption look like two
+separate allowances.
+
+### D17 -- Only the ride-alongs the survey confirmed
+
+`test_imagefetch.py`'s first test drops `inst1`'s pin and changes
+`inst2`'s to `inst1['node']`, per survey finding 8. Its second test
+is left alone. `test_commandline_artifacts.py` is left alone: it
+already has the shape the master plan asked for.
+`test_system_namespace.py` gains an `addCleanup` for its inline
+instance, so a failure between `:27` and `:56` no longer strands a
+charged instance in the system namespace for the rest of the run.
+
+Nothing else. A phase which is about measuring how long the suite
+waits should not quietly change how much capacity the suite uses
+beyond what it can justify, or the numbers it reports are about a
+different suite than the one that produced the baseline.
+
+## Step plan
+
+| Step | Effort | Model | Isolation | Brief for sub-agent |
+|------|--------|-------|-----------|---------------------|
+| 2a | high | opus | none | Add `wait_for_capacity()` to `shakenfist/deploy/shakenfist_ci/retries.py` beside `retry_while_transient`, and `create_instance()` to `BaseTestCase` in `shakenfist/deploy/shakenfist_ci/base.py:119`. Read `retries.py`'s docstring first: it imports nothing from the suite or from `shakenfist_client` so `shakenfist/tests/test_ci_claims_headroom.py` can load it by path, and that must survive -- take the resources poll as a callable, with `clock` and `sleep` injected exactly as `retry_while_transient` does (D11). Implement the predicate in D8 literally: per node, `available = per_node[n]['cpu_available']`, and where `per_node[n]['cpu_limit']` is not `None`, `available = min(available, cpu_limit - cpu_committed)`; proceed when the pinned target satisfies `available >= cpus`, or when any node does for an unpinned create. Do **not** use `total['cpu_available']`: it is a sum across nodes (`shakenfist/scheduler.py:1091-1093`) and an instance must fit on one. An absent `per_node[target]` is zero available and keeps waiting, never a `KeyError` (D9); a poll that raises is logged into the record and the wait continues. When `total['capacity_degraded']` is set, sleep the interval instead of evaluating the predicate and mark the wait `mode: degraded` (D10). The wrapper catches only `apiclient.InsufficientResourcesException` -- not the 409 from `AffinityConstraintUnsatisfiable`, which is a subclass of `LowResourceException` on the server and is kept distinct only by clause ordering at `shakenfist/external_api/instance.py:890-899` (D12). Deadline 420 s, the `CLUSTER_HEADROOM_WAIT` the claims suite already uses (`cluster_ci_tests/test_namespace_claims.py:134`); poll interval 10 s. Each retry uses a fresh name suffixed with `self._uniquifier()` (`base.py:193`), because the refused instance is created and then `enqueue_delete_due_error`ed and its name is in use until that completes (D13). On exhausting the deadline, fail with the refusal body, the node waited for, and the `per_node` roster in the message. Attach every wait to the test as a detail: seconds waited, node, mode, and the headroom at first refusal and at admission. Unit tests in `shakenfist/tests/` against a fake clock and a scripted poll: an immediate success, a wait that ends informed, a wait that ends at the deadline, a degraded wait, a target absent from `per_node` that later appears, a node whose `cpu_available` is generous while `cpu_limit - cpu_committed` is not (the D8 case -- assert it does not proceed, and confirm that deleting the `cpu_limit` clause makes this test fail), and a 409 passing straight through. Single quotes, 120 columns, no trailing whitespace. |
+| 2b | medium | sonnet | none | Route every call site through the wrapper. There are 117 across 41 files in `shakenfist/deploy/shakenfist_ci/` -- `grep -rn '\.create_instance(' shakenfist/deploy/shakenfist_ci/` is the list, and note it includes `smoke_ci_tests/` (27 in 7 files), `base.py:1227` and `database_tier.py:275`, which the master plan's section omitted (D7). Each becomes `self.create_instance(...)` with the same arguments. Then add the AST guard per D15 as a new test in `shakenfist/tests/`: parse every `.py` under `shakenfist/deploy/shakenfist_ci/` with `ast` -- do not import the package, it imports `shakenfist_client`, which is not a test dependency here -- and fail on any `create_instance` attribute call not preceded by a `# raw-create: <reason>` comment with a non-empty reason. Follow the file-walking and call-finding helpers in `shakenfist/tests/test_ci_claims_headroom.py:171-190` rather than inventing new ones. The wrapper's own call inside `base.py` carries the marker. Run the full unit suite; it takes about ten minutes. |
+| 2c | medium | sonnet | none | The record and the summary, per D14. The wrapper appends one JSON object per wait as a line to `/srv/ci/traces/instance-waits.jsonl`, opened `'a'` per write, with keys: test id, instance name requested, node waited for or `null`, cpus, seconds waited, mode (`informed`/`degraded`), attempts, and the headroom at first refusal and at admission. Every failure to write is swallowed -- an instrument may never fail the thing it measures, exactly as `ci_headroom_collect.sh`'s header argues. The directory already exists and is writable by the suite's user: `smoke-cluster.yml:212` in `shakenfist/actions` creates and chowns it, and `:550` scp's the whole directory into the bundle, so this needs no change there. Then add `--waits <file>` to `tools/ci_headroom_report.py`, printing total seconds waited, number of waits, longest wait and its test, and the informed/degraded split; absent or empty file prints one line saying so, never zero. Extend `shakenfist/tests/test_ci_headroom_report.py` with a file of several waits, an empty file, an absent file and a file with a malformed line among good ones (which is skipped, counted and reported, not fatal). Finally D16: extend the prose above `HARNESS_DRIVEN_PAIRS` at `shakenfist/deploy/shakenfist_ci/load_budget.py:309` to name the wrapper as a second activity-coupled producer of `GetNodeMetrics`/`api`, and check `test_the_suite_still_probes_cluster_headroom` (`shakenfist/tests/test_database_tier_harness.py:374`) still passes -- it holds that prose up. No new budget entry. |
+| 2d | low | haiku | none | The two ride-alongs D17 allows, and no others. In `shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_imagefetch.py`, the first test pins both creates to `n`, an arbitrary first hypervisor (`:130-138`, `:152-160`): remove `inst1`'s `force_placement` entirely and change `inst2`'s to `inst1['node']`, which is what the test actually needs since the source URL is deleted between them. Leave the second test's `first`/`second` pins at `:222` and `:247` exactly as they are -- its comment says the second instance must land on a node which has *not* seen the image, so those pins are the assertion. In `cluster_ci_tests/test_system_namespace.py`, the instance created inline at `:27` is deleted at `:56`; add an `addCleanup` immediately after the create so a failure between the two does not strand a charged instance in the system namespace. Do **not** touch `test_commandline_artifacts.py`: `:182-190` already pins to `inst1['node']`, which is the shape the master plan asked for. |
+| 2e | medium | sonnet | none | Documentation. `docs/developer_guide/` is the home for how to write a functional test; find where it describes creating instances in the suite and say that `self.create_instance()` is the call, that a raw client call needs a `# raw-create:` marker and why, and what the 420 s deadline means for a test that is genuinely asking for more than the cloud has. Document the wait summary beside the headroom report's own documentation, including that it can be read from a downloaded bundle with `tools/ci_headroom_report.py --waits`. Do not touch `AGENTS.md` unless the `# raw-create:` marker counts as a convention an agent could not infer -- it does, so add one line there and no more. `ARCHITECTURE.md` does not change: no component boundary moves. |
+| 2f | low | haiku | none | The operator push, and the only step outside this repository. In `shakenfist/actions`, add to `tools/ci_headroom_collect.sh` an scp of `/srv/ci/traces/instance-waits.jsonl` beside the two it already fetches, and pass `--waits` to the report when the file is non-empty -- guarded by the same `grep -q -- '--waits' "${report}"` pattern the script already uses for `--census-limit`, because the report comes from the triggering component ref and may predate the flag. Nothing here may fail the job. This step depends on 2c having merged and nothing depends on it: the waits reach the bundle without it. |
+| 2g | low | haiku | none | Set the phase 2 row to `Complete` in the master plan's Execution table and in `docs/plans/index.md`, update the index arithmetic, then run `python3 tools/check-plan-status.py`. Only after 2a-2e are reviewed and merged, 2f is pushed or explicitly deferred, and a real CI run's bundle has been read with `tools/ci_headroom_report.py --waits` to confirm the summary is populated. Record that reading in an Outcome section, as phase 1 did. |
+
+The survey corrections that would otherwise have been a step here
+were made in the planning commit, per the note at the end of *What
+the survey found*.
+
+## Risks and mitigations
+
+* **The wrapper waits on the wrong quantity and stops early.** The
+  headline risk, and the reason for the high planning effort. It
+  fails silently: the create is retried, refuses again, and the run
+  looks like the status quo with extra latency. *Mitigation:* D8
+  writes the predicate against the ledger the guard reads, and 2a
+  requires a unit test for exactly the disagreement case plus a
+  confirmation that deleting the `cpu_limit` clause makes that test
+  fail. Mutation-checking an assertion that claims to prove a fix is
+  the standing lesson from a previous phase where five of seven
+  definition-of-done checks turned out not to test what they said.
+
+* **The wrapper hides a real capacity regression.** If the cloud is
+  genuinely too small, waiting turns a fast, loud failure into a slow
+  one, and the suite stops being a signal about sizing. *Mitigation:*
+  the wait summary is the signal instead, and it is strictly more
+  informative than the failure was -- but only if someone reads it.
+  The sizing plan's phase 5 guardrail is the intended reader, and D14
+  makes the data available from the bundle whether or not the job log
+  prints it. The 420 s deadline bounds the hiding.
+
+* **117 mechanical edits break a test in a way unit tests do not
+  see.** The suite is functional; nothing in `shakenfist/tests/`
+  executes these call sites. *Mitigation:* the edits are uniform and
+  the AST guard proves completeness rather than correctness; the real
+  check is a full CI run before 2g, which is why 2g requires one.
+
+* **The wait record fails the tests it is measuring.** A full disk,
+  an unwritable directory, a worker crash mid-line. *Mitigation:*
+  every write is swallowed, one line per wait so a partial line costs
+  one record, and the report skips and counts malformed lines rather
+  than failing on them (2c).
+
+* **The cross-repo step never happens.** `shakenfist/actions` needs
+  an operator push, which has stalled phases before. *Mitigation:*
+  D14 restructures the phase so nothing depends on it. 2f is the last
+  step and 2g accepts an explicit deferral.
+
+## Definition of done
+
+Falsifiable, in order:
+
+1. `BaseTestCase.create_instance()` exists and every one of the 117
+   `create_instance` call sites under `shakenfist/deploy/shakenfist_ci/`
+   either goes through it or carries a `# raw-create:` marker with a
+   non-empty reason. `grep -rn '\.create_instance(' shakenfist/deploy/shakenfist_ci/`
+   and the AST test agree on the count.
+2. The AST test fails when a raw call is added without a marker, and
+   fails when a marker is added with an empty reason. Both halves
+   confirmed by running them, not by reading them.
+3. A unit test asserts that a node publishing generous
+   `cpu_available` but a binding `cpu_limit - cpu_committed` does not
+   satisfy the wait predicate, and deleting the `cpu_limit` clause
+   from `wait_for_capacity()` makes that test fail.
+4. A unit test asserts that a target absent from `per_node`
+   continues the wait rather than raising, and that it proceeds when
+   the target appears.
+5. A unit test asserts that `total['capacity_degraded']` produces a
+   blind wait recorded as `mode: degraded`, and that an unpinned
+   create never consults `total['cpu_available']`.
+6. A unit test asserts a 409 affinity refusal is not retried.
+7. `retries.py` still imports nothing from the suite or from
+   `shakenfist_client`, and the tests which load it by path still
+   pass.
+8. `tools/ci_headroom_report.py --waits` prints the five figures in
+   D14 for a populated file, says so for an empty or absent one, and
+   counts rather than dies on a malformed line. Unit tests for all
+   four.
+9. A real CI bundle read with `--waits` shows a populated summary, or
+   shows zero waits with the run's own evidence that no create was
+   refused. Read from a downloaded artifact, as phase 1's item 9
+   ultimately was -- this is checkable from a worktree and is not to
+   be written off as operator-only.
+10. `test_imagefetch.py`'s first test has one pin, not two, and its
+    second test still has both. `test_system_namespace.py`'s inline
+    instance has an `addCleanup`. `test_commandline_artifacts.py` is
+    unchanged.
+11. The prose above `HARNESS_DRIVEN_PAIRS` names the wrapper, and
+    `test_the_suite_still_probes_cluster_headroom` passes.
+12. No document states the wait deadline as a number different from
+    `CLUSTER_HEADROOM_WAIT`, and none implies the wrapper makes
+    refusals rarer.
+13. `python3 tools/check-plan-status.py` passes and
+    `pre-commit run --all-files` passes.
+
+## What later phases inherit
+
+* A suite that survives a transient refusal, so a run's pass/fail
+  stops being a coin flip on sibling timing and phase 5's data is not
+  truncated by the runs that failed.
+* A per-wait record in every bundle, which is the input phase 5
+  decides the server-side-queue question from, and which the sizing
+  plan's phase 5 guardrail can read.
+* `wait_for_capacity()` with an injected poll, which phase 4's
+  client-side retry should match the semantics of rather than
+  reinvent -- the master plan's ordering puts phase 4 after this one
+  for exactly that reason.
+* A `# raw-create:` convention the sizing plan's phase 3 saturation
+  tests need in order to assert a refusal.
+
+## Back brief
+
+Before implementation begins, the implementer confirms in writing:
+
+* Which of D8's two halves they think is most likely to be wrong --
+  the `cpu_limit` clause or the per-node `max` -- and what they would
+  need to see to change it. This is the decision the phase rests on
+  and the one a reviewer should push back on.
+* That they have read `retries.py`'s docstring and understand why
+  `wait_for_capacity()` cannot import the client.
+* The exact call-site count they measured, before editing. If it is
+  not 117 across 41 files, the tree has moved and the survey needs
+  re-running before 2b starts.
+
+**Gate:** step 2b touches 41 files mechanically and is expensive to
+redo. It does not start until 2a has merged, or at minimum until
+`create_instance()`'s signature is agreed -- a signature change after
+2b means editing 117 call sites twice.

--- a/docs/plans/PLAN-transient-capacity-refusals.md
+++ b/docs/plans/PLAN-transient-capacity-refusals.md
@@ -498,7 +498,7 @@ spelling above is the one to write.
 | Phase | Plan | Status |
 |-------|------|--------|
 | 1. Close the warm-up window: reconcile when a hypervisor has metrics and no capacity row | [PLAN-transient-capacity-refusals-phase-01-warm-up.md](PLAN-transient-capacity-refusals-phase-01-warm-up.md) | Complete |
-| 2. The suite waits, and says so: an informed `create_instance` wrapper and a per-run wait summary | PLAN-transient-capacity-refusals-phase-02-suite-wait.md | Not started |
+| 2. The suite waits, and says so: an informed `create_instance` wrapper and a per-run wait summary | [PLAN-transient-capacity-refusals-phase-02-suite-wait.md](PLAN-transient-capacity-refusals-phase-02-suite-wait.md) | Not started |
 | 3. Publish metrics when the running-domain set changes | PLAN-transient-capacity-refusals-phase-03-metrics-on-change.md | Not started |
 | 4. `Retry-After` and a machine-readable transient refusal, with an opt-in client retry | PLAN-transient-capacity-refusals-phase-04-retry-after.md | Not started |
 | 5. Decide on server-side queued placement from the phase 2 data | PLAN-transient-capacity-refusals-phase-05-queue-decision.md | Not started |
@@ -585,12 +585,22 @@ brief gets wrong.
 
 Add `BaseTestCase.create_instance()` to
 `shakenfist/deploy/shakenfist_ci/base.py`, route every raw
-`test_client.create_instance(...)` call site in `cluster_ci_tests/`
-and `guest_ci_tests/` through it (there are 115 call sites across
-39 files; a list is a mechanical `grep`), and add a unit test in
+`test_client.create_instance(...)` call site in
+`shakenfist/deploy/shakenfist_ci/` through it (there are 117 call
+sites across 41 files; a list is a mechanical `grep`), and add a
+unit test in
 `shakenfist/tests/` that walks the suite's source with `ast` and
 fails on any raw call outside an explicit allowlist marker, the way
 `test_ci_claims_headroom.py` already asserts call sites by name.
+
+*Amended by the phase 2 survey: this section originally named only
+`cluster_ci_tests/` and `guest_ci_tests/`, which hold 88 of the
+calls. The 115 it quoted was a count over the whole of
+`shakenfist/deploy/shakenfist_ci/`, which today is 117 across 41
+files. The difference is `smoke_ci_tests/` (27 calls in 7 files),
+`base.py:1227` and `database_tier.py:275`. The smoke tier belongs in
+scope: it runs on the smallest cloud, where one sibling instance is
+the largest fraction of the cluster.*
 
 The wrapper: on `InsufficientResourcesException`, if the deadline
 (420 s, the claims suite's `CLUSTER_HEADROOM_WAIT`) has not passed,
@@ -607,6 +617,21 @@ unit-testable against a fake clock. Every wait is attached to the
 test as a detail: seconds waited, the node waited for, and the
 `per_node` headroom at the first refusal and at admission.
 
+*Amended by the phase 2 survey: both halves of the predicate above
+are wrong, and phase 2's D8 replaces them.
+`per_node[n]['cpu_available']` is derived from the live overcommit
+arithmetic (`scheduler.py:1086-1088`), not from the capacity row's
+`limit_cpus` that admission actually refuses against -- the endpoint
+publishes both precisely so a reader can see them disagree. And
+`total['cpu_available']` is a sum across nodes (`:1091-1093`) while
+an instance must fit on one, so it is satisfied by a cluster with a
+spare thread on each of ten nodes. `retry_while_transient` is also
+not reusable as written: it re-issues the request every 10 s, which
+here means a fresh refused create -- and each refused create builds
+an instance and error-deletes it -- and its module deliberately
+imports nothing from the suite so the unit tests can load it by
+path.*
+
 The run summary: total seconds waited, number of waits, longest
 wait and its test, written to the bundle beside the headroom
 probe's output and printed in the job log. The collection step is
@@ -614,6 +639,17 @@ in `shakenfist/actions` (the reusable `smoke-cluster` workflow),
 so this phase carries the same operator-push obligation the
 sizing plan's phase 1 did, and the summary is designed so that the
 sizing plan's phase 5 guardrail can read it.
+
+*Amended by the phase 2 survey: only the job-log print carries that
+obligation. `smoke-cluster.yml:212` creates `/srv/ci/traces` on the
+primary and chowns it to the base-image user, and the "Gather logs"
+step at `:550` scp's the whole directory into the artifact bundle;
+the suite runs on the primary as that user. So a file the suite
+writes there reaches the bundle with no change in
+`shakenfist/actions` at all, and the report can be run over a
+downloaded bundle -- which is how phase 1 ultimately verified its
+own definition-of-done item 9. Phase 2's D14 puts the cross-repo
+change last and lets nothing depend on it.*
 
 Budget the poll. `GET /admin/resources` reads `GetNodeMetrics` from
 the `api` caller, which is already in `HARNESS_DRIVEN_PAIRS`
@@ -633,6 +669,19 @@ And `test_system_namespace.py` subclasses `BaseTestCase` rather than
 the namespaced base, so a failure between its inline create and
 delete strands a charged instance in the system namespace for the
 rest of the run; give it an `addCleanup`.
+
+*Amended by the phase 2 survey: `test_commandline_artifacts.py`
+already has the shape asked for -- `:182-190` pins the second
+instance to `inst1['node']` and the first is not pinned at all --
+so there is nothing to change there. `test_imagefetch.py` has four
+pinned creates, not one. In its first test both (`:130`, `:152`)
+target an arbitrary first hypervisor, and since the source URL is
+deleted between them the second one's co-location is load-bearing:
+the first's pin comes out, the second's becomes `inst1['node']`. Its
+second test pins `first` and `second` deliberately, to place the
+second instance on a node which has not seen the image, and must be
+left alone. The `test_system_namespace.py` observation is correct as
+written.*
 
 The sizing plan's phase 3 saturation tests must call the raw client
 and assert the refusal; the allowlist marker exists for them.

--- a/shakenfist/deploy/shakenfist_ci/base.py
+++ b/shakenfist/deploy/shakenfist_ci/base.py
@@ -314,6 +314,15 @@ class BaseTestCase(testtools.TestCase):
         client = client or self.test_client
         deadline = self._now() + CLUSTER_HEADROOM_WAIT
         disk_gb = retries.requested_disk_gb(disk)
+        # Resolved lazily and then remembered: once per create that is
+        # actually refused, never for one that is not. Almost every
+        # create in a run succeeds first time, and making each of them
+        # pay a GET /nodes to answer a question no one asked would put
+        # a node listing behind every instance the suite builds. The
+        # mapping cannot change usefully within one create, so once is
+        # also enough for a create which is refused repeatedly.
+        roster_key = None
+        roster_key_resolved = None
 
         attempts = 0
         waits = []
@@ -364,14 +373,24 @@ class BaseTestCase(testtools.TestCase):
             # cannot see what is being refused, and an unpaced loop there
             # spins until the deadline leaving an error-deleted instance
             # behind on every turn.
+            if roster_key_resolved is None:
+                roster_key, roster_key_resolved = self._placement_roster_key(
+                    force_placement)
+
             wait = retries.wait_for_capacity(
                 self.system_client.get_cluster_resources, cpus, memory,
-                disk_gb, force_placement, deadline,
+                disk_gb, roster_key, deadline,
                 clock=self._now, sleep=self._sleep,
                 interval=CAPACITY_POLL_INTERVAL,
-                minimum_sleep=0 if attempts == 1 else CAPACITY_POLL_INTERVAL)
+                minimum_sleep=0 if attempts == 1 else CAPACITY_POLL_INTERVAL,
+                blind=not roster_key_resolved)
             wait['instance_name'] = name
             wait['attempt'] = attempts
+            # Both, because they are different facts and a reader of the
+            # trace needs each: what the test asked for, and which roster
+            # entry the wait actually watched.
+            wait['pinned_to'] = force_placement
+            wait['roster_key'] = roster_key
             waits.append(wait)
             self._record_capacity_wait(wait)
 
@@ -438,7 +457,12 @@ class BaseTestCase(testtools.TestCase):
             record = {
                 'test_id': self.id(),
                 'instance_name': wait.get('instance_name'),
-                'node': wait.get('node'),
+                # What the test asked for, which is what a person reading
+                # the bundle recognises. The roster is keyed by uuid, so
+                # the entry actually watched is recorded beside it rather
+                # than in place of it -- see _placement_roster_key().
+                'node': wait.get('pinned_to'),
+                'roster_key': wait.get('roster_key'),
                 'cpus': wait.get('cpus'),
                 'memory_mb': wait.get('memory_mb'),
                 'disk_gb': wait.get('disk_gb'),
@@ -470,8 +494,8 @@ class BaseTestCase(testtools.TestCase):
         waited = sum(wait.get('seconds_waited', 0) for wait in waits)
         self.fail(
             'Creating instance %s (%d cpus, %s) was refused for insufficient '
-            'resources and the cluster did not free enough within %ds. '
-            '%d attempts, %.1fs waited.\n\n'
+            'resources and the cluster did not free enough before its '
+            '%ds deadline. %d attempts, %.1fs waited.\n\n'
             '%s'
             'The last refusal was:\n%s\n\n'
             'The node waited for was: %s\n\n'
@@ -570,6 +594,51 @@ class BaseTestCase(testtools.TestCase):
     def _get_cluster_nodes(self):
         """Return the cluster's nodes as reported by the API."""
         return self.system_client.get_nodes()
+
+    def _placement_roster_key(self, force_placement):
+        """Which /admin/resources per_node key this pin refers to.
+
+        Returns a (key, resolved) pair. per_node is keyed by node UUID --
+        summarize_resources() builds it from the metrics dict, which
+        get_active_node_metrics() keys by str(n.uuid) and says so in a
+        comment (scheduler.py) -- while force_placement is almost always
+        a node *name*: 'sf-2' in test_networking.py, node['name'] in
+        test_nodes.py and test_placement.py, socket.getfqdn() in
+        test_instance_placement.py.
+
+        Handing the name straight to the wait made per_node.get(target)
+        miss on every poll, so the target read as zero headroom in every
+        dimension and no dimension was ever recorded as binding. The wait
+        could then never be satisfied however empty the cluster was: one
+        transient 507 on a name-pinned create became a guaranteed
+        CLUSTER_HEADROOM_WAIT failure, whose message said there was room
+        everywhere and so pointed at the predicate rather than at the pin.
+
+        A pin which is already a UUID is passed through. An unresolvable
+        pin returns (None, False), which the caller waits blind on rather
+        than reading as a node with no room -- not knowing which entry to
+        read is not evidence that the entry is empty.
+        """
+        if not force_placement:
+            return None, True
+
+        try:
+            nodes = self._get_cluster_nodes()
+        except Exception as e:
+            # Listing nodes is not this method's job to insist on. A
+            # failure here is the same kind of ignorance as a name which
+            # does not resolve, and is reported the same way.
+            LOG.info('Could not list nodes to resolve the pin %s: %s'
+                     % (force_placement, e))
+            return None, False
+
+        for n in nodes:
+            if force_placement in (n.get('uuid'), n.get('name')):
+                return n.get('uuid'), True
+
+        LOG.info('The pin %s matched no node, so its wait is blind'
+                 % force_placement)
+        return None, False
 
     def _network_node(self):
         """Return the node dict for the cluster's network node, or None."""

--- a/shakenfist/deploy/shakenfist_ci/base.py
+++ b/shakenfist/deploy/shakenfist_ci/base.py
@@ -222,6 +222,24 @@ class BaseTestCase(testtools.TestCase):
     def _uniquifier(self):
         return ''.join(random.choice(string.ascii_lowercase) for i in range(8))
 
+    def _now(self):
+        """The wall clock, as a seam a unit test can script.
+
+        create_instance()'s deadline arithmetic reads this rather than
+        calling time.time() directly, so a test can move the clock past
+        the deadline without patching the process-wide one. Patching it
+        is not an option here, and the reason is worth writing down
+        because it cost a red CI run: this method logs between two of
+        its own clock reads, and on Python 3.11 logging.LogRecord reads
+        time.time() once per record, so a scripted sequence sized for
+        the reads below is silently consumed by that log line and the
+        next read raises StopIteration. Python 3.13 reads time.time_ns()
+        instead and does not consume it, so the same test passes on a
+        3.13 workstation and fails on CI's 3.11 -- which looks like
+        flakiness and reads like a bug in this method.
+        """
+        return time.time()
+
     def create_instance(self, name, cpus, memory, network, disk, sshkey,
                         userdata, *, client=None, force_placement=None,
                         **kwargs):
@@ -260,7 +278,7 @@ class BaseTestCase(testtools.TestCase):
         # on a class without one has to say which client it means, and
         # the AttributeError says so.
         client = client or self.test_client
-        deadline = time.time() + CLUSTER_HEADROOM_WAIT
+        deadline = self._now() + CLUSTER_HEADROOM_WAIT
 
         attempts = 0
         waits = []
@@ -287,7 +305,7 @@ class BaseTestCase(testtools.TestCase):
             except apiclient.InsufficientResourcesException as e:
                 refusal = e
 
-            if time.time() > deadline:
+            if self._now() > deadline:
                 self._fail_capacity_wait(
                     name, cpus, force_placement, refusal, waits, attempts)
 
@@ -300,7 +318,7 @@ class BaseTestCase(testtools.TestCase):
             waits.append(wait)
             self._record_capacity_wait(wait)
 
-            if not wait['satisfied'] and time.time() > deadline:
+            if not wait['satisfied'] and self._now() > deadline:
                 self._fail_capacity_wait(
                     name, cpus, force_placement, refusal, waits, attempts)
 

--- a/shakenfist/deploy/shakenfist_ci/base.py
+++ b/shakenfist/deploy/shakenfist_ci/base.py
@@ -17,6 +17,7 @@ from prettytable import PrettyTable
 from shakenfist_client import apiclient
 
 from shakenfist_ci import process
+from shakenfist_ci import retries
 
 
 logging.basicConfig(level=logging.INFO, format='%(message)s')
@@ -25,6 +26,25 @@ TRACE_PATH = '/srv/ci/traces'
 
 
 CLUSTER_CI_IMAGE = 'sf://upload/system/debian-12'
+
+
+# How long create_instance() waits out a capacity refusal before failing
+# the test with it. The same number, for the same reason, as
+# cluster_ci_tests/test_namespace_claims.py's CLUSTER_HEADROOM_WAIT: the
+# capacity a create needs is usually being held by a sibling test which
+# is already deleting it, and deletion returns capacity asynchronously.
+# Comfortably longer than any sibling test holds its instances, far
+# shorter than the job timeout.
+#
+# This does not make refusals rarer. It makes them survivable, and each
+# wait is recorded so that a run which spent its time waiting says so.
+CLUSTER_HEADROOM_WAIT = 420
+
+# How often to re-read /admin/resources while waiting. The poll is
+# activity-coupled: it runs only while a create is being retried, so it
+# adds nothing to an idle cluster and adds load in proportion to how
+# full the cluster already is.
+CAPACITY_POLL_INTERVAL = 10
 
 
 # await_agent_command() and await_agent_fetch() can raise three unrelated
@@ -192,6 +212,134 @@ class BaseTestCase(testtools.TestCase):
 
     def _uniquifier(self):
         return ''.join(random.choice(string.ascii_lowercase) for i in range(8))
+
+    def create_instance(self, name, cpus, memory, network, disk, sshkey,
+                        userdata, *, client=None, force_placement=None,
+                        **kwargs):
+        """Create an instance, waiting out a transient capacity refusal.
+
+        Every create in this suite goes through here. A 507 in CI is
+        usually a statement about a moment rather than about the
+        cluster: the instance the refusing node is holding is very
+        often already being deleted by a sibling test, and deletion
+        returns its capacity asynchronously. Failing the test on that
+        makes a run's pass/fail a coin flip on sibling timing.
+
+        So a 507 is waited out for up to CLUSTER_HEADROOM_WAIT, and
+        only a 507 -- see retries.wait_for_capacity() for what "there
+        is room now" is read against. In particular the 409 from an
+        unsatisfiable affinity constraint is not caught here. Server
+        side that refusal is raised by a *subclass* of the low resource
+        exception and is kept distinct only by the ordering of two
+        except clauses (external_api/instance.py); an affinity
+        constraint does not become satisfiable by waiting, and
+        catching the family rather than the exact capacity exception
+        would turn a clear failure into a seven minute one.
+
+        Arguments are the client's, plus two:
+
+        * client -- which client to create as. Defaults to
+          self.test_client, which is what almost every caller wants; a
+          test creating in another namespace passes its own.
+        * force_placement is named explicitly rather than left in
+          kwargs because it is also the node the wait watches.
+
+        Everything else is forwarded to the client untouched, so this
+        wrapper does not have to track the client's defaults.
+        """
+        # self.test_client is set up by BaseNamespacedTestCase. A caller
+        # on a class without one has to say which client it means, and
+        # the AttributeError says so.
+        client = client or self.test_client
+        deadline = time.time() + CLUSTER_HEADROOM_WAIT
+
+        attempts = 0
+        waits = []
+        while True:
+            attempts += 1
+            if attempts == 1:
+                attempt_name = name
+            else:
+                # The refused instance was created and then
+                # enqueue_delete_due_error'd, so the name the caller
+                # chose stays in use until that delete completes. Retry
+                # under a fresh one; the caller only ever learns of it
+                # from a failure message or a wait record, both of
+                # which state it.
+                attempt_name = '%s-%s' % (name, self._uniquifier())
+
+            try:
+                # raw-create: this is the wrapper itself, and is the one
+                # place in the suite which has to issue the create.
+                return client.create_instance(
+                    attempt_name, cpus, memory, network, disk, sshkey,
+                    userdata, force_placement=force_placement, **kwargs)
+
+            except apiclient.InsufficientResourcesException as e:
+                refusal = e
+
+            if time.time() > deadline:
+                self._fail_capacity_wait(
+                    name, cpus, force_placement, refusal, waits, attempts)
+
+            wait = retries.wait_for_capacity(
+                self.system_client.get_cluster_resources, cpus,
+                force_placement, deadline,
+                interval=CAPACITY_POLL_INTERVAL)
+            wait['instance_name'] = name
+            wait['attempt'] = attempts
+            waits.append(wait)
+            self._record_capacity_wait(wait)
+
+            if not wait['satisfied'] and time.time() > deadline:
+                self._fail_capacity_wait(
+                    name, cpus, force_placement, refusal, waits, attempts)
+
+    def _record_capacity_wait(self, wait):
+        """Say that a create waited, and for how long.
+
+        An instrument may never fail the thing it measures, so nothing
+        here is allowed to raise into the test.
+        """
+        try:
+            self._capacity_waits = getattr(self, '_capacity_waits', 0) + 1
+            self.addDetail(
+                'capacity-wait-%d' % self._capacity_waits,
+                content.text_content(
+                    json.dumps(wait, indent=4, sort_keys=True, default=str)))
+            LOG.info(
+                'Creating %s waited %.1fs for capacity on %s (%s, headroom '
+                '%s -> %s)'
+                % (wait.get('instance_name'), wait.get('seconds_waited', 0),
+                   wait.get('node') or 'any node', wait.get('mode'),
+                   wait.get('headroom_at_start'), wait.get('headroom_at_end')))
+        except Exception as e:
+            LOG.info('Failed to record a capacity wait: %s' % e)
+
+    def _fail_capacity_wait(self, name, cpus, node, refusal, waits, attempts):
+        roster = None
+        errors = []
+        for wait in waits:
+            if wait.get('per_node') is not None:
+                roster = wait['per_node']
+            errors.extend(wait.get('poll_errors', []))
+
+        waited = sum(wait.get('seconds_waited', 0) for wait in waits)
+        self.fail(
+            'Creating instance %s (%d cpus, %s) was refused for insufficient '
+            'resources and the cluster did not free enough within %ds. '
+            '%d attempts, %.1fs waited.\n\n'
+            'The last refusal was:\n%s\n\n'
+            'The node waited for was: %s\n\n'
+            'The resource roster at the last successful poll was:\n%s\n\n'
+            'Polls which failed:\n%s'
+            % (name, cpus,
+               'pinned to %s' % node if node else 'unpinned',
+               CLUSTER_HEADROOM_WAIT, attempts, waited,
+               getattr(refusal, 'text', None) or str(refusal),
+               node or '(unpinned, any node would have done)',
+               json.dumps(roster, indent=4, sort_keys=True, default=str),
+               '\n'.join(errors) or '(none)'))
 
     def _emit_tracing_event(self, event):
         # This method implements a simple tracing scheme to help work out what

--- a/shakenfist/deploy/shakenfist_ci/base.py
+++ b/shakenfist/deploy/shakenfist_ci/base.py
@@ -1372,7 +1372,7 @@ class TestDistroBoots(BaseNamespacedTestCase):
         self._await_networks_ready([self.net['uuid']])
 
     def _test_distro_boot(self, base_image):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             base_image.replace(':', '-').replace('.', ''), 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/base.py
+++ b/shakenfist/deploy/shakenfist_ci/base.py
@@ -24,6 +24,15 @@ logging.basicConfig(level=logging.INFO, format='%(message)s')
 LOG = logging.getLogger()
 TRACE_PATH = '/srv/ci/traces'
 
+# One JSON object per capacity wait, appended as a line by
+# _append_capacity_wait_trace() below (D14). smoke-cluster.yml:212 in
+# shakenfist/actions creates TRACE_PATH on the primary and chowns it to the
+# base image user before the suite runs, and :550 scp's the whole directory
+# into the artifact bundle, so this file reaches the bundle with no change
+# needed there. A module-level constant so the path is greppable and
+# overridable (a test points it at a tempdir rather than the real path).
+CAPACITY_WAIT_TRACE_FILE = os.path.join(TRACE_PATH, 'instance-waits.jsonl')
+
 
 CLUSTER_CI_IMAGE = 'sf://upload/system/debian-12'
 
@@ -299,8 +308,12 @@ class BaseTestCase(testtools.TestCase):
         """Say that a create waited, and for how long.
 
         An instrument may never fail the thing it measures, so nothing
-        here is allowed to raise into the test.
+        here is allowed to raise into the test. This is also the seam
+        step 2c hooks the CI bundle's JSONL record into -- see
+        _append_capacity_wait_trace() below.
         """
+        self._append_capacity_wait_trace(wait)
+
         try:
             self._capacity_waits = getattr(self, '_capacity_waits', 0) + 1
             self.addDetail(
@@ -315,6 +328,45 @@ class BaseTestCase(testtools.TestCase):
                    wait.get('headroom_at_start'), wait.get('headroom_at_end')))
         except Exception as e:
             LOG.info('Failed to record a capacity wait: %s' % e)
+
+    def _append_capacity_wait_trace(self, wait):
+        """Append one line describing this wait to CAPACITY_WAIT_TRACE_FILE.
+
+        One line per wait, not per run (D14): concurrent stestr workers
+        never have to agree on anything, because the file is opened 'a' and
+        each write is one line, and a worker which crashes mid-wait loses
+        at most its own in-flight line.
+
+        Most of the record is read straight off ``wait``, the dict
+        wait_for_capacity() returns -- 'node', 'cpus', 'mode',
+        'seconds_waited', 'headroom_at_start' and 'headroom_at_end', plus
+        'instance_name' and 'attempt' which create_instance() adds before
+        calling here. The one field with no source in that dict is the test
+        id, which only BaseTestCase knows, via self.id().
+
+        Every failure here is swallowed. An instrument may never fail the
+        thing it measures, for the same reason ci_headroom_collect.sh's
+        header gives for never failing a job, and step 2a already
+        established this property for the caller above -- this must not
+        weaken it.
+        """
+        try:
+            record = {
+                'test_id': self.id(),
+                'instance_name': wait.get('instance_name'),
+                'node': wait.get('node'),
+                'cpus': wait.get('cpus'),
+                'seconds_waited': wait.get('seconds_waited'),
+                'mode': wait.get('mode'),
+                'attempts': wait.get('attempt'),
+                'headroom_at_first_refusal': wait.get('headroom_at_start'),
+                'headroom_at_admission': wait.get('headroom_at_end'),
+            }
+            with open(CAPACITY_WAIT_TRACE_FILE, 'a') as f:
+                f.write(json.dumps(record, sort_keys=True, default=str))
+                f.write('\n')
+        except Exception as e:
+            LOG.info('Failed to append a capacity wait trace: %s' % e)
 
     def _fail_capacity_wait(self, name, cpus, node, refusal, waits, attempts):
         roster = None

--- a/shakenfist/deploy/shakenfist_ci/base.py
+++ b/shakenfist/deploy/shakenfist_ci/base.py
@@ -38,10 +38,12 @@ CLUSTER_CI_IMAGE = 'sf://upload/system/debian-12'
 
 
 # How long create_instance() waits out a capacity refusal before failing
-# the test with it. The same number, for the same reason, as
-# cluster_ci_tests/test_namespace_claims.py's CLUSTER_HEADROOM_WAIT: the
-# capacity a create needs is usually being held by a sibling test which
-# is already deleting it, and deletion returns capacity asynchronously.
+# the test with it: the capacity a create needs is usually being held by
+# a sibling test which is already deleting it, and deletion returns
+# capacity asynchronously. This is the single definition --
+# cluster_ci_tests/test_namespace_claims.py retries a refused claim
+# request for the same span and for the same reason, and imports it from
+# here rather than keeping a second copy of the number.
 # Comfortably longer than any sibling test holds its instances, far
 # shorter than the job timeout.
 #
@@ -54,6 +56,27 @@ CLUSTER_HEADROOM_WAIT = 420
 # adds nothing to an idle cluster and adds load in proportion to how
 # full the cluster already is.
 CAPACITY_POLL_INTERVAL = 10
+
+# A ceiling on how many creates one wrapped call may issue. The pacing
+# floor create_instance() passes to wait_for_capacity() already bounds
+# the loop at about one attempt per poll interval, so this should never
+# be what stops it -- but the bound is derived from two other constants
+# and a predicate's behaviour, and a create which is refused for a
+# reason the predicate cannot see is exactly the case where derived
+# reasoning is least trustworthy. Each attempt leaves an error-deleted
+# instance behind, so the failure mode this closes is expensive.
+MAX_CREATE_ATTEMPTS = CLUSTER_HEADROOM_WAIT // CAPACITY_POLL_INTERVAL + 2
+
+# external_api/instance.py rejects an instance name longer than 63
+# characters, or one which is not a valid hostname, with a 400. A retry
+# appends '-' and an 8 character uniquifier, so a base name is trimmed
+# to leave room for that: otherwise a caller near the limit sees its
+# capacity retry come back as a RequestMalformedException which escapes
+# this wrapper and reads as an unrelated failure. No current caller is
+# close, but TestDistroBoots builds its name from a base image name, so
+# the length is not entirely under the suite's control.
+MAX_INSTANCE_NAME_LENGTH = 63
+RETRY_SUFFIX_LENGTH = 9
 
 
 # await_agent_command() and await_agent_fetch() can raise three unrelated
@@ -240,6 +263,17 @@ class BaseTestCase(testtools.TestCase):
         """
         return time.time()
 
+    def _sleep(self, seconds):
+        """The sleep create_instance()'s wait uses, as a seam.
+
+        Beside _now(), and there for the same reason: a unit test which
+        drives the whole wrapper loop against the real
+        retries.wait_for_capacity() -- rather than against a canned wait
+        record -- would otherwise take the deadline in wall clock time to
+        assert anything at all.
+        """
+        time.sleep(seconds)
+
     def create_instance(self, name, cpus, memory, network, disk, sshkey,
                         userdata, *, client=None, force_placement=None,
                         **kwargs):
@@ -279,6 +313,7 @@ class BaseTestCase(testtools.TestCase):
         # the AttributeError says so.
         client = client or self.test_client
         deadline = self._now() + CLUSTER_HEADROOM_WAIT
+        disk_gb = retries.requested_disk_gb(disk)
 
         attempts = 0
         waits = []
@@ -293,7 +328,9 @@ class BaseTestCase(testtools.TestCase):
                 # under a fresh one; the caller only ever learns of it
                 # from a failure message or a wait record, both of
                 # which state it.
-                attempt_name = '%s-%s' % (name, self._uniquifier())
+                attempt_name = '%s-%s' % (
+                    name[:MAX_INSTANCE_NAME_LENGTH - RETRY_SUFFIX_LENGTH],
+                    self._uniquifier())
 
             try:
                 # raw-create: this is the wrapper itself, and is the one
@@ -309,10 +346,30 @@ class BaseTestCase(testtools.TestCase):
                 self._fail_capacity_wait(
                     name, cpus, force_placement, refusal, waits, attempts)
 
+            if attempts >= MAX_CREATE_ATTEMPTS:
+                self._fail_capacity_wait(
+                    name, cpus, force_placement, refusal, waits, attempts,
+                    reason='The attempt ceiling (%d) was reached before the '
+                           'deadline was, which means the wait kept reporting '
+                           'capacity the create was then refused for anyway. '
+                           'The refusal is for something the predicate cannot '
+                           'see -- see retries.wait_for_capacity().'
+                           % MAX_CREATE_ATTEMPTS)
+
+            # The first wait may hand control straight back: capacity
+            # returned between the refusal and the poll is the common
+            # case, and sleeping on it would add an interval to every
+            # refusal in the run. Every wait after that is paced, because
+            # a second refusal after a satisfied wait means the predicate
+            # cannot see what is being refused, and an unpaced loop there
+            # spins until the deadline leaving an error-deleted instance
+            # behind on every turn.
             wait = retries.wait_for_capacity(
-                self.system_client.get_cluster_resources, cpus,
-                force_placement, deadline,
-                interval=CAPACITY_POLL_INTERVAL)
+                self.system_client.get_cluster_resources, cpus, memory,
+                disk_gb, force_placement, deadline,
+                clock=self._now, sleep=self._sleep,
+                interval=CAPACITY_POLL_INTERVAL,
+                minimum_sleep=0 if attempts == 1 else CAPACITY_POLL_INTERVAL)
             wait['instance_name'] = name
             wait['attempt'] = attempts
             waits.append(wait)
@@ -339,9 +396,10 @@ class BaseTestCase(testtools.TestCase):
                 content.text_content(
                     json.dumps(wait, indent=4, sort_keys=True, default=str)))
             LOG.info(
-                'Creating %s waited %.1fs for capacity on %s (%s, headroom '
-                '%s -> %s)'
+                'Creating %s waited %.1fs for %s capacity on %s (%s, '
+                'headroom %s -> %s)'
                 % (wait.get('instance_name'), wait.get('seconds_waited', 0),
+                   wait.get('binding_dimension') or 'no dimension of',
                    wait.get('node') or 'any node', wait.get('mode'),
                    wait.get('headroom_at_start'), wait.get('headroom_at_end')))
         except Exception as e:
@@ -356,11 +414,19 @@ class BaseTestCase(testtools.TestCase):
         at most its own in-flight line.
 
         Most of the record is read straight off ``wait``, the dict
-        wait_for_capacity() returns -- 'node', 'cpus', 'mode',
-        'seconds_waited', 'headroom_at_start' and 'headroom_at_end', plus
-        'instance_name' and 'attempt' which create_instance() adds before
-        calling here. The one field with no source in that dict is the test
-        id, which only BaseTestCase knows, via self.id().
+        wait_for_capacity() returns -- 'node', the three request
+        dimensions, 'binding_dimension', 'mode', 'seconds_waited',
+        'headroom_at_start' and 'headroom_at_end' -- plus 'instance_name'
+        and 'attempt' which create_instance() adds before calling here.
+        The one field with no source in that dict is the test id, which
+        only BaseTestCase knows, via self.id().
+
+        'attempt' is written out as 'attempt_number' rather than
+        'attempts', because it is a 1-indexed position and not a count: a
+        create refused three times writes three lines carrying 1, 2 and 3,
+        and a reader who summed a field called 'attempts' would get six.
+        The headroom fields are dicts keyed by dimension, for the same
+        reason wait_for_capacity() models three of them.
 
         Every failure here is swallowed. An instrument may never fail the
         thing it measures, for the same reason ci_headroom_collect.sh's
@@ -374,9 +440,12 @@ class BaseTestCase(testtools.TestCase):
                 'instance_name': wait.get('instance_name'),
                 'node': wait.get('node'),
                 'cpus': wait.get('cpus'),
+                'memory_mb': wait.get('memory_mb'),
+                'disk_gb': wait.get('disk_gb'),
+                'binding_dimension': wait.get('binding_dimension'),
                 'seconds_waited': wait.get('seconds_waited'),
                 'mode': wait.get('mode'),
-                'attempts': wait.get('attempt'),
+                'attempt_number': wait.get('attempt'),
                 'headroom_at_first_refusal': wait.get('headroom_at_start'),
                 'headroom_at_admission': wait.get('headroom_at_end'),
             }
@@ -386,28 +455,37 @@ class BaseTestCase(testtools.TestCase):
         except Exception as e:
             LOG.info('Failed to append a capacity wait trace: %s' % e)
 
-    def _fail_capacity_wait(self, name, cpus, node, refusal, waits, attempts):
+    def _fail_capacity_wait(self, name, cpus, node, refusal, waits, attempts,
+                            reason=None):
         roster = None
         errors = []
+        bindings = []
         for wait in waits:
             if wait.get('per_node') is not None:
                 roster = wait['per_node']
             errors.extend(wait.get('poll_errors', []))
+            if wait.get('binding_dimension'):
+                bindings.append(wait['binding_dimension'])
 
         waited = sum(wait.get('seconds_waited', 0) for wait in waits)
         self.fail(
             'Creating instance %s (%d cpus, %s) was refused for insufficient '
             'resources and the cluster did not free enough within %ds. '
             '%d attempts, %.1fs waited.\n\n'
+            '%s'
             'The last refusal was:\n%s\n\n'
             'The node waited for was: %s\n\n'
+            'What the waits were short of: %s\n\n'
             'The resource roster at the last successful poll was:\n%s\n\n'
             'Polls which failed:\n%s'
             % (name, cpus,
                'pinned to %s' % node if node else 'unpinned',
                CLUSTER_HEADROOM_WAIT, attempts, waited,
+               '%s\n\n' % reason if reason else '',
                getattr(refusal, 'text', None) or str(refusal),
                node or '(unpinned, any node would have done)',
+               ', '.join(sorted(set(bindings))) or
+               '(nothing -- every wait said there was room)',
                json.dumps(roster, indent=4, sort_keys=True, default=str),
                '\n'.join(errors) or '(none)'))
 

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_api_validation.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_api_validation.py
@@ -107,7 +107,7 @@ class TestNamespaceBodyParameterStillWorks(base.BaseNamespacedTestCase):
 
     def test_get_instance_with_namespace_body_parameter(self):
         minimal_disk = [{'size': 1, 'type': 'disk'}]
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'namespace-body-param', 1, 128, None, minimal_disk, None, None,
             namespace=self.namespace)
         self.addDetail(

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_artifacts.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_artifacts.py
@@ -69,7 +69,7 @@ class TestImages(base.BaseNamespacedTestCase):
 
     def test_instance_invalid_image(self):
         # Start our test instance
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'nosuch', 1, 1024,
             [
                 {
@@ -94,7 +94,7 @@ class TestImages(base.BaseNamespacedTestCase):
         self.assertEqual('error', i['state'])
 
     def test_resize_image_too_small(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'resizetoosmall', 2, 2048,
             [],
             [

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_artifacts.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_artifacts.py
@@ -521,6 +521,8 @@ class TestTypoedLabel(base.BaseNamespacedTestCase):
 
     def test_typo_is_error(self):
         self.assertRaises(apiclient.ResourceNotFoundException,
+                          # raw-create: asserts the 404 a label which does not exist gets,
+                          # which no amount of waiting for capacity turns into a success.
                           self.test_client.create_instance,
                           'typoedlabel', 1, 1024, None,
                           [

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_coalescing.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_coalescing.py
@@ -133,7 +133,7 @@ class TestCoalescing(base.BaseNamespacedTestCase):
     def test_duplicate_network_work_is_coalesced(self):
         instances = []
         for i in range(BURST):
-            instances.append(self.burst_client.create_instance(
+            instances.append(self.create_instance(
                 'coalesce-%d' % i, 1, 1024,
                 [
                     {
@@ -146,7 +146,7 @@ class TestCoalescing(base.BaseNamespacedTestCase):
                         'base': base.CLUSTER_CI_IMAGE,
                         'type': 'disk'
                     }
-                ], None, None))
+                ], None, None, client=self.burst_client))
 
         self.addDetail('instances', content.text_content(json.dumps(
             [i['uuid'] for i in instances], indent=4, sort_keys=True)))
@@ -474,6 +474,13 @@ class TestCoalescing(base.BaseNamespacedTestCase):
         for i in range(BURST):
             target = hypervisors[i % len(hypervisors)]
             try:
+                # raw-create: this burst deliberately tolerates a
+                # capacity refusal and records it, as the except clause
+                # below says, so it must see the 507 rather than have it
+                # waited out. Waiting would also serialise a burst whose
+                # simultaneity is the thing under test, and the wrapper's
+                # deadline failure is not an APIException, so it would
+                # not reach that clause at all.
                 instances.append(self.burst_client.create_instance(
                     'mesh-coalesce-%d' % i, 1, 1024,
                     [

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_coalescing.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_coalescing.py
@@ -133,7 +133,16 @@ class TestCoalescing(base.BaseNamespacedTestCase):
     def test_duplicate_network_work_is_coalesced(self):
         instances = []
         for i in range(BURST):
-            instances.append(self.create_instance(
+            # raw-create: the same reasoning as the mesh burst below.
+            # setUp built burst_client precisely so this loop does not
+            # pause between creates -- its comment says a pausing client
+            # 'would serialise the burst below into six sequential
+            # instance creates and leave nothing to coalesce' -- and a
+            # waited-out refusal would inject up to CLUSTER_HEADROOM_WAIT
+            # between two creates of a burst whose simultaneity is the
+            # thing under test. Passing the non-pausing client to a
+            # wrapper which pauses would have taken the pause back.
+            instances.append(self.burst_client.create_instance(
                 'coalesce-%d' % i, 1, 1024,
                 [
                     {
@@ -146,7 +155,7 @@ class TestCoalescing(base.BaseNamespacedTestCase):
                         'base': base.CLUSTER_CI_IMAGE,
                         'type': 'disk'
                     }
-                ], None, None, client=self.burst_client))
+                ], None, None))
 
         self.addDetail('instances', content.text_content(json.dumps(
             [i['uuid'] for i in instances], indent=4, sort_keys=True)))

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_commandline_artifacts.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_commandline_artifacts.py
@@ -136,7 +136,7 @@ class TestArtifactCommandLine(base.BaseNamespacedTestCase):
         # output from the command line client is JSON not a python dict.
 
         # Create an instance
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-artifact-show', 1, 1024, None,
             [
                 {
@@ -179,7 +179,7 @@ class TestArtifactCommandLine(base.BaseNamespacedTestCase):
         self.assertEqual(0, len(show_info['blobs']['1']['instances']))
 
         # Start an instance on the snapshot
-        inst2 = self.test_client.create_instance(
+        inst2 = self.create_instance(
             'test-cirros-boot-no-network', 1, 1024, None,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_console_log.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_console_log.py
@@ -23,7 +23,7 @@ class TestConsoleLog(base.BaseNamespacedTestCase):
 
     def test_console_log(self):
         # Start our test instance
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-console', 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_disk_specs.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_disk_specs.py
@@ -12,7 +12,7 @@ class TestDiskSpecifications(base.BaseNamespacedTestCase):
         super().__init__(*args, **kwargs)
 
     def test_default(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-default-disk', 1, 1024, None,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_disk_specs.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_disk_specs.py
@@ -39,6 +39,8 @@ class TestDiskSpecifications(base.BaseNamespacedTestCase):
     def test_bad_bus(self):
         self.assertRaises(
             apiclient.RequestMalformedException,
+            # raw-create: asserts the 400 a malformed disk bus gets, which is
+            # raised validating the request long before the scheduler runs.
             self.test_client.create_instance,
             'test-bad-bus-disk', 1, 1024, None,
             [

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_events.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_events.py
@@ -44,7 +44,7 @@ class TestEvents(base.BaseNamespacedTestCase):
         self.assertNotEqual(0, len(events))
 
     def test_instance_events(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-instance-events', 1, 1024,
             [
                 {
@@ -105,7 +105,7 @@ class TestEvents(base.BaseNamespacedTestCase):
         generated as a mutate event, which is the only view of that from
         outside the hypervisor.
         """
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-instance-domain-xml', 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_floating_ips.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_floating_ips.py
@@ -34,7 +34,7 @@ sudo chmod ugo+rw /var/www/html/index.html
 echo 'Floating IPs work!' > /var/www/html/index.html
 """
 
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'floating', 1, 1024,
             [
                 {
@@ -233,7 +233,7 @@ class TestFloatingIPLifecycle(base.BaseNamespacedTestCase):
         # guest -- the reachability ping. Floating and its host-side plumbing
         # live entirely on the network node, so callers that only assert
         # plumbing can wait for the cheaper 'created' state instead.
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'floatlifecycle', 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_imagefetch.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_imagefetch.py
@@ -109,14 +109,6 @@ class TestHTTPFetch(base.BaseNamespacedTestCase):
         self.assertEqual('created', img['state'])
 
     def test_disappearing_source_instance(self):
-        nodes = self.system_client.get_nodes()
-        self.addDetail('nodes', content.text_content(json.dumps(
-            nodes, indent=4, sort_keys=True)))
-        for n in nodes:
-            if n['is_hypervisor']:
-                break
-        n = n['name']
-
         p = subprocess.run(
             ['sudo /srv/shakenfist/venv/bin/sf-client '
              'artifact download debian-12 '
@@ -127,7 +119,7 @@ class TestHTTPFetch(base.BaseNamespacedTestCase):
             f'Command failed:\n\tstdout = {p.stdout}\n\tstderr = {p.stderr}\n')
 
         url = 'http://10.0.0.10/debian-12-disappearing-instance'
-        inst = self.test_client.create_instance(
+        inst1 = self.test_client.create_instance(
             'inst1', 1, 1024, None,
             [
                 {
@@ -135,10 +127,10 @@ class TestHTTPFetch(base.BaseNamespacedTestCase):
                     'base': url,
                     'type': 'disk'
                 }
-            ], None, None, force_placement=n)
+            ], None, None)
         self.addDetail('inst1', content.text_content(json.dumps(
-            inst, indent=4, sort_keys=True)))
-        self._await_instance_ready(inst['uuid'])
+            inst1, indent=4, sort_keys=True)))
+        self._await_instance_ready(inst1['uuid'])
 
         # Remove the source image
         p = subprocess.run(
@@ -157,7 +149,7 @@ class TestHTTPFetch(base.BaseNamespacedTestCase):
                     'base': url,
                     'type': 'disk'
                 }
-            ], None, None, force_placement=n)
+            ], None, None, force_placement=inst1['node'])
         self.addDetail('inst2', content.text_content(json.dumps(
             inst, indent=4, sort_keys=True)))
         self._await_instance_ready(inst['uuid'])

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_imagefetch.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_imagefetch.py
@@ -119,7 +119,7 @@ class TestHTTPFetch(base.BaseNamespacedTestCase):
             f'Command failed:\n\tstdout = {p.stdout}\n\tstderr = {p.stderr}\n')
 
         url = 'http://10.0.0.10/debian-12-disappearing-instance'
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'inst1', 1, 1024, None,
             [
                 {
@@ -141,7 +141,7 @@ class TestHTTPFetch(base.BaseNamespacedTestCase):
             f'Command failed:\n\tstdout = {p.stdout}\n\tstderr = {p.stderr}\n')
 
         # Ensure we can still start an instance
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'inst2', 1, 1024, None,
             [
                 {
@@ -211,7 +211,7 @@ class TestHTTPFetch(base.BaseNamespacedTestCase):
 
         url = ('http://10.0.0.10:%d/debian-12-vanished-server'
                % self.VANISHED_SERVER_PORT)
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'inst1', 1, 1024, None,
             [
                 {
@@ -236,7 +236,7 @@ class TestHTTPFetch(base.BaseNamespacedTestCase):
 
         # Ensure we can still start an instance, on a node which has not
         # seen this image before if the cluster has one.
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'inst2', 1, 1024, None,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_in_network_reachability.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_in_network_reachability.py
@@ -46,7 +46,7 @@ class TestInNetworkReachability(base.BaseNamespacedTestCase):
         self._await_networks_ready([self.net['uuid']])
 
     def _create_instance(self, name):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             name, 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_metadata.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_metadata.py
@@ -67,7 +67,7 @@ class TestInstanceMetadata(base.BaseNamespacedTestCase):
         self._await_networks_ready([self.net['uuid']])
 
     def test_simple(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-simple-metadata', 1, 1024,
             [
                 {
@@ -94,7 +94,7 @@ class TestInstanceMetadata(base.BaseNamespacedTestCase):
         self.assertEqual({}, self.test_client.get_instance_metadata(inst['uuid']))
 
     def test_set_during_create(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-set-during-create', 1, 1024,
             [
                 {
@@ -147,7 +147,7 @@ class TestInterfaceMetadata(base.BaseNamespacedTestCase):
         self._await_networks_ready([self.net['uuid']])
 
     def test_simple(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-simple-metadata', 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_namespace.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_namespace.py
@@ -55,7 +55,7 @@ class TestNamespace(base.BaseNamespacedTestCase):
 
         inst_uuids = set()
         for i in range(NUM_INSTANCES):
-            new_inst = self.test_client.create_instance(
+            new_inst = self.create_instance(
                 'test-%s' % i, 1, 1024,
                 [
                     {

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_namespace_claims.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_namespace_claims.py
@@ -129,9 +129,13 @@ CAPACITY_ACCOUNTING_WAIT = 420
 # where the caller is about to assert success. The capacity the request
 # needs is usually held by the rest of the suite, and instance deletion
 # returns it asynchronously -- full-now is not full-soon (issue 3907).
-# Comfortably longer than any sibling test holds its instances, far
-# shorter than the job timeout.
-CLUSTER_HEADROOM_WAIT = 420
+#
+# This is the same wait, for the same reason, that base.create_instance()
+# gives a refused instance create, so it is that constant rather than a
+# second copy of the number: two independent 420s which the plan requires
+# to stay equal are coupled by nothing but a comment, and a comment does
+# not fail when one of them moves.
+CLUSTER_HEADROOM_WAIT = base.CLUSTER_HEADROOM_WAIT
 
 
 class _ClaimTarget:

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_namespace_claims.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_namespace_claims.py
@@ -679,7 +679,7 @@ class TestNamespaceClaimAccounting(ClaimAPIMixin,
         self._await_networks_ready([self.net['uuid']])
 
     def _create_instance(self, name):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             name, INSTANCE_CPUS, INSTANCE_MEMORY_MB,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_network_lifecycle.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_network_lifecycle.py
@@ -85,7 +85,7 @@ class TestNetworkPlumbingLifecycle(base.BaseNamespacedTestCase):
                node['name']))
 
     def _create_instance_on(self, node):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'netlifecycle', 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_networking.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_networking.py
@@ -58,7 +58,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
         self.test_client.delete_network(n['uuid'])
 
     def test_virtual_networks_are_separate(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-networks-separate-1', 1, 1024,
             [
                 {
@@ -76,7 +76,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             'inst1',
             content.text_content(json.dumps(inst1, indent=4, sort_keys=True)))
 
-        inst2 = self.test_client.create_instance(
+        inst2 = self.create_instance(
             'test-networks-separate-1', 1, 1024,
             [
                 {
@@ -127,7 +127,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
         inst1_address = '192.168.242.10'
         inst2_address = '192.168.242.20'
 
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-overlap-cidr-1', 1, 1024,
             [
                 {
@@ -151,7 +151,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
         }
         )
 
-        inst2 = self.test_client.create_instance(
+        inst2 = self.create_instance(
             'test-overlap-cidr-2', 1, 1024,
             [
                 {
@@ -212,7 +212,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
         self.assertTrue(' 100% packet' in results['stdout'])
 
     def test_single_virtual_networks_work(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-networks-1', 1, 1024,
             [
                 {
@@ -230,7 +230,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             'inst1',
             content.text_content(json.dumps(inst1, indent=4, sort_keys=True)))
 
-        inst2 = self.test_client.create_instance(
+        inst2 = self.create_instance(
             'test-networks-2', 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_nodes.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_nodes.py
@@ -117,7 +117,7 @@ class TestNodes(base.BaseNamespacedTestCase):
         # is downloaded, so this costs the cluster almost nothing, and we
         # deliberately do not wait for it -- the whole point is to read the
         # cluster's view of the node before any domain exists.
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'unbooted', 1, 128, None, [{'size': 1, 'type': 'disk'}],
             None, None, force_placement=node['name'])
         self.addDetail('instance', content.text_content(json.dumps(

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_object_names.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_object_names.py
@@ -40,7 +40,7 @@ class TestObjectNames(base.BaseNamespacedTestCase):
 
         inst_uuids = {}
         for name in ['barry', 'dave', 'trouble-writing-tests']:
-            new_inst = self.test_client.create_instance(
+            new_inst = self.create_instance(
                 name, 1, 1024,
                 [
                     {
@@ -110,7 +110,7 @@ class TestSameNameLookup(base.BaseNamespacedTestCase):
 
         try:
             # Namespace A instance (self.namespace / self.test_client)
-            inst_a = self.test_client.create_instance(
+            inst_a = self.create_instance(
                 inst_name, 1, 128, None, minimal_disk, None, None,
                 namespace=self.namespace)
             self.addDetail(
@@ -118,9 +118,9 @@ class TestSameNameLookup(base.BaseNamespacedTestCase):
                 content.text_content(json.dumps(inst_a, indent=4, sort_keys=True)))
 
             # Namespace B instance
-            inst_b = client_b.create_instance(
+            inst_b = self.create_instance(
                 inst_name, 1, 128, None, minimal_disk, None, None,
-                namespace=ns_b_name)
+                client=client_b, namespace=ns_b_name)
             self.addDetail(
                 'inst_b',
                 content.text_content(json.dumps(inst_b, indent=4, sort_keys=True)))
@@ -194,12 +194,12 @@ class TestSameNameLookup(base.BaseNamespacedTestCase):
         inst_a = None
         inst_b = None
         try:
-            inst_a = self.test_client.create_instance(
+            inst_a = self.create_instance(
                 inst_name, 1, 128, None, minimal_disk, None, None,
                 namespace=self.namespace)
-            inst_b = client_b.create_instance(
+            inst_b = self.create_instance(
                 inst_name, 1, 128, None, minimal_disk, None, None,
-                namespace=ns_b_name)
+                client=client_b, namespace=ns_b_name)
             self.assertNotEqual(inst_a['uuid'], inst_b['uuid'])
 
             # System creds, explicit namespace=A → must be A's UUID.

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_object_names.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_object_names.py
@@ -58,7 +58,14 @@ class TestObjectNames(base.BaseNamespacedTestCase):
                 'new_inst_%s' % name,
                 content.text_content(json.dumps(new_inst, indent=4,
                                                 sort_keys=True)))
-            inst_uuids[name] = new_inst['uuid']
+            # Keyed by the name the instance actually got, not by the
+            # one requested. create_instance() retries a capacity refusal
+            # under a fresh name (see the wrapper in base.py), and this
+            # loop's assertion -- that an instance resolves by its own
+            # name -- is true either way. Keyed by the literal it would
+            # instead 404 after a wait, and report it as a name
+            # resolution bug.
+            inst_uuids[new_inst['name']] = new_inst['uuid']
         self.addDetail(
             'inst_uuids',
             content.text_content(json.dumps(inst_uuids, indent=4,
@@ -110,7 +117,16 @@ class TestSameNameLookup(base.BaseNamespacedTestCase):
 
         try:
             # Namespace A instance (self.namespace / self.test_client)
-            inst_a = self.create_instance(
+            # raw-create: this test's subject is the name itself --
+            # two instances sharing one name across namespaces -- so
+            # it cannot use the wrapper, whose capacity retry issues
+            # a fresh uniquified name. A renamed retry here would
+            # leave the two instances with different names and the
+            # assertions below would pass while testing nothing. The
+            # create is tiny (1 cpu, 128MB, no base image) so a
+            # capacity refusal is unlikely, and an honest failure is
+            # the right outcome if one happens.
+            inst_a = self.test_client.create_instance(
                 inst_name, 1, 128, None, minimal_disk, None, None,
                 namespace=self.namespace)
             self.addDetail(
@@ -118,9 +134,18 @@ class TestSameNameLookup(base.BaseNamespacedTestCase):
                 content.text_content(json.dumps(inst_a, indent=4, sort_keys=True)))
 
             # Namespace B instance
-            inst_b = self.create_instance(
+            # raw-create: this test's subject is the name itself --
+            # two instances sharing one name across namespaces -- so
+            # it cannot use the wrapper, whose capacity retry issues
+            # a fresh uniquified name. A renamed retry here would
+            # leave the two instances with different names and the
+            # assertions below would pass while testing nothing. The
+            # create is tiny (1 cpu, 128MB, no base image) so a
+            # capacity refusal is unlikely, and an honest failure is
+            # the right outcome if one happens.
+            inst_b = client_b.create_instance(
                 inst_name, 1, 128, None, minimal_disk, None, None,
-                client=client_b, namespace=ns_b_name)
+                namespace=ns_b_name)
             self.addDetail(
                 'inst_b',
                 content.text_content(json.dumps(inst_b, indent=4, sort_keys=True)))
@@ -194,12 +219,30 @@ class TestSameNameLookup(base.BaseNamespacedTestCase):
         inst_a = None
         inst_b = None
         try:
-            inst_a = self.create_instance(
+            # raw-create: this test's subject is the name itself --
+            # two instances sharing one name across namespaces -- so
+            # it cannot use the wrapper, whose capacity retry issues
+            # a fresh uniquified name. A renamed retry here would
+            # leave the two instances with different names and the
+            # assertions below would pass while testing nothing. The
+            # create is tiny (1 cpu, 128MB, no base image) so a
+            # capacity refusal is unlikely, and an honest failure is
+            # the right outcome if one happens.
+            inst_a = self.test_client.create_instance(
                 inst_name, 1, 128, None, minimal_disk, None, None,
                 namespace=self.namespace)
-            inst_b = self.create_instance(
+            # raw-create: this test's subject is the name itself --
+            # two instances sharing one name across namespaces -- so
+            # it cannot use the wrapper, whose capacity retry issues
+            # a fresh uniquified name. A renamed retry here would
+            # leave the two instances with different names and the
+            # assertions below would pass while testing nothing. The
+            # create is tiny (1 cpu, 128MB, no base image) so a
+            # capacity refusal is unlikely, and an honest failure is
+            # the right outcome if one happens.
+            inst_b = client_b.create_instance(
                 inst_name, 1, 128, None, minimal_disk, None, None,
-                client=client_b, namespace=ns_b_name)
+                namespace=ns_b_name)
             self.assertNotEqual(inst_a['uuid'], inst_b['uuid'])
 
             # System creds, explicit namespace=A → must be A's UUID.

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_placement.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_placement.py
@@ -25,6 +25,8 @@ class TestPlacement(base.BaseNamespacedTestCase):
         # Make sure we get an except for a missing node
         self.assertRaises(
             apiclient.ResourceNotFoundException,
+            # raw-create: asserts the 404 a force_placement onto a node which
+            # does not exist gets. That node never acquires capacity.
             self.test_client.create_instance,
             'ubuntu-2004', 1, 1024,
             [

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_placement.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_placement.py
@@ -43,7 +43,7 @@ class TestPlacement(base.BaseNamespacedTestCase):
     def test_local_placement_works(self):
         # Create an instance, force it to be on the name node as us.
         try:
-            inst = self.test_client.create_instance(
+            inst = self.create_instance(
                 'ubuntu-2004', 1, 1024,
                 [
                     {
@@ -79,7 +79,7 @@ class TestPlacement(base.BaseNamespacedTestCase):
     def test_remote_placement_works(self):
         # Create another instance, force it to be on a remote node.
         try:
-            inst = self.test_client.create_instance(
+            inst = self.create_instance(
                 'remotelyplaced', 1, 1024,
                 [
                     {

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_scheduler.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_scheduler.py
@@ -129,7 +129,7 @@ class TestAffinity(base.BaseNamespacedTestCase):
             self.skipTest('Insufficient nodes for test')
 
         # Create an instance with a tag
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'inst1', 1, 1024,
             [
                 {
@@ -149,7 +149,7 @@ class TestAffinity(base.BaseNamespacedTestCase):
         self._await_instance_create(inst1['uuid'])
 
         # Now create two more instances, one with affinity one without
-        inst2 = self.test_client.create_instance(
+        inst2 = self.create_instance(
             'inst2', 1, 1024,
             [
                 {
@@ -168,7 +168,7 @@ class TestAffinity(base.BaseNamespacedTestCase):
                     }
                 }
             )
-        inst3 = self.test_client.create_instance(
+        inst3 = self.create_instance(
             'inst3', 1, 1024,
             [
                 {
@@ -291,12 +291,12 @@ class TestAffinity(base.BaseNamespacedTestCase):
         if len(nodes) < 3:
             self.skipTest('Insufficient nodes for test')
 
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'binst1', 1, 1024, self._networks(), self._disks(), None, None,
             metadata={'tags': ['binary-tag']})
         self._await_instance_create(inst1['uuid'])
 
-        inst2 = self.test_client.create_instance(
+        inst2 = self.create_instance(
             'binst2', 1, 1024, self._networks(), self._disks(), None, None,
             metadata={'affinity': {'prefer_with_tag': ['binary-tag']}})
         self._await_instance_create(inst2['uuid'])

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_scheduler.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_scheduler.py
@@ -324,6 +324,9 @@ class TestAffinity(base.BaseNamespacedTestCase):
         """
         self.assertRaises(
             apiclient.ResourceStateConflictException,
+            # raw-create: asserts the 409 an unsatisfiable affinity constraint
+            # gets, and a 507 instead is the failure this test exists to catch.
+            # Waiting one out would hide it behind a seven minute timeout.
             self.test_client.create_instance,
             'binst-refused', 1, 1024, self._networks(), self._disks(),
             None, None,

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_snapshots.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_snapshots.py
@@ -18,7 +18,7 @@ class TestSnapshots(base.BaseNamespacedTestCase):
         self._await_networks_ready([self.net['uuid']])
 
     def test_single_disk_snapshots(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-snapshots', 1, 1024,
             [
                 {
@@ -148,7 +148,7 @@ class TestSnapshots(base.BaseNamespacedTestCase):
         })
 
         # Now attempt to boot the snapshot via blob uuid
-        inst2 = self.test_client.create_instance(
+        inst2 = self.create_instance(
             'cirros-from-blob', 1, 1024,
             [
                 {
@@ -174,7 +174,7 @@ class TestSnapshots(base.BaseNamespacedTestCase):
         self._await_instance_ready(inst2['uuid'])
 
         # Now attempt to boot the snapshot via snapshot uuid
-        inst3 = self.test_client.create_instance(
+        inst3 = self.create_instance(
             'cirros-from-snapshot', 1, 1024,
             [
                 {
@@ -260,7 +260,7 @@ class TestSnapshots(base.BaseNamespacedTestCase):
         self.test_client.delete_instance(inst3['uuid'])
 
     def test_multiple_disk_snapshots(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-multi-snapshots', 1, 1024,
             [
                 {
@@ -350,7 +350,7 @@ class TestSnapshots(base.BaseNamespacedTestCase):
         self.test_client.delete_instance(inst['uuid'])
 
     def test_labels(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-labels', 1, 1024,
             [
                 {
@@ -380,7 +380,7 @@ class TestSnapshots(base.BaseNamespacedTestCase):
         self.assertIsNotNone(snap)
 
         # Now attempt to boot the snapshot via snapshot uuid
-        inst2 = self.test_client.create_instance(
+        inst2 = self.create_instance(
             'cirros-from-snapshot', 1, 1024,
             [
                 {
@@ -405,7 +405,7 @@ class TestSnapshots(base.BaseNamespacedTestCase):
         self.test_client.delete_instance(inst2['uuid'])
 
     def test_labels_with_deleted_snapshot(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-deleted-snapshot', 1, 1024,
             [
                 {
@@ -457,7 +457,7 @@ class TestSnapshots(base.BaseNamespacedTestCase):
                 self.fail('Snapshot remains')
 
     def test_specific_device_snapshots(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-device-snapshots', 1, 1024,
             [
                 {
@@ -542,7 +542,7 @@ class TestSnapshots(base.BaseNamespacedTestCase):
         self.test_client.delete_instance(inst['uuid'])
 
     def test_thin_snapshots(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'thin-original', 1, 1024,
             [
                 {
@@ -617,7 +617,7 @@ class TestSnapshots(base.BaseNamespacedTestCase):
         self.assertLess(snap1_info['blobs'][1]['size'], b['size'])
 
         # Try booting an instance with the thin snapshot
-        inst2 = self.test_client.create_instance(
+        inst2 = self.create_instance(
             'thin-snapshot', 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_stray_vxlan.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_stray_vxlan.py
@@ -313,7 +313,7 @@ class TestStrayVxlanInstanceProtection(StrayVxlanHostMixin,
             json.dumps(hosted_net, indent=4, sort_keys=True)))
         self._await_networks_ready([hosted_net['uuid']])
 
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'strayvxlanprot', 1, 1024,
             [{'network_uuid': hosted_net['uuid']}],
             [{'size': 8, 'base': base.CLUSTER_CI_IMAGE, 'type': 'disk'}],

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_system_namespace.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_system_namespace.py
@@ -7,6 +7,13 @@ from shakenfist_client import apiclient
 
 
 class TestSystemNamespace(base.BaseTestCase):
+    def _safe_delete_instance(self, instance_uuid):
+        """Delete an instance, tolerating if it's already gone."""
+        try:
+            self.system_client.delete_instance(instance_uuid)
+        except apiclient.ResourceNotFoundException:
+            pass
+
     def test_system_namespace(self):
         self.assertEqual('system', self.system_client.namespace)
 
@@ -38,6 +45,7 @@ class TestSystemNamespace(base.BaseTestCase):
                     'type': 'disk'
                 }
             ], None, None)
+        self.addCleanup(self._safe_delete_instance, inst['uuid'])
         self.addDetail(
             'inst',
             content.text_content(json.dumps(inst, indent=4, sort_keys=True)))

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_system_namespace.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_system_namespace.py
@@ -31,7 +31,7 @@ class TestSystemNamespace(base.BaseTestCase):
             content.text_content(json.dumps(nets, indent=4, sort_keys=True)))
         self.assertIn(net['uuid'], nets)
 
-        inst = self.system_client.create_instance(
+        inst = self.create_instance(
             'test-system-ns', 1, 1024,
             [
                 {
@@ -44,7 +44,7 @@ class TestSystemNamespace(base.BaseTestCase):
                     'base': base.CLUSTER_CI_IMAGE,
                     'type': 'disk'
                 }
-            ], None, None)
+            ], None, None, client=self.system_client)
         self.addCleanup(self._safe_delete_instance, inst['uuid'])
         self.addDetail(
             'inst',

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_vdi_console_file.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_vdi_console_file.py
@@ -34,7 +34,7 @@ class TestVDIConsoleFile(base.BaseNamespacedTestCase):
         which is all the .vv generator reads.
         """
         minimal_disk = [{'size': 1, 'type': 'disk'}]
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'vvfile-%s' % self._uniquifier(), 1, 128, None, minimal_disk,
             None, None, namespace=self.namespace, video=video)
         self._await_instance_create(inst['uuid'])

--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_vdi_tokens.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_vdi_tokens.py
@@ -40,9 +40,9 @@ class TestVDIConsoleTokens(base.BaseNamespacedTestCase):
         # all the mint endpoint requires. video is left unset so the server
         # applies its default SPICE console.
         minimal_disk = [{'size': 1, 'type': 'disk'}]
-        inst = client.create_instance(
+        inst = self.create_instance(
             'vditoken-%s' % self._uniquifier(), 1, 128, None, minimal_disk,
-            None, None, namespace=namespace)
+            None, None, client=client, namespace=namespace)
         self.addDetail(
             'instance',
             content.text_content(json.dumps(inst, indent=4, sort_keys=True)))

--- a/shakenfist/deploy/shakenfist_ci/database_tier.py
+++ b/shakenfist/deploy/shakenfist_ci/database_tier.py
@@ -272,7 +272,7 @@ class DatabaseTierTestsMixin:
         # wrapped in the ResourceNotFoundException guard -- which is
         # exactly how this test failed every merge group from the day it
         # landed.
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'dbtier-attributes', 1, 1024, None,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_agentops.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_agentops.py
@@ -25,7 +25,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
         self._await_networks_ready([self.net_one['uuid']])
 
     def test_instance_execute_small(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-instance-execute-small', 1, 1024,
             [
                 {
@@ -59,7 +59,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             f'"root\\n": {aop}')
 
     def test_instance_execute_large(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-instance-execute-large', 1, 1024,
             [
                 {
@@ -101,7 +101,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
 
     def test_put_and_exec_large_stdout(self):
         # Create an instance to run our script on
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-put-and-get-file', 1, 1024, None,
             [
                 {
@@ -136,7 +136,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             '[0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987'))
 
     def test_instance_put_and_get_blob(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-instance-put-blob', 1, 1024,
             [
                 {
@@ -238,7 +238,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
 
     def test_get(self):
         # Create an instance to fetch files from
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-put-and-get-file', 1, 1024, None,
             [
                 {
@@ -258,7 +258,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
 
     def test_get_missing_file(self):
         # Create an instance to fetch files from
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-put-and-get-file-missing', 1, 1024, None,
             [
                 {
@@ -282,7 +282,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             '10.0.0.0/24', True, True, '%s-hotplug' % self.namespace)
 
         # Create an instance to run our command on
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-hotplug', 1, 1024, None,
             [
                 {
@@ -346,7 +346,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             '10.0.0.0/24', True, True, '%s-hotplug' % self.namespace)
 
         # Create an instance to run our command on
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-hotplug', 1, 1024, None,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_boot.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_boot.py
@@ -44,7 +44,7 @@ class TestBoot(testscenarios.WithScenarios, base.BaseNamespacedTestCase):
         Once we had a bug that only stopped instance creation when no network
         was specified.
         """
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             f'test-boot-no-network-{self.base}', 1, 1024, None,
             [
                 {
@@ -57,7 +57,7 @@ class TestBoot(testscenarios.WithScenarios, base.BaseNamespacedTestCase):
         self._await_instance_ready(inst['uuid'])
 
     def _boot_network(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             f'test-boot-network-{self.base}', 1, 1024,
             [
                 {
@@ -75,7 +75,7 @@ class TestBoot(testscenarios.WithScenarios, base.BaseNamespacedTestCase):
         self._await_instance_ready(inst['uuid'])
 
     def _boot_large_disk(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             f'test-boot-large-disk-{self.base}', 1, 1024, None,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_cloudinit.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_cloudinit.py
@@ -33,7 +33,7 @@ class TestCloudInit(base.BaseNamespacedTestCase):
         ud = """#!/bin/sh
 sudo echo 'banana' >  /tmp/output"""
 
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-instance', 1, 1024,
             [
                 {
@@ -74,7 +74,7 @@ sudo echo 'banana' >  /tmp/output"""
         self.assertTrue('elLwq/bpzBWsg0JjjGvtuuKMM' in out)
 
     def test_cloudinit_no_tracebacks(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'notracebacks', 2, 2048,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_disks.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_disks.py
@@ -23,7 +23,7 @@ class TestDisks(base.BaseNamespacedTestCase):
 
     def test_boot_nvme(self):
         self.skipTest('This test is flakey in CI for reasons I do not understand.')
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-cirros-boot-nvme', 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_multiple_nics.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_multiple_nics.py
@@ -39,7 +39,7 @@ sudo echo 'auto eth1'             >> /etc/network/interfaces
 sudo echo 'iface eth1 inet dhcp'  >> /etc/network/interfaces
 sudo /etc/init.d/S40network restart"""
 
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-multiple-nics', 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_networking.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_networking.py
@@ -77,6 +77,8 @@ class TestNetworking(base.BaseNamespacedTestCase):
     def test_specific_ip_request_invalid(self):
         self.assertRaises(
             apiclient.RequestMalformedException,
+            # raw-create: asserts the 400 an address outside the network gets,
+            # which is raised validating the request, not scheduling it.
             self.test_client.create_instance,
             'test-invalid-ip', 1, 1024,
             [

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_networking.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_networking.py
@@ -44,7 +44,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
                                     self.net_four['uuid']])
 
     def test_specific_ip_request(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-specific-ip', 1, 1024,
             [
                 {
@@ -94,7 +94,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             ], None, None)
 
     def test_specific_macaddress_request(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-macaddress', 1, 1024,
             [
                 {
@@ -118,7 +118,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
         self.assertTrue('04:ed:33:c0:2e:6c' in results['stdout'])
 
     def test_interface_delete(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-iface-delete', 1, 1024,
             [
                 {
@@ -162,7 +162,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
         self._await_networks_ready([dupnet['uuid']])
 
         try:
-            inst_hyp1_vm1 = self.test_client.create_instance(
+            inst_hyp1_vm1 = self.create_instance(
                 'dup1', 1, 1024,
                 [
                     {
@@ -177,7 +177,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
                     }
                 ], None, None, force_placement='sf-2')
 
-            inst_hyp1_vm2 = self.test_client.create_instance(
+            inst_hyp1_vm2 = self.create_instance(
                 'dup2', 1, 1024,
                 [
                     {
@@ -192,7 +192,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
                     }
                 ], None, None, force_placement='sf-2')
 
-            inst_hyp2_vm1 = self.test_client.create_instance(
+            inst_hyp2_vm1 = self.create_instance(
                 'dup3', 1, 1024,
                 [
                     {
@@ -226,7 +226,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
         self.assertFalse('DUP' in results['stdout'])
 
     def test_provided_dns(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-provided-dns', 1, 1024,
             [
                 {
@@ -240,7 +240,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
                     'type': 'disk'
                 }
             ], None, None)
-        inst2 = self.test_client.create_instance(
+        inst2 = self.create_instance(
             'test-provided-dns-2', 1, 1024,
             [
                 {
@@ -352,7 +352,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
                 f'output:\n\n{data}')
 
     def test_no_provided_dns(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-no-provided-dns', 1, 1024,
             [
                 {
@@ -409,7 +409,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
 
     # TODO(mikal): we should do this for Rocky 9 too.
     def test_provided_dns_debian_12(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-provided-dns', 1, 1024,
             [
                 {
@@ -516,7 +516,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
                 f'output:\n\n{data}')
 
     def test_no_provided_dns_debian12(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-no-provided-dns', 1, 1024,
             [
                 {
@@ -590,7 +590,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
         extra_dns_net = self.test_client.allocate_network(
             '192.168.242.0/24', True, True, '%s-extra-dns' % self.namespace,
             provide_dns=True)
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-provided-dns', 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_state_changes.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_state_changes.py
@@ -28,7 +28,7 @@ class TestStateChanges(base.BaseNamespacedTestCase):
 
         # We need to start a spare instance on the same node / network so that
         # the network doesn't get torn down during any of the tests.
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'keepalive-statechanges', 1, 1024,
             [
                 {
@@ -54,7 +54,7 @@ class TestStateChanges(base.BaseNamespacedTestCase):
         self._emit_tracing_event({
             'msg': 'Starting target instance'
         })
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-statechanges-%s' % suffix, 1, 1024,
             [
                 {
@@ -217,7 +217,7 @@ class TestDetectReboot(base.BaseNamespacedTestCase):
 
     def test_agent_detects_reboot(self):
         # Start our test instance
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-rebootdetect', 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_ubuntu.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_ubuntu.py
@@ -20,7 +20,7 @@ class TestUbuntu(base.BaseNamespacedTestCase):
         self._await_networks_ready([self.net['uuid']])
 
     def test_ubuntu_pings(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'ubuntu', 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/load_budget.py
+++ b/shakenfist/deploy/shakenfist_ci/load_budget.py
@@ -279,6 +279,18 @@ POLL_OVERCOUNT_TOLERANCE = 1.60
 # that outlives the probe's retirement, because the wrapper keeps calling
 # GET /admin/resources on its own.
 #
+# Sizing note for whoever reads this while working out why a full cluster
+# is busy: one poll is not one read. GET /admin/resources constructs a
+# Scheduler, which refreshes through get_active_node_metrics() -- an
+# iteration over active nodes plus one GetNodeMetrics per node -- so a
+# cluster of N nodes costs N node-metric reads per poll, every
+# CAPACITY_POLL_INTERVAL seconds, per stestr worker currently blocked on
+# a refusal. That arrives precisely when the cluster is fullest, which is
+# the same moment the workers are most likely to be waiting together. It
+# is bounded by CLUSTER_HEADROOM_WAIT and by how many workers can be
+# blocked at once, and GetNodeMetrics/api is exempt above, so this is
+# recorded as a thing to know rather than as a budget entry.
+#
 # The agent operation await helper is the same shape a third time, and it
 # brings the cluster's side of the conversation in with it. _await_command()
 # in shakenfist_ci/base.py submits an agent operation and then reads it back

--- a/shakenfist/deploy/shakenfist_ci/load_budget.py
+++ b/shakenfist/deploy/shakenfist_ci/load_budget.py
@@ -260,6 +260,25 @@ POLL_OVERCOUNT_TOLERANCE = 1.60
 # in ci_headroom_probe.py's own docstring, in the CI headroom section of
 # docs/developer_guide/ci.md, and against #3975 in PLAN-ci-cloud-sizing.md.
 #
+# GetNodeMetrics/api gained a second producer with
+# PLAN-transient-capacity-refusals phase 2: create_instance() on
+# BaseTestCase (shakenfist_ci/base.py) calls wait_for_capacity(), which
+# polls the same GET /admin/resources endpoint the probe above samples,
+# via self.system_client.get_cluster_resources(). It is not the same
+# shape of poll, though, and is named here rather than folded into the
+# probe's paragraph for that reason: the probe reads on a fixed --interval
+# timer for the whole test step regardless of what the suite is doing,
+# which is the independent_of_activity() signature the check is built to
+# catch, while the wrapper polls only while a create is being retried
+# after a 507 -- it adds nothing to an idle cluster and adds load in
+# proportion to how full the cluster already is, which tracks activity
+# rather than ignoring it. This does not widen the trim obligation above:
+# GetAllNodeDaemonStates/api, GetNode/api and GetNodeAttributes/api still
+# have only the probe behind them, and dropping the probe still means
+# dropping those three: GetNodeMetrics/api is the one pair of the four
+# that outlives the probe's retirement, because the wrapper keeps calling
+# GET /admin/resources on its own.
+#
 # The agent operation await helper is the same shape a third time, and it
 # brings the cluster's side of the conversation in with it. _await_command()
 # in shakenfist_ci/base.py submits an agent operation and then reads it back

--- a/shakenfist/deploy/shakenfist_ci/retries.py
+++ b/shakenfist/deploy/shakenfist_ci/retries.py
@@ -221,7 +221,7 @@ def best_node(per_node, request, node=None):
 
 def wait_for_capacity(poll, cpus, memory_mb, disk_gb, node, deadline,
                       clock=time.time, sleep=time.sleep, interval=10,
-                      minimum_sleep=0):
+                      minimum_sleep=0, blind=False):
     """Wait until the cluster could admit a create of this size.
 
     poll() returns the /admin/resources dict. It is injected rather
@@ -249,6 +249,13 @@ def wait_for_capacity(poll, cpus, memory_mb, disk_gb, node, deadline,
     A poll which raises is none of the three: the endpoint being
     briefly unreachable is not evidence about capacity, so it is
     recorded in 'poll_errors' and the wait continues.
+
+    blind says the caller could not work out which roster entry its
+    target is, so there is nothing here to read about it. That is not
+    the same as a target with no room, and must not be reported as one:
+    the roster is not consulted at all and the wait behaves as it does
+    for a degraded cluster, sleeping one interval and handing back
+    'mode': 'degraded'. See BaseTestCase._placement_roster_key().
 
     minimum_sleep is the floor under a satisfied wait, and exists
     because a satisfied wait hands control straight back to a caller
@@ -288,6 +295,12 @@ def wait_for_capacity(poll, cpus, memory_mb, disk_gb, node, deadline,
         slept = clock() - started
         if slept < minimum_sleep:
             sleep(minimum_sleep - slept)
+        return done()
+
+    if blind:
+        record['mode'] = 'degraded'
+        record['degraded_polls'] += 1
+        sleep(interval)
         return done()
 
     while True:

--- a/shakenfist/deploy/shakenfist_ci/retries.py
+++ b/shakenfist/deploy/shakenfist_ci/retries.py
@@ -1,11 +1,19 @@
 # Copyright 2019 Michael Still and contributors
-"""Retry a request while its answer is transient.
+"""Wait out an answer the cluster is entitled to change its mind about.
+
+Two loops, deliberately not one. retry_while_transient() re-issues the
+same request until its status stops being transient.
+wait_for_capacity() polls a *different* thing -- the published resource
+roster -- and hands control back once, so that its caller can re-issue
+a create which would otherwise leave an error-deleted instance behind
+on every attempt.
 
 Kept free of imports from the rest of this suite (and of
 shakenfist_client, which is not a test dependency of the repository) so
 the unit tests in shakenfist/tests can load it by path and exercise the
-loop with a fake clock. The functional suite is a client of a deployed
-cluster and is not otherwise importable from there.
+loops with a fake clock. The functional suite is a client of a deployed
+cluster and is not otherwise importable from there. That is also why
+wait_for_capacity() takes its poll as a callable rather than a client.
 """
 
 import time
@@ -27,4 +35,127 @@ def retry_while_transient(request, transient_statuses, deadline,
         status, body = request()
         if status not in transient_statuses or clock() > deadline:
             return status, body
+        sleep(interval)
+
+
+def node_available_cpus(node_entry):
+    """How many cpus a create may actually be admitted against on one node.
+
+    /admin/resources publishes two ledgers deliberately, and they
+    disagree during exactly the window this wait exists to survive.
+    'cpu_available' is the live overcommit arithmetic; 'cpu_limit' is
+    the capacity row's limit_cpus, which is what admission's guarded
+    UPDATE is measured against and which refreshes only once a
+    reconcile period. Whichever binds is what a create would be
+    allowed, so take the smaller of the two.
+
+    'cpu_limit' is None exactly when the node has no capacity row, in
+    which case admission is guarded by nothing and the published
+    headroom is all there is to read.
+    """
+    available = node_entry.get('cpu_available', 0)
+    limit = node_entry.get('cpu_limit')
+    if limit is not None:
+        available = min(available, limit - node_entry.get('cpu_committed', 0))
+    return available
+
+
+def available_cpus(per_node, node=None):
+    """The largest create the roster says could be placed right now.
+
+    For a pinned create that is the target node's own figure, and a
+    target absent from per_node is zero rather than a KeyError: the
+    roster skips a node whose queue is over the unreasonable length
+    and a node which has not published metrics yet, both of which are
+    transient and both of which are what a caller here is waiting out.
+
+    For an unpinned create it is the best single node, never
+    total['cpu_available'] -- that field is a sum across nodes and an
+    instance has to fit on one of them.
+    """
+    if node is not None:
+        entry = per_node.get(node)
+        if entry is None:
+            return 0
+        return node_available_cpus(entry)
+
+    if not per_node:
+        return 0
+    return max(node_available_cpus(entry) for entry in per_node.values())
+
+
+def wait_for_capacity(poll, cpus, node, deadline, clock=time.time,
+                      sleep=time.sleep, interval=10):
+    """Wait until the cluster could admit a create of this size.
+
+    poll() returns the /admin/resources dict. It is injected rather
+    than called through a client because this module imports nothing
+    from the suite or from shakenfist_client, so that the unit tests
+    can load it by path.
+
+    Three things end the wait, and the returned record says which:
+
+    * The predicate is satisfied ('satisfied' True), so the caller
+      should re-issue its create immediately.
+    * total['capacity_degraded'] is set, so the capacity mapping the
+      predicate rests on could not be read and waiting informed would
+      be waiting on noise. One interval is slept blind and the record
+      says 'mode': 'degraded', which is the caller's signal to retry
+      the create at this cadence rather than to conclude anything.
+    * The deadline passed. The record is unsatisfied and carries the
+      roster, which is the diagnosis a caller's failure message needs.
+
+    A poll which raises is none of the three: the endpoint being
+    briefly unreachable is not evidence about capacity, so it is
+    recorded in 'poll_errors' and the wait continues.
+    """
+    started = clock()
+    record = {
+        'cpus': cpus,
+        'node': node,
+        'mode': 'informed',
+        'polls': 0,
+        'degraded_polls': 0,
+        'poll_errors': [],
+        'headroom_at_start': None,
+        'headroom_at_end': None,
+        'per_node': None,
+        'satisfied': False,
+        'seconds_waited': 0.0,
+    }
+
+    def done():
+        record['seconds_waited'] = clock() - started
+        return record
+
+    while True:
+        record['polls'] += 1
+        try:
+            resources = poll()
+        except Exception as e:
+            record['poll_errors'].append('%s: %s' % (e.__class__.__name__, e))
+            resources = None
+
+        if resources is not None:
+            total = resources.get('total') or {}
+            per_node = resources.get('per_node') or {}
+            record['per_node'] = per_node
+
+            if total.get('capacity_degraded'):
+                record['mode'] = 'degraded'
+                record['degraded_polls'] += 1
+                sleep(interval)
+                return done()
+
+            headroom = available_cpus(per_node, node)
+            record['headroom_at_end'] = headroom
+            if record['headroom_at_start'] is None:
+                record['headroom_at_start'] = headroom
+
+            if headroom >= cpus:
+                record['satisfied'] = True
+                return done()
+
+        if clock() > deadline:
+            return done()
         sleep(interval)

--- a/shakenfist/deploy/shakenfist_ci/retries.py
+++ b/shakenfist/deploy/shakenfist_ci/retries.py
@@ -38,6 +38,39 @@ def retry_while_transient(request, transient_statuses, deadline,
         sleep(interval)
 
 
+# The three dimensions the scheduler pre-filters a candidate node on
+# (_has_sufficient_cpu(), _has_sufficient_ram() and
+# _has_sufficient_disk()). A predicate which models only one of them can
+# be permanently satisfied while the server is permanently refusing, and
+# the caller then re-issues its create as fast as two HTTP round trips
+# allow until its deadline -- turning one 507 into hundreds. Requests are
+# denominated in the same units /admin/resources publishes: whole cpus,
+# megabytes, gigabytes.
+DIMENSIONS = ('cpus', 'memory_mb', 'disk_gb')
+
+
+def requested_disk_gb(disk_spec):
+    """How much disk a create asks for, counted as the scheduler counts it.
+
+    _has_sufficient_disk() sums the 'size' of each disk which has one and
+    ignores the sizeless ones (a CD ROM is exactly the size of its base
+    image), so this does the same. A caller which passes no disk spec at
+    all asks for nothing.
+    """
+    requested = 0
+    for disk in disk_spec or []:
+        if not isinstance(disk, dict):
+            continue
+        size = disk.get('size')
+        if size is None:
+            continue
+        try:
+            requested += int(size)
+        except (TypeError, ValueError):
+            continue
+    return requested
+
+
 def node_available_cpus(node_entry):
     """How many cpus a create may actually be admitted against on one node.
 
@@ -52,46 +85,154 @@ def node_available_cpus(node_entry):
     'cpu_limit' is None exactly when the node has no capacity row, in
     which case admission is guarded by nothing and the published
     headroom is all there is to read.
+
+    'cpu_max_per_instance' is a third bound of a different kind: it
+    caps the largest single instance the node will take however much
+    aggregate headroom it has, so a create larger than it is refused
+    permanently rather than transiently. A zero there means the node
+    has published no metrics for it rather than that it will take
+    nothing, so it is read only when it is non-zero.
     """
     available = node_entry.get('cpu_available', 0)
     limit = node_entry.get('cpu_limit')
     if limit is not None:
         available = min(available, limit - node_entry.get('cpu_committed', 0))
+    largest = node_entry.get('cpu_max_per_instance')
+    if largest:
+        available = min(available, largest)
     return available
 
 
-def available_cpus(per_node, node=None):
-    """The largest create the roster says could be placed right now.
+def node_available_memory_mb(node_entry):
+    """How much memory a create may actually be admitted against on one node.
 
-    For a pinned create that is the target node's own figure, and a
+    Unlike cpus this needs no manual clamp against the capacity row:
+    summarize_resources() has already taken min(overcommit arithmetic,
+    limit_memory_mb - committed) before publishing 'ram_available'.
+
+    'ram_max_per_instance' is the node's memory_available less its
+    published reservation, which is _has_sufficient_ram()'s first
+    check and is a bound on one instance rather than on the aggregate.
+    It is legitimately zero or negative on a full node, so unlike the
+    cpu equivalent it is read whenever it is present at all.
+    """
+    available = node_entry.get('ram_available', 0)
+    largest = node_entry.get('ram_max_per_instance')
+    if largest is not None:
+        available = min(available, largest)
+    return available
+
+
+def node_available_disk_gb(node_entry):
+    """How much instance disk one node has, in gigabytes.
+
+    summarize_resources() has already subtracted that node's own
+    published reservation, which is the same arithmetic
+    _has_sufficient_disk() does, so the published figure is the answer.
+    """
+    return node_entry.get('disk_available', 0)
+
+
+HEADROOM_READERS = {
+    'cpus': node_available_cpus,
+    'memory_mb': node_available_memory_mb,
+    'disk_gb': node_available_disk_gb,
+}
+
+ZERO_HEADROOM = {dimension: 0 for dimension in DIMENSIONS}
+
+
+def node_headroom(node_entry):
+    """What one roster entry says the node has left, per dimension."""
+    return {dimension: HEADROOM_READERS[dimension](node_entry)
+            for dimension in DIMENSIONS}
+
+
+def coverage_of(headroom, request):
+    """How much of a create one node could take, and what holds it back.
+
+    Returns a (fraction, dimension) pair. The fraction is the smallest
+    available/requested ratio across the dimensions the create actually
+    asks for, so 1.0 or more means every dimension fits and the node
+    could take the whole create; the dimension is the one which produced
+    that smallest ratio, which is the thing the create is waiting on.
+
+    A dimension the create asks nothing of cannot bind and is skipped --
+    a sizeless disk spec asks for no disk, and a node with no disk left
+    would otherwise never satisfy it.
+    """
+    worst = None
+    binding = None
+    for dimension in DIMENSIONS:
+        requested = request.get(dimension) or 0
+        if requested <= 0:
+            continue
+        available = headroom.get(dimension) or 0
+        covered = available / requested
+        if worst is None or covered < worst:
+            worst = covered
+            binding = dimension
+    if worst is None:
+        return float('inf'), None
+    return worst, binding
+
+
+def best_node(per_node, request, node=None):
+    """The node most likely to admit this create, with its headroom.
+
+    Returns a (headroom, coverage, binding dimension) triple.
+
+    For a pinned create that is the target node's own figures, and a
     target absent from per_node is zero rather than a KeyError: the
     roster skips a node whose queue is over the unreasonable length
     and a node which has not published metrics yet, both of which are
     transient and both of which are what a caller here is waiting out.
+    A binding dimension of None means the roster said nothing about the
+    node at all, rather than that nothing binds.
 
-    For an unpinned create it is the best single node, never
-    total['cpu_available'] -- that field is a sum across nodes and an
-    instance has to fit on one of them.
+    For an unpinned create it is the single node which covers the
+    largest fraction of the request, never a cluster total -- those
+    fields are sums across nodes and an instance has to fit on one of
+    them.
     """
     if node is not None:
         entry = per_node.get(node)
         if entry is None:
-            return 0
-        return node_available_cpus(entry)
+            return dict(ZERO_HEADROOM), 0.0, None
+        headroom = node_headroom(entry)
+        coverage, binding = coverage_of(headroom, request)
+        return headroom, coverage, binding
 
-    if not per_node:
-        return 0
-    return max(node_available_cpus(entry) for entry in per_node.values())
+    # Seeded from the first node rather than from a zero, so that a
+    # roster of nodes which all cover nothing still names the dimension
+    # they are short of. Seeding with 0.0 meant a node whose coverage was
+    # exactly zero never beat the seed, and the wait recorded "nothing
+    # bound" for a create which was refused for cpus.
+    best = None
+    for entry in per_node.values():
+        headroom = node_headroom(entry)
+        coverage, binding = coverage_of(headroom, request)
+        if best is None or coverage > best[1]:
+            best = (headroom, coverage, binding)
+    if best is None:
+        return dict(ZERO_HEADROOM), 0.0, None
+    return best
 
 
-def wait_for_capacity(poll, cpus, node, deadline, clock=time.time,
-                      sleep=time.sleep, interval=10):
+def wait_for_capacity(poll, cpus, memory_mb, disk_gb, node, deadline,
+                      clock=time.time, sleep=time.sleep, interval=10,
+                      minimum_sleep=0):
     """Wait until the cluster could admit a create of this size.
 
     poll() returns the /admin/resources dict. It is injected rather
     than called through a client because this module imports nothing
     from the suite or from shakenfist_client, so that the unit tests
     can load it by path.
+
+    The size is the whole size: a create is refused for whichever of
+    cpus, memory and disk the candidate node is short of, so a wait
+    which modelled only one of them would report "there is room now"
+    while the server went on refusing. See DIMENSIONS above.
 
     Three things end the wait, and the returned record says which:
 
@@ -108,10 +249,23 @@ def wait_for_capacity(poll, cpus, node, deadline, clock=time.time,
     A poll which raises is none of the three: the endpoint being
     briefly unreachable is not evidence about capacity, so it is
     recorded in 'poll_errors' and the wait continues.
+
+    minimum_sleep is the floor under a satisfied wait, and exists
+    because a satisfied wait hands control straight back to a caller
+    which has just been refused. If the refusal was for something this
+    predicate cannot see -- a pre-filter it does not model, or the
+    admission guard losing a race it cannot observe -- then satisfied
+    is the permanent answer and the caller would re-issue as fast as
+    two HTTP round trips allow until its deadline. A caller passes zero
+    for its first wait, where believing the roster immediately is the
+    common and correct case, and one interval thereafter.
     """
     started = clock()
+    request = {'cpus': cpus, 'memory_mb': memory_mb, 'disk_gb': disk_gb}
     record = {
         'cpus': cpus,
+        'memory_mb': memory_mb,
+        'disk_gb': disk_gb,
         'node': node,
         'mode': 'informed',
         'polls': 0,
@@ -120,6 +274,7 @@ def wait_for_capacity(poll, cpus, node, deadline, clock=time.time,
         'headroom_at_start': None,
         'headroom_at_end': None,
         'per_node': None,
+        'binding_dimension': None,
         'satisfied': False,
         'seconds_waited': 0.0,
     }
@@ -127,6 +282,13 @@ def wait_for_capacity(poll, cpus, node, deadline, clock=time.time,
     def done():
         record['seconds_waited'] = clock() - started
         return record
+
+    def done_paced():
+        """Hand back no sooner than minimum_sleep after starting."""
+        slept = clock() - started
+        if slept < minimum_sleep:
+            sleep(minimum_sleep - slept)
+        return done()
 
     while True:
         record['polls'] += 1
@@ -147,14 +309,20 @@ def wait_for_capacity(poll, cpus, node, deadline, clock=time.time,
                 sleep(interval)
                 return done()
 
-            headroom = available_cpus(per_node, node)
+            headroom, coverage, binding = best_node(per_node, request, node)
             record['headroom_at_end'] = headroom
             if record['headroom_at_start'] is None:
                 record['headroom_at_start'] = headroom
+                # What the create was short of when it was refused, which
+                # is the question phase 5 asks of this data. Only the
+                # first poll can answer it: by the last one the shortfall
+                # is usually gone, which is why the wait ended.
+                if coverage < 1.0:
+                    record['binding_dimension'] = binding
 
-            if headroom >= cpus:
+            if coverage >= 1.0:
                 record['satisfied'] = True
-                return done()
+                return done_paced()
 
         if clock() > deadline:
             return done()

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentop_deadlines.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentop_deadlines.py
@@ -162,7 +162,7 @@ class TestAgentOperationDeadlines(base.BaseNamespacedTestCase):
         self._await_networks_ready([self.net_one['uuid']])
 
     def _create_ready_instance(self, name):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             name, 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_agentops.py
@@ -25,7 +25,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
         self._await_networks_ready([self.net_one['uuid']])
 
     def test_instance_execute_small(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-instance-execute-small', 1, 1024,
             [
                 {
@@ -62,7 +62,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             f'"root\\n": {aop}')
 
     def test_instance_execute_large(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-instance-execute-large', 1, 1024,
             [
                 {
@@ -104,7 +104,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
 
     def test_put_and_exec_large_stdout(self):
         # Create an instance to run our script on
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-put-and-get-file', 1, 1024, None,
             [
                 {
@@ -139,7 +139,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             '[0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987'))
 
     def test_instance_put_and_get_blob(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-instance-put-blob', 1, 1024,
             [
                 {
@@ -227,7 +227,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
 
     def test_get(self):
         # Create an instance to fetch files from
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-put-and-get-file', 1, 1024, None,
             [
                 {
@@ -247,7 +247,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
 
     def test_get_missing_file(self):
         # Create an instance to fetch files from
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-put-and-get-file-missing', 1, 1024, None,
             [
                 {
@@ -271,7 +271,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             '10.0.0.0/24', True, True, '%s-hotplug' % self.namespace)
 
         # Create an instance to run our command on
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-hotplug', 1, 1024, None,
             [
                 {
@@ -339,7 +339,7 @@ class TestAgentOperations(base.BaseNamespacedTestCase):
             '10.0.0.0/24', True, True, '%s-hotplug' % self.namespace)
 
         # Create an instance to run our command on
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-hotplug', 1, 1024, None,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_disk_specs.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_disk_specs.py
@@ -11,7 +11,7 @@ class TestDiskSpecifications(base.BaseNamespacedTestCase):
         super().__init__(*args, **kwargs)
 
     def test_default(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-default-disk', 1, 1024, None,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_events.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_events.py
@@ -32,7 +32,7 @@ class TestEvents(base.BaseNamespacedTestCase):
             0, len(self.test_client.get_network_events(self.net_one['uuid'])))
 
     def test_instance_events(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-instance-events', 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_loki.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_loki.py
@@ -233,7 +233,7 @@ class TestLoki(base.BaseNamespacedTestCase):
             content.text_content(json.dumps(net, indent=4, sort_keys=True)))
         self._await_networks_ready([net['uuid']])
 
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-event-extra-uuid', 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_metadata.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_metadata.py
@@ -73,7 +73,7 @@ class TestInstanceMetadata(base.BaseNamespacedTestCase):
         self._await_networks_ready([self.net['uuid']])
 
     def test_simple(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-simple-metadata', 1, 1024,
             [
                 {
@@ -101,7 +101,7 @@ class TestInstanceMetadata(base.BaseNamespacedTestCase):
         self.assertEqual({}, self.test_client.get_instance_metadata(inst['uuid']))
 
     def test_set_during_create(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-set-during-create', 1, 1024,
             [
                 {
@@ -155,7 +155,7 @@ class TestInterfaceMetadata(base.BaseNamespacedTestCase):
         self._await_networks_ready([self.net['uuid']])
 
     def test_simple(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-simple-metadata', 1, 1024,
             [
                 {

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_networking.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_networking.py
@@ -127,6 +127,8 @@ class TestNetworking(base.BaseNamespacedTestCase):
     def test_specific_ip_request_invalid(self):
         self.assertRaises(
             apiclient.RequestMalformedException,
+            # raw-create: asserts the 400 an address outside the network gets,
+            # which is raised validating the request, not scheduling it.
             self.test_client.create_instance,
             'test-invalid-ip', 1, 1024,
             [

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_networking.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_networking.py
@@ -44,7 +44,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
                                     self.net_four['uuid']])
 
     def test_specific_ip_request(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-specific-ip', 1, 1024,
             [
                 {
@@ -101,7 +101,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             }
         ]
 
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-specific-ip-reuse', 1, 1024, netdesc, diskdesc, None, None)
         self.addDetail(
             'inst',
@@ -111,7 +111,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
         self.test_client.delete_instance(inst['uuid'])
         self._await_instance_deleted(inst['uuid'])
 
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-specific-ip-reuse', 1, 1024, netdesc, diskdesc, None, None)
         self.addDetail(
             'inst_recreated',
@@ -144,7 +144,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
             ], None, None)
 
     def test_specific_macaddress_request(self):
-        inst = self.test_client.create_instance(
+        inst = self.create_instance(
             'test-macaddress', 1, 1024,
             [
                 {
@@ -168,7 +168,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
         self.assertTrue('04:ed:33:c0:2e:6c' in results['stdout'])
 
     def test_interface_delete(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-iface-delete', 1, 1024,
             [
                 {
@@ -212,7 +212,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
         self._await_networks_ready([dupnet['uuid']])
 
         try:
-            inst_hyp1_vm1 = self.test_client.create_instance(
+            inst_hyp1_vm1 = self.create_instance(
                 'dup1', 1, 1024,
                 [
                     {
@@ -227,7 +227,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
                     }
                 ], None, None, force_placement='sf-2')
 
-            inst_hyp1_vm2 = self.test_client.create_instance(
+            inst_hyp1_vm2 = self.create_instance(
                 'dup2', 1, 1024,
                 [
                     {
@@ -242,7 +242,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
                     }
                 ], None, None, force_placement='sf-2')
 
-            inst_hyp2_vm1 = self.test_client.create_instance(
+            inst_hyp2_vm1 = self.create_instance(
                 'dup3', 1, 1024,
                 [
                     {
@@ -276,7 +276,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
         self.assertFalse('DUP' in results['stdout'])
 
     def test_provided_dns(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-provided-dns', 1, 1024,
             [
                 {
@@ -290,7 +290,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
                     'type': 'disk'
                 }
             ], None, None)
-        inst2 = self.test_client.create_instance(
+        inst2 = self.create_instance(
             'test-provided-dns-2', 1, 1024,
             [
                 {
@@ -402,7 +402,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
                 f'output:\n\n{data}')
 
     def test_no_provided_dns(self):
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-no-provided-dns', 1, 1024,
             [
                 {
@@ -461,7 +461,7 @@ class TestNetworking(base.BaseNamespacedTestCase):
         extra_dns_net = self.test_client.allocate_network(
             '192.168.242.0/24', True, True, '%s-extra-dns' % self.namespace,
             provide_dns=True)
-        inst1 = self.test_client.create_instance(
+        inst1 = self.create_instance(
             'test-provided-dns', 1, 1024,
             [
                 {

--- a/shakenfist/tests/test_ci_capacity_wait.py
+++ b/shakenfist/tests/test_ci_capacity_wait.py
@@ -1,0 +1,609 @@
+# Copyright 2019 Michael Still and contributors
+"""A capacity refusal in CI is usually about a moment, not the cluster.
+
+The functional suite runs concurrently against one cluster, so a create
+which is refused for insufficient resources is very often refused
+because a sibling test is holding the capacity and is already deleting
+the instance which holds it -- deletion returns capacity
+asynchronously. Treating every 507 as a hard failure makes a run's
+pass/fail a coin flip on sibling timing.
+
+``BaseTestCase.create_instance()`` waits such a refusal out, and
+``shakenfist_ci/retries.py``'s ``wait_for_capacity()`` decides when to
+stop waiting. That decision is the whole risk of the design, because
+getting it wrong does not fail loudly: a wrapper which stops waiting
+early re-issues a create which refuses again, turning one 507 into six
+while reporting that it waited.
+
+So the predicate is what most of this file is about. ``/admin/resources``
+publishes two cpu ledgers deliberately: ``cpu_available`` is live
+overcommit arithmetic, while ``cpu_limit`` is the capacity row's
+``limit_cpus`` -- which is what admission's guarded UPDATE is actually
+measured against, and which refreshes only once a reconcile period. The
+window where they disagree is precisely the window this wait exists to
+survive, so the predicate takes whichever binds. It also reads per-node
+figures only: ``total['cpu_available']`` is a sum across nodes
+(``scheduler.py``) and an instance has to fit on one of them.
+
+``retries.py`` is loaded by path and ``base.py`` by path with stubs,
+because the functional suite imports ``shakenfist_client`` and
+``prettytable``, neither of which is a test dependency of this
+repository.
+"""
+
+import importlib.util
+import logging
+import os
+import sys
+import types
+
+from unittest import mock
+
+from shakenfist.tests import base as test_base
+
+
+CI_SUITE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    'deploy', 'shakenfist_ci')
+
+RETRIES_PATH = os.path.join(CI_SUITE, 'retries.py')
+
+
+def _load_retries():
+    spec = importlib.util.spec_from_file_location(
+        'shakenfist_ci_retries_capacity_under_test', RETRIES_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+retries = _load_retries()
+
+
+def _client_stubs():
+    """A shakenfist_client which is only its exception taxonomy.
+
+    The wrapper's behaviour turns entirely on which exception classes
+    it catches, so the stub defines those and nothing else. The class
+    names and, more importantly, the fact that a 409 and a 507 are
+    *siblings* rather than one being a subclass of the other, are
+    copied from client-python's STATUS_CODES_TO_ERRORS. (On the server
+    the affinity exception is a subclass of the low-resource one, which
+    is why the API path's except clause ordering matters there; the
+    client's mapping is by status code, so the two arrive here
+    unrelated.)
+    """
+    client = types.ModuleType('shakenfist_client')
+    apiclient = types.ModuleType('shakenfist_client.apiclient')
+
+    class APIException(Exception):
+        def __init__(self, message='', method=None, url=None,
+                     status_code=None, text=None):
+            super().__init__(message)
+            self.status_code = status_code
+            self.text = text
+
+    apiclient.APIException = APIException
+    for name in ('InsufficientResourcesException',
+                 'ResourceStateConflictException',
+                 'ResourceNotFoundException',
+                 'RequestMalformedException',
+                 'ServiceUnavailableException',
+                 'IncapableException',
+                 'AgentCommandError',
+                 'AgentOperationFailed',
+                 'AgentAwaitTimeout'):
+        setattr(apiclient, name, type(name, (APIException,), {}))
+
+    apiclient.ASYNC_PAUSE = 'pause'
+    apiclient.Client = type('Client', (), {'__init__': lambda self, *a, **kw: None})
+
+    client.apiclient = apiclient
+    return client, apiclient
+
+
+def _load_ci_base():
+    """Import the functional suite's base.py without its dependencies.
+
+    Everything mutated here is put back, because stestr runs the whole
+    unit suite in one process and a stubbed shakenfist_client left in
+    sys.modules would be a trap for a later test rather than a
+    convenience for this one.
+    """
+    stub_names = ('prettytable', 'shakenfist_client',
+                  'shakenfist_client.apiclient', 'shakenfist_ci',
+                  'shakenfist_ci.base', 'shakenfist_ci.process',
+                  'shakenfist_ci.retries')
+    saved_path = list(sys.path)
+    saved_modules = {name: sys.modules.get(name) for name in stub_names}
+    root_logger = logging.getLogger()
+    saved_handlers = list(root_logger.handlers)
+    saved_level = root_logger.level
+
+    try:
+        sys.path.insert(0, os.path.dirname(CI_SUITE))
+        for name in stub_names:
+            sys.modules.pop(name, None)
+
+        prettytable = types.ModuleType('prettytable')
+        prettytable.PrettyTable = type('PrettyTable', (), {})
+        sys.modules['prettytable'] = prettytable
+
+        client, apiclient = _client_stubs()
+        sys.modules['shakenfist_client'] = client
+        sys.modules['shakenfist_client.apiclient'] = apiclient
+
+        import shakenfist_ci.base as ci_base
+        return ci_base, apiclient
+
+    finally:
+        sys.path[:] = saved_path
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+        root_logger.handlers[:] = saved_handlers
+        root_logger.setLevel(saved_level)
+
+
+ci_base, ci_apiclient = _load_ci_base()
+
+
+def node(cpu_available, cpu_limit=None, cpu_committed=0):
+    """One entry as summarize_resources() publishes it, trimmed."""
+    return {
+        'cpu_available': cpu_available,
+        'cpu_limit': cpu_limit,
+        'cpu_committed': cpu_committed,
+        'cpu_committed_row_present': cpu_limit is not None,
+    }
+
+
+def roster(per_node, degraded=False, total_cpu_available=None):
+    if total_cpu_available is None:
+        total_cpu_available = sum(
+            max(0, entry['cpu_available']) for entry in per_node.values())
+    return {
+        'total': {
+            'cpu_available': total_cpu_available,
+            'capacity_degraded': degraded,
+        },
+        'per_node': per_node,
+    }
+
+
+class FakeCluster:
+    """A scripted sequence of resource rosters, and a fake clock.
+
+    The clock advances only when the loop sleeps, so a test can say
+    exactly how many polls fit inside a deadline. An entry which is an
+    exception instance is raised instead of returned, which is how a
+    briefly unreachable endpoint is scripted.
+    """
+
+    def __init__(self, answers):
+        self.answers = list(answers)
+        self.now = 100.0
+        self.sleeps = 0
+        self.polls = 0
+
+    def poll(self):
+        self.polls += 1
+        if len(self.answers) > 1:
+            answer = self.answers.pop(0)
+        else:
+            answer = self.answers[0]
+        if isinstance(answer, Exception):
+            raise answer
+        return answer
+
+    def clock(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.sleeps += 1
+        self.now += seconds
+
+
+class WaitForCapacityTestCase(test_base.ShakenFistTestCase):
+    def _wait(self, cluster, cpus=2, target=None, deadline=420):
+        return retries.wait_for_capacity(
+            cluster.poll, cpus, target, cluster.now + deadline,
+            clock=cluster.clock, sleep=cluster.sleep)
+
+    def test_room_already_means_no_wait_at_all(self):
+        """The common case must cost one poll and no sleep.
+
+        Every retried create pays for this loop, so a wrapper which
+        slept once before believing an answer would add ten seconds to
+        every refusal in the run.
+        """
+        cluster = FakeCluster([
+            roster({'n1': node(8, cpu_limit=16, cpu_committed=4)})])
+        record = self._wait(cluster)
+
+        self.assertTrue(record['satisfied'])
+        self.assertEqual(0, cluster.sleeps)
+        self.assertEqual(1, record['polls'])
+        self.assertEqual(0.0, record['seconds_waited'])
+        self.assertEqual('informed', record['mode'])
+        self.assertEqual(8, record['headroom_at_start'])
+        self.assertEqual(8, record['headroom_at_end'])
+
+    def test_a_wait_ends_when_a_sibling_gives_its_capacity_back(self):
+        """The whole point: full now is not full soon.
+
+        The headroom at the first poll and at admission are both kept,
+        because a wait record which said only "waited 20s" could not
+        tell a reader whether the cluster was one cpu short or empty.
+        """
+        cluster = FakeCluster([
+            roster({'n1': node(0, cpu_limit=16, cpu_committed=16)}),
+            roster({'n1': node(1, cpu_limit=16, cpu_committed=15)}),
+            roster({'n1': node(4, cpu_limit=16, cpu_committed=12)}),
+        ])
+        record = self._wait(cluster, cpus=2)
+
+        self.assertTrue(record['satisfied'])
+        self.assertEqual(3, record['polls'])
+        self.assertEqual(2, cluster.sleeps)
+        self.assertEqual(20.0, record['seconds_waited'])
+        self.assertEqual(0, record['headroom_at_start'])
+        self.assertEqual(4, record['headroom_at_end'])
+
+    def test_a_cluster_which_stays_full_gives_up_at_the_deadline(self):
+        """Waiting is bounded, and the roster comes back with the answer.
+
+        The caller fails the test with this record in hand, so a
+        cluster which is genuinely too small still produces a failure
+        -- a slower one, but one which says what was full.
+        """
+        cluster = FakeCluster([
+            roster({'n1': node(0, cpu_limit=16, cpu_committed=16)})])
+        record = self._wait(cluster, cpus=2, deadline=25)
+
+        self.assertFalse(record['satisfied'])
+        # 25 seconds of deadline at a 10 second interval is polls at
+        # t=0, 10, 20 and a final one at t=30 which sees the deadline
+        # passed and returns.
+        self.assertEqual(4, record['polls'])
+        self.assertEqual(3, cluster.sleeps)
+        self.assertEqual(30.0, record['seconds_waited'])
+        self.assertEqual({'n1': node(0, cpu_limit=16, cpu_committed=16)},
+                         record['per_node'])
+
+    def test_a_degraded_read_waits_blind_and_admits_to_it(self):
+        """capacity_degraded means cpu_limit is None for an unrelated reason.
+
+        Every node's limit going missing because the capacity mapping
+        could not be read looks identical, to the predicate, to every
+        node having no capacity row. Waiting informed on that is
+        waiting on noise, so the loop sleeps one interval and hands
+        back a record which says the wait told us nothing.
+        """
+        cluster = FakeCluster([
+            roster({'n1': node(64)}, degraded=True)])
+        record = self._wait(cluster, cpus=2)
+
+        self.assertEqual('degraded', record['mode'])
+        self.assertEqual(1, record['degraded_polls'])
+        self.assertFalse(record['satisfied'])
+        self.assertEqual(1, cluster.sleeps)
+        self.assertEqual(10.0, record['seconds_waited'])
+        self.assertIsNone(
+            record['headroom_at_start'],
+            'A degraded read must not be recorded as a headroom '
+            'measurement, or the summary reports noise as data.')
+
+    def test_a_target_missing_from_the_roster_is_not_yet_rather_than_never(self):
+        """per_node omits a node for two reasons which both clear.
+
+        summarize_resources() skips a node whose queue is over the
+        unreasonable length and a node which has published no metrics
+        yet, and a node the cluster has just started shows up a moment
+        later. A predicate written as per_node[target]['cpu_available']
+        raises KeyError inside the loop for a condition which is
+        exactly what the loop is waiting out.
+        """
+        cluster = FakeCluster([
+            roster({'other': node(64, cpu_limit=64)}),
+            roster({'other': node(64, cpu_limit=64),
+                    'n1': node(8, cpu_limit=16, cpu_committed=8)}),
+        ])
+        record = self._wait(cluster, cpus=2, target='n1')
+
+        self.assertTrue(record['satisfied'])
+        self.assertEqual(2, record['polls'])
+        self.assertEqual(
+            0, record['headroom_at_start'],
+            'An absent node must read as no headroom, not as the '
+            'headroom of whichever node happened to be listed.')
+        self.assertEqual(8, record['headroom_at_end'])
+
+    def test_a_binding_limit_beats_generous_published_headroom(self):
+        """The decision this whole phase rests on.
+
+        A node can measure as idle -- 64 threads of live overcommit
+        headroom -- while the capacity row admission is guarded by says
+        it has one cpu left, because the row refreshes once a reconcile
+        period and the node was filled since. A wait which believed
+        cpu_available would stop immediately, re-issue the create, be
+        refused again, and record a wait far shorter than the one the
+        run actually spent.
+
+        Deleting the cpu_limit clause from node_available_cpus() makes
+        this test fail, which was confirmed by doing it.
+        """
+        cluster = FakeCluster([
+            roster({'n1': node(64, cpu_limit=16, cpu_committed=15)})])
+        record = self._wait(cluster, cpus=4, target='n1', deadline=5)
+
+        self.assertFalse(
+            record['satisfied'],
+            'The wait believed the published headroom over the ledger '
+            'admission is measured against, so it would stop waiting '
+            'during exactly the window the two disagree.')
+        self.assertEqual(
+            1, record['headroom_at_start'],
+            'The headroom recorded must be the binding one (limit 16 '
+            'less 15 committed), not the published 64.')
+
+    def test_an_unpinned_create_reads_nodes_and_never_the_cluster_total(self):
+        """total['cpu_available'] is a sum, and an instance is not.
+
+        Ten nodes with one spare thread each publish a cluster total of
+        ten, and refuse a two cpu create every time.
+        """
+        per_node = {
+            'n%d' % i: node(1, cpu_limit=16, cpu_committed=15)
+            for i in range(10)}
+        cluster = FakeCluster([roster(per_node)])
+        self.assertEqual(10, roster(per_node)['total']['cpu_available'])
+
+        record = self._wait(cluster, cpus=2, deadline=5)
+
+        self.assertFalse(
+            record['satisfied'],
+            'The wait was satisfied by capacity spread across ten '
+            'nodes, which no single instance can be placed into.')
+        self.assertEqual(1, record['headroom_at_start'])
+
+    def test_an_unpinned_create_takes_the_best_single_node(self):
+        cluster = FakeCluster([roster({
+            'n1': node(1, cpu_limit=16, cpu_committed=15),
+            'n2': node(6, cpu_limit=16, cpu_committed=10)})])
+        record = self._wait(cluster, cpus=4)
+
+        self.assertTrue(record['satisfied'])
+        self.assertEqual(6, record['headroom_at_end'])
+
+    def test_a_poll_which_raises_is_not_evidence_about_capacity(self):
+        """An unreachable endpoint says nothing, so the wait continues.
+
+        It is recorded rather than swallowed, because a wait which
+        ended at its deadline having never once read the roster is a
+        different diagnosis from one which read a full cluster the
+        whole time.
+        """
+        cluster = FakeCluster([
+            ValueError('connection reset'),
+            roster({'n1': node(8, cpu_limit=16, cpu_committed=8)}),
+        ])
+        record = self._wait(cluster, cpus=2)
+
+        self.assertTrue(record['satisfied'])
+        self.assertEqual(2, record['polls'])
+        self.assertEqual(['ValueError: connection reset'],
+                         record['poll_errors'])
+
+    def test_a_node_with_no_capacity_row_is_read_as_published(self):
+        """cpu_limit None means admission is guarded by nothing.
+
+        A node the reconciler has not sized is charged nothing by the
+        guard, so the published headroom is both all we know and the
+        right answer.
+        """
+        cluster = FakeCluster([roster({'n1': node(8, cpu_limit=None)})])
+        record = self._wait(cluster, cpus=4, target='n1')
+
+        self.assertTrue(record['satisfied'])
+        self.assertEqual(8, record['headroom_at_end'])
+
+
+class _WrapperHarness(ci_base.BaseTestCase):
+    """Drives create_instance() without running the suite's setUp.
+
+    setUp() builds a real apiclient and writes a tracing event to
+    /srv/ci/traces, neither of which a unit test should do, so the
+    harness supplies the four things the wrapper touches instead.
+    """
+
+    def __init__(self, client):
+        # Deliberately not calling TestCase.__init__: this is not being
+        # run as a test, only used as a bound self for the wrapper.
+        self.test_client = client
+        self.system_client = client
+        self.details = {}
+        self.failure = None
+        self.uniquifiers = 0
+
+    def _uniquifier(self):
+        self.uniquifiers += 1
+        return 'uniq%04d' % self.uniquifiers
+
+    def addDetail(self, name, detail):
+        self.details[name] = detail
+
+    def fail(self, message):
+        self.failure = message
+        raise AssertionError(message)
+
+
+class FakeInstanceClient:
+    """Answers create_instance() from a script, and records what it saw."""
+
+    def __init__(self, answers, resources=None):
+        self.answers = list(answers)
+        self.calls = []
+        self.resources = resources or roster(
+            {'n1': node(64, cpu_limit=64)})
+
+    def create_instance(self, name, cpus, memory, network, disk, sshkey,
+                        userdata, **kwargs):
+        self.calls.append((name, cpus, kwargs))
+        answer = self.answers.pop(0)
+        if isinstance(answer, Exception):
+            raise answer
+        return answer
+
+    def get_cluster_resources(self):
+        return self.resources
+
+
+class CreateInstanceWrapperTestCase(test_base.ShakenFistTestCase):
+    def test_a_create_which_is_not_refused_is_not_wrapped_at_all(self):
+        client = FakeInstanceClient([{'uuid': 'inst-1'}])
+        harness = _WrapperHarness(client)
+
+        inst = harness.create_instance(
+            'plain', 1, 1024, None, [], None, None)
+
+        self.assertEqual({'uuid': 'inst-1'}, inst)
+        self.assertEqual([('plain', 1, {'force_placement': None})],
+                         client.calls)
+        self.assertEqual({}, harness.details)
+
+    def test_an_affinity_refusal_is_not_waited_out(self):
+        """A 409 does not become satisfiable by waiting.
+
+        The server keeps the affinity refusal apart from the capacity
+        one only by the ordering of two except clauses, because the
+        affinity exception is a subclass of the low resource one there.
+        A wrapper which caught the family rather than the exact
+        capacity exception would spend seven minutes turning a clear
+        failure into a slow one.
+        """
+        refusal = ci_apiclient.ResourceStateConflictException(
+            'affinity constraint cannot be satisfied', status_code=409)
+        client = FakeInstanceClient([refusal])
+        harness = _WrapperHarness(client)
+
+        with mock.patch.object(ci_base.retries, 'wait_for_capacity') as waiter:
+            self.assertRaises(
+                ci_apiclient.ResourceStateConflictException,
+                harness.create_instance,
+                'affine', 1, 1024, None, [], None, None,
+                force_placement='n1')
+
+        self.assertEqual(
+            1, len(client.calls),
+            'The 409 was retried, so an unsatisfiable affinity '
+            'constraint would be waited out for the whole deadline.')
+        waiter.assert_not_called()
+        self.assertIsNone(harness.failure)
+
+    def test_a_retried_create_uses_a_fresh_name(self):
+        """The refused instance holds the caller's name until it is gone.
+
+        A refusal creates the instance and then enqueues a delete for
+        it, which completes asynchronously, so re-issuing under the
+        same name races the delete for a duplicate-name refusal that
+        has nothing to do with capacity.
+        """
+        refusal = ci_apiclient.InsufficientResourcesException(
+            'no node has 4 cpus', status_code=507, text='no node has 4 cpus')
+        client = FakeInstanceClient([refusal, {'uuid': 'inst-2'}])
+        harness = _WrapperHarness(client)
+
+        satisfied = {'satisfied': True, 'mode': 'informed',
+                     'seconds_waited': 12.5, 'node': 'n1',
+                     'headroom_at_start': 0, 'headroom_at_end': 4,
+                     'per_node': {}, 'polls': 2, 'poll_errors': []}
+        with mock.patch.object(ci_base.retries, 'wait_for_capacity',
+                               return_value=dict(satisfied)) as waiter:
+            inst = harness.create_instance(
+                'retried', 4, 1024, None, [], None, None,
+                force_placement='n1')
+
+        self.assertEqual({'uuid': 'inst-2'}, inst)
+        self.assertEqual('retried', client.calls[0][0])
+        self.assertEqual(
+            'retried-uniq0001', client.calls[1][0],
+            'The retry reused the refused instance\'s name, which is '
+            'still in use until its error delete completes.')
+
+        # The wait watches the node the create was pinned to, and asks
+        # for the cpus the create asked for.
+        self.assertEqual(4, waiter.call_args[0][1])
+        self.assertEqual('n1', waiter.call_args[0][2])
+
+        self.assertEqual(
+            ['capacity-wait-1'], list(harness.details),
+            'A wait which is not attached to the test is a wait the '
+            'run cannot be asked about afterwards.')
+
+    def test_the_deadline_fails_with_the_refusal_and_the_roster(self):
+        """A genuinely too-small cloud must still fail, and say what was full."""
+        refusal = ci_apiclient.InsufficientResourcesException(
+            'no node has 4 cpus', status_code=507,
+            text='instance could not be placed')
+        client = FakeInstanceClient([refusal])
+        harness = _WrapperHarness(client)
+
+        exhausted = {'satisfied': False, 'mode': 'informed',
+                     'seconds_waited': 420.0, 'node': 'n1',
+                     'headroom_at_start': 0, 'headroom_at_end': 0,
+                     'per_node': {'n1': node(0, cpu_limit=16,
+                                             cpu_committed=16)},
+                     'polls': 43, 'poll_errors': ['ValueError: reset']}
+        with mock.patch.object(ci_base.retries, 'wait_for_capacity',
+                               return_value=dict(exhausted)):
+            with mock.patch.object(ci_base.time, 'time',
+                                   side_effect=[0.0, 0.0, 10000.0]):
+                self.assertRaises(
+                    AssertionError, harness.create_instance,
+                    'toobig', 4, 1024, None, [], None, None,
+                    force_placement='n1')
+
+        self.assertIn('instance could not be placed', harness.failure)
+        self.assertIn('n1', harness.failure)
+        self.assertIn('cpu_committed', harness.failure)
+        self.assertIn('ValueError: reset', harness.failure)
+        self.assertIn('420', harness.failure)
+
+    def test_a_degraded_wait_retries_the_create_at_the_same_cadence(self):
+        """A blind wait is still a wait, and it still gets recorded.
+
+        D10's fallback is to keep re-issuing at the poll interval, so
+        the create must be retried after a degraded wait rather than
+        the wrapper concluding anything from it.
+        """
+        refusal = ci_apiclient.InsufficientResourcesException(
+            'full', status_code=507, text='full')
+        client = FakeInstanceClient([refusal, {'uuid': 'inst-3'}])
+        harness = _WrapperHarness(client)
+
+        degraded = {'satisfied': False, 'mode': 'degraded',
+                    'seconds_waited': 10.0, 'node': None,
+                    'degraded_polls': 1, 'headroom_at_start': None,
+                    'headroom_at_end': None, 'per_node': {},
+                    'polls': 1, 'poll_errors': []}
+        with mock.patch.object(ci_base.retries, 'wait_for_capacity',
+                               return_value=dict(degraded)):
+            inst = harness.create_instance(
+                'blind', 1, 1024, None, [], None, None)
+
+        self.assertEqual({'uuid': 'inst-3'}, inst)
+        self.assertEqual(2, len(client.calls))
+        self.assertEqual(['capacity-wait-1'], list(harness.details))
+
+    def test_recording_a_wait_may_never_fail_the_test_it_measures(self):
+        """An instrument which breaks the run is worse than no instrument."""
+        harness = _WrapperHarness(FakeInstanceClient([]))
+
+        def explode(name, detail):
+            raise OSError('no space left on device')
+
+        harness.addDetail = explode
+        harness._record_capacity_wait({'instance_name': 'x', 'mode': 'informed'})

--- a/shakenfist/tests/test_ci_capacity_wait.py
+++ b/shakenfist/tests/test_ci_capacity_wait.py
@@ -153,14 +153,29 @@ def _load_ci_base():
 ci_base, ci_apiclient = _load_ci_base()
 
 
-def node(cpu_available, cpu_limit=None, cpu_committed=0):
-    """One entry as summarize_resources() publishes it, trimmed."""
-    return {
+def node(cpu_available, cpu_limit=None, cpu_committed=0,
+         ram_available=64 * 1024, disk_available=1024,
+         cpu_max_per_instance=None, ram_max_per_instance=None):
+    """One entry as summarize_resources() publishes it, trimmed.
+
+    Memory and disk default to far more than any test here asks for, so
+    a test about cpus is about cpus. The two per-instance ceilings are
+    omitted unless a test asks for them, because a node which has
+    published no metrics for them omits them too.
+    """
+    entry = {
         'cpu_available': cpu_available,
         'cpu_limit': cpu_limit,
         'cpu_committed': cpu_committed,
         'cpu_committed_row_present': cpu_limit is not None,
+        'ram_available': ram_available,
+        'disk_available': disk_available,
     }
+    if cpu_max_per_instance is not None:
+        entry['cpu_max_per_instance'] = cpu_max_per_instance
+    if ram_max_per_instance is not None:
+        entry['ram_max_per_instance'] = ram_max_per_instance
+    return entry
 
 
 def roster(per_node, degraded=False, total_cpu_available=None):
@@ -209,11 +224,45 @@ class FakeCluster:
         self.now += seconds
 
 
+class RequestedDiskTestCase(test_base.ShakenFistTestCase):
+    """The disk a create asks for, counted as the scheduler counts it."""
+
+    def test_the_sizes_are_summed(self):
+        self.assertEqual(28, retries.requested_disk_gb(
+            [{'size': 20, 'type': 'disk'}, {'size': 8, 'type': 'disk'}]))
+
+    def test_a_sizeless_disk_asks_for_nothing(self):
+        """_has_sufficient_disk() ignores them, so this must too.
+
+        A cdrom is exactly the size of its base image and carries no
+        size, and charging it as zero is what the server does.
+        """
+        self.assertEqual(8, retries.requested_disk_gb(
+            [{'size': 8, 'type': 'disk'},
+             {'type': 'cdrom', 'base': 'sf://upload/system/debian-12'},
+             {'size': None, 'type': 'disk'}]))
+
+    def test_no_disk_spec_at_all_asks_for_nothing(self):
+        self.assertEqual(0, retries.requested_disk_gb(None))
+        self.assertEqual(0, retries.requested_disk_gb([]))
+
+    def test_a_size_which_is_not_a_number_is_skipped_rather_than_fatal(self):
+        """The wrapper must not raise on a spec the server would reject.
+
+        A malformed disk spec is the server's 400 to give, and it gives a
+        far better message than a TypeError from inside a wait predicate.
+        """
+        self.assertEqual(8, retries.requested_disk_gb(
+            [{'size': 8}, {'size': 'banana'}, 'not-a-dict']))
+
+
 class WaitForCapacityTestCase(test_base.ShakenFistTestCase):
-    def _wait(self, cluster, cpus=2, target=None, deadline=420):
+    def _wait(self, cluster, cpus=2, memory_mb=1024, disk_gb=8, target=None,
+              deadline=420, minimum_sleep=0):
         return retries.wait_for_capacity(
-            cluster.poll, cpus, target, cluster.now + deadline,
-            clock=cluster.clock, sleep=cluster.sleep)
+            cluster.poll, cpus, memory_mb, disk_gb, target,
+            cluster.now + deadline, clock=cluster.clock, sleep=cluster.sleep,
+            minimum_sleep=minimum_sleep)
 
     def test_room_already_means_no_wait_at_all(self):
         """The common case must cost one poll and no sleep.
@@ -231,8 +280,11 @@ class WaitForCapacityTestCase(test_base.ShakenFistTestCase):
         self.assertEqual(1, record['polls'])
         self.assertEqual(0.0, record['seconds_waited'])
         self.assertEqual('informed', record['mode'])
-        self.assertEqual(8, record['headroom_at_start'])
-        self.assertEqual(8, record['headroom_at_end'])
+        self.assertEqual(8, record['headroom_at_start']['cpus'])
+        self.assertEqual(8, record['headroom_at_end']['cpus'])
+        self.assertIsNone(
+            record['binding_dimension'],
+            'Nothing was short, so nothing was waited on.')
 
     def test_a_wait_ends_when_a_sibling_gives_its_capacity_back(self):
         """The whole point: full now is not full soon.
@@ -252,8 +304,9 @@ class WaitForCapacityTestCase(test_base.ShakenFistTestCase):
         self.assertEqual(3, record['polls'])
         self.assertEqual(2, cluster.sleeps)
         self.assertEqual(20.0, record['seconds_waited'])
-        self.assertEqual(0, record['headroom_at_start'])
-        self.assertEqual(4, record['headroom_at_end'])
+        self.assertEqual(0, record['headroom_at_start']['cpus'])
+        self.assertEqual(4, record['headroom_at_end']['cpus'])
+        self.assertEqual('cpus', record['binding_dimension'])
 
     def test_a_cluster_which_stays_full_gives_up_at_the_deadline(self):
         """Waiting is bounded, and the roster comes back with the answer.
@@ -319,10 +372,10 @@ class WaitForCapacityTestCase(test_base.ShakenFistTestCase):
         self.assertTrue(record['satisfied'])
         self.assertEqual(2, record['polls'])
         self.assertEqual(
-            0, record['headroom_at_start'],
+            0, record['headroom_at_start']['cpus'],
             'An absent node must read as no headroom, not as the '
             'headroom of whichever node happened to be listed.')
-        self.assertEqual(8, record['headroom_at_end'])
+        self.assertEqual(8, record['headroom_at_end']['cpus'])
 
     def test_a_binding_limit_beats_generous_published_headroom(self):
         """The decision this whole phase rests on.
@@ -348,7 +401,7 @@ class WaitForCapacityTestCase(test_base.ShakenFistTestCase):
             'admission is measured against, so it would stop waiting '
             'during exactly the window the two disagree.')
         self.assertEqual(
-            1, record['headroom_at_start'],
+            1, record['headroom_at_start']['cpus'],
             'The headroom recorded must be the binding one (limit 16 '
             'less 15 committed), not the published 64.')
 
@@ -370,7 +423,7 @@ class WaitForCapacityTestCase(test_base.ShakenFistTestCase):
             record['satisfied'],
             'The wait was satisfied by capacity spread across ten '
             'nodes, which no single instance can be placed into.')
-        self.assertEqual(1, record['headroom_at_start'])
+        self.assertEqual(1, record['headroom_at_start']['cpus'])
 
     def test_an_unpinned_create_takes_the_best_single_node(self):
         cluster = FakeCluster([roster({
@@ -379,7 +432,7 @@ class WaitForCapacityTestCase(test_base.ShakenFistTestCase):
         record = self._wait(cluster, cpus=4)
 
         self.assertTrue(record['satisfied'])
-        self.assertEqual(6, record['headroom_at_end'])
+        self.assertEqual(6, record['headroom_at_end']['cpus'])
 
     def test_a_poll_which_raises_is_not_evidence_about_capacity(self):
         """An unreachable endpoint says nothing, so the wait continues.
@@ -400,6 +453,152 @@ class WaitForCapacityTestCase(test_base.ShakenFistTestCase):
         self.assertEqual(['ValueError: connection reset'],
                          record['poll_errors'])
 
+    def test_a_create_waits_on_memory_the_same_way_it_waits_on_cpus(self):
+        """The dimension most likely to bind in CI, and the one D8 missed.
+
+        CI instances are 1 vCPU and 1-2 GB, so a node runs out of memory
+        long before it runs out of threads. A predicate which read only
+        cpus would report "there is room now" for the whole deadline
+        while the server went on refusing, and the caller would re-issue
+        as fast as two HTTP round trips allow -- leaving an
+        error-deleted instance behind every time.
+        """
+        cluster = FakeCluster([
+            roster({'n1': node(64, cpu_limit=64, ram_available=512)}),
+            roster({'n1': node(64, cpu_limit=64, ram_available=4096)}),
+        ])
+        record = self._wait(cluster, cpus=1, memory_mb=2048, target='n1')
+
+        self.assertTrue(record['satisfied'])
+        self.assertEqual(2, record['polls'])
+        self.assertEqual(
+            'memory_mb', record['binding_dimension'],
+            'The wait must say what it waited on, or phase 5 reads a '
+            'duration with no cause attached to it.')
+        self.assertEqual(512, record['headroom_at_start']['memory_mb'])
+        self.assertEqual(4096, record['headroom_at_end']['memory_mb'])
+
+    def test_a_create_waits_on_disk_the_same_way(self):
+        cluster = FakeCluster([
+            roster({'n1': node(64, cpu_limit=64, disk_available=4)})])
+        record = self._wait(cluster, cpus=1, disk_gb=20, target='n1',
+                            deadline=5)
+
+        self.assertFalse(record['satisfied'])
+        self.assertEqual('disk_gb', record['binding_dimension'])
+
+    def test_a_node_must_cover_every_dimension_at_once(self):
+        """Two nodes which each cover half the request cover none of it.
+
+        The same error as reading total['cpu_available'], one level down:
+        an instance is placed on one node and needs all three of its
+        dimensions there.
+        """
+        cluster = FakeCluster([roster({
+            'plenty-of-cpu': node(64, cpu_limit=64, ram_available=512),
+            'plenty-of-ram': node(1, cpu_limit=16, cpu_committed=15,
+                                  ram_available=64 * 1024)})])
+        record = self._wait(cluster, cpus=4, memory_mb=2048, deadline=5)
+
+        self.assertFalse(
+            record['satisfied'],
+            'The wait was satisfied by cpus on one node and memory on '
+            'another, which no single instance can be placed into.')
+
+    def test_a_per_instance_ceiling_is_not_aggregate_headroom(self):
+        """cpu_max_per_instance bounds one instance, not the node.
+
+        A node can publish ample aggregate headroom and still refuse a
+        create larger than the biggest single instance it will take, and
+        that refusal is permanent rather than transient -- so a predicate
+        which ignored the ceiling is satisfied forever while the server
+        refuses forever.
+        """
+        cluster = FakeCluster([roster({
+            'n1': node(64, cpu_limit=64, cpu_max_per_instance=2)})])
+        record = self._wait(cluster, cpus=4, target='n1', deadline=5)
+
+        self.assertFalse(record['satisfied'])
+        self.assertEqual(2, record['headroom_at_start']['cpus'])
+        self.assertEqual('cpus', record['binding_dimension'])
+
+    def test_a_missing_per_instance_ceiling_does_not_read_as_zero(self):
+        """A node publishing no cpu_max_per_instance metric publishes a 0.
+
+        Reading that as "this node will take no instances" would make
+        every wait against a node mid-upgrade run to its deadline.
+        """
+        entry = node(8, cpu_limit=16, cpu_committed=8,
+                     cpu_max_per_instance=0)
+        cluster = FakeCluster([roster({'n1': entry})])
+        record = self._wait(cluster, cpus=4, target='n1', deadline=5)
+
+        self.assertTrue(record['satisfied'])
+        self.assertEqual(8, record['headroom_at_start']['cpus'])
+
+    def test_a_memory_ceiling_of_zero_is_a_real_full_node(self):
+        """ram_max_per_instance differs from the cpu one, deliberately.
+
+        It is memory_available less the node's reservation, which is
+        legitimately zero or negative on a genuinely full node rather
+        than a sign of a missing metric, so it is read whenever present.
+        """
+        cluster = FakeCluster([roster({
+            'n1': node(64, cpu_limit=64, ram_available=64 * 1024,
+                       ram_max_per_instance=0)})])
+        record = self._wait(cluster, cpus=1, memory_mb=1024, target='n1',
+                            deadline=5)
+
+        self.assertFalse(record['satisfied'])
+        self.assertEqual('memory_mb', record['binding_dimension'])
+
+    def test_a_dimension_the_create_asks_nothing_of_cannot_bind(self):
+        """A sizeless disk spec asks for no disk.
+
+        A node with no disk left would otherwise never satisfy a create
+        which wants none of it, and the wait would run to its deadline
+        over a dimension nobody asked about.
+        """
+        cluster = FakeCluster([roster({
+            'n1': node(8, cpu_limit=16, cpu_committed=8, disk_available=0)})])
+        record = self._wait(cluster, cpus=1, disk_gb=0, target='n1',
+                            deadline=5)
+
+        self.assertTrue(record['satisfied'])
+
+    def test_a_satisfied_wait_can_be_paced_by_its_caller(self):
+        """The floor which stops a caller busy-looping on a blind refusal.
+
+        A satisfied wait hands control straight back to a caller which
+        has just been refused. If the refusal is for something this
+        predicate cannot see, satisfied is the permanent answer, and an
+        unpaced caller re-issues as fast as two HTTP round trips allow
+        until its deadline.
+        """
+        cluster = FakeCluster([
+            roster({'n1': node(64, cpu_limit=64)})])
+        record = self._wait(cluster, cpus=1, target='n1', minimum_sleep=10)
+
+        self.assertTrue(record['satisfied'])
+        self.assertEqual(1, record['polls'])
+        self.assertEqual(1, cluster.sleeps)
+        self.assertEqual(
+            10.0, record['seconds_waited'],
+            'A paced wait must report the time it actually spent, or the '
+            'trace under-reports what the run cost.')
+
+    def test_pacing_never_adds_to_a_wait_which_already_waited(self):
+        """The floor is a minimum, not a tax on every wait."""
+        cluster = FakeCluster([
+            roster({'n1': node(0, cpu_limit=16, cpu_committed=16)}),
+            roster({'n1': node(8, cpu_limit=16, cpu_committed=8)}),
+        ])
+        record = self._wait(cluster, cpus=1, target='n1', minimum_sleep=10)
+
+        self.assertTrue(record['satisfied'])
+        self.assertEqual(1, cluster.sleeps)
+        self.assertEqual(10.0, record['seconds_waited'])
+
     def test_a_node_with_no_capacity_row_is_read_as_published(self):
         """cpu_limit None means admission is guarded by nothing.
 
@@ -411,7 +610,7 @@ class WaitForCapacityTestCase(test_base.ShakenFistTestCase):
         record = self._wait(cluster, cpus=4, target='n1')
 
         self.assertTrue(record['satisfied'])
-        self.assertEqual(8, record['headroom_at_end'])
+        self.assertEqual(8, record['headroom_at_end']['cpus'])
 
 
 class _WrapperHarness(ci_base.BaseTestCase):
@@ -422,7 +621,7 @@ class _WrapperHarness(ci_base.BaseTestCase):
     harness supplies the four things the wrapper touches instead.
     """
 
-    def __init__(self, client, clock=None):
+    def __init__(self, client, clock=None, advancing=False):
         # Deliberately not calling TestCase.__init__: this is not being
         # run as a test, only used as a bound self for the wrapper.
         self.test_client = client
@@ -431,6 +630,8 @@ class _WrapperHarness(ci_base.BaseTestCase):
         self.failure = None
         self.uniquifiers = 0
         self.clock = list(clock or [0.0])
+        self.advancing = advancing
+        self.slept = []
 
     def _uniquifier(self):
         self.uniquifiers += 1
@@ -453,10 +654,23 @@ class _WrapperHarness(ci_base.BaseTestCase):
         not an error worth raising on. Scripting this rather than
         patching time.time() is what keeps the module's log lines out of
         the clock -- see BaseTestCase._now() for what that cost once.
+
+        An 'advancing' harness is the other mode: one clock which moves
+        only when something sleeps, for a test which drives the real
+        wait_for_capacity() through the wrapper and needs the two to
+        agree about what time it is.
         """
+        if self.advancing:
+            return self.clock[0]
         if len(self.clock) > 1:
             return self.clock.pop(0)
         return self.clock[0]
+
+    def _sleep(self, seconds):
+        """The seam which keeps a real wait out of real wall clock time."""
+        self.slept.append(seconds)
+        if self.advancing:
+            self.clock[0] += seconds
 
     def addDetail(self, name, detail):
         self.details[name] = detail
@@ -467,10 +681,16 @@ class _WrapperHarness(ci_base.BaseTestCase):
 
 
 class FakeInstanceClient:
-    """Answers create_instance() from a script, and records what it saw."""
+    """Answers create_instance() from a script, and records what it saw.
 
-    def __init__(self, answers, resources=None):
+    A script of one entry repeats that entry forever, which is how "the
+    server refuses this create for a reason the roster does not show"
+    is written down.
+    """
+
+    def __init__(self, answers, resources=None, repeat_last=False):
         self.answers = list(answers)
+        self.repeat_last = repeat_last
         self.calls = []
         self.resources = resources or roster(
             {'n1': node(64, cpu_limit=64)})
@@ -478,7 +698,10 @@ class FakeInstanceClient:
     def create_instance(self, name, cpus, memory, network, disk, sshkey,
                         userdata, **kwargs):
         self.calls.append((name, cpus, kwargs))
-        answer = self.answers.pop(0)
+        if self.repeat_last and len(self.answers) == 1:
+            answer = self.answers[0]
+        else:
+            answer = self.answers.pop(0)
         if isinstance(answer, Exception):
             raise answer
         return answer
@@ -554,13 +777,16 @@ class CreateInstanceWrapperTestCase(test_base.ShakenFistTestCase):
 
         satisfied = {'satisfied': True, 'mode': 'informed',
                      'seconds_waited': 12.5, 'node': 'n1',
-                     'headroom_at_start': 0, 'headroom_at_end': 4,
+                     'headroom_at_start': {'cpus': 0}, 'headroom_at_end': {'cpus': 4},
                      'per_node': {}, 'polls': 2, 'poll_errors': []}
         with mock.patch.object(ci_base.retries, 'wait_for_capacity',
                                return_value=dict(satisfied)) as waiter:
             inst = harness.create_instance(
-                'retried', 4, 1024, None, [], None, None,
-                force_placement='n1')
+                'retried', 4, 1024, None,
+                [{'size': 12, 'type': 'disk'},
+                 {'size': 8, 'type': 'disk'},
+                 {'type': 'cdrom'}],
+                None, None, force_placement='n1')
 
         self.assertEqual({'uuid': 'inst-2'}, inst)
         self.assertEqual('retried', client.calls[0][0])
@@ -570,14 +796,55 @@ class CreateInstanceWrapperTestCase(test_base.ShakenFistTestCase):
             'still in use until its error delete completes.')
 
         # The wait watches the node the create was pinned to, and asks
-        # for the cpus the create asked for.
+        # for the whole size the create asked for -- all three dimensions
+        # the scheduler pre-filters on, not just the cpus.
         self.assertEqual(4, waiter.call_args[0][1])
-        self.assertEqual('n1', waiter.call_args[0][2])
+        self.assertEqual(1024, waiter.call_args[0][2])
+        self.assertEqual(20, waiter.call_args[0][3])
+        self.assertEqual('n1', waiter.call_args[0][4])
 
         self.assertEqual(
             ['capacity-wait-1'], list(harness.details),
             'A wait which is not attached to the test is a wait the '
             'run cannot be asked about afterwards.')
+
+    def test_a_retry_cannot_build_a_name_the_server_will_reject(self):
+        """63 characters, or a 400 which reads as an unrelated failure.
+
+        external_api/instance.py rejects a name over 63 characters, and a
+        retry appends a hyphen and eight characters. A caller near the
+        limit would see its capacity retry come back as a
+        RequestMalformedException, which is not caught here and so escapes
+        the wrapper -- reported as a malformed request rather than as the
+        capacity problem it actually is. TestDistroBoots builds its name
+        from a base image name, so the length is not entirely under the
+        suite's control.
+        """
+        refusal = ci_apiclient.InsufficientResourcesException(
+            'full', status_code=507, text='full')
+        client = FakeInstanceClient([refusal, {'uuid': 'inst-7'}])
+        harness = _WrapperHarness(client)
+
+        long_name = 'x' * 63
+        satisfied = {'satisfied': True, 'mode': 'informed',
+                     'seconds_waited': 10.0, 'node': None, 'cpus': 1,
+                     'headroom_at_start': {'cpus': 0},
+                     'headroom_at_end': {'cpus': 2},
+                     'per_node': {}, 'polls': 2, 'poll_errors': []}
+        with mock.patch.object(ci_base.retries, 'wait_for_capacity',
+                               return_value=dict(satisfied)):
+            harness.create_instance(long_name, 1, 1024, None, [], None, None)
+
+        retried = client.calls[1][0]
+        self.assertLessEqual(
+            len(retried), 63,
+            'The retry built a %d character name, which the server '
+            'rejects with a 400 the wrapper does not catch.' % len(retried))
+        self.assertTrue(retried.startswith('x' * 54))
+        self.assertEqual(
+            'x' * 63, client.calls[0][0],
+            'Only a retry is trimmed. The first attempt must use the '
+            'name the caller asked for.')
 
     def test_the_deadline_fails_with_the_refusal_and_the_roster(self):
         """A genuinely too-small cloud must still fail, and say what was full."""
@@ -591,7 +858,7 @@ class CreateInstanceWrapperTestCase(test_base.ShakenFistTestCase):
 
         exhausted = {'satisfied': False, 'mode': 'informed',
                      'seconds_waited': 420.0, 'node': 'n1',
-                     'headroom_at_start': 0, 'headroom_at_end': 0,
+                     'headroom_at_start': {'cpus': 0}, 'headroom_at_end': {'cpus': 0},
                      'per_node': {'n1': node(0, cpu_limit=16,
                                              cpu_committed=16)},
                      'polls': 43, 'poll_errors': ['ValueError: reset']}
@@ -634,6 +901,103 @@ class CreateInstanceWrapperTestCase(test_base.ShakenFistTestCase):
         self.assertEqual(2, len(client.calls))
         self.assertEqual(['capacity-wait-1'], list(harness.details))
 
+    def test_a_refusal_the_predicate_cannot_see_does_not_busy_loop(self):
+        """The seam between the wrapper and the real wait, unpatched.
+
+        Every other test here hands the wrapper a canned wait record, so
+        none of them can see what happens when the two disagree -- and
+        that disagreement is the whole failure mode. The server refuses
+        every create while the roster reports ample room in all three
+        dimensions, which is what a refusal for something the predicate
+        does not model looks like: an admission guard losing a race, a
+        pre-filter this does not read, a 507 from a path the roster says
+        nothing about.
+
+        With no floor under the loop the wrapper re-issues as fast as two
+        HTTP round trips allow for the whole seven minutes, leaving an
+        error-deleted instance and a trace line behind on every turn --
+        thousands of each from one refusal. With the floor the loop runs
+        at the poll interval, so the attempts are bounded by the deadline
+        and the clock really moves between them.
+        """
+        refusal = ci_apiclient.InsufficientResourcesException(
+            'full', status_code=507, text='no node would take it')
+        client = FakeInstanceClient([refusal], repeat_last=True)
+        harness = _WrapperHarness(client, clock=[0.0], advancing=True)
+
+        self.assertRaises(
+            AssertionError, harness.create_instance,
+            'blind', 1, 1024, None, [{'size': 8, 'type': 'disk'}], None, None)
+
+        ceiling = (ci_base.CLUSTER_HEADROOM_WAIT //
+                   ci_base.CAPACITY_POLL_INTERVAL) + 2
+        self.assertLessEqual(
+            len(client.calls), ceiling,
+            'The wrapper issued %d creates inside one deadline. Each one '
+            'leaves an error-deleted instance behind, so an unpaced loop '
+            'turns a single transient refusal into an outage.'
+            % len(client.calls))
+        self.assertGreater(
+            len(client.calls), 1,
+            'The create was not retried at all, so this proves nothing '
+            'about pacing.')
+        self.assertEqual(
+            len(client.calls) - 2, len(harness.slept),
+            'The first retry is free -- capacity returning between the '
+            'refusal and the poll is the common case -- and every retry '
+            'after that must be preceded by a sleep.')
+        self.assertGreater(
+            harness.clock[0], ci_base.CLUSTER_HEADROOM_WAIT / 2,
+            'The clock barely moved, so the loop was spinning rather '
+            'than waiting.')
+
+    def test_the_attempt_ceiling_says_what_it_means(self):
+        """The failure a blind refusal produces must name its own cause.
+
+        "The cluster did not free enough" is the wrong diagnosis when
+        every poll said there was room. The message has to send the
+        reader at the predicate instead.
+        """
+        refusal = ci_apiclient.InsufficientResourcesException(
+            'full', status_code=507, text='no node would take it')
+        client = FakeInstanceClient([refusal], repeat_last=True)
+        harness = _WrapperHarness(client, clock=[0.0], advancing=True)
+
+        self.assertRaises(
+            AssertionError, harness.create_instance,
+            'blind', 1, 1024, None, [{'size': 8, 'type': 'disk'}], None, None)
+
+        self.assertIn('no node would take it', harness.failure)
+        self.assertIn(
+            'every wait said there was room', harness.failure,
+            'The failure must say that nothing bound, which is the whole '
+            'diagnosis: the refusal is for something the wait cannot see.')
+
+    def test_a_wait_which_really_ends_lets_the_create_through(self):
+        """The positive control for the test above.
+
+        Without it, a wrapper which had simply stopped retrying would
+        pass every assertion in test_a_refusal_the_predicate_cannot_see
+        _does_not_busy_loop.
+        """
+        refusal = ci_apiclient.InsufficientResourcesException(
+            'full', status_code=507, text='full')
+        client = FakeInstanceClient(
+            [refusal, refusal, {'uuid': 'inst-6'}],
+            resources=roster({'n1': node(64, cpu_limit=64)}))
+        harness = _WrapperHarness(client, clock=[0.0], advancing=True)
+
+        inst = harness.create_instance(
+            'eventually', 1, 1024, None, [{'size': 8, 'type': 'disk'}],
+            None, None)
+
+        self.assertEqual({'uuid': 'inst-6'}, inst)
+        self.assertEqual(3, len(client.calls))
+        self.assertEqual(
+            [ci_base.CAPACITY_POLL_INTERVAL], harness.slept,
+            'The first wait is free and every later one is paced, so two '
+            'retries cost exactly one interval.')
+
     def test_recording_a_wait_may_never_fail_the_test_it_measures(self):
         """An instrument which breaks the run is worse than no instrument."""
         harness = _WrapperHarness(FakeInstanceClient([]))
@@ -661,12 +1025,16 @@ class CreateInstanceWrapperTestCase(test_base.ShakenFistTestCase):
 
         satisfied = {'satisfied': True, 'mode': 'informed',
                      'seconds_waited': 30.0, 'node': 'n1', 'cpus': 2,
-                     'headroom_at_start': 0, 'headroom_at_end': 4,
+                     'memory_mb': 1024, 'disk_gb': 8,
+                     'binding_dimension': 'memory_mb',
+                     'headroom_at_start': {'cpus': 0},
+                     'headroom_at_end': {'cpus': 4},
                      'per_node': {}, 'polls': 4, 'poll_errors': []}
         with mock.patch.object(ci_base.retries, 'wait_for_capacity',
                                return_value=dict(satisfied)):
-            harness.create_instance('traced', 2, 1024, None, [], None, None,
-                                    force_placement='n1')
+            harness.create_instance(
+                'traced', 2, 1024, None, [{'size': 8, 'type': 'disk'}], None,
+                None, force_placement='n1')
 
         with open(self.trace) as f:
             lines = f.read().splitlines()
@@ -681,9 +1049,17 @@ class CreateInstanceWrapperTestCase(test_base.ShakenFistTestCase):
         self.assertEqual(2, record['cpus'])
         self.assertEqual(30.0, record['seconds_waited'])
         self.assertEqual('informed', record['mode'])
-        self.assertEqual(1, record['attempts'])
-        self.assertEqual(0, record['headroom_at_first_refusal'])
-        self.assertEqual(4, record['headroom_at_admission'])
+        self.assertEqual(
+            1, record['attempt_number'],
+            'The field is a 1-indexed position, not a count: a create '
+            'refused three times writes three lines carrying 1, 2 and 3, '
+            'and a reader who summed a field called "attempts" would get '
+            'six.')
+        self.assertEqual(1024, record['memory_mb'])
+        self.assertEqual(8, record['disk_gb'])
+        self.assertEqual('memory_mb', record['binding_dimension'])
+        self.assertEqual({'cpus': 0}, record['headroom_at_first_refusal'])
+        self.assertEqual({'cpus': 4}, record['headroom_at_admission'])
         self.assertIn('test_create', record['test_id'])
 
     def test_an_unwritable_trace_never_fails_the_create(self):
@@ -701,7 +1077,7 @@ class CreateInstanceWrapperTestCase(test_base.ShakenFistTestCase):
 
         satisfied = {'satisfied': True, 'mode': 'informed',
                      'seconds_waited': 10.0, 'node': None, 'cpus': 1,
-                     'headroom_at_start': 0, 'headroom_at_end': 2,
+                     'headroom_at_start': {'cpus': 0}, 'headroom_at_end': {'cpus': 2},
                      'per_node': {}, 'polls': 2, 'poll_errors': []}
         with mock.patch.object(
                 ci_base, 'CAPACITY_WAIT_TRACE_FILE',

--- a/shakenfist/tests/test_ci_capacity_wait.py
+++ b/shakenfist/tests/test_ci_capacity_wait.py
@@ -32,9 +32,12 @@ repository.
 """
 
 import importlib.util
+import json
 import logging
 import os
+import shutil
 import sys
+import tempfile
 import types
 
 from unittest import mock
@@ -419,7 +422,7 @@ class _WrapperHarness(ci_base.BaseTestCase):
     harness supplies the four things the wrapper touches instead.
     """
 
-    def __init__(self, client):
+    def __init__(self, client, clock=None):
         # Deliberately not calling TestCase.__init__: this is not being
         # run as a test, only used as a bound self for the wrapper.
         self.test_client = client
@@ -427,10 +430,33 @@ class _WrapperHarness(ci_base.BaseTestCase):
         self.details = {}
         self.failure = None
         self.uniquifiers = 0
+        self.clock = list(clock or [0.0])
 
     def _uniquifier(self):
         self.uniquifiers += 1
         return 'uniq%04d' % self.uniquifiers
+
+    def id(self):
+        # _append_capacity_wait_trace() reads this for the trace record's
+        # test_id, and it is the only field with no source in the wait
+        # dict. A harness without it makes every write raise into the
+        # swallowing except clause, so the trace path looks exercised and
+        # is not.
+        return 'shakenfist_ci.tests.test_harness.FakeTest.test_create'
+
+    def _now(self):
+        """The scripted clock create_instance() reads its deadline from.
+
+        The last value sticks rather than the script running out. A test
+        here is saying "and then the deadline had passed", which stays
+        true however many times the wrapper asks, so an extra read is
+        not an error worth raising on. Scripting this rather than
+        patching time.time() is what keeps the module's log lines out of
+        the clock -- see BaseTestCase._now() for what that cost once.
+        """
+        if len(self.clock) > 1:
+            return self.clock.pop(0)
+        return self.clock[0]
 
     def addDetail(self, name, detail):
         self.details[name] = detail
@@ -462,6 +488,16 @@ class FakeInstanceClient:
 
 
 class CreateInstanceWrapperTestCase(test_base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+        self.tempdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tempdir, True)
+        self.trace = os.path.join(self.tempdir, 'instance-waits.jsonl')
+        patcher = mock.patch.object(
+            ci_base, 'CAPACITY_WAIT_TRACE_FILE', self.trace)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_a_create_which_is_not_refused_is_not_wrapped_at_all(self):
         client = FakeInstanceClient([{'uuid': 'inst-1'}])
         harness = _WrapperHarness(client)
@@ -549,7 +585,9 @@ class CreateInstanceWrapperTestCase(test_base.ShakenFistTestCase):
             'no node has 4 cpus', status_code=507,
             text='instance could not be placed')
         client = FakeInstanceClient([refusal])
-        harness = _WrapperHarness(client)
+        # Inside the deadline for the first check, past it for the second,
+        # which is what makes the wrapper give up rather than loop.
+        harness = _WrapperHarness(client, clock=[0.0, 0.0, 10000.0])
 
         exhausted = {'satisfied': False, 'mode': 'informed',
                      'seconds_waited': 420.0, 'node': 'n1',
@@ -559,12 +597,10 @@ class CreateInstanceWrapperTestCase(test_base.ShakenFistTestCase):
                      'polls': 43, 'poll_errors': ['ValueError: reset']}
         with mock.patch.object(ci_base.retries, 'wait_for_capacity',
                                return_value=dict(exhausted)):
-            with mock.patch.object(ci_base.time, 'time',
-                                   side_effect=[0.0, 0.0, 10000.0]):
-                self.assertRaises(
-                    AssertionError, harness.create_instance,
-                    'toobig', 4, 1024, None, [], None, None,
-                    force_placement='n1')
+            self.assertRaises(
+                AssertionError, harness.create_instance,
+                'toobig', 4, 1024, None, [], None, None,
+                force_placement='n1')
 
         self.assertIn('instance could not be placed', harness.failure)
         self.assertIn('n1', harness.failure)
@@ -607,3 +643,76 @@ class CreateInstanceWrapperTestCase(test_base.ShakenFistTestCase):
 
         harness.addDetail = explode
         harness._record_capacity_wait({'instance_name': 'x', 'mode': 'informed'})
+
+    def test_a_wait_appends_one_well_formed_line_to_the_trace(self):
+        """The trace is this phase's only output, so its shape is asserted.
+
+        D14 makes the JSONL file the evidence a later phase reads the
+        baseline from, and tools/ci_headroom_report.py --waits parses it
+        one line at a time. A record missing a field the report names
+        does not fail anything at write time; it shows up as a malformed
+        line in a bundle weeks later, which is the wrong place to find
+        out.
+        """
+        refusal = ci_apiclient.InsufficientResourcesException(
+            'full', status_code=507, text='full')
+        client = FakeInstanceClient([refusal, {'uuid': 'inst-4'}])
+        harness = _WrapperHarness(client)
+
+        satisfied = {'satisfied': True, 'mode': 'informed',
+                     'seconds_waited': 30.0, 'node': 'n1', 'cpus': 2,
+                     'headroom_at_start': 0, 'headroom_at_end': 4,
+                     'per_node': {}, 'polls': 4, 'poll_errors': []}
+        with mock.patch.object(ci_base.retries, 'wait_for_capacity',
+                               return_value=dict(satisfied)):
+            harness.create_instance('traced', 2, 1024, None, [], None, None,
+                                    force_placement='n1')
+
+        with open(self.trace) as f:
+            lines = f.read().splitlines()
+
+        self.assertEqual(
+            1, len(lines),
+            'One line per wait, not per run (D14): a worker which crashes '
+            'mid-wait must lose at most its own in-flight line.')
+        record = json.loads(lines[0])
+        self.assertEqual('traced', record['instance_name'])
+        self.assertEqual('n1', record['node'])
+        self.assertEqual(2, record['cpus'])
+        self.assertEqual(30.0, record['seconds_waited'])
+        self.assertEqual('informed', record['mode'])
+        self.assertEqual(1, record['attempts'])
+        self.assertEqual(0, record['headroom_at_first_refusal'])
+        self.assertEqual(4, record['headroom_at_admission'])
+        self.assertIn('test_create', record['test_id'])
+
+    def test_an_unwritable_trace_never_fails_the_create(self):
+        """The trace is an instrument, and shares their one absolute rule.
+
+        ci_headroom_collect.sh gives the reasoning for a job; it holds
+        the same way for a test. /srv/ci/traces does not exist on a
+        workstation, so this is the ordinary case when the suite is run
+        outside CI rather than an exotic one.
+        """
+        refusal = ci_apiclient.InsufficientResourcesException(
+            'full', status_code=507, text='full')
+        client = FakeInstanceClient([refusal, {'uuid': 'inst-5'}])
+        harness = _WrapperHarness(client)
+
+        satisfied = {'satisfied': True, 'mode': 'informed',
+                     'seconds_waited': 10.0, 'node': None, 'cpus': 1,
+                     'headroom_at_start': 0, 'headroom_at_end': 2,
+                     'per_node': {}, 'polls': 2, 'poll_errors': []}
+        with mock.patch.object(
+                ci_base, 'CAPACITY_WAIT_TRACE_FILE',
+                os.path.join(self.tempdir, 'no', 'such', 'waits.jsonl')):
+            with mock.patch.object(ci_base.retries, 'wait_for_capacity',
+                                   return_value=dict(satisfied)):
+                inst = harness.create_instance(
+                    'untraced', 1, 1024, None, [], None, None)
+
+        self.assertEqual({'uuid': 'inst-5'}, inst)
+        self.assertEqual(
+            ['capacity-wait-1'], list(harness.details),
+            'The wait was still attached to the test, so a missing trace '
+            'file costs the bundle record and nothing else.')

--- a/shakenfist/tests/test_ci_capacity_wait.py
+++ b/shakenfist/tests/test_ci_capacity_wait.py
@@ -688,12 +688,24 @@ class FakeInstanceClient:
     is written down.
     """
 
-    def __init__(self, answers, resources=None, repeat_last=False):
+    def __init__(self, answers, resources=None, repeat_last=False,
+                 nodes=None):
         self.answers = list(answers)
         self.repeat_last = repeat_last
         self.calls = []
         self.resources = resources or roster(
             {'n1': node(64, cpu_limit=64)})
+        # Shaped as get_nodes() really answers: a uuid and a name per
+        # node, which is the whole point of the pin resolution these
+        # fixtures exercise. Defaulted so that the rosters keyed by 'n1'
+        # elsewhere in this file keep resolving 'n1' to themselves.
+        self.nodes = nodes if nodes is not None else [
+            {'uuid': 'n1', 'name': 'n1', 'is_hypervisor': True}]
+        self.node_listings = 0
+
+    def get_nodes(self):
+        self.node_listings += 1
+        return self.nodes
 
     def create_instance(self, name, cpus, memory, network, disk, sshkey,
                         userdata, **kwargs):
@@ -1092,3 +1104,121 @@ class CreateInstanceWrapperTestCase(test_base.ShakenFistTestCase):
             ['capacity-wait-1'], list(harness.details),
             'The wait was still attached to the test, so a missing trace '
             'file costs the bundle record and nothing else.')
+
+    def test_a_name_pinned_wait_reads_the_uuid_keyed_roster_entry(self):
+        """The roster is keyed by uuid; almost every pin in the suite is a name.
+
+        summarize_resources() builds per_node from the metrics dict,
+        which get_active_node_metrics() keys by str(n.uuid). The suite
+        pins by name -- 'sf-2', node['name'], socket.getfqdn(). Handing
+        the name to the wait made the target absent from per_node on
+        every poll, which reads as zero headroom in every dimension
+        rather than as "no entry", so a name-pinned create could never be
+        satisfied however empty the cluster was.
+
+        This is written through the real wait_for_capacity() on an
+        advancing clock rather than a canned record, because a mocked
+        wait cannot show a lookup missing.
+        """
+        refusal = ci_apiclient.InsufficientResourcesException(
+            'full', status_code=507, text='no room on sf-2')
+        uuid = '7f1c9e26-5a0e-4b76-9a7f-2d4f0a1b3c5d'
+        client = FakeInstanceClient(
+            [refusal, {'uuid': 'inst-9'}],
+            resources=roster({uuid: node(64, cpu_limit=64)}),
+            nodes=[{'uuid': uuid, 'name': 'sf-2', 'is_hypervisor': True}])
+        harness = _WrapperHarness(client, clock=[0.0], advancing=True)
+
+        inst = harness.create_instance(
+            'pinned', 2, 1024, None, [{'size': 8, 'type': 'disk'}], None, None,
+            force_placement='sf-2')
+
+        self.assertEqual({'uuid': 'inst-9'}, inst)
+        record = json.loads(harness.details['capacity-wait-1'].as_text())
+        self.assertTrue(
+            record['satisfied'],
+            'The wait could not find the node it was pinned to, so a '
+            'cluster with 64 spare cpus read as a full one.')
+        self.assertEqual('informed', record['mode'])
+        self.assertEqual(uuid, record['roster_key'])
+        self.assertEqual('sf-2', record['pinned_to'])
+        self.assertIsNone(
+            record['binding_dimension'],
+            'Nothing was short, so nothing should be recorded as binding. '
+            'A missing roster entry reports every dimension as zero, which '
+            'names a binding dimension that does not exist.')
+
+    def test_an_unresolvable_pin_waits_blind_rather_than_reading_zero(self):
+        """Not knowing which entry to read is not evidence the entry is empty.
+
+        A pin which matches no node leaves the wait with nothing to read
+        about its target. Reading the roster anyway would report zero
+        headroom in every dimension -- a confident answer built from an
+        absent key -- so the wait is blind instead, exactly as it is for
+        a cluster whose capacity mapping could not be read.
+        """
+        refusal = ci_apiclient.InsufficientResourcesException(
+            'full', status_code=507, text='full')
+        uuid = '7f1c9e26-5a0e-4b76-9a7f-2d4f0a1b3c5d'
+        client = FakeInstanceClient(
+            [refusal, {'uuid': 'inst-10'}],
+            resources=roster({uuid: node(64, cpu_limit=64)}),
+            nodes=[{'uuid': uuid, 'name': 'sf-2', 'is_hypervisor': True}])
+        harness = _WrapperHarness(client, clock=[0.0], advancing=True)
+
+        inst = harness.create_instance(
+            'orphan', 2, 1024, None, [{'size': 8, 'type': 'disk'}], None, None,
+            force_placement='sf-nosuchnode')
+
+        self.assertEqual({'uuid': 'inst-10'}, inst)
+        record = json.loads(harness.details['capacity-wait-1'].as_text())
+        self.assertEqual('degraded', record['mode'])
+        self.assertIsNone(record['roster_key'])
+        self.assertEqual('sf-nosuchnode', record['pinned_to'])
+        self.assertIsNone(
+            record['headroom_at_start'],
+            'The roster was read for a target which is not in it, so the '
+            'wait recorded a headroom figure it had no basis for.')
+
+    def test_a_create_which_is_not_refused_lists_no_nodes(self):
+        """Resolving the pin is a cost only a refused create should pay.
+
+        Almost every create in a run is admitted first time. Resolving
+        force_placement eagerly would put a GET /nodes behind every
+        instance the suite builds, to answer a question that create
+        never asks -- and GET /nodes hydrates every node and renders an
+        external view for each, so it is not a cheap call to add to a
+        hot path. See load_budget.py.
+        """
+        client = FakeInstanceClient([{'uuid': 'inst-11'}])
+        harness = _WrapperHarness(client)
+
+        harness.create_instance('quick', 1, 1024, None, [], None, None,
+                                force_placement='n1')
+
+        self.assertEqual(
+            0, client.node_listings,
+            'The wrapper listed the clusternodes for a create which was '
+            'never refused, so every instance the suite builds now pays '
+            'for a lookup only a wait needs.')
+
+    def test_a_refused_create_resolves_its_pin_once(self):
+        """And only once, however many times it is refused."""
+        refusal = ci_apiclient.InsufficientResourcesException(
+            'full', status_code=507, text='full')
+        uuid = '7f1c9e26-5a0e-4b76-9a7f-2d4f0a1b3c5d'
+        client = FakeInstanceClient(
+            [refusal, refusal, {'uuid': 'inst-12'}],
+            resources=roster({uuid: node(64, cpu_limit=64)}),
+            nodes=[{'uuid': uuid, 'name': 'sf-2', 'is_hypervisor': True}])
+        harness = _WrapperHarness(client, clock=[0.0], advancing=True)
+
+        harness.create_instance(
+            'twice', 2, 1024, None, [{'size': 8, 'type': 'disk'}], None, None,
+            force_placement='sf-2')
+
+        self.assertEqual(3, len(client.calls))
+        self.assertEqual(
+            1, client.node_listings,
+            'The pin was resolved once per wait rather than once per '
+            'create, which puts a node listing into the retry loop.')

--- a/shakenfist/tests/test_ci_headroom_report.py
+++ b/shakenfist/tests/test_ci_headroom_report.py
@@ -145,18 +145,33 @@ def census_payload(events):
 
 
 def wait_event(test_id='pkg.mod.TestCase.test_something', instance_name='i1',
-               node='n1', cpus=2, seconds_waited=12.5, mode='informed',
-               attempts=1, headroom_at_first_refusal=0,
+               node='n1', roster_key='n1', cpus=2, memory_mb=1024, disk_gb=8,
+               binding_dimension=None, seconds_waited=12.5, mode='informed',
+               attempt_number=1, headroom_at_first_refusal=0,
                headroom_at_admission=2):
-    """One line of the capacity-wait trace create_instance() writes (D14)."""
+    """One line of the capacity-wait trace create_instance() writes (D14).
+
+    These keys must stay identical to the record
+    BaseTestCase._append_capacity_wait_trace() builds in
+    shakenfist/deploy/shakenfist_ci/base.py. A fixture which drifts from
+    the writer tests the parser against a line shape nothing emits,
+    which is the one failure this report is supposed to survive and the
+    one its tests would then not notice. The drift is not hypothetical:
+    this fixture said 'attempts' while the writer said 'attempt_number',
+    and omitted three fields the writer has always written.
+    """
     return {
         'test_id': test_id,
         'instance_name': instance_name,
         'node': node,
+        'roster_key': roster_key,
         'cpus': cpus,
+        'memory_mb': memory_mb,
+        'disk_gb': disk_gb,
+        'binding_dimension': binding_dimension,
         'seconds_waited': seconds_waited,
         'mode': mode,
-        'attempts': attempts,
+        'attempt_number': attempt_number,
         'headroom_at_first_refusal': headroom_at_first_refusal,
         'headroom_at_admission': headroom_at_admission,
     }

--- a/shakenfist/tests/test_ci_headroom_report.py
+++ b/shakenfist/tests/test_ci_headroom_report.py
@@ -144,6 +144,24 @@ def census_payload(events):
     }
 
 
+def wait_event(test_id='pkg.mod.TestCase.test_something', instance_name='i1',
+               node='n1', cpus=2, seconds_waited=12.5, mode='informed',
+               attempts=1, headroom_at_first_refusal=0,
+               headroom_at_admission=2):
+    """One line of the capacity-wait trace create_instance() writes (D14)."""
+    return {
+        'test_id': test_id,
+        'instance_name': instance_name,
+        'node': node,
+        'cpus': cpus,
+        'seconds_waited': seconds_waited,
+        'mode': mode,
+        'attempts': attempts,
+        'headroom_at_first_refusal': headroom_at_first_refusal,
+        'headroom_at_admission': headroom_at_admission,
+    }
+
+
 class HeadroomReportTestCase(base.ShakenFistTestCase):
     """Every test drives main() and reads the printed report."""
 
@@ -169,6 +187,12 @@ class HeadroomReportTestCase(base.ShakenFistTestCase):
 
     def _census(self, events):
         return self._write('census.json', json.dumps(census_payload(events)))
+
+    def _waits(self, records, trailing=None):
+        body = ''.join(json.dumps(r) + '\n' for r in records)
+        if trailing is not None:
+            body += trailing
+        return self._write('instance-waits.jsonl', body)
 
     def _run(self, *argv):
         """Run the tool, returning (exit code, stdout)."""
@@ -2002,3 +2026,127 @@ class SummaryRecordTestCase(HeadroomReportTestCase):
             'A run with no samples must have no band verdict rather than a '
             'verdict computed from nothing.')
         self.assertIsNone(record['cluster']['committed_cpu']['p90'])
+
+
+class CapacityWaitsTestCase(HeadroomReportTestCase):
+    """--waits summarises the JSONL trace create_instance() writes (D14).
+
+    An absent or empty file must read as "unknown", never as "0 seconds
+    waited" -- printing a zero there is precisely the misreading a broken
+    instrument would produce, which is why census_record() and now
+    waits_record() both refuse to say it. A malformed line among good ones
+    is skipped and counted, not fatal, because a crashed stestr worker
+    leaves one on every run that hits it.
+    """
+
+    def test_a_populated_file_reports_the_five_figures(self):
+        path = self._waits([
+            wait_event(test_id='t.test_a', seconds_waited=10.0,
+                       mode='informed'),
+            wait_event(test_id='t.test_b', seconds_waited=90.0,
+                       mode='degraded'),
+            wait_event(test_id='t.test_c', seconds_waited=5.0,
+                       mode='informed'),
+        ])
+        series = self._series([sample({NODE_ONE: node_payload()})])
+        code, output = self._run('--series', series, '--waits', path)
+        self.assertEqual(0, code)
+
+        self.assertIn('Waits:             3', output)
+        self.assertIn('Total time waited: 105.0s', output)
+        self.assertIn('Longest wait:      90.0s (t.test_b)', output,
+                      'The longest wait and the test it belongs to were not '
+                      'both printed.')
+        self.assertIn('Mode split:        2 informed, 1 degraded', output)
+
+    def test_an_absent_waits_file_is_never_zero_seconds(self):
+        series = self._series([sample({NODE_ONE: node_payload()})])
+        code, output = self._run(
+            '--series', series,
+            '--waits', os.path.join(self.tempdir, 'does-not-exist.jsonl'))
+        self.assertEqual(0, code)
+        self.assertIn('NO CAPACITY WAIT DATA IS AVAILABLE', output)
+        self.assertIn('never as zero waits', output)
+        self.assertNotIn('0 seconds waited', output)
+        self.assertNotIn('Total time waited', output)
+
+    def test_an_empty_waits_file_is_never_zero_seconds(self):
+        path = self._write('instance-waits.jsonl', '')
+        series = self._series([sample({NODE_ONE: node_payload()})])
+        code, output = self._run('--series', series, '--waits', path)
+        self.assertEqual(0, code)
+        self.assertIn('NO CAPACITY WAIT DATA IS AVAILABLE', output)
+        self.assertIn('empty', output)
+        self.assertIn('never as zero waits', output)
+        self.assertNotIn('Total time waited', output)
+
+    def test_no_waits_argument_says_nothing_was_looked_at(self):
+        series = self._series([sample({NODE_ONE: node_payload()})])
+        code, output = self._run('--series', series)
+        self.assertEqual(0, code)
+        self.assertIn('NO WAITS FILE WAS SUPPLIED', output)
+        self.assertIn('nothing was looked at', output)
+
+    def test_a_malformed_line_among_good_ones_is_skipped_and_counted(self):
+        path = self._waits(
+            [wait_event(test_id='t.test_a', seconds_waited=20.0)],
+            trailing='not json at all\n')
+        series = self._series([sample({NODE_ONE: node_payload()})])
+        code, output = self._run('--series', series, '--waits', path)
+        self.assertEqual(0, code)
+        self.assertIn('Waits:             1 (1 malformed line skipped)', output)
+        self.assertIn('Total time waited: 20.0s', output)
+
+    def test_a_file_of_only_malformed_lines_is_unknown_not_zero(self):
+        """Every line malformed is a broken writer, not a quiet run.
+
+        A JSONL file with content, none of which parsed, must not print
+        '0 seconds waited' either: that reading is indistinguishable from a
+        run which genuinely never waited, and the two are different facts.
+        """
+        path = self._write('instance-waits.jsonl', 'garbage\nmore garbage\n')
+        series = self._series([sample({NODE_ONE: node_payload()})])
+        code, output = self._run('--series', series, '--waits', path)
+        self.assertEqual(0, code)
+        self.assertIn('0 well-formed wait records, 2 malformed lines', output)
+        self.assertIn('cannot be said from this', output)
+        self.assertNotIn('Total time waited', output)
+
+    def test_an_unrecognised_mode_is_counted_apart_from_the_split(self):
+        path = self._waits([
+            wait_event(test_id='t.test_a', mode='informed'),
+            wait_event(test_id='t.test_b', mode='sideways'),
+        ])
+        series = self._series([sample({NODE_ONE: node_payload()})])
+        code, output = self._run('--series', series, '--waits', path)
+        self.assertEqual(0, code)
+        self.assertIn('Mode split:        1 informed, 0 degraded', output)
+        self.assertIn('1 wait carried a mode this report does not '
+                      'recognise', output)
+
+    def test_read_waits_and_waits_record_agree_with_the_printed_report(self):
+        """The functions the report is built from, exercised directly.
+
+        Phase 2's harvest is expected to call these the way phase 1's does
+        summary_record() -- straight over a downloaded bundle -- so they
+        need to work without going through main().
+        """
+        path = self._waits([
+            wait_event(test_id='t.test_a', seconds_waited=1.0, mode='informed'),
+            wait_event(test_id='t.test_b', seconds_waited=2.0, mode='degraded'),
+        ])
+        record = report.waits_record(report.read_waits(path))
+        self.assertEqual('read', record['state'])
+        self.assertTrue(record['available'])
+        self.assertEqual(2, record['count'])
+        self.assertEqual(0, record['malformed_lines'])
+        self.assertEqual(3.0, record['seconds_waited_total'])
+        self.assertEqual(1, record['informed_waits'])
+        self.assertEqual(1, record['degraded_waits'])
+        self.assertEqual(2.0, record['longest_wait_seconds'])
+        self.assertEqual('t.test_b', record['longest_wait_test'])
+
+        not_requested = report.waits_record(report.read_waits(None))
+        self.assertEqual('not requested', not_requested['state'])
+        self.assertFalse(not_requested['available'])
+        self.assertIsNone(not_requested['count'])

--- a/shakenfist/tests/test_ci_headroom_report.py
+++ b/shakenfist/tests/test_ci_headroom_report.py
@@ -2108,9 +2108,56 @@ class CapacityWaitsTestCase(HeadroomReportTestCase):
         series = self._series([sample({NODE_ONE: node_payload()})])
         code, output = self._run('--series', series, '--waits', path)
         self.assertEqual(0, code)
-        self.assertIn('0 well-formed wait records, 2 malformed lines', output)
-        self.assertIn('cannot be said from this', output)
+        self.assertIn('NO CAPACITY WAIT DATA IS AVAILABLE: unparseable', output)
+        self.assertIn('every one of the 2 lines in the file was malformed',
+                      output)
+        self.assertIn('never as zero waits', output)
         self.assertNotIn('Total time waited', output)
+
+    def test_an_all_malformed_file_reads_as_unknown_to_a_machine_too(self):
+        """The prose said unknown; the record said 'available, zero waits'.
+
+        waits_record() is what phase 5 and the sizing plan's guardrail
+        read, and a consumer which cannot read prose saw 'available: true,
+        count: 0' -- indistinguishable from a run which genuinely never
+        waited, which is the exact confusion the printed text spends three
+        paragraphs guarding against.
+        """
+        path = self._write('instance-waits.jsonl', 'garbage\nmore garbage\n')
+        record = report.waits_record(report.read_waits(path))
+
+        self.assertEqual('unparseable', record['state'])
+        self.assertFalse(
+            record['available'],
+            'A file nothing could be parsed out of carries no data, so it '
+            'must not be marked available.')
+        self.assertIsNone(
+            record['count'],
+            'A count of 0 here is a lie: the run may have waited for '
+            'hours and lost every line to a broken writer.')
+        self.assertIsNone(record['seconds_waited_total'])
+        self.assertEqual(
+            2, record['malformed_lines'],
+            'How much was lost is the one thing which can be said, so it '
+            'is still said.')
+
+    def test_a_file_of_good_lines_is_a_real_zero_when_it_is_empty_of_waits(self):
+        """The positive control for the state above.
+
+        Malformed lines among good ones are skipped and counted, and the
+        file is still read: the unparseable state must not swallow a run
+        which produced usable data.
+        """
+        path = self._waits(
+            [wait_event(test_id='t.test_a', seconds_waited=4.0)],
+            trailing='{"partial": ')
+        record = report.waits_record(report.read_waits(path))
+
+        self.assertEqual('read', record['state'])
+        self.assertTrue(record['available'])
+        self.assertEqual(1, record['count'])
+        self.assertEqual(1, record['malformed_lines'])
+        self.assertEqual(4.0, record['seconds_waited_total'])
 
     def test_an_unrecognised_mode_is_counted_apart_from_the_split(self):
         path = self._waits([

--- a/shakenfist/tests/test_ci_raw_creates.py
+++ b/shakenfist/tests/test_ci_raw_creates.py
@@ -1,0 +1,207 @@
+# Copyright 2019 Michael Still and contributors
+"""Every create_instance() call in the CI suite goes through the wrapper.
+
+``BaseTestCase.create_instance()`` waits out a transient capacity
+refusal instead of failing the test on it (see
+``shakenfist/tests/test_ci_capacity_wait.py`` for that wrapper's own
+behaviour). That protection only exists for a caller which spells its
+create as ``self.create_instance(...)``. A call which reaches a client's
+``create_instance()`` directly -- ``self.test_client.create_instance(...)``,
+a local variable, another test's client -- skips the wait entirely, and
+does so silently: nothing about a raw call looks different from a
+wrapped one in a test run, right up until a sibling test's capacity
+turns it into a flake.
+
+So a raw call is not banned, it is priced. It needs a
+``# raw-create: <reason>`` comment immediately above it, with a
+non-empty reason, or this guard fails the build. Two kinds of caller pay
+that price on purpose: the wrapper's own single internal call in
+``base.py`` (it has to reach the client somehow), and a caller which
+must see the refusal rather than have it waited out -- the CI cloud
+sizing plan's phase 3 saturation tests, which assert that a full
+cluster actually refuses, are the case this exists for even though none
+of them exist yet.
+
+The check parses source with ``ast`` rather than importing the suite,
+following ``test_ci_claims_headroom.py``'s ``_calls_of()`` pattern for
+finding the calls and ``test_ci_namespace_membership.py``'s directory
+walk for finding the files: the functional suite imports
+``shakenfist_client``, which is not a test dependency of this
+repository, so nothing under ``shakenfist/deploy/shakenfist_ci/`` can be
+imported here.
+
+The reason is required to be non-empty specifically so the allowlist
+cannot grow by copy-pasting an existing marker line without writing a
+new sentence -- an empty ``# raw-create:`` is treated exactly like no
+marker at all.
+"""
+
+import ast
+import os
+import re
+
+from shakenfist.tests import base
+
+
+CI_SUITE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    'deploy', 'shakenfist_ci')
+
+# The suite held 41 files with a create_instance() call when this was
+# written, across 62 total .py files. The floor is a long way below
+# that: its job is to catch a walk which found nothing or almost
+# nothing, not to track the file count.
+MINIMUM_SUITE_FILES = 20
+
+# A call reaches the client's create_instance() through this receiver
+# name with no marker required: it is BaseTestCase's own wrapper, which
+# is the protection this guard exists to make mandatory.
+WRAPPED_RECEIVER = 'self'
+
+RAW_CREATE_RE = re.compile(r'^\s*#\s*raw-create:\s*(.*)$')
+COMMENT_RE = re.compile(r'^\s*#')
+
+
+def _is_create_instance_call(node):
+    return (isinstance(node, ast.Call) and
+            isinstance(node.func, ast.Attribute) and
+            node.func.attr == 'create_instance')
+
+
+def _is_wrapped_call(node):
+    """True for self.create_instance(...), which needs no marker."""
+    return (isinstance(node.func.value, ast.Name) and
+            node.func.value.id == WRAPPED_RECEIVER)
+
+
+def _preceding_comment_block(lines, lineno):
+    """Contiguous comment lines immediately above 1-indexed `lineno`.
+
+    A marker's reason often wraps onto a second comment line, as the
+    wrapper's own does in base.py, so the whole contiguous block is
+    collected; only its first line is required to carry the
+    ``raw-create:`` prefix.
+    """
+    block = []
+    i = lineno - 2
+    while i >= 0 and COMMENT_RE.match(lines[i]):
+        block.insert(0, lines[i])
+        i -= 1
+    return block
+
+
+def _raw_create_reason(lines, lineno):
+    """The marker's reason text for a call at 1-indexed `lineno`, or None."""
+    block = _preceding_comment_block(lines, lineno)
+    if not block:
+        return None
+    m = RAW_CREATE_RE.match(block[0])
+    if not m:
+        return None
+    return m.group(1).strip()
+
+
+def find_unmarked_raw_creates(source):
+    """Line numbers of raw create_instance() calls with no non-empty marker."""
+    tree = ast.parse(source)
+    lines = source.splitlines()
+    offences = []
+    for node in ast.walk(tree):
+        if not _is_create_instance_call(node):
+            continue
+        if _is_wrapped_call(node):
+            continue
+        if not _raw_create_reason(lines, node.lineno):
+            offences.append(node.lineno)
+    return offences
+
+
+class RawCreateInstanceMarkerTestCase(base.ShakenFistTestCase):
+    def test_the_check_recognises_an_unmarked_raw_call(self):
+        """The positive control: without this a clean scan proves nothing."""
+        offences = find_unmarked_raw_creates(
+            "client.create_instance('a', 1, 1024, None, None, None, None)\n")
+        self.assertEqual([1], offences)
+
+    def test_an_empty_reason_is_treated_as_unmarked(self):
+        """A marker with nothing after the colon does not buy an exemption.
+
+        Otherwise the allowlist grows by pasting a bare
+        ``# raw-create:`` in front of a call, which is the copy-paste
+        this guard exists to prevent.
+        """
+        offences = find_unmarked_raw_creates(
+            "# raw-create:\n"
+            "client.create_instance('a', 1, 1024, None, None, None, None)\n")
+        self.assertEqual([2], offences)
+
+    def test_a_marker_with_a_reason_is_accepted(self):
+        offences = find_unmarked_raw_creates(
+            "# raw-create: must see the raw refusal, not a waited-out one\n"
+            "client.create_instance('a', 1, 1024, None, None, None, None)\n")
+        self.assertEqual([], offences)
+
+    def test_a_marker_may_wrap_onto_a_second_comment_line(self):
+        """Matches the wrapper's own marker in base.py, which wraps."""
+        offences = find_unmarked_raw_creates(
+            "# raw-create: this is the wrapper itself, and is the one\n"
+            "# place in the suite which has to issue the create.\n"
+            "return client.create_instance(\n"
+            "    'a', 1, 1024, None, None, None, None)\n")
+        self.assertEqual([], offences)
+
+    def test_a_call_through_self_needs_no_marker(self):
+        """self.create_instance(...) is the wrapper: this is the safe path."""
+        offences = find_unmarked_raw_creates(
+            "self.create_instance('a', 1, 1024, None, None, None, None)\n")
+        self.assertEqual([], offences)
+
+    def test_a_call_through_a_self_attribute_is_not_exempt(self):
+        """self.test_client.create_instance(...) still bypasses the wait.
+
+        The receiver has to be the bare name ``self``, not merely start
+        with it -- otherwise every raw call already in this suite's
+        history (``self.test_client``, ``self.system_client``,
+        ``self.burst_client``) would have been silently exempt.
+        """
+        offences = find_unmarked_raw_creates(
+            "self.test_client.create_instance("
+            "'a', 1, 1024, None, None, None, None)\n")
+        self.assertEqual([1], offences)
+
+    def test_no_unmarked_raw_create_calls_in_the_suite(self):
+        """The real guard: every call under shakenfist_ci/ is wrapped or paid for."""
+        found = []
+        scanned = 0
+        for dirpath, _, filenames in os.walk(CI_SUITE):
+            for filename in filenames:
+                if not filename.endswith('.py'):
+                    continue
+                path = os.path.join(dirpath, filename)
+                with open(path) as f:
+                    source = f.read()
+                scanned += 1
+                for lineno in find_unmarked_raw_creates(source):
+                    found.append(
+                        '%s:%d' % (os.path.relpath(path, CI_SUITE), lineno))
+
+        # os.walk() over a directory which is not there yields nothing
+        # and raises nothing, so a clean result has to be shown to be a
+        # result before it is trusted -- the same reasoning
+        # test_ci_namespace_membership.py's floor uses.
+        self.assertGreater(
+            scanned, MINIMUM_SUITE_FILES,
+            'The CI suite scan found %d Python files under %s, so an '
+            'empty offence list below would mean nothing.'
+            % (scanned, CI_SUITE))
+
+        self.assertEqual(
+            [], found,
+            'A create_instance() call bypasses BaseTestCase\'s wrapper '
+            'and is not marked with a non-empty "# raw-create: <reason>" '
+            'comment immediately above it, so a transient capacity '
+            'refusal there fails the test instead of being waited out. '
+            'Route it through self.create_instance() (passing client= if '
+            'it needs a client other than self.test_client), or add the '
+            'marker if it must see the raw refusal. Sites: %s'
+            % ', '.join(found))

--- a/shakenfist/tests/test_ci_raw_creates.py
+++ b/shakenfist/tests/test_ci_raw_creates.py
@@ -12,9 +12,17 @@ does so silently: nothing about a raw call looks different from a
 wrapped one in a test run, right up until a sibling test's capacity
 turns it into a flake.
 
+A call is not the only way to reach one. ``assertRaises(Exc,
+self.test_client.create_instance, ...)`` hands the bound method over as a
+*reference* and lets assertRaises do the calling, which is how six sites
+in this suite reach the raw client. A guard which matched only
+``ast.Call`` saw none of them while claiming to cover everything, so
+references are checked too and carry the same marker.
+
 So a raw call is not banned, it is priced. It needs a
-``# raw-create: <reason>`` comment immediately above it, with a
-non-empty reason, or this guard fails the build. Two kinds of caller pay
+``# raw-create: <reason>`` comment in the block of comment lines
+immediately above it, with a non-empty reason, or this guard fails the
+build. Two kinds of caller pay
 that price on purpose: the wrapper's own single internal call in
 ``base.py`` (it has to reach the client somehow), and a caller which
 must see the refusal rather than have it waited out -- the CI cloud
@@ -62,16 +70,36 @@ RAW_CREATE_RE = re.compile(r'^\s*#\s*raw-create:\s*(.*)$')
 COMMENT_RE = re.compile(r'^\s*#')
 
 
-def _is_create_instance_call(node):
-    return (isinstance(node, ast.Call) and
-            isinstance(node.func, ast.Attribute) and
-            node.func.attr == 'create_instance')
+def _is_wrapped_receiver(attribute):
+    """True for self.create_instance, which needs no marker.
+
+    The receiver has to be the bare name ``self``, not merely start with
+    it: ``self.test_client.create_instance`` reaches the client directly
+    and is exactly what this guard is for.
+    """
+    return (isinstance(attribute.value, ast.Name) and
+            attribute.value.id == WRAPPED_RECEIVER)
 
 
-def _is_wrapped_call(node):
-    """True for self.create_instance(...), which needs no marker."""
-    return (isinstance(node.func.value, ast.Name) and
-            node.func.value.id == WRAPPED_RECEIVER)
+def _create_instance_sites(tree):
+    """Every place this source names a client's create_instance.
+
+    A call is not the only way to reach one. ``assertRaises(Exc,
+    self.test_client.create_instance, ...)`` passes the bound method as a
+    *reference* and lets assertRaises do the calling, so a guard which
+    only matched ast.Call saw none of those -- six of them, at the time
+    this was written, every one a raw create which the marker rule
+    claimed to cover and did not.
+
+    Walking attribute nodes rather than call nodes finds both shapes, and
+    finds each exactly once. An ast.Call's ``func`` *is* the attribute
+    node, and CPython gives a call and its func the same lineno, so
+    walking calls as well would report every call twice and tell us
+    nothing the attribute had not already said.
+    """
+    return [node for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and node.attr == 'create_instance']
 
 
 def _preceding_comment_block(lines, lineno):
@@ -91,29 +119,32 @@ def _preceding_comment_block(lines, lineno):
 
 
 def _raw_create_reason(lines, lineno):
-    """The marker's reason text for a call at 1-indexed `lineno`, or None."""
-    block = _preceding_comment_block(lines, lineno)
-    if not block:
-        return None
-    m = RAW_CREATE_RE.match(block[0])
-    if not m:
-        return None
-    return m.group(1).strip()
+    """The marker's reason text for a call at 1-indexed `lineno`, or None.
+
+    Any line of the comment block carries the marker, not only its first.
+    Requiring the first meant that an ordinary comment above a marker --
+    ``# Start our test instance`` on the line above ``# raw-create: ...``
+    -- silently disabled it, which fails safe but is a baffling thing to
+    debug when adding one.
+    """
+    for line in _preceding_comment_block(lines, lineno):
+        m = RAW_CREATE_RE.match(line)
+        if m:
+            return m.group(1).strip()
+    return None
 
 
 def find_unmarked_raw_creates(source):
-    """Line numbers of raw create_instance() calls with no non-empty marker."""
+    """Line numbers of raw create_instance uses with no non-empty marker."""
     tree = ast.parse(source)
     lines = source.splitlines()
     offences = []
-    for node in ast.walk(tree):
-        if not _is_create_instance_call(node):
+    for attribute in _create_instance_sites(tree):
+        if _is_wrapped_receiver(attribute):
             continue
-        if _is_wrapped_call(node):
-            continue
-        if not _raw_create_reason(lines, node.lineno):
-            offences.append(node.lineno)
-    return offences
+        if not _raw_create_reason(lines, attribute.lineno):
+            offences.append(attribute.lineno)
+    return sorted(offences)
 
 
 class RawCreateInstanceMarkerTestCase(base.ShakenFistTestCase):
@@ -154,6 +185,72 @@ class RawCreateInstanceMarkerTestCase(base.ShakenFistTestCase):
         """self.create_instance(...) is the wrapper: this is the safe path."""
         offences = find_unmarked_raw_creates(
             "self.create_instance('a', 1, 1024, None, None, None, None)\n")
+        self.assertEqual([], offences)
+
+    def test_a_marker_may_sit_under_an_ordinary_comment(self):
+        """The marker is looked for anywhere in the block, not only first.
+
+        Requiring the first line meant an ordinary comment above a marker
+        silently disabled it, and the call was then reported as unmarked
+        with no hint as to why -- which is a baffling thing to debug at
+        exactly the moment someone is adding their first marker.
+        """
+        offences = find_unmarked_raw_creates(
+            "# Start our test instance\n"
+            "# raw-create: must see the raw refusal, not a waited-out one\n"
+            "client.create_instance('a', 1, 1024, None, None, None, None)\n")
+        self.assertEqual([], offences)
+
+    def test_a_reference_passed_to_assert_raises_is_not_exempt(self):
+        """The shape six sites in this suite use, which ast.Call misses.
+
+        assertRaises() is handed the bound method and does the calling
+        itself, so there is no ast.Call naming create_instance anywhere in
+        the source. Without this the guard reported a clean scan while six
+        raw creates went unmarked, and the next one added would have been
+        exempt for free.
+        """
+        offences = find_unmarked_raw_creates(
+            "self.assertRaises(\n"
+            "    Exception,\n"
+            "    self.test_client.create_instance,\n"
+            "    'a', 1, 1024, None, None, None, None)\n")
+        self.assertEqual([3], offences)
+
+    def test_a_marked_reference_is_accepted(self):
+        offences = find_unmarked_raw_creates(
+            "self.assertRaises(\n"
+            "    Exception,\n"
+            "    # raw-create: asserts a 404, which waiting cannot fix\n"
+            "    self.test_client.create_instance,\n"
+            "    'a', 1, 1024, None, None, None, None)\n")
+        self.assertEqual([], offences)
+
+    def test_a_call_is_reported_once(self):
+        """A call is an attribute node too, so it can be found twice.
+
+        ast.walk() visits a call's own func attribute as well as the call
+        itself, and the two share a lineno, so a guard which walked both
+        kinds would report every unmarked call twice -- and every
+        offence list, and the failure message built from it, would be
+        double length for no reason.
+        """
+        offences = find_unmarked_raw_creates(
+            "return client.create_instance(\n"
+            "    'a', 1, 1024, None, None, None, None)\n")
+        self.assertEqual([1], offences)
+
+    def test_a_marker_above_a_wrapped_call_line_is_found(self):
+        """The marker sits above the call, which is where the receiver is."""
+        offences = find_unmarked_raw_creates(
+            "# raw-create: this is the wrapper itself\n"
+            "return client.create_instance(\n"
+            "    'a', 1, 1024, None, None, None, None)\n")
+        self.assertEqual([], offences)
+
+    def test_a_reference_through_self_needs_no_marker(self):
+        offences = find_unmarked_raw_creates(
+            "self.assertRaises(Exception, self.create_instance, 'a')\n")
         self.assertEqual([], offences)
 
     def test_a_call_through_a_self_attribute_is_not_exempt(self):

--- a/tools/ci_headroom_report.py
+++ b/tools/ci_headroom_report.py
@@ -1622,13 +1622,31 @@ def waits_record(waits):
     say the wrapper found nothing to wait out, when in fact nothing was
     looked at.
 
-    A file which *was* read and holds no records at all -- 0 good lines,
-    whether because the run genuinely never waited or because every line in
-    it was malformed -- is a real zero, and is reported as one, with the
-    malformed count alongside it so the two readings are not confused.
+    A file which was read and holds no records because the run genuinely
+    never waited is a real zero and is reported as one. A file whose every
+    line was malformed is not: nothing can be said about whether the suite
+    waited. print_waits() has always said so in prose, but the record is
+    what phase 5 and the sizing plan's guardrail read, and 'available:
+    true, count: 0' is indistinguishable from a clean run to a reader which
+    cannot read prose. So that case gets its own state, and its counts are
+    nulled exactly as an unread file's are.
     """
     record = collections.OrderedDict()
     record['state'] = waits.status
+    if waits.available and waits.malformed_lines and not waits.records:
+        record['state'] = 'unparseable'
+        record['available'] = False
+        record['detail'] = (
+            'every one of the %d %s in the file was malformed'
+            % (waits.malformed_lines,
+               plural(waits.malformed_lines, 'line')))
+        record['path'] = waits.path
+        record['malformed_lines'] = waits.malformed_lines
+        for key in ('count', 'seconds_waited_total', 'informed_waits',
+                    'degraded_waits', 'other_mode_waits',
+                    'longest_wait_seconds', 'longest_wait_test'):
+            record[key] = None
+        return record
     record['available'] = waits.available
     record['detail'] = waits.detail
     record['path'] = waits.path
@@ -2414,19 +2432,12 @@ def print_waits(waits):
               % (waits['state'], waits['detail']))
         print('  File: %s' % waits['path'])
         print('  Read this as "unknown", never as zero waits. An unwritten')
-        print('  or empty file looks exactly like a run with perfect')
-        print('  headroom unless the difference is said out loud.')
+        print('  or empty file -- or one nothing could be parsed out of --')
+        print('  looks exactly like a run with perfect headroom unless the')
+        print('  difference is said out loud.')
         return
 
     print('  File:              %s' % waits['path'])
-    if waits['count'] == 0:
-        print('  0 well-formed wait records, %d malformed %s'
-              % (waits['malformed_lines'], plural(waits['malformed_lines'], 'line')))
-        print('  Every line in the file was malformed, so whether the suite')
-        print('  ever actually waited on capacity cannot be said from this')
-        print('  file. Read this as unknown, not as zero seconds waited.')
-        return
-
     print('  Waits:             %d (%d malformed %s skipped)'
           % (waits['count'], waits['malformed_lines'],
              plural(waits['malformed_lines'], 'line')))

--- a/tools/ci_headroom_report.py
+++ b/tools/ci_headroom_report.py
@@ -947,6 +947,80 @@ class Census:
                    for t in self.stages.values())
 
 
+class Waits:
+    """The capacity-wait trace PLAN-transient-capacity-refusals phase 2 writes.
+
+    ``create_instance()`` on ``BaseTestCase`` (shakenfist_ci/base.py) appends
+    one JSON object per waited-out 507 to /srv/ci/traces/instance-waits.jsonl,
+    and this is that file read back. Absent and empty are kept apart from a
+    file which was read and simply holds no records, for the same reason a
+    census which was never collected is kept apart from one which found
+    nothing (D14): a wrapper which never ran here and a wrapper which ran and
+    never waited are different findings, and only the second is genuinely
+    zero.
+    """
+
+    def __init__(self):
+        self.path = None
+        self.status = 'not requested'
+        self.detail = None
+        self.records = []
+        self.total_lines = 0
+        self.malformed_lines = 0
+
+    @property
+    def available(self):
+        return self.status == 'read'
+
+
+def read_waits(path):
+    """Read the capacity-wait JSONL trace, tolerating a killed writer.
+
+    Mirrors read_census()'s honesty about absence: ``path`` of None (--waits
+    not given) is 'not requested', a file which does not exist is
+    'unreadable', and a file which exists but is empty is 'empty'. Only a
+    file which was actually opened and read is 'read', and even then a
+    malformed line -- one worker's write clipped by a crash, per D14 -- is
+    skipped and counted rather than treated as fatal, exactly as
+    read_series() treats a truncated final line.
+    """
+    waits = Waits()
+    if path is None:
+        return waits
+    waits.path = path
+
+    try:
+        with open(path) as f:
+            lines = f.readlines()
+    except OSError as e:
+        waits.status = 'unreadable'
+        waits.detail = str(e)
+        return waits
+
+    if not any(line.strip() for line in lines):
+        waits.status = 'empty'
+        waits.detail = 'the file exists but is empty'
+        return waits
+
+    waits.status = 'read'
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        waits.total_lines += 1
+        try:
+            record = json.loads(line)
+        except ValueError:
+            waits.malformed_lines += 1
+            continue
+        if not isinstance(record, dict):
+            waits.malformed_lines += 1
+            continue
+        waits.records.append(record)
+
+    return waits
+
+
 def stage_of(message):
     """The stage a schedule audit message names, or None if it names none.
 
@@ -1535,6 +1609,67 @@ def guard_record(census):
         sorted(guard.forced_write_stages.items()))
     record['forced_write_exceeded'] = collections.OrderedDict(
         sorted(guard.forced_write_exceeded.items()))
+    return record
+
+
+def waits_record(waits):
+    """What the capacity-wait trace says, or an honest account of why not.
+
+    Every count is null unless the trace was actually read (D14), for the
+    same reason census_record() nulls everything for a census which was
+    never collected: --waits not given, and a --waits file which is absent
+    or empty, must never print as "0 seconds waited". That reading would
+    say the wrapper found nothing to wait out, when in fact nothing was
+    looked at.
+
+    A file which *was* read and holds no records at all -- 0 good lines,
+    whether because the run genuinely never waited or because every line in
+    it was malformed -- is a real zero, and is reported as one, with the
+    malformed count alongside it so the two readings are not confused.
+    """
+    record = collections.OrderedDict()
+    record['state'] = waits.status
+    record['available'] = waits.available
+    record['detail'] = waits.detail
+    record['path'] = waits.path
+    if not waits.available:
+        for key in ('count', 'malformed_lines', 'seconds_waited_total',
+                    'informed_waits', 'degraded_waits', 'other_mode_waits',
+                    'longest_wait_seconds', 'longest_wait_test'):
+            record[key] = None
+        return record
+
+    record['malformed_lines'] = waits.malformed_lines
+    record['count'] = len(waits.records)
+
+    total_seconds = 0.0
+    informed = 0
+    degraded = 0
+    other_mode = 0
+    longest_seconds = None
+    longest_test = None
+    for wait in waits.records:
+        seconds = numeric(wait.get('seconds_waited')) or 0.0
+        total_seconds += seconds
+
+        mode = wait.get('mode')
+        if mode == 'informed':
+            informed += 1
+        elif mode == 'degraded':
+            degraded += 1
+        else:
+            other_mode += 1
+
+        if longest_seconds is None or seconds > longest_seconds:
+            longest_seconds = seconds
+            longest_test = wait.get('test_id')
+
+    record['seconds_waited_total'] = total_seconds if waits.records else None
+    record['informed_waits'] = informed
+    record['degraded_waits'] = degraded
+    record['other_mode_waits'] = other_mode
+    record['longest_wait_seconds'] = longest_seconds
+    record['longest_wait_test'] = longest_test
     return record
 
 
@@ -2250,6 +2385,64 @@ def print_guard_census(record):
                   % (dimension, fmt(guard['claim_shortfalls'][dimension], 3)))
 
 
+def print_waits(waits):
+    """The capacity-wait trace, under its own heading.
+
+    PLAN-transient-capacity-refusals phase 2's create_instance() wrapper
+    waits out a transient 507 rather than failing the test on it, and
+    records each wait to /srv/ci/traces/instance-waits.jsonl. This is a
+    summary of that file (``waits_record()``'s output), read the same way
+    the series and census are: an absent or empty file says so and prints
+    no figures, never a zero, because "the wrapper never ran here" and
+    "the wrapper ran and never had to wait" are different findings.
+
+    Deliberately not folded into the main summary record (D18's dict): the
+    two files are unrelated inputs on unrelated schedules -- the series and
+    census cover one job's headroom, the waits file accumulates across
+    every stestr worker of the same job -- and this section is optional in
+    a way the rest of the report is not.
+    """
+    print_heading('Capacity waits')
+    if waits['state'] == 'not requested':
+        print('  NO WAITS FILE WAS SUPPLIED (--waits was not given).')
+        print('  This is not "no waits": nothing was looked at. A run whose')
+        print('  capacity waits were never collected and a run which never')
+        print('  waited are different findings, and this is the first.')
+        return
+    if not waits['available']:
+        print('  NO CAPACITY WAIT DATA IS AVAILABLE: %s (%s)'
+              % (waits['state'], waits['detail']))
+        print('  File: %s' % waits['path'])
+        print('  Read this as "unknown", never as zero waits. An unwritten')
+        print('  or empty file looks exactly like a run with perfect')
+        print('  headroom unless the difference is said out loud.')
+        return
+
+    print('  File:              %s' % waits['path'])
+    if waits['count'] == 0:
+        print('  0 well-formed wait records, %d malformed %s'
+              % (waits['malformed_lines'], plural(waits['malformed_lines'], 'line')))
+        print('  Every line in the file was malformed, so whether the suite')
+        print('  ever actually waited on capacity cannot be said from this')
+        print('  file. Read this as unknown, not as zero seconds waited.')
+        return
+
+    print('  Waits:             %d (%d malformed %s skipped)'
+          % (waits['count'], waits['malformed_lines'],
+             plural(waits['malformed_lines'], 'line')))
+    print('  Total time waited: %.1fs' % waits['seconds_waited_total'])
+    print('  Longest wait:      %.1fs (%s)'
+          % (waits['longest_wait_seconds'], waits['longest_wait_test'] or
+             '(no test id recorded)'))
+    print('  Mode split:        %d informed, %d degraded'
+          % (waits['informed_waits'], waits['degraded_waits']))
+    if waits['other_mode_waits']:
+        print('  %d %s carried a mode this report does not recognise, and '
+              'are counted in neither split above.'
+              % (waits['other_mode_waits'],
+                 plural(waits['other_mode_waits'], 'wait')))
+
+
 def print_verdict(record):
     census = record['census']
     guard = record['guard']
@@ -2344,13 +2537,18 @@ def print_verdict(record):
         print('  lower bound. Absence of a warning is not evidence of absence.')
 
 
-def print_report(record):
+def print_report(record, waits=None):
     """Render the whole report from the record, and nothing but the record.
 
     Every figure printed here is read out of the dict rather than computed,
     so the job log and the --json file cannot disagree (D18). The sections
     which are not printed for an empty series are skipped on the record's
     own sample count for the same reason.
+
+    ``waits``, if given, is a waits_record() dict and is printed in its own
+    section (D14). It is a separate argument rather than a key folded into
+    ``record`` because it is not part of the versioned summary record --
+    see write_record() and the note on RECORD_VERSION.
     """
     title = 'Shaken Fist CI headroom report'
     print(title)
@@ -2372,6 +2570,8 @@ def print_report(record):
 
     print_census(record)
     print_guard_census(record)
+    if waits is not None:
+        print_waits(waits)
     print_verdict(record)
     print()
 
@@ -2379,12 +2579,15 @@ def print_report(record):
 def report(args):
     record = summary_record(args.series, census=args.census, label=args.label,
                             census_limit=args.census_limit)
-    print_report(record)
+    waits = waits_record(read_waits(args.waits))
+    print_report(record, waits=waits)
     if args.json:
         # Deliberately silent on success. The printed report must read
         # identically whether or not a summary record was also written, so
         # that a reader comparing a job log from before --json was wired up
-        # against one from after sees no difference at all.
+        # against one from after sees no difference at all. The waits
+        # summary is not written here (see print_report()'s docstring): it
+        # is not part of the versioned record.
         write_record(record, args.json)
 
 
@@ -2423,6 +2626,15 @@ def main(argv=None):
               'short. Defaults to 5000, which is both Loki\'s default '
               'max_entries_limit_per_query and the value used by '
               'tools/ci_headroom_collect.sh in shakenfist/actions.'))
+    parser.add_argument(
+        '--waits', default=None,
+        help=('Path to the capacity-wait JSONL trace written by '
+              'create_instance() on BaseTestCase '
+              '(/srv/ci/traces/instance-waits.jsonl in the bundle) -- one '
+              'line per transient 507 the suite waited out '
+              '(PLAN-transient-capacity-refusals phase 2, D14). Optional: '
+              'the report says so explicitly when it is absent or empty, '
+              'rather than printing zero seconds waited.'))
 
     try:
         args = parser.parse_args(argv)

--- a/tools/ci_headroom_report.py
+++ b/tools/ci_headroom_report.py
@@ -2438,9 +2438,16 @@ def print_waits(waits):
         return
 
     print('  File:              %s' % waits['path'])
-    print('  Waits:             %d (%d malformed %s skipped)'
-          % (waits['count'], waits['malformed_lines'],
-             plural(waits['malformed_lines'], 'line')))
+    # Conditional, like the other_mode_waits note below: a healthy run
+    # printing "(0 malformed lines skipped)" invites the reader to wonder
+    # what went wrong, and every other caveat in this report appears only
+    # when it has something to say.
+    if waits['malformed_lines']:
+        print('  Waits:             %d (%d malformed %s skipped)'
+              % (waits['count'], waits['malformed_lines'],
+                 plural(waits['malformed_lines'], 'line')))
+    else:
+        print('  Waits:             %d' % waits['count'])
     print('  Total time waited: %.1fs' % waits['seconds_waited_total'])
     print('  Longest wait:      %.1fs (%s)'
           % (waits['longest_wait_seconds'], waits['longest_wait_test'] or


### PR DESCRIPTION
Phase 2 of `PLAN-transient-capacity-refusals`, planned and implemented. Six commits: the plan, then steps 2a, 2b, 2c, 2d and 2e of its own step table.

A capacity refusal in CI is usually a statement about a moment rather than about the cluster — the capacity the refusing node is holding is very often already being returned by a sibling test that is mid-delete. The suite called `create_instance()` raw at every site, so every one of those was a hard failure. This makes them survivable and writes down how long survival took, because that number is what phase 5 decides the server-side-queue question from.

## The survey changed the design, not just the wording

The master plan's phase 2 section was written on 2026-09-08, before phase 1 executed. Two of its claims were wrong in ways that would have produced a working-looking wrapper that did the wrong thing. Both are corrected at their source in that section, with the correction marked.

**The wait predicate.** The section said to poll `/admin/resources` and proceed when `per_node[target]['cpu_available']` covers the create, or `total['cpu_available']` for an unpinned one. Both halves are wrong:

- `cpu_available` is derived from the live overcommit arithmetic (`scheduler.py:1086`), not from the capacity row's `limit_cpus` that admission actually refuses against. The endpoint publishes **both** deliberately, and the comment three lines above `cpu_limit` says in as many words that the field has no fallback precisely so a reader can see the two ledgers disagree. A wrapper reading only the published figure stops waiting during exactly the window this plan exists to describe.
- `total['cpu_available']` is a sum across nodes (`:1091-1093`) and an instance has to fit on one. It is satisfied by a cluster with one spare thread on each of ten nodes.

D8 replaces both: per node, `min(cpu_available, cpu_limit - cpu_committed)` when there is a capacity row, and the best single node rather than the total. **Deleting the three-line `cpu_limit` clause fails exactly one test**, which was verified by doing it rather than by reading it.

**The cross-repo obligation.** The section said this phase carried the same operator-push obligation the sizing plan's phase 1 did. Only the job-log print does. `smoke-cluster.yml:212` creates `/srv/ci/traces` on the primary and chowns it to the base-image user, `:550` scp's the whole directory into the artifact bundle, and the suite runs on the primary as that user — so the wait data reaches the bundle with no change in `shakenfist/actions` at all. That let the phase be restructured so **nothing depends on the cross-repo step**, and the evidence is readable from a downloaded bundle the moment this merges. Which is how phase 1's own definition-of-done item 9 was ultimately verified.

Three smaller corrections: the call-site count is 117 across 41 files, not 115 across 39, and the two directories the section named hold only 88 of them — `smoke_ci_tests/` was omitted entirely, and it is the tier that runs on the smallest cloud. `retry_while_transient` is not reusable as written. And of the two ride-along test fixes, one was already done and the other was mis-described.

## What landed

- **2a** — `wait_for_capacity()` in `retries.py` and `BaseTestCase.create_instance()`. The poll is injected as a callable so `retries.py` keeps the property its docstring claims: it imports nothing from the suite or from `shakenfist_client`, so the unit tests can load it by path. Only `InsufficientResourcesException` is waited on; the affinity 409 is a subclass of `LowResourceException` on the server, kept distinct only by clause ordering in the handler, and does not become satisfiable by waiting. Sixteen unit tests on a fake clock.
- **2b** — all 117 call sites routed, plus an `ast` guard that fails on any raw call without a `# raw-create: <reason>` marker carrying a **non-empty** reason. An allowlist that can be extended by copying the line above it is not an allowlist.
- **2c** — one JSON line per wait appended to `/srv/ci/traces/instance-waits.jsonl`, and `--waits` in `tools/ci_headroom_report.py`. One line per wait rather than per run, so concurrent stestr workers need agree on nothing and a dead worker loses at most its own in-flight line. Every write failure is swallowed: an instrument may never fail the thing it measures.
- **2d** — one convenience pin removed from `test_imagefetch.py`, its sibling repointed at `inst1['node']` where co-location really is the assertion, and the missing `addCleanup` added to `test_system_namespace.py`, which subclasses `BaseTestCase` and so has nothing tearing its instance down for it.
- **2e** — `docs/developer_guide/ci.md`, and one bullet in `AGENTS.md` for the marker convention alone.

## One call site went back to the raw client

`test_coalescing.py`'s mesh burst pins creates round-robin across the hypervisors inside a `try` that records a capacity refusal and carries on — because, as its own comment says, a forced placement onto a node the scheduler will not admit is a capacity outcome on a shared CI cluster rather than a coalescing defect. Wrapping it broke it twice: the wrapper's deadline failure is a test failure rather than an `APIException` that `except` clause could catch, so one node's refusal would have failed the whole burst; and waiting up to seven minutes per refused create would serialise a burst whose simultaneity is the thing under test.

It carries a marker saying so. This is the case D15 wrote the marker for, arriving earlier than the decision expected — D15 named the sizing plan's phase 3 saturation tests, which do not exist yet. The other burst in the same file keeps the wrapper: it has no tolerant handling and a refusal fails it outright today, so a wait can only improve it.

## Where to push back

The back brief asked which half of D8 was most likely to be wrong. The answer that came back is better than the one I would have given: the `cpu_limit` clause is sound, and the weaker half is the per-node `max` for an **unpinned** create. It reads the roster the scheduler also reads, but the scheduler's choice is subject to pre-filters the predicate does not model — queue length, `cpu_max_per_instance`, memory, disk, affinity. So an unpinned wait can be satisfied by a node the scheduler then declines, producing a create that refuses again and one logical wait split across two records.

That is bounded by the 420 s deadline and is visible in the data as a satisfied wait followed by another attempt. The right move is to look at phase 5's first real numbers before modelling more of the pre-filter, not to guess now — but a reviewer who disagrees should say so, because it is cheap to change today and expensive once the baseline is being read.

## Test plan

- [x] `pre-commit run --all-files` after every step
- [x] 16 new unit tests for the wait predicate, on a fake clock and a scripted poll
- [x] D8 mutation check run independently of the implementer: deleting the `cpu_limit` clause fails exactly one test, restoring it passes 16/16
- [x] AST guard verified by breaking it three ways — unmarked call fails, empty reason still fails, revert passes
- [x] All five `--waits` states exercised end to end: populated, malformed-among-good, empty file, absent file, flag not given. The last three report unknown, never zero
- [x] `test_the_suite_still_probes_cluster_headroom` still passes, which is what holds the load-budget prose up
- [ ] A real CI run — this branch has not been through one, and that is step 2g

The functional suite cannot run from a worktree, so 117 mechanically edited call sites are covered by the AST guard, flake8 and reading. A full CI run before the phase closes out is not optional here.

## Not in this PR

**2f**, the one-line addition to `ci_headroom_collect.sh` in `shakenfist/actions` that prints the summary in the job log. It needs a push to another repository, and that file changed on disk during this work, so it wants a fresh read rather than a remembered one. Nothing here depends on it.

**2g**, the close-out, which needs a real bundle read back with `--waits` and an Outcome section recording it — including the D8 caveat above.

## Ordering note

This PR and #4160 both edit `PLAN-transient-capacity-refusals.md`'s Execution table and the plan's row in `docs/plans/index.md`. #4160 appends a phase 7 and adds a `Merged` column; this one links phase 2's file. No phase renumbers, so there is no correctness hazard, but whichever merges second will need a mechanical rebase. #4160 is currently clean, so merging it first is the cheaper order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015y4fDJF57hRTfkfxn16Bve
