### PR TITLE
Add an sf_claim ansible module for namespace capacity claims

### DIFF
--- a/docs/user_guide/ansible.md
+++ b/docs/user_guide/ansible.md
@@ -21,6 +21,20 @@ The modules import the `shakenfist_client` python SDK and call the Shaken
 Fist REST API directly — they do not shell out to `sf-client`, and the
 control node never needs the Shaken Fist server package installed.
 
+`sf_claim` is the exception to that `pip3 install`. It calls the namespace
+capacity claim verbs, which are on the client's `develop` branch and are not
+in any release yet, so there is no minimum released version to ask for. A
+control node which uses `sf_claim` installs the client from git instead:
+
+```bash
+pip3 install git+https://github.com/shakenfist/client-python@develop
+```
+
+which is how the Shaken Fist CI conductor installs it. The module checks the
+client for those verbs and fails with this advice, naming the verb it could
+not find, rather than raising an `AttributeError`. Every other module works
+with the released client.
+
 ???+ note
     This example installs the Shaken Fist client in the system pip so that it
     is globally available to all Ansible users. The system pip is protected on
@@ -75,7 +89,11 @@ omitted, the module auto-discovers credentials from the environment and
 `sf_claim` is the exception, because claim management is administrator
 only and the caller is therefore acting on somebody else's namespace:
 there `namespace` names the namespace the claim covers, and the namespace
-to authenticate as is `auth_namespace`.
+to authenticate as is `auth_namespace`. Because that rename makes it easy
+to supply `api_url` and `key` while leaving `auth_namespace` unset,
+`sf_claim` treats a partly specified connection as an error rather than
+quietly falling back to the control node's ambient credentials — which
+might be pointed at another cluster entirely.
 
 ## Namespaces
 
@@ -298,6 +316,7 @@ does.
 | limit_memory_mb<br/>*integer* | The instance memory, in megabytes, the namespace may hold at once. Required when `state` is `present`. |
 | limit_disk_gb<br/>*integer* | The instance disk, in gigabytes, the namespace may hold at once. Required when `state` is `present`. |
 | expires_in_seconds<br/>*integer* | How long the claim should cover placements for, in seconds from now. Required when `state` is `present`, and must be positive. A duration rather than a timestamp: the expiry is computed from the cluster's clock, which is the only clock the expiry sweep ever compares against. Every run re-dates the claim to exactly this far in the future, which can shorten a claim as well as extend one. |
+| renew_within_seconds<br/>*integer* | Re-date the claim only when it has less than this long left to run. Optional, must be positive when set, and ignored when `state` is `absent`. See [Idempotence](#idempotence). |
 | state<br/>*string* | The state of the resource. Valid states are `present` or `absent`, defaults to `present`. |
 | auth_namespace<br/>*string* | The namespace to authenticate as, which is normally `system`. |
 
@@ -313,6 +332,20 @@ control node's clock is never compared against the cluster's. A play which
 renews on a schedule and does not want the renewal in its change count should
 set `changed_when` on the task.
 
+Re-dating on every run is the default because it is what a scheduled
+reconcile wants: every run is another chance to re-date before the claim
+lapses, so a weekly play against a thirty day expiry has four of them. A play
+which would rather converge than renew sets `renew_within_seconds`, and the
+module then leaves the claim alone — writing nothing and reporting no
+change — while it is further from its expiry than that window and its limits
+already match. Check mode says the same, so `--check` converges too. The
+remaining life is measured as the server's own `expires_at` against the
+control node's clock, which is the only comparison the module makes that
+spans two clocks and is deliberately a coarse one: skew moves the moment the
+renewal happens by the amount of the skew and decides nothing else, and never
+decides what is reported as changed. Choose a window comfortably larger than
+both the play's cadence and any plausible skew.
+
 ### A lapsed claim
 
 The server refuses to re-date a claim which is no longer active, and says to
@@ -321,6 +354,14 @@ creates the replacement first and only then removes the lapsed rows, so a
 capacity refusal leaves the namespace exactly as it was found. An expired
 claim holds no cluster capacity, so nothing is released by the removal and
 nothing is lost by the failure.
+
+Lapsed rows are reaped beside an active claim as well, so that a namespace
+which expired and was recreated out of band does not accumulate them — the
+server has no sweep which removes them, and otherwise somebody has to delete
+them by hand. That reaping is deliberately **not** reported as a change: an
+expired claim holds no cluster capacity and no admission decision anywhere
+depends on it, so removing the row alters nothing an operator can observe
+about the namespace's coverage. It is recorded in `log`.
 
 ### Refusals
 
@@ -331,6 +372,17 @@ task fails and `refusal` carries the status code and the server's
 per-dimension detail, so a play which can proceed without the claim should
 rescue it explicitly. HTTP 503 means the cluster capacity accounting is not
 ready yet, or the claim row was contended, and is worth retrying with `until`.
+HTTP 409 on a change to an existing claim means either that the shrink asked
+for is below what the namespace is already using, or that the claim stopped
+being active between the read and the write; the module says both rather than
+reporting a bare failure, because the first is a likely operator mistake.
+
+A refusal happens before anything is written, so it leaves the namespace
+exactly as it was found. The one exception is a failure while reaping lapsed
+rows, which happens after the claim itself was created or re-dated: the task
+fails, `meta` carries the claim that was written so the failure does not hide
+the half which succeeded, and the lapsed rows are still there. They hold no
+capacity, and the next run reaps them.
 
 !!! warning
     Removal is not symmetric with creation. `state: absent` hands the reserved
@@ -380,6 +432,21 @@ reconcile run:
     limit_memory_mb: 65536
     limit_disk_gb: 1200
     expires_in_seconds: 2592000
+    state: present
+```
+
+Renew only once the claim is inside its last week, so that a play which runs
+more often than that converges instead of re-dating every time:
+
+```yaml
+- name: Hold a standing claim for the static runner fleet
+  shakenfist.shakenfist.sf_claim:
+    namespace: static-runners
+    limit_cpus: 32
+    limit_memory_mb: 65536
+    limit_disk_gb: 1200
+    expires_in_seconds: 2592000
+    renew_within_seconds: 604800
     state: present
 ```
 

--- a/docs/user_guide/ansible.md
+++ b/docs/user_guide/ansible.md
@@ -2,10 +2,10 @@
 
 Shaken Fist ships native Ansible modules for orchestration of cloud
 resources as part of the `shakenfist.shakenfist` collection:
-`sf_namespace`, `sf_network`, `sf_instance` and `sf_snapshot`. Earlier
-releases shipped the modules as bash shims that redirected to the command
-line client; those shims have been removed, and this documentation covers
-the native collection modules.
+`sf_namespace`, `sf_network`, `sf_instance`, `sf_snapshot` and `sf_claim`.
+Earlier releases shipped the modules as bash shims that redirected to the
+command line client; those shims have been removed, and this documentation
+covers the native collection modules.
 
 ## Installation
 
@@ -71,6 +71,11 @@ omitted, the module auto-discovers credentials from the environment and
 `sfrc` / `~/.shakenfist` / `/etc/sf/shakenfist.json` exactly like the
 `sf-client` command line client does (see
 [Authentication and Namespaces](../developer_guide/authentication.md)).
+
+`sf_claim` is the exception, because claim management is administrator
+only and the caller is therefore acting on somebody else's namespace:
+there `namespace` names the namespace the claim covers, and the namespace
+to authenticate as is `auth_namespace`.
 
 ## Namespaces
 
@@ -269,4 +274,120 @@ Snapshot an instance and update a label:
     instance_uuid: "{{ ci_worker['meta']['uuid'] }}"
     label: ciimage
     state: present
+```
+
+## Capacity claims
+
+A capacity claim reserves aggregate cluster capacity for a namespace, so that
+placements the namespace makes later are drawn from capacity the cluster has
+already promised it rather than won from whatever happens to be free at the
+time. Claim management requires cluster administrator rights.
+
+The server permits only one **active** claim per namespace and refuses a
+second creation, so `sf_claim` has no separate "update" state: with
+`state: present` it creates the claim when the namespace holds no active one,
+and re-dates the existing claim (adjusting its limits if they differ) when it
+does.
+
+### Parameters
+
+| **Parameter** | **Comments** |
+|---|---|
+| namespace<br/>*string* | The namespace the claim covers. This must always be specified, and is **not** the namespace the module authenticates as — see `auth_namespace`. |
+| limit_cpus<br/>*integer* | The number of vCPUs the namespace may hold at once. Required when `state` is `present`. |
+| limit_memory_mb<br/>*integer* | The instance memory, in megabytes, the namespace may hold at once. Required when `state` is `present`. |
+| limit_disk_gb<br/>*integer* | The instance disk, in gigabytes, the namespace may hold at once. Required when `state` is `present`. |
+| expires_in_seconds<br/>*integer* | How long the claim should cover placements for, in seconds from now. Required when `state` is `present`, and must be positive. A duration rather than a timestamp: the expiry is computed from the cluster's clock, which is the only clock the expiry sweep ever compares against. Every run re-dates the claim to exactly this far in the future, which can shorten a claim as well as extend one. |
+| state<br/>*string* | The state of the resource. Valid states are `present` or `absent`, defaults to `present`. |
+| auth_namespace<br/>*string* | The namespace to authenticate as, which is normally `system`. |
+
+### Idempotence
+
+The module reports `changed` when it created a claim, when any of the three
+limits differed from the claim on the server, or when a re-date actually moved
+the claim's expiry. A re-date alone is therefore reported as a change, because
+it is one: the claim now holds cluster capacity for longer than it did, and
+admission decisions elsewhere on the cluster depend on that. The test is made
+against the server's own `expires_at` before and after the write, so the
+control node's clock is never compared against the cluster's. A play which
+renews on a schedule and does not want the renewal in its change count should
+set `changed_when` on the task.
+
+### A lapsed claim
+
+The server refuses to re-date a claim which is no longer active, and says to
+delete it and create a new one. The module does that, in that order — it
+creates the replacement first and only then removes the lapsed rows, so a
+capacity refusal leaves the namespace exactly as it was found. An expired
+claim holds no cluster capacity, so nothing is released by the removal and
+nothing is lost by the failure.
+
+### Refusals
+
+Creating or growing a claim is a guarded admission against the cluster, so the
+cluster may refuse it with HTTP 507 when there is not enough capacity to
+promise. That is an answer about the cluster, not a fault in the module: the
+task fails and `refusal` carries the status code and the server's
+per-dimension detail, so a play which can proceed without the claim should
+rescue it explicitly. HTTP 503 means the cluster capacity accounting is not
+ready yet, or the claim row was contended, and is worth retrying with `until`.
+
+!!! warning
+    Removal is not symmetric with creation. `state: absent` hands the reserved
+    capacity straight back to the general pool, which takes effect
+    immediately, while getting it back is a fresh admission decision which a
+    busy cluster may refuse. Deleting a standing claim is easy to do and may
+    not be possible to undo.
+
+### Return value
+
+Unless an error is experienced the full REST API information for the claim is
+returned in a dictionary element called `meta`. An example returned dictionary
+is:
+
+```python
+{
+    "changed": true,
+    "failed": false,
+    "log": [...],
+    "meta": {
+        "uuid": "0b1c1bbf-2b04-4e67-9b35-9fc1b27c0d40",
+        "namespace": "static-runners",
+        "state": "created",
+        "coverage_state": "active",
+        "limit_cpus": 32,
+        "limit_memory_mb": 65536,
+        "limit_disk_gb": 1200,
+        "used_cpus": 32,
+        "used_memory_mb": 65536,
+        "used_disk_gb": 1200,
+        "expires_at": 1755300000.0,
+        "updated_at": 1755213600.0
+    }
+}
+```
+
+### Examples
+
+Hold a standing claim for a fleet of static instances, renewing it on every
+reconcile run:
+
+```yaml
+- name: Hold a standing claim for the static runner fleet
+  shakenfist.shakenfist.sf_claim:
+    namespace: static-runners
+    limit_cpus: 32
+    limit_memory_mb: 65536
+    limit_disk_gb: 1200
+    expires_in_seconds: 2592000
+    state: present
+```
+
+Give the reserved capacity back to the cluster:
+
+```yaml
+- name: Release the static runner claim
+  shakenfist.shakenfist.sf_claim:
+    namespace: static-runners
+    state: absent
 ```

--- a/shakenfist/deploy/ansible_module_ci/006.yml
+++ b/shakenfist/deploy/ansible_module_ci/006.yml
@@ -4,6 +4,19 @@
 # cluster capacity and the cluster refuses one it cannot keep, so a CI
 # scenario which asked for a realistic fleet's worth would fail on a busy
 # cluster for reasons which have nothing to do with the module.
+#
+# Every claim task retries the refusals the claim API documents as
+# transient, which is the discipline cluster_ci_tests/test_namespace_claims.py
+# applies to every request in the functional suite. A 503 means the
+# reconciler has not built the cluster_capacity singleton yet (it is built on
+# the first reconcile pass, which is a genuine cold start on the freshly
+# deployed cluster this scenario runs against) or that the claim row was
+# contended. A 507 means the cluster was full at that instant, and capacity
+# the rest of a CI run is releasing comes back asynchronously. Both are
+# waited out here rather than failed on, because every task below asserts
+# success: 42 retries at 10 seconds is the 420 second budget and the ten
+# second cadence the functional suite uses, for the same reasons. Anything
+# else -- a refusal the module should not have provoked -- fails at once.
 
 - hosts: localhost
   gather_facts: no
@@ -33,6 +46,11 @@
         namespace: "{{ namespace_name }}"
         state: absent
       register: ci_claim
+      until: >-
+        not (ci_claim['failed'] | default(false))
+        or (ci_claim['refusal']['status_code'] | default(0)) not in [503, 507]
+      retries: 42
+      delay: 10
 
     - name: Assert removing a claim which is not there is not a change
       assert:
@@ -48,6 +66,11 @@
         expires_in_seconds: 3600
         state: present
       register: ci_claim
+      until: >-
+        not (ci_claim['failed'] | default(false))
+        or (ci_claim['refusal']['status_code'] | default(0)) not in [503, 507]
+      retries: 42
+      delay: 10
 
     - name: Assert the claim is new
       assert:
@@ -77,6 +100,11 @@
         expires_in_seconds: 3600
         state: present
       register: ci_claim
+      until: >-
+        not (ci_claim['failed'] | default(false))
+        or (ci_claim['refusal']['status_code'] | default(0)) not in [503, 507]
+      retries: 42
+      delay: 10
 
     # Deliberately no assertion on changed here. The module reports a
     # re-date as a change when the server's expiry actually moved, and
@@ -93,6 +121,59 @@
           - ci_claim['meta']['limit_disk_gb'] == 1
         fail_msg: "re-presentation was not idempotent in {{ ci_claim }}"
 
+    # renew_within_seconds is how a play asks for convergence rather than
+    # renewal, and it is what lets this scenario assert idempotence at all.
+    # The claim above was just re-dated to an hour out, which is well
+    # outside a sixty second window, and its limits already match, so there
+    # is nothing to write and the module must say so.
+    - name: Re-present the claim inside a renewal window
+      sf_claim:
+        namespace: "{{ namespace_name }}"
+        limit_cpus: 1
+        limit_memory_mb: 128
+        limit_disk_gb: 1
+        expires_in_seconds: 3600
+        renew_within_seconds: 60
+        state: present
+      register: ci_claim
+      until: >-
+        not (ci_claim['failed'] | default(false))
+        or (ci_claim['refusal']['status_code'] | default(0)) not in [503, 507]
+      retries: 42
+      delay: 10
+
+    - name: Assert a claim outside its renewal window is not a change
+      assert:
+        that:
+          - not ci_claim['failed']
+          - not ci_claim['changed']
+          - ci_claim['meta']['limit_cpus'] == 1
+        fail_msg: "renew_within_seconds did not converge in {{ ci_claim }}"
+
+    - name: Re-present the claim in check mode inside a renewal window
+      sf_claim:
+        namespace: "{{ namespace_name }}"
+        limit_cpus: 1
+        limit_memory_mb: 128
+        limit_disk_gb: 1
+        expires_in_seconds: 3600
+        renew_within_seconds: 60
+        state: present
+      check_mode: true
+      register: ci_claim
+      until: >-
+        not (ci_claim['failed'] | default(false))
+        or (ci_claim['refusal']['status_code'] | default(0)) not in [503, 507]
+      retries: 42
+      delay: 10
+
+    - name: Assert check mode converges with a renewal window
+      assert:
+        that:
+          - not ci_claim['failed']
+          - not ci_claim['changed']
+        fail_msg: "check mode did not converge in {{ ci_claim }}"
+
     - name: Re-date the claim to a longer expiry
       sf_claim:
         namespace: "{{ namespace_name }}"
@@ -102,6 +183,11 @@
         expires_in_seconds: 7200
         state: present
       register: ci_claim
+      until: >-
+        not (ci_claim['failed'] | default(false))
+        or (ci_claim['refusal']['status_code'] | default(0)) not in [503, 507]
+      retries: 42
+      delay: 10
 
     - name: Assert a re-date which moves the expiry is a change
       assert:
@@ -117,6 +203,11 @@
         expires_in_seconds: 7200
         state: present
       register: ci_claim
+      until: >-
+        not (ci_claim['failed'] | default(false))
+        or (ci_claim['refusal']['status_code'] | default(0)) not in [503, 507]
+      retries: 42
+      delay: 10
 
     - name: Assert the claim grew
       assert:
@@ -132,6 +223,11 @@
         namespace: "{{ namespace_name }}"
         state: absent
       register: ci_claim
+      until: >-
+        not (ci_claim['failed'] | default(false))
+        or (ci_claim['refusal']['status_code'] | default(0)) not in [503, 507]
+      retries: 42
+      delay: 10
 
     - name: Assert the claim was deleted
       assert:
@@ -143,6 +239,11 @@
         namespace: "{{ namespace_name }}"
         state: absent
       register: ci_claim
+      until: >-
+        not (ci_claim['failed'] | default(false))
+        or (ci_claim['refusal']['status_code'] | default(0)) not in [503, 507]
+      retries: 42
+      delay: 10
 
     - name: Assert the second deletion is not a change
       assert:

--- a/shakenfist/deploy/ansible_module_ci/006.yml
+++ b/shakenfist/deploy/ansible_module_ci/006.yml
@@ -1,0 +1,161 @@
+# Tests: sf_claim, the namespace capacity claim lifecycle
+#
+# The claim here is deliberately tiny. A claim is a promise of aggregate
+# cluster capacity and the cluster refuses one it cannot keep, so a CI
+# scenario which asked for a realistic fleet's worth would fail on a busy
+# cluster for reasons which have nothing to do with the module.
+
+- hosts: localhost
+  gather_facts: no
+  collections:
+    - shakenfist.shakenfist
+
+  tasks:
+    - name: Create a unique namespace name
+      shell: pwgen 10 -n 1
+      register: unique
+
+    - name: Store unique name
+      set_fact:
+        namespace_name: "ansibleci-006-{{ unique['stdout'] }}"
+
+    - name: Log namespace name
+      debug:
+        msg: "Test namespace is {{ namespace_name }}"
+
+    - name: Create a namespace to hold the claim
+      sf_namespace:
+        name: "{{ namespace_name }}"
+        state: present
+
+    - name: Assert the namespace holds no claim yet
+      sf_claim:
+        namespace: "{{ namespace_name }}"
+        state: absent
+      register: ci_claim
+
+    - name: Assert removing a claim which is not there is not a change
+      assert:
+        that: not ci_claim['changed']
+        fail_msg: "changed should be false in {{ ci_claim }}"
+
+    - name: Create a claim
+      sf_claim:
+        namespace: "{{ namespace_name }}"
+        limit_cpus: 1
+        limit_memory_mb: 128
+        limit_disk_gb: 1
+        expires_in_seconds: 3600
+        state: present
+      register: ci_claim
+
+    - name: Assert the claim is new
+      assert:
+        that: ci_claim['changed']
+        fail_msg: "changed should be true in {{ ci_claim }}"
+
+    - name: Assert no errors
+      assert:
+        that: not ci_claim['failed']
+        fail_msg: "failed should be false in {{ ci_claim }}"
+
+    - name: Assert the claim covers what was asked for
+      assert:
+        that:
+          - ci_claim['meta']['limit_cpus'] == 1
+          - ci_claim['meta']['limit_memory_mb'] == 128
+          - ci_claim['meta']['limit_disk_gb'] == 1
+          - ci_claim['meta']['coverage_state'] == 'active'
+        fail_msg: "claim is not as requested in {{ ci_claim }}"
+
+    - name: Re-present the same claim
+      sf_claim:
+        namespace: "{{ namespace_name }}"
+        limit_cpus: 1
+        limit_memory_mb: 128
+        limit_disk_gb: 1
+        expires_in_seconds: 3600
+        state: present
+      register: ci_claim
+
+    # Deliberately no assertion on changed here. The module reports a
+    # re-date as a change when the server's expiry actually moved, and
+    # expires_at has one second resolution, so two tasks in the same second
+    # legitimately report no change. What must hold either way is that the
+    # server did not refuse the second create (it would: only one active
+    # claim per namespace) and that the limits are untouched.
+    - name: Assert the re-presentation was accepted and changed no limits
+      assert:
+        that:
+          - not ci_claim['failed']
+          - ci_claim['meta']['limit_cpus'] == 1
+          - ci_claim['meta']['limit_memory_mb'] == 128
+          - ci_claim['meta']['limit_disk_gb'] == 1
+        fail_msg: "re-presentation was not idempotent in {{ ci_claim }}"
+
+    - name: Re-date the claim to a longer expiry
+      sf_claim:
+        namespace: "{{ namespace_name }}"
+        limit_cpus: 1
+        limit_memory_mb: 128
+        limit_disk_gb: 1
+        expires_in_seconds: 7200
+        state: present
+      register: ci_claim
+
+    - name: Assert a re-date which moves the expiry is a change
+      assert:
+        that: ci_claim['changed']
+        fail_msg: "changed should be true in {{ ci_claim }}"
+
+    - name: Grow the claim
+      sf_claim:
+        namespace: "{{ namespace_name }}"
+        limit_cpus: 2
+        limit_memory_mb: 256
+        limit_disk_gb: 2
+        expires_in_seconds: 7200
+        state: present
+      register: ci_claim
+
+    - name: Assert the claim grew
+      assert:
+        that:
+          - ci_claim['changed']
+          - ci_claim['meta']['limit_cpus'] == 2
+          - ci_claim['meta']['limit_memory_mb'] == 256
+          - ci_claim['meta']['limit_disk_gb'] == 2
+        fail_msg: "claim did not grow in {{ ci_claim }}"
+
+    - name: Delete the claim
+      sf_claim:
+        namespace: "{{ namespace_name }}"
+        state: absent
+      register: ci_claim
+
+    - name: Assert the claim was deleted
+      assert:
+        that: ci_claim['changed']
+        fail_msg: "changed should be true in {{ ci_claim }}"
+
+    - name: Delete the claim again
+      sf_claim:
+        namespace: "{{ namespace_name }}"
+        state: absent
+      register: ci_claim
+
+    - name: Assert the second deletion is not a change
+      assert:
+        that: not ci_claim['changed']
+        fail_msg: "changed should be false in {{ ci_claim }}"
+
+    - name: Delete the namespace
+      sf_namespace:
+        name: "{{ namespace_name }}"
+        state: absent
+      register: ci_namespace
+
+    - name: Assert the namespace was deleted
+      assert:
+        that: ci_namespace['changed']
+        fail_msg: "changed should be true in {{ ci_namespace }}"

--- a/shakenfist/deploy/collection/README.md
+++ b/shakenfist/deploy/collection/README.md
@@ -59,7 +59,7 @@ node whose database rows have drifted.
 
 ## Modules
 
-The collection ships four native Ansible modules (under
+The collection ships five native Ansible modules (under
 `plugins/modules/`) for managing Shaken Fist resources from a playbook. They
 import the `shakenfist_client` SDK and call the Shaken Fist REST API directly
 — they do **not** shell out to `sf-client`.
@@ -70,12 +70,15 @@ import the `shakenfist_client` SDK and call the Shaken Fist REST API directly
 | `shakenfist.shakenfist.sf_network` | Idempotently create or delete a network (`name`/`uuid`, `netblock`, `nat`, `dhcp`, `dns`, `state`). A changed specification deletes and recreates the network. |
 | `shakenfist.shakenfist.sf_instance` | Idempotently create, replace or delete an instance (`name`/`uuid`, `cpu`, `ram`, `disks`/`diskspecs`, `networks`/`networkspecs`, `metadata`, `await`, `state`). A changed specification deletes and recreates the instance. |
 | `shakenfist.shakenfist.sf_snapshot` | Snapshot an instance's disks (optionally updating a label) or delete a snapshot artifact (`instance_uuid`/`uuid`, `all`, `label`, `state`). |
+| `shakenfist.shakenfist.sf_claim` | Idempotently create, resize, re-date or delete a namespace's capacity claim (`namespace`, `limit_cpus`, `limit_memory_mb`, `limit_disk_gb`, `expires_in_seconds`, `state`). Administrator only. |
 
 Every module accepts optional `api_url`, `namespace` and `key` connection
 parameters. When all three are supplied they are used verbatim; when omitted,
 the module auto-discovers credentials from the environment and
 `sfrc`/`~/.shakenfist`/`/etc/sf/shakenfist.json` exactly like the `sf-client`
-CLI. Each module returns `changed`, `failed`, a `meta` object describing the
+CLI. `sf_claim` is the exception: claim management is administrator only, so
+there `namespace` names the namespace the claim covers and the namespace to
+authenticate as is `auth_namespace`. Each module returns `changed`, `failed`, a `meta` object describing the
 resource, and a `log` list of progress messages for debugging.
 
 ## Requirements

--- a/shakenfist/deploy/collection/README.md
+++ b/shakenfist/deploy/collection/README.md
@@ -70,7 +70,7 @@ import the `shakenfist_client` SDK and call the Shaken Fist REST API directly
 | `shakenfist.shakenfist.sf_network` | Idempotently create or delete a network (`name`/`uuid`, `netblock`, `nat`, `dhcp`, `dns`, `state`). A changed specification deletes and recreates the network. |
 | `shakenfist.shakenfist.sf_instance` | Idempotently create, replace or delete an instance (`name`/`uuid`, `cpu`, `ram`, `disks`/`diskspecs`, `networks`/`networkspecs`, `metadata`, `await`, `state`). A changed specification deletes and recreates the instance. |
 | `shakenfist.shakenfist.sf_snapshot` | Snapshot an instance's disks (optionally updating a label) or delete a snapshot artifact (`instance_uuid`/`uuid`, `all`, `label`, `state`). |
-| `shakenfist.shakenfist.sf_claim` | Idempotently create, resize, re-date or delete a namespace's capacity claim (`namespace`, `limit_cpus`, `limit_memory_mb`, `limit_disk_gb`, `expires_in_seconds`, `state`). Administrator only. |
+| `shakenfist.shakenfist.sf_claim` | Idempotently create, resize, re-date or delete a namespace's capacity claim (`namespace`, `limit_cpus`, `limit_memory_mb`, `limit_disk_gb`, `expires_in_seconds`, `renew_within_seconds`, `state`). Administrator only. |
 
 Every module accepts optional `api_url`, `namespace` and `key` connection
 parameters. When all three are supplied they are used verbatim; when omitted,
@@ -78,8 +78,11 @@ the module auto-discovers credentials from the environment and
 `sfrc`/`~/.shakenfist`/`/etc/sf/shakenfist.json` exactly like the `sf-client`
 CLI. `sf_claim` is the exception: claim management is administrator only, so
 there `namespace` names the namespace the claim covers and the namespace to
-authenticate as is `auth_namespace`. Each module returns `changed`, `failed`, a `meta` object describing the
-resource, and a `log` list of progress messages for debugging.
+authenticate as is `auth_namespace`, and supplying only some of `api_url`,
+`auth_namespace` and `key` is an error rather than a silent fall back to
+whatever credentials the control node happens to hold. Each module returns
+`changed`, `failed`, a `meta` object describing the resource, and a `log`
+list of progress messages for debugging.
 
 ## Requirements
 
@@ -92,6 +95,21 @@ pip install shakenfist-client
 (or `pip install -r requirements.txt` from the collection root). The control
 node never needs the Shaken Fist server package. The roles additionally
 require `ansible >= 2.15` (see `meta/runtime.yml`).
+
+`sf_claim` needs more than that. It calls the namespace capacity claim verbs
+(`get_namespace_claims`, `create_namespace_claim`, `update_namespace_claim`
+and `delete_namespace_claim`), which are on the client's `develop` branch and
+are **not in any release yet**, so there is no minimum released version to
+ask for. A control node which uses `sf_claim` installs the client from git:
+
+```bash
+pip install git+https://github.com/shakenfist/client-python@develop
+```
+
+which is how the Shaken Fist CI conductor installs it. The module checks the
+client it built for those verbs and fails with this advice, naming the verb
+it could not find, rather than raising an `AttributeError`. Every other
+module in the collection works with the released client.
 
 The `internal_ca` role generates certificates on the control node with
 `certtool` from the `gnutls-bin` package (Debian/Ubuntu). The role installs it

--- a/shakenfist/deploy/collection/plugins/modules/sf_claim.py
+++ b/shakenfist/deploy/collection/plugins/modules/sf_claim.py
@@ -9,6 +9,8 @@
 # entire contract this module implements.
 from __future__ import annotations
 
+import time
+
 from ansible.module_utils.basic import AnsibleModule
 
 from shakenfist_client import apiclient
@@ -18,6 +20,14 @@ DOCUMENTATION = r'''
 ---
 module: sf_claim
 short_description: Manage a Shaken Fist namespace capacity claim.
+requirements:
+  - >-
+    shakenfist-client on the ansible control node, built from a source tree
+    which carries the namespace claim verbs. No release carries them yet, so
+    today that means installing the client from git - pip install
+    git+https://github.com/shakenfist/client-python@develop. The module says
+    so, and names the verb it could not find, rather than raising an
+    AttributeError at the first call.
 description:
   - Idempotently ensure a namespace holds a capacity claim of a given size,
     or holds none at all.
@@ -42,8 +52,8 @@ description:
     C(expires_at) before and after the write, so it never compares the
     control node's clock against the cluster's. A play which renews on a
     schedule and does not want the renewal in its change count should set
-    C(changed_when) on the task rather than expecting the module to decide
-    the renewal was uninteresting.
+    C(changed_when) on the task, or set O(renew_within_seconds) so that the
+    module re-dates only a claim which is actually near its expiry.
   - >-
     A lapsed claim. The server refuses to re-date a claim which is no longer
     active, and says to delete it and create a new one. This module does
@@ -53,6 +63,21 @@ description:
     nothing is released by the removal and nothing is lost by the failure.
     Restoring coverage is the whole point of running the play, and failing
     instead would leave the fleet uncovered until somebody noticed.
+  - >-
+    Lapsed rows are reaped beside an active claim as well, so that a
+    namespace which expired and was recreated out of band does not
+    accumulate them. That reaping is deliberately B(not) reported as a
+    change: an expired claim holds no cluster capacity and no admission
+    decision anywhere depends on it, so removing the row alters nothing an
+    operator can observe about the namespace's coverage. It is recorded in
+    RV(log).
+  - >-
+    What a failure leaves behind. A refusal happens before anything is
+    written, so it leaves the namespace exactly as it was found. The one
+    exception is a failure while reaping lapsed rows, which happens after
+    the claim itself was created or re-dated: the task fails, RV(meta)
+    carries the claim that was written, and the lapsed rows are still
+    there. They hold no capacity and the next run reaps them.
   - >-
     Capacity refusals. Creating or growing a claim is a guarded admission
     against the cluster, so the cluster may refuse it with HTTP 507 when
@@ -107,6 +132,30 @@ options:
         extend one.
     required: false
     type: int
+  renew_within_seconds:
+    description:
+      - Re-date the claim only when it has less than this long left to run.
+        Must be positive when it is set, and is ignored when
+        O(state=absent).
+      - >-
+        When this is not set, which is the default, every O(state=present)
+        run re-dates the claim. That is what a play which reconciles on a
+        schedule wants: every run is another chance to re-date before the
+        claim lapses, so a weekly play against a thirty day expiry has four
+        of them.
+      - >-
+        Set it when the play would rather converge than renew. With a
+        window set, a run which finds the limits already correct and the
+        claim further from its expiry than the window writes nothing and
+        reports no change, and check mode says the same. The remaining life
+        is the server's own C(expires_at) against the control node's clock,
+        which is the only comparison in this module spanning two clocks and
+        is deliberately a coarse one: skew moves the moment the renewal
+        happens and decides nothing else, and in particular never decides
+        what is reported as changed. Choose a window comfortably larger
+        than both the play's cadence and any plausible skew.
+    required: false
+    type: int
   state:
     description: Whether the namespace should hold a claim or not.
     required: false
@@ -116,10 +165,12 @@ options:
   api_url:
     description:
       - Base URL of the Shaken Fist API (for example
-        C(http://sf-1:13000)). When omitted (together with O(auth_namespace)
-        and O(key)) the module auto-discovers credentials from the
-        environment and C(sfrc)/C(~/.shakenfist)/C(/etc/sf/shakenfist.json)
-        exactly like the C(sf-client) CLI.
+        C(http://sf-1:13000)). This, O(auth_namespace) and O(key) are all
+        supplied together or not at all, and supplying only some of them is
+        an error. When all three are omitted the module auto-discovers
+        credentials from the environment and
+        C(sfrc)/C(~/.shakenfist)/C(/etc/sf/shakenfist.json) exactly like the
+        C(sf-client) CLI.
     required: false
     type: str
   auth_namespace:
@@ -158,6 +209,15 @@ EXAMPLES = r'''
     expires_in_seconds: 2592000
   changed_when: false
 
+- name: Renew the claim only once it is inside its last week
+  shakenfist.shakenfist.sf_claim:
+    namespace: static-runners
+    limit_cpus: 32
+    limit_memory_mb: 65536
+    limit_disk_gb: 1200
+    expires_in_seconds: 2592000
+    renew_within_seconds: 604800
+
 - name: Give the reserved capacity back to the cluster
   shakenfist.shakenfist.sf_claim:
     namespace: static-runners
@@ -174,8 +234,12 @@ failed:
   returned: always
   type: bool
 meta:
-  description: The claim object as returned by the API, when available.
-  returned: success
+  description:
+    - The claim object as returned by the API, when available. It is also
+      returned when the claim itself was written and the reaping of a
+      lapsed row afterwards failed, so that the failure does not hide the
+      half of the operation which succeeded.
+  returned: success, and on a failure to reap a lapsed claim
   type: dict
 refusal:
   description:
@@ -201,6 +265,13 @@ log:
 COVERAGE_ACTIVE = 'active'
 
 LIMIT_FIELDS = ('limit_cpus', 'limit_memory_mb', 'limit_disk_gb')
+
+# The client SDK verbs this module calls. They are newer than any released
+# shakenfist-client, so a control node which installed the client from PyPI
+# has an apiclient.Client without them and every call here would be an
+# AttributeError traceback. See _require_claim_verbs().
+CLAIM_VERBS = ('get_namespace_claims', 'create_namespace_claim',
+               'update_namespace_claim', 'delete_namespace_claim')
 
 
 def _make_client(module):
@@ -229,6 +300,32 @@ def _make_client(module):
     except apiclient.UnconfiguredException as e:
         module.fail_json(
             msg='Could not configure the Shaken Fist client: %s' % e, meta=None, log=[])
+
+
+def _require_claim_verbs(client, module, log):
+    """Fail clearly when the installed client SDK predates the claim verbs.
+
+    The verbs landed on client-python's develop branch and no release
+    carries them yet, so "your client is too old" is the most likely
+    reason this module does not work on a control node which has done
+    nothing wrong. An AttributeError traceback names the attribute and
+    nothing an operator can act on, so name the fix instead. The check is
+    against the client which was actually built, so it starts passing on
+    its own once a release does carry the verbs.
+    """
+    missing = [verb for verb in CLAIM_VERBS
+               if not callable(getattr(client, verb, None))]
+    if not missing:
+        return
+
+    module.fail_json(
+        msg='The installed shakenfist-client does not have the namespace '
+            'claim verbs this module needs (missing: %s). They are not in a '
+            'released client yet, so install the client from git on the '
+            'ansible control node: pip install '
+            'git+https://github.com/shakenfist/client-python@develop'
+            % ', '.join(missing),
+        meta=None, log=log)
 
 
 def _live_claims(claims):
@@ -272,22 +369,67 @@ def _limit_differences(claim, module):
     return differences
 
 
-def _fail_api(module, log, message, e):
+def _renewal_is_due(claim, module, log):
+    """Whether this run should re-date the claim.
+
+    Without renew_within_seconds every run re-dates, which is the default
+    because it is what a scheduled reconcile wants: each run is another
+    chance to re-date before the claim lapses.
+
+    With a window set the claim is left alone while it has more than that
+    long to run, so a repeat run and a check mode run both converge. The
+    remaining life is the server's own expires_at against the control
+    node's clock. That is the only comparison in this module which spans
+    two clocks and it is deliberately a coarse one: skew moves the moment
+    the renewal happens by the amount of the skew and decides nothing else.
+    In particular it never decides what is reported as changed, which stays
+    a comparison of two of the server's own timestamps.
+    """
+    window = module.params.get('renew_within_seconds')
+    if not window:
+        return True
+
+    expires_at = claim.get('expires_at')
+    if expires_at is None:
+        # The server did not say when this claim expires, so there is
+        # nothing for the window to be measured against. Re-date, which is
+        # what this module does when there is no window at all.
+        log.append('Claim %s has no expiry to measure the renewal window '
+                   'against, re-dating' % claim.get('uuid'))
+        return True
+
+    remaining = expires_at - time.time()
+    log.append(
+        'Claim %s has about %d seconds left against a %d second renewal '
+        'window' % (claim.get('uuid'), remaining, window))
+    return remaining <= window
+
+
+def _fail_api(module, log, message, e, meta=None):
     # An API refusal is an answer, not a crash, and the play needs enough of
     # it to tell a capacity refusal from a malformed request. sf_api.error()
     # carries the per-dimension detail of a capacity refusal in the response
     # body, so the body goes back to the play rather than only the summary.
+    #
+    # meta is the claim this module wrote before the failure, when there is
+    # one. A reap which fails after a successful create or re-date must not
+    # hide the claim it wrote from the play.
     module.fail_json(
-        msg='%s: %s' % (message, e.message), meta=None, log=log,
+        msg='%s: %s' % (message, e.message), meta=meta, log=log,
         refusal={'status_code': e.status_code, 'text': e.text})
 
 
 def _create_claim(client, module, log):
     try:
+        # By keyword: the SDK lives in another repository and these are
+        # four mutually type-compatible integers, so a reordering there
+        # would silently mis-assign limits rather than raising.
         return client.create_namespace_claim(
-            module.params['namespace'], module.params['limit_cpus'],
-            module.params['limit_memory_mb'], module.params['limit_disk_gb'],
-            module.params['expires_in_seconds'])
+            module.params['namespace'],
+            limit_cpus=module.params['limit_cpus'],
+            limit_memory_mb=module.params['limit_memory_mb'],
+            limit_disk_gb=module.params['limit_disk_gb'],
+            expires_in_seconds=module.params['expires_in_seconds'])
     except apiclient.InsufficientResourcesException as e:
         _fail_api(
             module, log,
@@ -297,7 +439,9 @@ def _create_claim(client, module, log):
         _fail_api(module, log, 'Creating the namespace claim failed', e)
 
 
-def _delete_claims(client, module, log, claims, description):
+def _delete_claims(client, module, log, claims, description, meta=None):
+    # meta is the claim this run wrote, when it wrote one, so that a reap
+    # which fails still hands the play the claim which succeeded.
     for c in claims:
         log.append('Deleting %s claim %s' % (description, c.get('uuid')))
         try:
@@ -307,7 +451,7 @@ def _delete_claims(client, module, log, claims, description):
             log.append('Claim %s was already gone' % c.get('uuid'))
         except apiclient.APIException as e:
             _fail_api(module, log, 'Deleting namespace claim %s failed'
-                      % c.get('uuid'), e)
+                      % c.get('uuid'), e, meta=meta)
 
 
 def _ensure_present(client, module, log):
@@ -345,19 +489,31 @@ def _ensure_present(client, module, log):
             module.exit_json(changed=True, meta=None, log=log)
 
         c = _create_claim(client, module, log)
-        _delete_claims(client, module, log, inactive, 'lapsed')
+        _delete_claims(client, module, log, inactive, 'lapsed', meta=c)
         module.exit_json(changed=True, meta=c, log=log)
 
     differences = _limit_differences(active, module)
     if differences:
         log.append('Claim %s limits differ: %s' % (active.get('uuid'), differences))
 
+    if not differences and not _renewal_is_due(active, module, log):
+        # There is nothing to write: the limits match and the claim is
+        # further from its expiry than the renewal window the play asked
+        # for. Lapsed rows are still worth reaping, and reaping is not a
+        # change, so this run converges.
+        log.append('Claim %s needs nothing' % active.get('uuid'))
+        if not module.check_mode:
+            _delete_claims(client, module, log, inactive, 'lapsed', meta=active)
+        module.exit_json(changed=False, meta=active, log=log)
+
     if module.check_mode:
         # Check mode reports the re-date it cannot perform as a change,
         # because performing it would be one. There is no way to know
         # whether the server's clock has moved without asking it to move
         # the expiry, and guessing from the control node's clock is exactly
-        # the comparison this module avoids making.
+        # the comparison this module avoids making. A play which wants
+        # check mode to converge sets renew_within_seconds, which is
+        # answered above without writing anything.
         module.exit_json(changed=True, meta=active, log=log)
 
     # Only the limits which actually differ are named in the field mask, so
@@ -374,6 +530,19 @@ def _ensure_present(client, module, log):
             module, log,
             'The cluster refused to grow this claim, it does not have the '
             'capacity to promise it', e)
+    except apiclient.ResourceStateConflictException as e:
+        # The server answers 409 for a shrink below what the namespace is
+        # already using, and for a claim which stopped being active between
+        # the listing above and this write. Both are the caller's to fix
+        # and neither is a fault in the cluster, so say which they are
+        # rather than reporting a bare failure. The wording follows
+        # CLAIM_REFUSAL_MESSAGE in the server's external_api/auth.py.
+        _fail_api(
+            module, log,
+            'The cluster refused this change to claim %s: a claim cannot be '
+            'shrunk below what it is already using, and a claim which is no '
+            'longer active cannot be changed (delete it and create a new '
+            'one)' % active['uuid'], e)
     except apiclient.APIException as e:
         _fail_api(module, log, 'Updating namespace claim %s failed'
                   % active['uuid'], e)
@@ -384,6 +553,12 @@ def _ensure_present(client, module, log):
     if redated:
         log.append('Claim %s expiry moved to %s'
                    % (active.get('uuid'), updated.get('expires_at')))
+
+    # Reap here as well as on the create path, so that lapsed rows beside an
+    # active claim do not accumulate until somebody removes them by hand.
+    # Not a change: an expired claim holds no cluster capacity, so removing
+    # it alters nothing the namespace's coverage depends on.
+    _delete_claims(client, module, log, inactive, 'lapsed', meta=updated)
 
     module.exit_json(changed=bool(differences) or redated, meta=updated, log=log)
 
@@ -418,6 +593,7 @@ def run_module():
         'limit_memory_mb': {'required': False, 'type': 'int'},
         'limit_disk_gb': {'required': False, 'type': 'int'},
         'expires_in_seconds': {'required': False, 'type': 'int'},
+        'renew_within_seconds': {'required': False, 'type': 'int'},
         'state': {
             'default': 'present',
             'choices': ['present', 'absent'],
@@ -434,7 +610,14 @@ def run_module():
             ('state', 'present',
              ['limit_cpus', 'limit_memory_mb', 'limit_disk_gb',
               'expires_in_seconds'])
-        ])
+        ],
+        # All three connection parameters or none of them. A partial triple
+        # is otherwise ignored in favour of whatever ambient credentials the
+        # control node holds, which may be a different cluster entirely --
+        # and this module's namespace parameter names the claim's target
+        # rather than the identity, so a playbook written against the rest
+        # of the collection lands exactly there.
+        required_together=[['api_url', 'auth_namespace', 'key']])
 
     log = []
 
@@ -446,7 +629,16 @@ def run_module():
         module.fail_json(
             msg='expires_in_seconds must be positive', meta=None, log=log)
 
+    renew_within = module.params['renew_within_seconds']
+    if state == 'present' and renew_within is not None and renew_within < 1:
+        # A negative window would silently mean "never renew", which is the
+        # opposite of what somebody setting it wants.
+        module.fail_json(
+            msg='renew_within_seconds must be positive when it is set',
+            meta=None, log=log)
+
     client = _make_client(module)
+    _require_claim_verbs(client, module, log)
 
     if state == 'present':
         _ensure_present(client, module, log)

--- a/shakenfist/deploy/collection/plugins/modules/sf_claim.py
+++ b/shakenfist/deploy/collection/plugins/modules/sf_claim.py
@@ -1,0 +1,462 @@
+# Copyright 2026 Michael Still and contributors
+#
+# A native Shaken Fist ansible module for managing a namespace's capacity
+# claim. Shaped on sf_namespace.py, and like it it talks to the REST API
+# through the shakenfist_client SDK rather than shelling out to sf-client.
+#
+# The server permits one *active* claim per namespace and refuses a second
+# create outright, so "create it or re-date the one that is there" is the
+# entire contract this module implements.
+from __future__ import annotations
+
+from ansible.module_utils.basic import AnsibleModule
+
+from shakenfist_client import apiclient
+
+
+DOCUMENTATION = r'''
+---
+module: sf_claim
+short_description: Manage a Shaken Fist namespace capacity claim.
+description:
+  - Idempotently ensure a namespace holds a capacity claim of a given size,
+    or holds none at all.
+  - A capacity claim reserves aggregate cluster capacity for a namespace, so
+    that placements the namespace makes later are drawn from capacity the
+    cluster has already promised it rather than won from whatever is free at
+    the time. The intended user is a play which reconciles a standing fleet
+    of instances and wants that fleet's footprint to survive a retire and
+    rebuild of the instances themselves.
+  - The server permits only one B(active) claim per namespace and refuses a
+    second creation, so there is no separate "update" state. With
+    O(state=present) the module creates the claim when the namespace holds
+    no active one, and re-dates the existing claim (adjusting its limits if
+    they differ) when it does.
+  - >-
+    Idempotence. The module reports C(changed) when it created a claim, when
+    any of the three limits differed from the claim on the server, or when a
+    re-date actually moved the claim's expiry. A re-date alone is therefore
+    reported as a change, because it is one: the claim now holds cluster
+    capacity for longer than it did, and an admission decision somewhere else
+    on the cluster depends on that. The test is made against the server's own
+    C(expires_at) before and after the write, so it never compares the
+    control node's clock against the cluster's. A play which renews on a
+    schedule and does not want the renewal in its change count should set
+    C(changed_when) on the task rather than expecting the module to decide
+    the renewal was uninteresting.
+  - >-
+    A lapsed claim. The server refuses to re-date a claim which is no longer
+    active, and says to delete it and create a new one. This module does
+    that, in that order - it creates the replacement first and only then
+    removes the lapsed rows, so a capacity refusal leaves the namespace
+    exactly as it found it. An expired claim holds no cluster capacity, so
+    nothing is released by the removal and nothing is lost by the failure.
+    Restoring coverage is the whole point of running the play, and failing
+    instead would leave the fleet uncovered until somebody noticed.
+  - >-
+    Capacity refusals. Creating or growing a claim is a guarded admission
+    against the cluster, so the cluster may refuse it with HTTP 507 when
+    there is not enough capacity to promise. That is an answer about the
+    cluster and not a fault in this module: the task fails, RV(refusal)
+    carries the status code and the server's per-dimension detail, and a
+    play which can proceed without the claim should rescue it explicitly. A
+    HTTP 503 means the cluster capacity accounting is not ready yet or the
+    claim row was contended, and is worth retrying with C(until).
+  - >-
+    Removal is not symmetric with creation. O(state=absent) hands the
+    reserved capacity straight back to the general pool, which takes effect
+    immediately, while getting it back is a fresh admission decision which a
+    busy cluster may refuse. Deleting a standing claim is therefore easy to
+    do and may not be possible to undo.
+options:
+  namespace:
+    description:
+      - The namespace the claim covers.
+      - This is not the namespace the module authenticates as. Claim
+        management requires cluster administrator rights, so the caller is
+        normally C(system) acting on somebody else's namespace.
+    required: true
+    type: str
+  limit_cpus:
+    description:
+      - The number of vCPUs this namespace may hold at once. Required when
+        O(state=present).
+    required: false
+    type: int
+  limit_memory_mb:
+    description:
+      - The instance memory, in megabytes, this namespace may hold at once.
+        Required when O(state=present).
+    required: false
+    type: int
+  limit_disk_gb:
+    description:
+      - The instance disk, in gigabytes, this namespace may hold at once.
+        Required when O(state=present).
+    required: false
+    type: int
+  expires_in_seconds:
+    description:
+      - How long the claim should cover placements for, in seconds from now.
+        Required when O(state=present), and must be positive.
+      - >-
+        A duration rather than a timestamp, and deliberately so: the expiry
+        is computed from the cluster's clock, which is the only clock the
+        expiry sweep ever compares against. Every run re-dates the claim to
+        exactly this far in the future, which can shorten a claim as well as
+        extend one.
+    required: false
+    type: int
+  state:
+    description: Whether the namespace should hold a claim or not.
+    required: false
+    default: present
+    choices: [present, absent]
+    type: str
+  api_url:
+    description:
+      - Base URL of the Shaken Fist API (for example
+        C(http://sf-1:13000)). When omitted (together with O(auth_namespace)
+        and O(key)) the module auto-discovers credentials from the
+        environment and C(sfrc)/C(~/.shakenfist)/C(/etc/sf/shakenfist.json)
+        exactly like the C(sf-client) CLI.
+    required: false
+    type: str
+  auth_namespace:
+    description:
+      - The namespace to authenticate as, which is not O(namespace). Claim
+        management is administrator only, so this is normally C(system). See
+        O(api_url).
+    required: false
+    type: str
+  key:
+    description: The authentication key for O(auth_namespace). See O(api_url).
+    required: false
+    type: str
+    no_log: true
+author:
+  - Michael Still and contributors
+'''
+
+EXAMPLES = r'''
+- name: Hold a standing claim for a static runner fleet
+  shakenfist.shakenfist.sf_claim:
+    namespace: static-runners
+    limit_cpus: 32
+    limit_memory_mb: 65536
+    limit_disk_gb: 1200
+    expires_in_seconds: 2592000
+    state: present
+  register: result
+
+- name: Renew the claim without counting the renewal as a change
+  shakenfist.shakenfist.sf_claim:
+    namespace: static-runners
+    limit_cpus: 32
+    limit_memory_mb: 65536
+    limit_disk_gb: 1200
+    expires_in_seconds: 2592000
+  changed_when: false
+
+- name: Give the reserved capacity back to the cluster
+  shakenfist.shakenfist.sf_claim:
+    namespace: static-runners
+    state: absent
+'''
+
+RETURN = r'''
+changed:
+  description: Whether the module created, resized or re-dated a claim.
+  returned: always
+  type: bool
+failed:
+  description: Whether the module failed.
+  returned: always
+  type: bool
+meta:
+  description: The claim object as returned by the API, when available.
+  returned: success
+  type: dict
+refusal:
+  description:
+    - The status code and body of an API refusal, when the server refused
+      the request. A C(status_code) of 507 means the cluster does not have
+      the capacity to promise the claim; 503 means the request should be
+      retried; 409 means the request conflicts with the claim which is
+      already there.
+  returned: on an API failure
+  type: dict
+log:
+  description: A list of human readable progress messages, for debugging.
+  returned: always
+  type: list
+  elements: str
+'''
+
+
+# The coverage state of a claim which is actually covering placements.
+# Coverage is not the object's existence state and the two are deliberately
+# separate on the wire, so both are checked below rather than either being
+# read as the other.
+COVERAGE_ACTIVE = 'active'
+
+LIMIT_FIELDS = ('limit_cpus', 'limit_memory_mb', 'limit_disk_gb')
+
+
+def _make_client(module):
+    # Build a quiet, patient, blocking client. When all three connection
+    # parameters are supplied we suppress configuration lookup and use them
+    # verbatim; otherwise we let the client auto-discover from the environment
+    # and sfrc config exactly like the sf-client CLI does.
+    api_url = module.params.get('api_url')
+    auth_namespace = module.params.get('auth_namespace')
+    key = module.params.get('key')
+
+    kwargs = {
+        'verbose': False,
+        'sync_request_timeout': 1800,
+        'async_strategy': apiclient.ASYNC_BLOCK,
+    }
+    if api_url and auth_namespace and key:
+        kwargs.update({
+            'base_url': api_url,
+            'namespace': auth_namespace,
+            'key': key,
+            'suppress_configuration_lookup': True,
+        })
+    try:
+        return apiclient.Client(**kwargs)
+    except apiclient.UnconfiguredException as e:
+        module.fail_json(
+            msg='Could not configure the Shaken Fist client: %s' % e, meta=None, log=[])
+
+
+def _live_claims(claims):
+    """The claims which still exist, whatever their coverage state.
+
+    The claims listing deliberately returns expired claims as well as active
+    ones, because an expired claim still has a row and is the only thing
+    which explains a namespace that stopped being charged for what it holds.
+    A deleted claim is not interesting to either branch below, so it is
+    dropped here rather than at each use.
+    """
+    return [c for c in claims or [] if c.get('state') != 'deleted']
+
+
+def _partition_claims(claims):
+    """Split a namespace's claims into the active one and the rest.
+
+    Two creates racing for one namespace can both pass the server's
+    existing-claim probe, so a namespace can legitimately hold more than one
+    active claim. Admission draws down the lowest uuid, so that is the one
+    re-dated here; the others are reported rather than touched, because
+    deleting a claim which is holding capacity is not a thing to do as a
+    side effect of a renewal.
+    """
+    active = sorted(
+        [c for c in claims if c.get('coverage_state') == COVERAGE_ACTIVE],
+        key=lambda c: str(c.get('uuid')))
+    inactive = [c for c in claims if c.get('coverage_state') != COVERAGE_ACTIVE]
+
+    if not active:
+        return None, [], inactive
+    return active[0], active[1:], inactive
+
+
+def _limit_differences(claim, module):
+    """The requested limits which do not match the claim on the server."""
+    differences = {}
+    for field in LIMIT_FIELDS:
+        if claim.get(field) != module.params[field]:
+            differences[field] = module.params[field]
+    return differences
+
+
+def _fail_api(module, log, message, e):
+    # An API refusal is an answer, not a crash, and the play needs enough of
+    # it to tell a capacity refusal from a malformed request. sf_api.error()
+    # carries the per-dimension detail of a capacity refusal in the response
+    # body, so the body goes back to the play rather than only the summary.
+    module.fail_json(
+        msg='%s: %s' % (message, e.message), meta=None, log=log,
+        refusal={'status_code': e.status_code, 'text': e.text})
+
+
+def _create_claim(client, module, log):
+    try:
+        return client.create_namespace_claim(
+            module.params['namespace'], module.params['limit_cpus'],
+            module.params['limit_memory_mb'], module.params['limit_disk_gb'],
+            module.params['expires_in_seconds'])
+    except apiclient.InsufficientResourcesException as e:
+        _fail_api(
+            module, log,
+            'The cluster refused this claim, it does not have the capacity '
+            'to promise it', e)
+    except apiclient.APIException as e:
+        _fail_api(module, log, 'Creating the namespace claim failed', e)
+
+
+def _delete_claims(client, module, log, claims, description):
+    for c in claims:
+        log.append('Deleting %s claim %s' % (description, c.get('uuid')))
+        try:
+            client.delete_namespace_claim(
+                module.params['namespace'], c['uuid'])
+        except apiclient.ResourceNotFoundException:
+            log.append('Claim %s was already gone' % c.get('uuid'))
+        except apiclient.APIException as e:
+            _fail_api(module, log, 'Deleting namespace claim %s failed'
+                      % c.get('uuid'), e)
+
+
+def _ensure_present(client, module, log):
+    namespace = module.params['namespace']
+
+    try:
+        claims = _live_claims(client.get_namespace_claims(namespace))
+    except apiclient.ResourceNotFoundException:
+        module.fail_json(
+            msg='Namespace %s does not exist, so it cannot hold a claim'
+                % namespace, meta=None, log=log)
+    except apiclient.APIException as e:
+        _fail_api(module, log, 'Listing the claims of namespace %s failed'
+                  % namespace, e)
+
+    active, extra_active, inactive = _partition_claims(claims)
+    for c in extra_active:
+        log.append(
+            'Namespace holds more than one active claim, leaving %s alone'
+            % c.get('uuid'))
+
+    if not active:
+        if inactive:
+            # The server refuses to re-date a claim which is not active and
+            # says to replace it. Create first and reap afterwards: the
+            # create is the half which can be refused, and an expired claim
+            # holds no capacity, so this ordering means a refusal leaves the
+            # namespace exactly as it was found.
+            log.append('Namespace holds %d lapsed claim(s) and no active '
+                       'claim, replacing' % len(inactive))
+        else:
+            log.append('Namespace holds no claim')
+
+        if module.check_mode:
+            module.exit_json(changed=True, meta=None, log=log)
+
+        c = _create_claim(client, module, log)
+        _delete_claims(client, module, log, inactive, 'lapsed')
+        module.exit_json(changed=True, meta=c, log=log)
+
+    differences = _limit_differences(active, module)
+    if differences:
+        log.append('Claim %s limits differ: %s' % (active.get('uuid'), differences))
+
+    if module.check_mode:
+        # Check mode reports the re-date it cannot perform as a change,
+        # because performing it would be one. There is no way to know
+        # whether the server's clock has moved without asking it to move
+        # the expiry, and guessing from the control node's clock is exactly
+        # the comparison this module avoids making.
+        module.exit_json(changed=True, meta=active, log=log)
+
+    # Only the limits which actually differ are named in the field mask, so
+    # an unchanged dimension is not re-asserted and cannot race a resize
+    # somebody else is making. The expiry is always named: re-dating is the
+    # reason this task is in the play.
+    try:
+        updated = client.update_namespace_claim(
+            namespace, active['uuid'],
+            expires_in_seconds=module.params['expires_in_seconds'],
+            **differences)
+    except apiclient.InsufficientResourcesException as e:
+        _fail_api(
+            module, log,
+            'The cluster refused to grow this claim, it does not have the '
+            'capacity to promise it', e)
+    except apiclient.APIException as e:
+        _fail_api(module, log, 'Updating namespace claim %s failed'
+                  % active['uuid'], e)
+
+    # Both timestamps came from the cluster, so this asks whether the claim
+    # moved and not whether two clocks agree.
+    redated = updated.get('expires_at') != active.get('expires_at')
+    if redated:
+        log.append('Claim %s expiry moved to %s'
+                   % (active.get('uuid'), updated.get('expires_at')))
+
+    module.exit_json(changed=bool(differences) or redated, meta=updated, log=log)
+
+
+def _ensure_absent(client, module, log):
+    namespace = module.params['namespace']
+
+    try:
+        claims = _live_claims(client.get_namespace_claims(namespace))
+    except apiclient.ResourceNotFoundException:
+        log.append('Namespace did not exist')
+        module.exit_json(changed=False, meta=None, log=log)
+    except apiclient.APIException as e:
+        _fail_api(module, log, 'Listing the claims of namespace %s failed'
+                  % namespace, e)
+
+    if not claims:
+        log.append('Namespace holds no claim')
+        module.exit_json(changed=False, meta=None, log=log)
+
+    if module.check_mode:
+        module.exit_json(changed=True, meta=None, log=log)
+
+    _delete_claims(client, module, log, claims, 'existing')
+    module.exit_json(changed=True, meta=None, log=log)
+
+
+def run_module():
+    argument_spec = {
+        'namespace': {'required': True, 'type': 'str'},
+        'limit_cpus': {'required': False, 'type': 'int'},
+        'limit_memory_mb': {'required': False, 'type': 'int'},
+        'limit_disk_gb': {'required': False, 'type': 'int'},
+        'expires_in_seconds': {'required': False, 'type': 'int'},
+        'state': {
+            'default': 'present',
+            'choices': ['present', 'absent'],
+            'type': 'str',
+        },
+        'api_url': {'required': False, 'type': 'str'},
+        'auth_namespace': {'required': False, 'type': 'str'},
+        'key': {'required': False, 'type': 'str', 'no_log': True},
+    }
+
+    module = AnsibleModule(
+        argument_spec=argument_spec, supports_check_mode=True,
+        required_if=[
+            ('state', 'present',
+             ['limit_cpus', 'limit_memory_mb', 'limit_disk_gb',
+              'expires_in_seconds'])
+        ])
+
+    log = []
+
+    state = module.params['state']
+    if state == 'present' and module.params['expires_in_seconds'] < 1:
+        # The server requires a positive duration. Say so here rather than
+        # spending a round trip to be told, because a zero or negative
+        # expiry in a play is a typo and not a decision.
+        module.fail_json(
+            msg='expires_in_seconds must be positive', meta=None, log=log)
+
+    client = _make_client(module)
+
+    if state == 'present':
+        _ensure_present(client, module, log)
+    else:
+        _ensure_absent(client, module, log)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/shakenfist/deploy/collection/requirements.txt
+++ b/shakenfist/deploy/collection/requirements.txt
@@ -1,11 +1,26 @@
 # Control-node Python requirements for the shakenfist.shakenfist collection.
 #
 # The native modules under plugins/modules/ (sf_namespace, sf_network,
-# sf_instance, sf_snapshot) import the shakenfist_client SDK to talk to the
-# Shaken Fist REST API. Install this on the Ansible control node with:
+# sf_instance, sf_snapshot, sf_claim) import the shakenfist_client SDK to
+# talk to the Shaken Fist REST API. Install this on the Ansible control node
+# with:
 #
 #     pip install -r requirements.txt
 #
 # The control node only needs the client package -- never the Shaken Fist
 # server package.
+#
+# sf_claim is the exception to the line below, and deliberately not pinned
+# here. It needs the namespace capacity claim verbs (get_namespace_claims,
+# create_namespace_claim, update_namespace_claim, delete_namespace_claim),
+# which are on client-python's develop branch and are in no release yet --
+# there is no version to name. A control node which uses sf_claim therefore
+# installs the client from git instead of from this file:
+#
+#     pip install git+https://github.com/shakenfist/client-python@develop
+#
+# which is how the CI conductor installs it. sf_claim checks for the verbs
+# on the client it builds and says this if they are missing, so an older
+# client is a diagnosable failure rather than an AttributeError traceback.
+# Every other module here works with the released client.
 shakenfist-client

--- a/shakenfist/tests/test_ansible_sf_claim.py
+++ b/shakenfist/tests/test_ansible_sf_claim.py
@@ -37,6 +37,10 @@ class FakeInsufficientResourcesException(FakeAPIException):
     ...
 
 
+class FakeResourceStateConflictException(FakeAPIException):
+    ...
+
+
 def _load_sf_claim():
     stubs = {}
 
@@ -63,6 +67,7 @@ def _load_sf_claim():
     apiclient.APIException = FakeAPIException
     apiclient.ResourceNotFoundException = FakeResourceNotFoundException
     apiclient.InsufficientResourcesException = FakeInsufficientResourcesException
+    apiclient.ResourceStateConflictException = FakeResourceStateConflictException
     apiclient.UnconfiguredException = Exception
     apiclient.ASYNC_BLOCK = 'block'
     apiclient.Client = mock.MagicMock()
@@ -117,6 +122,7 @@ class FakeModule:
             'limit_memory_mb': 65536,
             'limit_disk_gb': 1200,
             'expires_in_seconds': 2592000,
+            'renew_within_seconds': None,
             'state': 'present'
         }
         self.params.update(params)
@@ -222,8 +228,11 @@ class SfClaimPresentTestCase(base.ShakenFistTestCase):
 
         result = self._present(client, FakeModule())
         self.assertTrue(result['changed'])
+        # By keyword, because the SDK is in another repository and these
+        # are four mutually type-compatible integers.
         client.create_namespace_claim.assert_called_once_with(
-            'static-runners', 32, 65536, 1200, 2592000)
+            'static-runners', limit_cpus=32, limit_memory_mb=65536,
+            limit_disk_gb=1200, expires_in_seconds=2592000)
         client.delete_namespace_claim.assert_not_called()
 
     def test_a_lapsed_claim_is_replaced_and_reaped_afterwards(self):
@@ -410,3 +419,310 @@ class SfClaimAbsentTestCase(base.ShakenFistTestCase):
 
         result = self._absent(client, FakeModule(state='absent'))
         self.assertTrue(result['changed'])
+
+
+class SfClaimReapingTestCase(base.ShakenFistTestCase):
+    """Lapsed rows are reaped on both paths, and reaping is not a change."""
+
+    def _present(self, client, module):
+        try:
+            sf_claim._ensure_present(client, module, [])
+        except ModuleExited as e:
+            return e.result
+        self.fail('the module did not exit')
+
+    def _present_failure(self, client, module):
+        try:
+            sf_claim._ensure_present(client, module, [])
+        except ModuleFailed as e:
+            return e.result
+        self.fail('the module did not fail')
+
+    def test_lapsed_rows_beside_an_active_claim_are_reaped(self):
+        # Without this the rows accumulate forever: the server has no soft
+        # delete and no sweep which removes them.
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [
+            _claim(uuid='a'), _claim(uuid='old', coverage_state='expired')]
+        client.update_namespace_claim.return_value = _claim(
+            uuid='a', expires_at=2000.0)
+
+        result = self._present(client, FakeModule())
+        self.assertTrue(result['changed'])
+        client.delete_namespace_claim.assert_called_once_with(
+            'static-runners', 'old')
+
+    def test_reaping_alone_is_not_a_change(self):
+        # An expired claim holds no cluster capacity and no admission
+        # decision depends on it, so removing the row alters nothing an
+        # operator can observe about the namespace's coverage.
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [
+            _claim(uuid='a', expires_at=1000.0),
+            _claim(uuid='old', coverage_state='expired')]
+        client.update_namespace_claim.return_value = _claim(
+            uuid='a', expires_at=1000.0)
+
+        result = self._present(client, FakeModule())
+        self.assertFalse(result['changed'])
+        client.delete_namespace_claim.assert_called_once_with(
+            'static-runners', 'old')
+
+    def test_check_mode_reaps_nothing(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [
+            _claim(uuid='a'), _claim(uuid='old', coverage_state='expired')]
+
+        self._present(client, FakeModule(check_mode=True))
+        client.delete_namespace_claim.assert_not_called()
+
+    def test_a_failed_reap_after_a_create_still_reports_the_new_claim(self):
+        # The create half succeeded, and a failure which hides it leaves the
+        # play with no claim details for a claim which now exists.
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [
+            _claim(uuid='old', coverage_state='expired')]
+        client.create_namespace_claim.return_value = _claim(uuid='new')
+        client.delete_namespace_claim.side_effect = FakeAPIException(
+            'boom', 'DELETE', '/claims/old', 500, 'detail')
+
+        result = self._present_failure(client, FakeModule())
+        self.assertEqual('new', result['meta']['uuid'])
+        self.assertEqual(500, result['refusal']['status_code'])
+
+    def test_a_failed_reap_after_a_redate_still_reports_the_claim(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [
+            _claim(uuid='a'), _claim(uuid='old', coverage_state='expired')]
+        client.update_namespace_claim.return_value = _claim(
+            uuid='a', expires_at=2000.0)
+        client.delete_namespace_claim.side_effect = FakeAPIException(
+            'boom', 'DELETE', '/claims/old', 500, 'detail')
+
+        result = self._present_failure(client, FakeModule())
+        self.assertEqual('a', result['meta']['uuid'])
+        self.assertEqual(2000.0, result['meta']['expires_at'])
+
+    def test_a_reap_failure_on_absent_reports_no_claim(self):
+        # state: absent wrote no claim, so there is nothing to hand back.
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [_claim(uuid='a')]
+        client.delete_namespace_claim.side_effect = FakeAPIException(
+            'boom', 'DELETE', '/claims/a', 500, 'detail')
+
+        try:
+            sf_claim._ensure_absent(client, FakeModule(state='absent'), [])
+        except ModuleFailed as e:
+            self.assertIsNone(e.result['meta'])
+        else:
+            self.fail('the module did not fail')
+
+
+class SfClaimRenewalWindowTestCase(base.ShakenFistTestCase):
+    """renew_within_seconds, the opt in which makes repeat runs converge."""
+
+    def _present(self, client, module, now=0.0):
+        with mock.patch.object(sf_claim.time, 'time', return_value=now):
+            try:
+                sf_claim._ensure_present(client, module, [])
+            except ModuleExited as e:
+                return e.result
+        self.fail('the module did not exit')
+
+    def test_without_a_window_every_run_redates(self):
+        # The default, and D10's "four chances to re-date before a lapse".
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [_claim(expires_at=1000.0)]
+        client.update_namespace_claim.return_value = _claim(expires_at=2000.0)
+
+        result = self._present(client, FakeModule(), now=100.0)
+        self.assertTrue(result['changed'])
+        client.update_namespace_claim.assert_called_once()
+
+    def test_a_claim_outside_the_window_is_left_alone(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [_claim(expires_at=1000.0)]
+
+        result = self._present(
+            client, FakeModule(renew_within_seconds=100), now=100.0)
+        self.assertFalse(result['changed'])
+        self.assertEqual('11111111-1111-1111-1111-111111111111',
+                         result['meta']['uuid'])
+        client.update_namespace_claim.assert_not_called()
+
+    def test_a_claim_inside_the_window_is_redated(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [_claim(expires_at=1000.0)]
+        client.update_namespace_claim.return_value = _claim(expires_at=3592000.0)
+
+        result = self._present(
+            client, FakeModule(renew_within_seconds=100), now=950.0)
+        self.assertTrue(result['changed'])
+        client.update_namespace_claim.assert_called_once_with(
+            'static-runners', '11111111-1111-1111-1111-111111111111',
+            expires_in_seconds=2592000)
+
+    def test_check_mode_converges_when_a_window_is_set(self):
+        # The point of the option: --check on an already correct claim
+        # reports no change rather than a change it cannot know about.
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [_claim(expires_at=1000.0)]
+
+        result = self._present(
+            client, FakeModule(renew_within_seconds=100, check_mode=True),
+            now=100.0)
+        self.assertFalse(result['changed'])
+        client.update_namespace_claim.assert_not_called()
+
+    def test_a_resize_is_made_even_outside_the_window(self):
+        # The window governs the re-date, not the limits. A resize is an
+        # instruction and is carried out whenever it differs.
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [_claim(expires_at=1000.0)]
+        client.update_namespace_claim.return_value = _claim(
+            expires_at=1000.0, limit_cpus=40)
+
+        result = self._present(
+            client, FakeModule(renew_within_seconds=100, limit_cpus=40),
+            now=100.0)
+        self.assertTrue(result['changed'])
+        client.update_namespace_claim.assert_called_once_with(
+            'static-runners', '11111111-1111-1111-1111-111111111111',
+            expires_in_seconds=2592000, limit_cpus=40)
+
+    def test_a_claim_with_no_expiry_is_redated(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [_claim(expires_at=None)]
+        client.update_namespace_claim.return_value = _claim(expires_at=2000.0)
+
+        result = self._present(
+            client, FakeModule(renew_within_seconds=100), now=100.0)
+        self.assertTrue(result['changed'])
+        client.update_namespace_claim.assert_called_once()
+
+    def test_lapsed_rows_are_still_reaped_when_nothing_is_written(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [
+            _claim(uuid='a', expires_at=1000.0),
+            _claim(uuid='old', coverage_state='expired')]
+
+        result = self._present(
+            client, FakeModule(renew_within_seconds=100), now=100.0)
+        self.assertFalse(result['changed'])
+        client.update_namespace_claim.assert_not_called()
+        client.delete_namespace_claim.assert_called_once_with(
+            'static-runners', 'old')
+
+
+class SfClaimConflictTestCase(base.ShakenFistTestCase):
+    def test_a_409_names_the_two_things_it_can_mean(self):
+        # The server answers 409 for a shrink below current usage and for a
+        # claim which is no longer active. Both are the caller's to fix, so
+        # the message says which they are rather than reporting a bare
+        # failure with the body attached.
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [_claim()]
+        client.update_namespace_claim.side_effect = (
+            FakeResourceStateConflictException(
+                'a claim cannot be shrunk below what it is already using',
+                'PUT', '/claims/x', 409, 'detail'))
+
+        try:
+            sf_claim._ensure_present(client, FakeModule(limit_cpus=1), [])
+        except ModuleFailed as e:
+            self.assertIn('shrunk below what it is already using', e.result['msg'])
+            self.assertIn('no longer active', e.result['msg'])
+            self.assertEqual(409, e.result['refusal']['status_code'])
+        else:
+            self.fail('the module did not fail')
+
+
+class SfClaimClientVerbsTestCase(base.ShakenFistTestCase):
+    """The claim verbs are newer than any released client."""
+
+    class OldClient:
+        def get_namespace_claims(self, namespace):
+            ...
+
+    class NewClient(OldClient):
+        def create_namespace_claim(self, namespace, **kwargs):
+            ...
+
+        def update_namespace_claim(self, namespace, claim_uuid, **kwargs):
+            ...
+
+        def delete_namespace_claim(self, namespace, claim_uuid):
+            ...
+
+    def test_a_client_without_the_verbs_fails_with_advice(self):
+        try:
+            sf_claim._require_claim_verbs(self.OldClient(), FakeModule(), [])
+        except ModuleFailed as e:
+            self.assertIn('create_namespace_claim', e.result['msg'])
+            self.assertIn('client-python@develop', e.result['msg'])
+        else:
+            self.fail('the module did not fail')
+
+    def test_a_client_with_the_verbs_is_accepted(self):
+        # Returns rather than failing, so this starts passing on its own
+        # once a release carries the verbs.
+        self.assertIsNone(
+            sf_claim._require_claim_verbs(self.NewClient(), FakeModule(), []))
+
+
+class SfClaimArgumentSpecTestCase(base.ShakenFistTestCase):
+    """run_module()'s validation, which the decision functions do not see.
+
+    AnsibleModule itself is not importable here, so the spec it is handed
+    is asserted rather than exercised. That is the whole of what the module
+    controls: required_together and required_if are enforced by ansible.
+    """
+
+    def _run_module(self, **params):
+        module = FakeModule(**params)
+        client = mock.MagicMock()
+        with mock.patch.object(sf_claim, 'AnsibleModule') as ansible_module, \
+                mock.patch.object(sf_claim, '_make_client') as make_client, \
+                mock.patch.object(sf_claim, '_ensure_present') as present, \
+                mock.patch.object(sf_claim, '_ensure_absent') as absent:
+            ansible_module.return_value = module
+            make_client.return_value = client
+            try:
+                sf_claim.run_module()
+                failure = None
+            except ModuleFailed as e:
+                failure = e.result
+            return ansible_module.call_args, failure, present, absent
+
+    def test_the_connection_triple_is_all_or_nothing(self):
+        # Otherwise a partial triple is silently ignored in favour of the
+        # ambient credentials, which may be a different cluster -- and this
+        # module's namespace parameter names the claim target rather than
+        # the identity, so a playbook written against the rest of the
+        # collection lands exactly there.
+        call, failure, _present, _absent = self._run_module()
+        self.assertIsNone(failure)
+        self.assertEqual(
+            [['api_url', 'auth_namespace', 'key']],
+            call.kwargs['required_together'])
+
+    def test_a_non_positive_expiry_is_rejected(self):
+        _call, failure, present, _absent = self._run_module(
+            expires_in_seconds=0)
+        self.assertIn('expires_in_seconds must be positive', failure['msg'])
+        present.assert_not_called()
+
+    def test_a_non_positive_renewal_window_is_rejected(self):
+        # A negative window would silently mean "never renew", which is the
+        # opposite of what somebody setting it wants.
+        _call, failure, present, _absent = self._run_module(
+            renew_within_seconds=-1)
+        self.assertIn('renew_within_seconds must be positive', failure['msg'])
+        present.assert_not_called()
+
+    def test_the_claim_verbs_are_checked_before_anything_is_done(self):
+        with mock.patch.object(sf_claim, '_require_claim_verbs') as require:
+            call, _failure, present, _absent = self._run_module()
+        self.assertEqual(1, require.call_count)
+        self.assertEqual(1, present.call_count)
+        self.assertIn('renew_within_seconds', call.kwargs['argument_spec'])

--- a/shakenfist/tests/test_ansible_sf_claim.py
+++ b/shakenfist/tests/test_ansible_sf_claim.py
@@ -1,0 +1,412 @@
+# Copyright 2026 Michael Still and contributors
+import importlib.util
+import os
+import sys
+import types
+from unittest import mock
+
+from shakenfist.tests import base
+
+
+# The collection module is not importable in the normal way: it lives in an
+# ansible collection tree (no __init__.py), and it imports ansible and
+# shakenfist_client, neither of which is a test dependency of this
+# repository. Load it from source with those two imports stubbed out so the
+# decisions the module makes can be tested here rather than only in the
+# ansible module CI job. This mirrors test_ansible_sf_instance.py.
+MODULE_PATH = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), '..', 'deploy', 'collection', 'plugins',
+    'modules', 'sf_claim.py'))
+
+
+class FakeAPIException(Exception):
+    def __init__(self, message, method, url, status_code, text):
+        super().__init__(message)
+        self.message = message
+        self.method = method
+        self.url = url
+        self.status_code = status_code
+        self.text = text
+
+
+class FakeResourceNotFoundException(FakeAPIException):
+    ...
+
+
+class FakeInsufficientResourcesException(FakeAPIException):
+    ...
+
+
+def _load_sf_claim():
+    stubs = {}
+
+    ansible = types.ModuleType('ansible')
+    ansible.__path__ = []
+    module_utils = types.ModuleType('ansible.module_utils')
+    module_utils.__path__ = []
+    basic = types.ModuleType('ansible.module_utils.basic')
+    basic.AnsibleModule = mock.MagicMock()
+    module_utils.basic = basic
+    ansible.module_utils = module_utils
+    stubs['ansible'] = ansible
+    stubs['ansible.module_utils'] = module_utils
+    stubs['ansible.module_utils.basic'] = basic
+
+    client = types.ModuleType('shakenfist_client')
+    client.__path__ = []
+    apiclient = types.ModuleType('shakenfist_client.apiclient')
+
+    # Mirror the real hierarchy: both of the specific exceptions subclass
+    # APIException, so the exception clause ordering in the module (the
+    # capacity refusal before the generic API failure) is exercised the same
+    # way it runs in production.
+    apiclient.APIException = FakeAPIException
+    apiclient.ResourceNotFoundException = FakeResourceNotFoundException
+    apiclient.InsufficientResourcesException = FakeInsufficientResourcesException
+    apiclient.UnconfiguredException = Exception
+    apiclient.ASYNC_BLOCK = 'block'
+    apiclient.Client = mock.MagicMock()
+    client.apiclient = apiclient
+    stubs['shakenfist_client'] = client
+    stubs['shakenfist_client.apiclient'] = apiclient
+
+    saved = {name: sys.modules.get(name) for name in stubs}
+    sys.modules.update(stubs)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            'sf_claim_under_test', MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        for name, previous in saved.items():
+            if previous is None:
+                del sys.modules[name]
+            else:
+                sys.modules[name] = previous
+
+    return module
+
+
+sf_claim = _load_sf_claim()
+
+
+class ModuleExited(Exception):
+    def __init__(self, result):
+        super().__init__('module exited')
+        self.result = result
+
+
+class ModuleFailed(Exception):
+    def __init__(self, result):
+        super().__init__('module failed')
+        self.result = result
+
+
+class FakeModule:
+    """Enough of AnsibleModule for the decision logic.
+
+    exit_json() and fail_json() terminate the module in production, so they
+    raise here. A mock which simply returned would let the module carry on
+    past its own exit and test a code path which cannot run.
+    """
+
+    def __init__(self, check_mode=False, **params):
+        self.params = {
+            'namespace': 'static-runners',
+            'limit_cpus': 32,
+            'limit_memory_mb': 65536,
+            'limit_disk_gb': 1200,
+            'expires_in_seconds': 2592000,
+            'state': 'present'
+        }
+        self.params.update(params)
+        self.check_mode = check_mode
+
+    def exit_json(self, **kwargs):
+        raise ModuleExited(kwargs)
+
+    def fail_json(self, **kwargs):
+        raise ModuleFailed(kwargs)
+
+
+def _claim(uuid='11111111-1111-1111-1111-111111111111', coverage_state='active',
+           expires_at=1000.0, **kwargs):
+    claim = {
+        'uuid': uuid,
+        'state': 'created',
+        'coverage_state': coverage_state,
+        'namespace': 'static-runners',
+        'limit_cpus': 32,
+        'limit_memory_mb': 65536,
+        'limit_disk_gb': 1200,
+        'expires_at': expires_at
+    }
+    claim.update(kwargs)
+    return claim
+
+
+class SfClaimPartitionTestCase(base.ShakenFistTestCase):
+    def test_deleted_claims_are_not_live(self):
+        claims = sf_claim._live_claims([
+            _claim(uuid='a', state='deleted'), _claim(uuid='b')])
+        self.assertEqual(['b'], [c['uuid'] for c in claims])
+
+    def test_no_claims(self):
+        active, extra, inactive = sf_claim._partition_claims([])
+        self.assertIsNone(active)
+        self.assertEqual([], extra)
+        self.assertEqual([], inactive)
+
+    def test_one_active_claim(self):
+        claims = [_claim(uuid='a')]
+        active, extra, inactive = sf_claim._partition_claims(claims)
+        self.assertEqual('a', active['uuid'])
+        self.assertEqual([], extra)
+        self.assertEqual([], inactive)
+
+    def test_expired_claim_is_not_active(self):
+        claims = [_claim(uuid='a', coverage_state='expired')]
+        active, extra, inactive = sf_claim._partition_claims(claims)
+        self.assertIsNone(active)
+        self.assertEqual([], extra)
+        self.assertEqual(['a'], [c['uuid'] for c in inactive])
+
+    def test_racing_creates_pick_the_lowest_uuid(self):
+        # Two creates racing for one namespace can both commit, and
+        # admission then draws down the lowest uuid. That is the claim to
+        # re-date; the other is reported and left alone.
+        claims = [_claim(uuid='b'), _claim(uuid='a')]
+        active, extra, inactive = sf_claim._partition_claims(claims)
+        self.assertEqual('a', active['uuid'])
+        self.assertEqual(['b'], [c['uuid'] for c in extra])
+        self.assertEqual([], inactive)
+
+
+class SfClaimLimitDifferenceTestCase(base.ShakenFistTestCase):
+    def test_matching_limits_do_not_differ(self):
+        self.assertEqual(
+            {}, sf_claim._limit_differences(_claim(), FakeModule()))
+
+    def test_only_the_changed_dimension_is_reported(self):
+        self.assertEqual(
+            {'limit_cpus': 40},
+            sf_claim._limit_differences(_claim(), FakeModule(limit_cpus=40)))
+
+    def test_every_dimension_can_change(self):
+        self.assertEqual(
+            {'limit_cpus': 1, 'limit_memory_mb': 2, 'limit_disk_gb': 3},
+            sf_claim._limit_differences(
+                _claim(),
+                FakeModule(limit_cpus=1, limit_memory_mb=2, limit_disk_gb=3)))
+
+
+class SfClaimPresentTestCase(base.ShakenFistTestCase):
+    def _present(self, client, module):
+        try:
+            sf_claim._ensure_present(client, module, [])
+        except ModuleExited as e:
+            return e.result
+        self.fail('the module did not exit')
+
+    def _present_failure(self, client, module):
+        try:
+            sf_claim._ensure_present(client, module, [])
+        except ModuleFailed as e:
+            return e.result
+        self.fail('the module did not fail')
+
+    def test_creates_when_the_namespace_holds_nothing(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = []
+        client.create_namespace_claim.return_value = _claim()
+
+        result = self._present(client, FakeModule())
+        self.assertTrue(result['changed'])
+        client.create_namespace_claim.assert_called_once_with(
+            'static-runners', 32, 65536, 1200, 2592000)
+        client.delete_namespace_claim.assert_not_called()
+
+    def test_a_lapsed_claim_is_replaced_and_reaped_afterwards(self):
+        # The server refuses to re-date an inactive claim, so the module
+        # replaces it. The create must happen before the delete: a capacity
+        # refusal then leaves the namespace exactly as it was found.
+        client = mock.MagicMock()
+        calls = []
+        client.get_namespace_claims.return_value = [
+            _claim(uuid='old', coverage_state='expired')]
+        client.create_namespace_claim.side_effect = (
+            lambda *a, **kw: calls.append('create') or _claim())
+        client.delete_namespace_claim.side_effect = (
+            lambda *a, **kw: calls.append('delete'))
+
+        result = self._present(client, FakeModule())
+        self.assertTrue(result['changed'])
+        self.assertEqual(['create', 'delete'], calls)
+        client.delete_namespace_claim.assert_called_once_with(
+            'static-runners', 'old')
+
+    def test_a_lapsed_claim_is_not_reaped_when_the_create_is_refused(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [
+            _claim(uuid='old', coverage_state='expired')]
+        client.create_namespace_claim.side_effect = (
+            FakeInsufficientResourcesException(
+                'no capacity', 'POST', '/claims', 507, 'detail'))
+
+        result = self._present_failure(client, FakeModule())
+        self.assertEqual(507, result['refusal']['status_code'])
+        self.assertEqual('detail', result['refusal']['text'])
+        client.delete_namespace_claim.assert_not_called()
+
+    def test_a_redate_which_moves_the_expiry_is_a_change(self):
+        # The idempotence contract: a re-date alone reports changed, because
+        # the claim now holds cluster capacity for longer than it did. The
+        # test is made against the server's own before and after expiry, so
+        # the control node's clock is never compared to the cluster's.
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [_claim(expires_at=1000.0)]
+        client.update_namespace_claim.return_value = _claim(expires_at=2000.0)
+
+        result = self._present(client, FakeModule())
+        self.assertTrue(result['changed'])
+        client.update_namespace_claim.assert_called_once_with(
+            'static-runners', '11111111-1111-1111-1111-111111111111',
+            expires_in_seconds=2592000)
+
+    def test_a_redate_which_moves_nothing_is_not_a_change(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [_claim(expires_at=1000.0)]
+        client.update_namespace_claim.return_value = _claim(expires_at=1000.0)
+
+        result = self._present(client, FakeModule())
+        self.assertFalse(result['changed'])
+
+    def test_a_differing_limit_is_a_change_and_is_the_only_field_sent(self):
+        # Only the dimensions which actually differ are named in the field
+        # mask, so an unchanged dimension cannot race a resize somebody else
+        # is making. The expiry is always named.
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [_claim(expires_at=1000.0)]
+        client.update_namespace_claim.return_value = _claim(
+            expires_at=1000.0, limit_cpus=40)
+
+        result = self._present(client, FakeModule(limit_cpus=40))
+        self.assertTrue(result['changed'])
+        client.update_namespace_claim.assert_called_once_with(
+            'static-runners', '11111111-1111-1111-1111-111111111111',
+            expires_in_seconds=2592000, limit_cpus=40)
+
+    def test_check_mode_writes_nothing(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [_claim()]
+
+        result = self._present(client, FakeModule(check_mode=True))
+        self.assertTrue(result['changed'])
+        client.update_namespace_claim.assert_not_called()
+        client.create_namespace_claim.assert_not_called()
+
+    def test_check_mode_creates_nothing(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = []
+
+        result = self._present(client, FakeModule(check_mode=True))
+        self.assertTrue(result['changed'])
+        client.create_namespace_claim.assert_not_called()
+
+    def test_a_capacity_refusal_on_a_grow_is_reported_as_a_refusal(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [_claim()]
+        client.update_namespace_claim.side_effect = (
+            FakeInsufficientResourcesException(
+                'no capacity', 'PUT', '/claims/x', 507, 'detail'))
+
+        result = self._present_failure(client, FakeModule(limit_cpus=40))
+        self.assertEqual(507, result['refusal']['status_code'])
+
+    def test_a_missing_namespace_fails_clearly(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.side_effect = (
+            FakeResourceNotFoundException(
+                'not found', 'GET', '/claims', 404, ''))
+
+        result = self._present_failure(client, FakeModule())
+        self.assertIn('does not exist', result['msg'])
+
+    def test_a_transient_listing_failure_is_reported_as_a_refusal(self):
+        # A 503 means the cluster capacity accounting is not ready yet, or
+        # the row was contended. The play needs the status code to know it
+        # is worth retrying, so it does not arrive as a bare traceback.
+        client = mock.MagicMock()
+        client.get_namespace_claims.side_effect = FakeAPIException(
+            'not ready', 'GET', '/claims', 503, 'retry')
+
+        result = self._present_failure(client, FakeModule())
+        self.assertEqual(503, result['refusal']['status_code'])
+
+
+class SfClaimAbsentTestCase(base.ShakenFistTestCase):
+    def _absent(self, client, module):
+        try:
+            sf_claim._ensure_absent(client, module, [])
+        except ModuleExited as e:
+            return e.result
+        self.fail('the module did not exit')
+
+    def test_no_claims_is_no_change(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = []
+
+        result = self._absent(client, FakeModule(state='absent'))
+        self.assertFalse(result['changed'])
+        client.delete_namespace_claim.assert_not_called()
+
+    def test_a_missing_namespace_is_no_change(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.side_effect = (
+            FakeResourceNotFoundException(
+                'not found', 'GET', '/claims', 404, ''))
+
+        result = self._absent(client, FakeModule(state='absent'))
+        self.assertFalse(result['changed'])
+
+    def test_every_claim_is_deleted(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [
+            _claim(uuid='a'), _claim(uuid='b', coverage_state='expired')]
+
+        result = self._absent(client, FakeModule(state='absent'))
+        self.assertTrue(result['changed'])
+        self.assertEqual(
+            [mock.call('static-runners', 'a'),
+             mock.call('static-runners', 'b')],
+            client.delete_namespace_claim.call_args_list)
+
+    def test_check_mode_deletes_nothing(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [_claim()]
+
+        result = self._absent(client, FakeModule(state='absent', check_mode=True))
+        self.assertTrue(result['changed'])
+        client.delete_namespace_claim.assert_not_called()
+
+    def test_a_transient_listing_failure_is_reported_as_a_refusal(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.side_effect = FakeAPIException(
+            'not ready', 'GET', '/claims', 503, 'retry')
+
+        try:
+            sf_claim._ensure_absent(client, FakeModule(state='absent'), [])
+        except ModuleFailed as e:
+            self.assertEqual(503, e.result['refusal']['status_code'])
+        else:
+            self.fail('the module did not fail')
+
+    def test_a_claim_which_vanished_is_not_an_error(self):
+        client = mock.MagicMock()
+        client.get_namespace_claims.return_value = [_claim(uuid='a')]
+        client.delete_namespace_claim.side_effect = (
+            FakeResourceNotFoundException(
+                'not found', 'DELETE', '/claims/a', 404, ''))
+
+        result = self._absent(client, FakeModule(state='absent'))
+        self.assertTrue(result['changed'])


### PR DESCRIPTION
Adds `sf_claim` to the shakenfist ansible collection, managing one
namespace capacity claim: `state: present` creates the claim when the
namespace holds none and re-dates it when it does.

## Why

This is step 5 of `PLAN-claim-coverage-and-sizing` phase 1 in
shakenfist/private-ci, whose decision `D10` gives mach33labs/33fl
ownership of the standing capacity claim for the static CI runner
fleet on sfcbr — 32 vCPU / 65536 MB / 1200 GB, re-dated on every
reconcile with a 30 day expiry.

The claim belongs to the play rather than to the CI conductor because
the play owns the fleet spec it is sized from, so a claim derived from
the same list that builds the instances cannot drift from the fleet it
covers. That is the one property neither alternative offers at any
price: the fleet has already shrunk once under cluster pressure
(four shakenfist static runners to two, 2026-08-12) and a
conductor-side constant would have gone on claiming for four.

`D10` also prices the alternative it rejects. `sf-client namespace
claim create` has no default expiry and the server permits only one
active claim per namespace, so the `command:` form is not one task but
a read-then-create-or-update: list as JSON, parse, branch, and
hand-write `changed_when` and `failed_when` for both branches — three
tasks and two JSON expressions whose correctness depends on the CLI's
output shape, in a play whose very first task is already
`sf_namespace`.

## What is here

- `shakenfist/deploy/collection/plugins/modules/sf_claim.py`
- `shakenfist/tests/test_ansible_sf_claim.py` — 25 unit tests, using
  the `test_ansible_sf_instance.py` idiom
- `shakenfist/deploy/ansible_module_ci/006.yml` — a lifecycle scenario,
  picked up automatically by `ansiblemoduletests.sh`
- Collection README and `docs/user_guide/ansible.md`

## Three decisions worth a reviewer's attention

**It splits `namespace` from `auth_namespace`, which deviates from the
collection's convention.** Every other module overloads a single
`namespace` parameter as both the target and the authenticating
identity — `sf_network.py:70` says "The namespace the network belongs
to / authenticate as". Claim management is admin-only, so the caller is
*always* acting on somebody else's namespace, and that overload cannot
express it. 33fl is unaffected because it authenticates from `sfrc` and
leaves all three connection parameters unset, but this is a real
divergence and it is documented in both READMEs.

**A re-date alone reports `changed`.** Extending a standing reservation
is a change to cluster state that other workloads' admission decisions
depend on, and reporting `ok` would hide the one thing the play exists
to do. A play that does not want the weekly renewal in its change count
can set `changed_when: false`; the module should not decide that for
it. The move is tested against the server's own `expires_at` from
before and after the PUT, so the control host's clock is never compared
against the cluster's — `expires_in_seconds` is a duration against the
cluster clock and `expires_at` is an absolute timestamp on it.

**A lapsed claim is replaced rather than reported as an error**, and
the ordering is deliberate: the replacement is created *first* and the
lapsed rows reaped afterwards, because the create is the half that can
be refused. An expired claim holds no `claimed_*` capacity, so nothing
is released by the reaping and nothing is lost if the create is
refused. Extra *active* claims are left alone and only logged —
deleting a claim that is holding capacity is not something to do as a
side effect of a renewal.

Note this is the opposite of what the CI conductor does with a lapse,
on purpose. The conductor never re-creates, because a re-create is a
guarded admission that can be refused mid-job for a runner already
serving somebody's work. A weekly reconcile whose entire purpose is
restoring coverage is a different case.

A 507 surfaces as a task failure carrying a structured `refusal`
(`status_code`, `text`), so a play can `rescue` a capacity refusal
explicitly rather than parsing a message, and can tell 507 (durable)
from 503 (retry).

`state: absent` is implemented plainly, with no `force` gate. The risk
is not in the typing but in the asymmetry — releasing capacity takes
effect immediately while winning it back is a fresh guarded admission a
busy cluster may refuse — so that is documented loudly rather than
guarded with a parameter that would suggest the opposite diagnosis.

## Verification

`pre-commit run --all-files` clean (all ten hooks, including
`tox -e flake8`, the full `tox -e py3` unit suite and `tox -e mypy`),
plus `tox -e docs` and a YAML parse of the `DOCUMENTATION`/`EXAMPLES`/
`RETURN` blocks — that parse caught a real bug, a `: ` inside a plain
scalar that broke the `expires_in_seconds` docs.

**Not run:** the functional cluster CI, so `006.yml` has never executed
against a real cluster; `validate-modules` (ansible-lint's config here
does not cover `plugins/modules/` and there is no sanity-test target);
and nothing was run against a live Shaken Fist API.

## Merge ordering

**This should merge before mach33labs/33fl's `static-runner-claim`.**
33fl's `ansible.cfg:13` points `library` at a sibling shakenfist
checkout, so until this lands `ansible-playbook --syntax-check
static_runner.yml` there fails with `couldn't resolve module/action
'sf_claim'` — which is exactly what it does today, and was checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQUXhVAGyR8YDji93oAKQJ
