### PR TITLE
Clear five of the six open consistency audits

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,6 +8,7 @@ self-hosted-runner:
     - static
     - claude-code
     - debian-12
+    - debian-12-docker
     - ubuntu-22-04
     - ubuntu-24-04
     - xs

--- a/.github/workflows/agent-context.yml
+++ b/.github/workflows/agent-context.yml
@@ -1,0 +1,96 @@
+# Lints the agent context -- AGENTS.md, CLAUDE.md and the skills under
+# .claude/ -- for malformed frontmatter, smuggled instructions,
+# embedded credentials and dangerous hook or settings configuration.
+#
+# The job runs the pre-commit hook rather than invoking skillsaw
+# directly, so .pre-commit-config.yaml's rev is the only place the
+# skillsaw version is written down. skillsaw's rule set moves between
+# releases, and Renovate's pre-commit manager raises the hook bump as
+# its own reviewable pull request, so a second pin here would drift
+# without anyone choosing it. pre-commit itself is pinned, in
+# tools/ci/pre-commit-requirements.txt: the harness that enforces the
+# hook rev should not be the one floating thing in the job.
+#
+# This is its own workflow rather than a job in functional-tests.yml
+# because that workflow's expensive lanes are gated on code_changed:
+# sharing it would either leave this job unable to trigger on a
+# documentation-only change, or widen that gate.
+#
+# Living in its own file has one consequence worth stating. This job
+# can fail a pull request, but a needs: list in another workflow cannot
+# reach across workflow files, so it is named in neither can_enqueue's
+# nor can_merge's. It is not a required status check either -- see the
+# note on the push trigger below for why a path-filtered required check
+# is a trap. So a red Agent context is visible on the pull request and
+# blocks nothing automatically.
+
+name: Agent context
+
+on:
+  # Also on push, because a commit that lands on develop without a pull
+  # request -- an admin push, a bot commit -- would otherwise never be
+  # linted, and AGENTS.md and .claude/ are exactly the files where an
+  # unreviewed change is worth catching late if it was not caught early.
+  # There is deliberately no merge_group trigger: this is not a required
+  # check, and a path-filtered workflow made required reports pending
+  # forever on the pull requests it filters out.
+  push:
+    branches:
+      - develop
+    paths:
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - '.claude/**'
+      - '.pre-commit-config.yaml'
+      - 'tools/ci/pre-commit-requirements.txt'
+      - '.github/workflows/agent-context.yml'
+  pull_request:
+    paths:
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - '.claude/**'
+      - '.pre-commit-config.yaml'
+      - 'tools/ci/pre-commit-requirements.txt'
+      - '.github/workflows/agent-context.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  http_proxy: http://192.168.1.15:3128
+  https_proxy: http://192.168.1.15:3128
+  PIP_INDEX_URL: https://devpi.home.stillhq.com/root/pypi/+simple/
+  # Fall back to pypi so a devpi cold-cache miss (empty index on a
+  # first-touch package) cannot hard-fail the job.
+  PIP_EXTRA_INDEX_URL: https://pypi.org/simple/
+
+jobs:
+  skillsaw:
+    name: skillsaw
+    runs-on: [self-hosted, static]
+    timeout-minutes: 15
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-skillsaw
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Into a venv, not the system python: the runners enforce PEP 668,
+      # so a bare pip install is refused with
+      # "error: externally-managed-environment". pre-commit then builds
+      # the skillsaw hook its own environment from the pinned rev.
+      - name: Install pre-commit
+        run: |
+          python3 -m venv "${RUNNER_TEMP}/venv-skillsaw"
+          "${RUNNER_TEMP}/venv-skillsaw/bin/pip" install --quiet \
+              --disable-pip-version-check \
+              -r tools/ci/pre-commit-requirements.txt
+          echo "${RUNNER_TEMP}/venv-skillsaw/bin" >> "${GITHUB_PATH}"
+
+      # Only the skillsaw hook: every other hook in the config wants
+      # tox, ansible-lint or a built shakenfist, which this lane
+      # deliberately does not install.
+      - name: Lint the agent context
+        run: pre-commit run skillsaw --all-files --show-diff-on-failure

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -718,7 +718,12 @@ jobs:
       (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
       && needs.check_paths.outputs.code_changed != 'false'
     needs: [check_paths]
-    runs-on: [self-hosted, vm, debian-12]
+    # Carries a size element because the conductor falls back to xs
+    # (1 vCPU / 2048 MB, no swap) when the labels name none. This job
+    # apt-installs a real MariaDB server and then runs the live test
+    # modules against it, which is the same shape that ran out of
+    # memory on xs in node_lifecycle_collection above.
+    runs-on: [self-hosted, vm, debian-12, s]
     timeout-minutes: 30
     concurrency:
       group: >-

--- a/.github/workflows/mermaid-lint.yml
+++ b/.github/workflows/mermaid-lint.yml
@@ -1,0 +1,91 @@
+# Render every mermaid diagram in the repository's markdown and fail on
+# any that does not parse.
+#
+# Copied from shakenfist/development at templates/mermaid-lint/. See
+# that directory's README.md before editing, and in particular before
+# making this a required status check -- a path-filtered workflow that
+# a merge queue requires never reports, and blocks the queue.
+#
+# The runner label is not a typo. This needs a docker daemon, and
+# static runners do not have one: `debian-12-docker` is the fleet's
+# docker-capable image. Add it to .github/actionlint.yaml's runner
+# labels or actionlint fails.
+#
+# Living in its own file has one consequence worth stating. This job
+# can fail a pull request, but a `needs:` list in another workflow
+# cannot reach it, and it is deliberately not a required check either
+# -- see "Required status checks" in the template README for why a
+# path-filtered required check is a trap. So a red Mermaid lint is
+# visible on the pull request and blocks nothing automatically. Where
+# a repository records which jobs gate a pull request, this one
+# belongs on the list of deliberate exceptions.
+name: Mermaid lint
+
+on:
+  # Also on push, because a commit that lands on the default branch
+  # without a pull request -- an admin push, a bot commit -- would
+  # otherwise never be linted here. It would be caught by whichever
+  # unrelated pull request next touches markdown, which is worse than
+  # not catching it: the whole tree is linted every run, so the failure
+  # lands on an author who did not write the diagram.
+  #
+  # Both branch names ship, because the fleet's default branch is
+  # `develop` in some repositories and `main` in others; the one a
+  # given repository does not have simply never matches. There is
+  # deliberately no merge_group trigger: this is not a required check,
+  # and a path-filtered workflow made required reports pending forever
+  # on the pull requests it filters out.
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - '**.md'
+      - '.github/workflows/mermaid-lint.yml'
+      - 'tools/mermaid-lint.sh'
+      - '!REVIEWS.md'
+  pull_request:
+    # Markdown can break a diagram, and so can the checker itself: a
+    # pull request that edits the script or this workflow and no
+    # markdown would otherwise ship a change to the lane that was never
+    # run.
+    #
+    # REVIEWS.md is excluded because a review session or a bot prune
+    # rewrites it and changes no diagram, while this lane costs a
+    # virtual machine. A repository that has no REVIEWS.md keeps the
+    # line anyway, so that the exclusion is in force from the first
+    # commit of one rather than from whenever somebody remembered it.
+    # The negation is last because a later pattern wins.
+    #
+    # mermaid-lint.sh drops the same file from its own candidate set,
+    # and the two must stay in step: the script lints the whole tree
+    # every run, so a file excluded here but linted there fails
+    # somebody else's pull request over a diagram they did not write.
+    paths:
+      - '**.md'
+      - '.github/workflows/mermaid-lint.yml'
+      - 'tools/mermaid-lint.sh'
+      - '!REVIEWS.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mermaid-lint:
+    name: Mermaid lint
+    runs-on: [self-hosted, vm, debian-12-docker, s]
+    timeout-minutes: 15
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v7
+
+      # The script does the work; see the CI script rule in AGENTS.md.
+      # It lints every tracked markdown file rather than only the
+      # changed ones: the whole run is a few seconds per file, and a
+      # diagram can also be broken by a mermaid upgrade that no diff
+      # touches.
+      - name: Lint mermaid diagrams
+        run: ./tools/mermaid-lint.sh

--- a/.github/workflows/pin-indirect-dependencies.yml
+++ b/.github/workflows/pin-indirect-dependencies.yml
@@ -47,7 +47,12 @@ jobs:
     # The apt steps below need passwordless sudo (build deps + the gh
     # install), which the shared static pool does not grant, so this stays
     # on an ephemeral vm runner.
-    runs-on: [self-hosted, vm, debian-12]
+    #
+    # The size element is explicit because the conductor falls back to
+    # xs (1 vCPU / 2048 MB, no swap) when the labels name none. The
+    # resolve below builds an isolated venv and resolves the whole
+    # dependency tree, which wants more headroom than that.
+    runs-on: [self-hosted, vm, debian-12, s]
     timeout-minutes: 60
     env:
       http_proxy: http://192.168.1.15:3128

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,19 @@ repos:
         name: Lint GitHub Actions workflows
         description: Static checker for GitHub Actions workflow files
 
+  # Lints the agent context -- AGENTS.md, CLAUDE.md and the skills
+  # under .claude/ -- for malformed frontmatter, smuggled instructions,
+  # embedded credentials and dangerous hook or settings configuration.
+  # The llm-context-lint-ci audit requires this here and in CI: the
+  # daily consistency audit is a backstop, so a secret pasted into
+  # CLAUDE.md should fail the commit that introduces it rather than a
+  # report up to a day later. Renovate's pre-commit manager keeps the
+  # rev current.
+  - repo: https://github.com/stbenjam/skillsaw
+    rev: v0.20.0
+    hooks:
+      - id: skillsaw
+
   # Ansible linter for the shakenfist.shakenfist deployer collection
   # Requires: pip install ansible-lint
   # Note: Uses 'local' repo because the upstream pre-commit hook has Python 3.13

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -191,14 +191,14 @@ publishes the schedulable remainder (`cpu_schedulable`,
 See [`docs/operator_guide/scheduler.md`](docs/operator_guide/scheduler.md)
 for the full pipeline, the configuration knobs, the admission RPCs at the
 bottom of it, and how to diagnose a placement decision from audit events.
-Atomic reservation-table scheduling is being built in phases per
-`docs/plans/PLAN-scheduler-reservations.md`; the capacity tables and their
-reconciler are described under
+Atomic reservation-table scheduling is being built per
+[`docs/plans/PLAN-scheduler-reservations.md`](docs/plans/PLAN-scheduler-reservations.md);
+the capacity tables and their reconciler are described under
 [Cluster Operation Storage and Work Queues](docs/developer_guide/database_internals.md#cluster-operation-storage-and-work-queues).
-Placement admission consumes them as of phase 3, and phase 4 added
-per-namespace capacity claims whose ceilings are advisory this release;
-later phases enforce those ceilings and move more pre-filter logic into
-SQL.
+Placement admission consumes those tables, and per-namespace capacity
+claims exist but their ceilings are advisory this release. Enforcing
+those ceilings and moving more pre-filter logic into SQL is still to
+come; the plan is where that work is tracked.
 
 ## State Machines
 

--- a/PUSH-AUDIT.md
+++ b/PUSH-AUDIT.md
@@ -189,6 +189,29 @@ Add the judgment-level review on the diff
   blocking or advisory and why. Skip ones inside test
   modules unless they disable coverage on production code.
 
+<!-- shared-block: python-version-discipline v1 -->
+Python version and typing (shared block; do not edit -- the
+canonical copy lives in shakenfist/development at
+`templates/shared-blocks/python-version-discipline.md`):
+
+- No syntax or standard library API newer than the floor in
+  `requires-python`. Structural pattern matching, `X | Y` unions in
+  annotations evaluated at runtime, `tomllib`, and
+  `datetime.UTC` each raise on an interpreter the package still
+  claims to support, and none of them fail in CI when CI runs only
+  the newest version. This is the finding to look for first: it is
+  a real break on a real user's machine, not a style point.
+- New and modified code carries type hints, and mypy is expected to
+  be clean over it. A project part way through a staged rollout is
+  held to the new code, not to the whole tree.
+- Prefer the walrus operator and f-strings where they make the code
+  read better, subject to the floor above.
+- Raising the floor in `requires-python` is a supported-platforms
+  decision, not a convenience: it drops users. If it is genuinely
+  right, the platforms table, `requires-python` and
+  `constraints.python` in `renovate.json` all move together.
+<!-- shared-block-end -->
+
 <!-- shared-block: comment-proportion v1 -->
 Comment proportion (shared block; do not edit -- the canonical
 copy lives in shakenfist/development at
@@ -250,6 +273,32 @@ Also verify:
   the database daemon, note which `cluster_ci` tests in
   particular would exercise the new behaviour and whether
   they should be run before push.
+
+<!-- shared-block: functional-test-coverage v1 -->
+Functional test coverage (shared block; do not edit -- the
+canonical copy lives in shakenfist/development at
+`templates/shared-blocks/functional-test-coverage.md`):
+
+- The standard is "do we run the code to do the real thing, and
+  does it work as intended". Every subcommand exposed on the command
+  line, and every endpoint exposed by an API, should have a test
+  that exercises it for real rather than against a mock of itself.
+- For a change that adds or alters user-visible behaviour, the
+  question to answer is which functional test would have failed
+  before it and passes after. If there is none, that is the finding,
+  and it is a finding about this change rather than a note for
+  later.
+- Unit tests are held to no coverage percentage, but a branch that
+  is reachable from outside the process and has no test is worth
+  naming. Error paths and argument validation are where this bites:
+  they are the code most often written once and never run again.
+- Mocking the system under test proves nothing. Mock the boundary --
+  the network, the clock, the hypervisor -- and let the code being
+  tested actually run.
+- Where a gap is real but out of scope for the change in hand, say
+  so plainly and record it, rather than silently widening the
+  change or silently leaving it unsaid.
+<!-- shared-block-end -->
 
 Report findings as a bullet list grouped by file.
 
@@ -328,6 +377,36 @@ edit -- the canonical copy lives in shakenfist/development at
   worth a quick pass even when the diff does not touch
   `state_targets`, as the diagrams have drifted from the maps
   before.
+
+<!-- shared-block: diagram-discipline v1 -->
+Diagram discipline (shared block; do not edit -- the canonical
+copy lives in shakenfist/development at
+`templates/shared-blocks/diagram-discipline.md`):
+
+- A diagram of *structure or flow* -- components and the arrows
+  between them, an ordered exchange of messages, a state machine
+  -- is written as a fenced `mermaid` block, not drawn in ASCII.
+  GitHub renders those natively and the mkdocs sites render them
+  through `pymdownx.superfences`, so the same source is a picture
+  in both places.
+- Not every box of characters is a diagram. These stay as plain
+  code fences, because mermaid cannot express them and would lose
+  what they show: directory and file trees; memory maps, address
+  space layouts and register or bit-field diagrams, where column
+  alignment carries the meaning; wire-format and on-disk byte
+  layouts; captured terminal output; and tables. The test is
+  whether the picture is nodes and edges. Something that is a
+  table with lines drawn on it is a table.
+- Pick the diagram type that matches the claim: `flowchart` for
+  components and data flow, `sequenceDiagram` for an ordered
+  exchange between parties, `stateDiagram-v2` for a state
+  machine, `erDiagram` for data relationships. A sequence drawn
+  as a flowchart has thrown away the ordering it existed to show.
+- A new ASCII box-and-arrow diagram in the diff is a finding.
+  Converting one the diff already touches is in scope; converting
+  every other diagram in the file is not, because a sweep is its
+  own change and its own review.
+<!-- shared-block-end -->
 
 <!-- shared-block: plan-phase-references v1 -->
 Plan phase references (shared block; do not edit -- the canonical
@@ -415,6 +494,33 @@ Check for:
 - **Concurrency:** Are there new shared-state patterns or
   lock acquisitions? Could they deadlock with existing
   locks? Is lock ordering documented or obvious?
+
+<!-- shared-block: path-traversal-review v1 -->
+Path construction from outside data (shared block; do not edit --
+the canonical copy lives in shakenfist/development at
+`templates/shared-blocks/path-traversal-review.md`):
+
+- Treat as a candidate any filesystem path built from a value the
+  process did not choose: a request parameter, an image name, tag or
+  digest, a layer path, an archive member name, a filename out of a
+  configuration file or a database row.
+- The question is not whether the value looks dangerous but whether
+  the resulting path is *proved* to stay inside its intended base
+  directory. Resolve the joined path with `os.path.realpath()` and
+  verify it still starts with the base; a check on the untrusted
+  component alone is defeated by symlinks and by encodings the
+  check did not anticipate.
+- Prefer a helper that cannot be forgotten at a call site --
+  `safe_path_join()` in occystrap, or the framework's own
+  (`send_from_directory` in Flask) -- over an inline guard repeated
+  at each join.
+- Archive extraction is the case most often missed: a member name
+  inside a tarball or zip is attacker-controlled in exactly the same
+  way as a request parameter.
+- Where a bare join is correct because every component is
+  process-chosen, say so in a comment rather than leaving the
+  reader to re-derive it.
+<!-- shared-block-end -->
 
 Report findings with severity (critical / high / medium /
 low / informational). For each finding, state the file,

--- a/docs/developer_guide/ci.md
+++ b/docs/developer_guide/ci.md
@@ -68,13 +68,13 @@ That leaves a released client mattering to exactly one audience -- operators
 -- which is worth knowing before treating a release as a prerequisite for
 anything internal.
 
-Phase 4 of `docs/plans/PLAN-scheduler-reservations.md` reasoned from the
+Work on `docs/plans/PLAN-scheduler-reservations.md` reasoned from the
 opposite belief and deliberately wrote its functional coverage against
 `apiclient.Client._request_url()` to work around a constraint which had
-already been gone for seven weeks. Its phase 4b then made the same mistake
-about the conductor, in the same document that corrected the first one --
-because it checked this repository's install path and took the conductor's
-from another plan. If you find yourself about to do something similar, check
+already been gone for seven weeks. It then made the same mistake about the
+conductor, in the same document that corrected the first one -- because it
+checked this repository's install path and took the conductor's from
+another plan. If you find yourself about to do something similar, check
 this section first, and check the install path itself rather than a
 description of it.
 
@@ -218,20 +218,21 @@ break it twice, since the wrapper's own deadline failure is a test failure
 rather than an `APIException` the `except` clause could catch, and waiting
 up to seven minutes per refusal would serialise a burst whose simultaneity
 is the thing under test. The other reserved use is the wrapper's own call
-inside `base.py`, which has to reach the client somehow. The CI cloud
-sizing plan's phase 3 saturation tests are expected to need the marker
-too, to assert that a genuinely full cluster refuses rather than have the
-refusal waited away.
+inside `base.py`, which has to reach the client somehow. The saturation
+tests planned in
+[PLAN-ci-cloud-sizing](../plans/PLAN-ci-cloud-sizing.md) are expected to
+need the marker too, to assert that a genuinely full cluster refuses
+rather than have the refusal waited away.
 
 ## CI headroom instrumentation
 
-Phase 1 of `docs/plans/PLAN-ci-cloud-sizing.md` (see
-`docs/plans/PLAN-ci-cloud-sizing-phase-01-headroom-probe.md` for the
-decisions behind it) added two data-gathering instruments to every
-functional cluster job, so that later phases can size CI's clouds from
-a distribution instead of the handful of hand-collected numbers the
-plan started from. Neither instrument gates anything itself -- see
-"Nothing here is a quality gate" below -- but the poller's own traffic
+Every functional cluster job carries two data-gathering instruments,
+so that CI's clouds can be sized from a distribution instead of the
+handful of hand-collected numbers
+[PLAN-ci-cloud-sizing](../plans/PLAN-ci-cloud-sizing.md) started from;
+`docs/plans/PLAN-ci-cloud-sizing-phase-01-headroom-probe.md` records
+the decisions behind them. Neither instrument gates anything itself
+-- see "Nothing here is a quality gate" below -- but the poller's own traffic
 does interact with a check that gates, which is the one reason a
 reader troubleshooting a CI failure might need this section; see "The
 probe's traffic is exempted from the idle-load check". Otherwise it
@@ -328,9 +329,8 @@ moves with the day it is run on.
 ### A third file: the capacity-wait trace (`--waits`)
 
 A third file lands beside the other two, written by a different
-mechanism. `PLAN-transient-capacity-refusals` phase 2's
-`self.create_instance()` wrapper (see "Creating instances in the
-functional suite" above) appends one JSON line to
+mechanism. The `self.create_instance()` wrapper (see "Creating
+instances in the functional suite" above) appends one JSON line to
 `/srv/ci/traces/instance-waits.jsonl` every time a create waits out a
 transient 507. It reaches the bundle through the same "Gather logs"
 scp as `headroom.jsonl` and `headroom-census.json`, with no separate
@@ -370,9 +370,9 @@ consumers of the record.
 
 ### The series record format
 
-Phase 2 parses `headroom.jsonl` as a contract, so treat the shape
-below as load-bearing rather than as prose to paraphrase; the tool's
-own docstring is the source of truth if the two ever disagree. Each
+`headroom.jsonl` is parsed as a contract, so treat the shape below as
+load-bearing rather than as prose to paraphrase; the tool's own
+docstring is the source of truth if the two ever disagree. Each
 line is one JSON object. A successful sample carries:
 
 * `sampled_at` -- float, unix epoch seconds, wall clock at sample
@@ -416,14 +416,16 @@ evidence the cloud needs more disk capacity.
 
 ### Nothing here is a quality gate
 
-Every workflow step this phase added is `continue-on-error`, and
-`ci_headroom_report.py` always exits 0 whatever it finds -- even an
-internal error in the report is printed, not raised. The band verdict
-it prints (committed vCPU as a fraction of the admission ledger,
-against bounds of 0.35 and 0.70) is explicitly labelled PROVISIONAL:
-phase 0 set those bounds with no distribution to check them against,
-phase 2 replaces or defends them, and any enforcement is phase 5's to
-add. No verdict this instrumentation prints can fail a job.
+Every workflow step this instrumentation added is
+`continue-on-error`, and `ci_headroom_report.py` always exits 0
+whatever it finds -- even an internal error in the report is printed,
+not raised. The band verdict it prints (committed vCPU as a fraction
+of the admission ledger, against bounds of 0.35 and 0.70) is
+explicitly labelled PROVISIONAL: those bounds were set with no
+distribution to check them against, and replacing or defending them --
+and turning any of this into something that gates -- is work
+[PLAN-ci-cloud-sizing](../plans/PLAN-ci-cloud-sizing.md) still has
+ahead of it. No verdict this instrumentation prints can fail a job.
 
 That is not the same as the instrumentation being invisible to the
 checks that do gate, which is what this section used to say and what

--- a/docs/developer_guide/database_internals.md
+++ b/docs/developer_guide/database_internals.md
@@ -342,9 +342,8 @@ node without a row is admitted against nothing at all: a
 process-local five minute timer left every placement in a new
 cluster's first minutes unguarded, and the first pass then recorded
 the resulting over-limit usage on the row it created (issue 4087).
-The check was a one-shot on the election path until
-`PLAN-transient-capacity-refusals` phase 1, which is why it used to
-miss a cold cluster entirely -- election happens seconds after
+The check used to be a one-shot on the election path, which is why it
+missed a cold cluster entirely -- election happens seconds after
 start-up, before any hypervisor has published, so the pass it forced
 had nothing to size. See
 [the subsystem internals](subsystem_internals.md) for the predicate
@@ -356,13 +355,12 @@ claims, re-derives per-hypervisor limits from the typed
 instances and the decaying expected-demand signal, and rebuilds
 the `cluster_capacity` singleton. The reconciler recomputes the
 three capacity tables (`scheduler_node_capacity`,
-`namespace_claims`, `cluster_capacity`) wholesale; as of
-scheduler-reservations phase 3 the atomic admission and release
-RPCs also write them incrementally, and are the sole *drawdown*
-path against them, so a divergence between what the reconciler
-computes and what the counters hold is drift, healed on the next
-pass rather than expected steady state. Phase 4 added the claim
-CRUD RPCs as a third writer: they move capacity between
+`namespace_claims`, `cluster_capacity`) wholesale; the atomic
+admission and release RPCs also write them incrementally, and are
+the sole *drawdown* path against them, so a divergence between
+what the reconciler computes and what the counters hold is drift,
+healed on the next pass rather than expected steady state. The
+claim CRUD RPCs are a third writer: they move capacity between
 `namespace_claims` and `cluster_capacity` (a claim's limits into
 `claimed_*`, its namespace's existing drawdown out of
 `unclaimed_used_*` and onto the claim, and the reverse on

--- a/docs/developer_guide/state_machine.md
+++ b/docs/developer_guide/state_machine.md
@@ -47,7 +47,7 @@ the operation's own deadline, and is never taken by `execute` operations.
 
 The following transitions are possible:
 
-``` mermaid
+```mermaid
 stateDiagram-v2
   [*] --> initial
   [*] --> error
@@ -93,7 +93,7 @@ stateDiagram-v2
 
 The following transitions are possible:
 
-``` mermaid
+```mermaid
 stateDiagram-v2
   [*] --> initial
 
@@ -119,7 +119,7 @@ stateDiagram-v2
 
 The following transitions are possible:
 
-``` mermaid
+```mermaid
 stateDiagram-v2
   [*] --> initial
 
@@ -167,7 +167,7 @@ caller deletes it.
 The following transitions are possible (note that hyphens have been replaced with
 underscores in some state names due to limitations in the diagram renderer):
 
-``` mermaid
+```mermaid
 stateDiagram-v2
   [*] --> initial
   [*] --> error
@@ -229,7 +229,7 @@ namespace. Writing a rule is atomic, so there is no error state.
 
 The following transitions are possible:
 
-``` mermaid
+```mermaid
 stateDiagram-v2
   [*] --> initial
   initial --> created
@@ -263,7 +263,7 @@ still a `created` object. See
 
 The following transitions are possible:
 
-``` mermaid
+```mermaid
 stateDiagram-v2
   [*] --> initial
   initial --> created
@@ -279,7 +279,7 @@ stateDiagram-v2
 
 The following transitions are possible:
 
-``` mermaid
+```mermaid
 stateDiagram-v2
   [*] --> created
   created --> deleted
@@ -302,7 +302,7 @@ A network is regarded as "dead" when it is in state `deleted`, `delete-wait` or
 The following transitions are possible (note that hyphens have been replaced with
 underscores in some state names due to limitations in the diagram renderer):
 
-``` mermaid
+```mermaid
 stateDiagram-v2
   [*] --> initial
 
@@ -332,7 +332,7 @@ stateDiagram-v2
 
 The following transitions are possible:
 
-``` mermaid
+```mermaid
 stateDiagram-v2
   [*] --> initial
 
@@ -375,7 +375,7 @@ stateDiagram-v2
 
 The following transitions are possible:
 
-``` mermaid
+```mermaid
 stateDiagram-v2
   [*] --> initial
 
@@ -433,7 +433,7 @@ willing to validate. Configuring one is atomic, so there is no error state.
 
 The following transitions are possible:
 
-``` mermaid
+```mermaid
 stateDiagram-v2
   [*] --> initial
   initial --> created
@@ -449,7 +449,7 @@ stateDiagram-v2
 
 The following transitions are possible:
 
-``` mermaid
+```mermaid
 stateDiagram-v2
   [*] --> created
   created --> deleted

--- a/docs/developer_guide/subsystem_internals.md
+++ b/docs/developer_guide/subsystem_internals.md
@@ -48,8 +48,8 @@ placed, non-deleted instance, whereas the resources daemon's
 only active libvirt domains. A powered-off instance holds its
 reservation in the ledger and is absent from the measurement, so the
 two legitimately disagree, and any counter-based admission has to
-choose between them explicitly rather than assume parity. Phase 3 chose
-the ledger. Admission is the guarded UPDATE the
+choose between them explicitly rather than assume parity. Admission
+uses the ledger, and is the guarded UPDATE the
 `AdmitInstancePlacement` RPC makes against `scheduler_node_capacity`,
 in the same transaction that writes the `placement` attribute and
 rewrites the instance's `INSTANCE_LOCATION` reference rows — so a
@@ -107,7 +107,7 @@ breakdown of zeroes; the three allocation dimensions never carry the
 keys.
 
 Every dimension detail also carries `shortfall`
-(`_capacity_dimension()`, phase 7): `max(0.0, effective_used -
+(`_capacity_dimension()`): `max(0.0, effective_used -
 limit)`, where `effective_used` is `used + requested` on a charged
 dimension and `used` alone on the uncharged demand dimension -- the
 same `effective_used` the `exceeded` flag above compares against
@@ -175,10 +175,8 @@ toward neither the total nor the unclaimed-used side (a claim's
 wherever they are stranded). If you add a capacity consumer, it
 inherits these filters by reading the tables — do not re-derive
 capacity from `node_metrics` directly. The tables are consumed for
-admission as of phase 3
-(`docs/plans/PLAN-scheduler-reservations-phase-03-primitive.md`), and
-`namespace_claims` became writable in phase 4 — see [The claim admission
-transaction](#the-claim-admission-transaction) below.
+admission, and `namespace_claims` is writable — see [The claim
+admission transaction](#the-claim-admission-transaction) below.
 
 A capacity row is created only by a reconcile pass, so a hypervisor
 with none is admitted against nothing at all (the placement fail-open
@@ -201,7 +199,7 @@ maintenance loop runs at most once every 60s, so this closes the
 warm-up window to roughly a minute after a hypervisor's metrics
 become visible, not immediately — the larger remaining term is the
 resources daemon's own publication cadence for those metrics, which
-this does not shorten (phase 3 of
+this does not shorten (see
 [PLAN-transient-capacity-refusals](../plans/PLAN-transient-capacity-refusals.md)).
 The check also forces at most once per distinct unguarded set: a node
 that qualifies here but which the reconciler declines to size anyway
@@ -230,7 +228,7 @@ Operator-facing documentation is
 
 ### The claim admission transaction
 
-Phase 4 made `namespace_claims` writable. A claim is a namespace's
+`namespace_claims` is writable. A claim is a namespace's
 promise of aggregate cluster capacity, so creating, growing or shrinking
 one is an admission decision in its own right — against the
 `cluster_capacity` singleton rather than against a node — and the five
@@ -286,7 +284,7 @@ Two decisions deliberately diverge from placement admission:
   against totals nothing has computed, which the next pass folds into
   `claimed_*` whether it fits or not.
 - **Claim ceilings are advisory** for one release.
-  `_direct_admit_instance_placement()` splits phase 3's single
+  `_direct_admit_instance_placement()` splits what was a single
   `guarded = enforce and node_present` into `node_guarded`,
   `cluster_guarded` (both unchanged) and `claim_guarded = enforce and
   CLAIM_ENFORCEMENT_HARD`, a module constant set `False`. The node and
@@ -300,16 +298,16 @@ Two decisions deliberately diverge from placement admission:
   `claim_over_limit` / `claim_dimensions`, deliberately separate from
   `failing_stage` and `dimensions`, which both mean "this was refused".
   `Instance._event_claim_over_limit()` turns them into the audit
-  events -- one on the instance and, since phase 7 (G2), the same
-  facts again on the namespace, because a claim's own events die
-  with the claim and the namespace is where the calibration history
-  needs to survive one. See [Namespace capacity
+  events -- one on the instance and the same facts again on the
+  namespace, because a claim's own events die with the claim and the
+  namespace is where the calibration history needs to survive one.
+  See [Namespace capacity
   claims](../operator_guide/scheduler.md#namespace-capacity-claims).
   Read-back rather than the probe-then-force idiom beside it because
   probe-then-force would make every create in a claimed namespace pay a
   probe round trip, and the namespaces that want claims are the ones
-  creating instances hardest; it also leaves phase 5's flip as moving an
-  existing predicate into a `WHERE` clause.
+  creating instances hardest; it also leaves the eventual flip to hard
+  enforcement as moving an existing predicate into a `WHERE` clause.
 
 `NamespaceClaim` (`shakenfist/namespace_claim.py`) is an ordinary
 `DatabaseBackedObject` over these rows, with two states that are two
@@ -517,9 +515,9 @@ a placement. References are single-row inserts and deletes, needing no
 cross-writer coordination. `Node.instances` queries them via
 `mariadb.get_references_from()` filtered by `INSTANCE_LOCATION`. Unlike
 `BLOB_LOCATION`, these rows key the node by UUID, not FQDN. The dual-write and the
-read-side union were removed in scheduler-reservations phase 3, once every
-placement writer had moved onto the atomic admission primitive; the column
-itself remains declared in the table (nullable, no longer read or written)
+read-side union were removed once every placement writer had moved onto
+the atomic admission primitive; the column itself remains declared in
+the table (nullable, no longer read or written)
 so upgraded databases keep a rollback fallback, and is dropped in a later
 release — the same treatment as the legacy `daemon_states` column.
 

--- a/docs/operator_guide/database.md
+++ b/docs/operator_guide/database.md
@@ -730,10 +730,10 @@ table whose rows are ephemeral by design.
 The three capacity tables (`scheduler_node_capacity`, `namespace_claims` and
 `cluster_capacity`) are recomputed wholesale from ground truth by a
 reconciler that runs every five minutes on the elected cluster node, and —
-since phase 3, described below — are also drawn down and released
-incrementally by the placement admission and release RPCs between those
-passes. The reconciler is therefore the drift corrector rather than the
-only writer. Each pass is a single `ReconcileSchedulerCapacity`
+as described below — are also drawn down and released incrementally by
+the placement admission and release RPCs between those passes. The
+reconciler is therefore the drift corrector rather than the only
+writer. Each pass is a single `ReconcileSchedulerCapacity`
 RPC which expires stale claims, re-derives each hypervisor's limits from
 the typed `node_metrics` columns (deliberately mirroring the scheduler's
 admission arithmetic), recomputes usage counters from placed instances,
@@ -742,9 +742,8 @@ recomputes the decaying expected-demand signal, and rebuilds the
 ensure-mariadb-schema` (run it before rolling the daemons after an
 upgrade, as always).
 
-As of scheduler-reservations phase 3 the counters are consumed for
-admission, not just observed. Instance placement goes through two
-`sf-database` RPCs, `AdmitInstancePlacement` and
+The counters are consumed for admission, not just observed. Instance
+placement goes through two `sf-database` RPCs, `AdmitInstancePlacement` and
 `ReleaseInstancePlacement`, each performing its guarded counter update,
 the `placement` attribute write and the `instance_location` reference
 rewrite in a single transaction, so a placement can never be recorded
@@ -810,10 +809,10 @@ row) exported from the cluster daemon's metrics port
 (`CLUSTER_METRICS_PORT`, default `13007`), plus one structured log line
 per reconcile pass.
 
-Disk capacity is claimed at virtual size, which the phase 0 step 3
-addendum measured at 40-140x actual usage (median ~65x) for sparse
-qcow2 images, so a within-period burst of virtual claims would be
-rejected against last-observed actual free space.
+Disk capacity is claimed at virtual size, measured at 40-140x actual
+usage (median ~65x) for sparse qcow2 images, so a within-period burst
+of virtual claims would be rejected against last-observed actual free
+space.
 `SCHEDULER_DISK_OVERCOMMIT` (default 5.0) multiplies the free-space
 headroom term of each node's derived disk limit — `used + max(0,
 floor(free/GiB) - reservation) x SCHEDULER_DISK_OVERCOMMIT` — never
@@ -874,8 +873,8 @@ own frozen value. A per-instance staleness alert would fire permanently
 on all of them. Aggregating asks the question you actually want
 answered: has *anybody* reconciled recently.
 
-As of scheduler-reservations phase 4 the `namespace_claims` table has
-writers other than the reconciler. Five `sf-database` RPCs —
+The `namespace_claims` table has writers other than the reconciler.
+Five `sf-database` RPCs —
 `CreateNamespaceClaim`, `GetNamespaceClaim`, `GetNamespaceClaims`,
 `UpdateNamespaceClaim` and `DeleteNamespaceClaim` — back the admin-only
 REST endpoints at `/auth/namespaces/<namespace>/claims`, and the
@@ -927,7 +926,7 @@ Two behaviours differ deliberately from instance admission:
   the reply, which `Instance` turns into a `placement admitted over
   namespace capacity claim` audit event. See [the scheduler operator
   guide](scheduler.md#namespace-capacity-claims) for the operator view.
-  Phase 3's single fail-open flag was split into three for this: the node
+  What was a single fail-open flag is split into three for this: the node
   and cluster guards keep failing open on a node with no capacity row,
   because that reasoning is about *this node's* limits being absent from
   the totals, which says nothing about whether a namespace has exceeded
@@ -1112,7 +1111,7 @@ dedicated attribute tables:
 | Table | Object Type | Key Fields |
 |-------|-------------|------------|
 | `blob_attributes` | Blob | uuid, size, info, last_used, retention |
-| `node_attributes` | Node | uuid, last_seen, installed_version, roles, daemons, versions, metrics. Per-daemon state lives in `node_daemon_states` since v19; the legacy `daemon_states` JSON column on this table is no longer read or written. Instance placement lives in `object_references` as `instance_location` rows since `object_references` schema v3; the dual-write and the union into reads were removed in scheduler-reservations phase 3; the legacy `instances` JSON column itself remains in place (nullable, unread) as a rollback fallback until a later release drops it |
+| `node_attributes` | Node | uuid, last_seen, installed_version, roles, daemons, versions, metrics. Per-daemon state lives in `node_daemon_states` since v19; the legacy `daemon_states` JSON column on this table is no longer read or written. Instance placement lives in `object_references` as `instance_location` rows since `object_references` schema v3; the dual-write and the union into reads have been removed; the legacy `instances` JSON column itself remains in place (nullable, unread) as a rollback fallback until a later release drops it |
 | `namespace_attributes` | Namespace | name, keys (JSON), trust (JSON). Keys live in `namespace_keys` / `namespace_key_attributes` since the v2 `namespace_keys` migration; the legacy `keys` JSON column is left in place until a later schema bump drops it |
 | `namespace_key_attributes` | NamespaceKey | uuid, key (base64 encoded bcrypt hash), nonce, expiry (nullable epoch seconds), scopes (nullable JSON list), provenance (nullable JSON dict) |
 | `trusted_issuer_attributes` | TrustedIssuer | uuid, issuer_url, jwks_uri, audience |

--- a/docs/operator_guide/scheduler.md
+++ b/docs/operator_guide/scheduler.md
@@ -641,7 +641,7 @@ decays linearly to zero over `SCHEDULER_DEMAND_DECAY_SECONDS` of
 instance age. The purpose is to stop a burst of placements all choosing
 the same node because none of them have started doing any work yet.
 
-Since scheduler-reservations phase 3 they do affect placement: each
+They do affect placement: each
 successful admission adds `vcpus × SCHEDULER_DEMAND_PER_VCPU` to the
 target node's `expected_demand` counter in the same transaction, and
 the admission guard refuses a node whose existing load is *already*

--- a/tools/ci/pre-commit-requirements.txt
+++ b/tools/ci/pre-commit-requirements.txt
@@ -1,0 +1,5 @@
+# pre-commit for .github/workflows/agent-context.yml, pinned so the
+# harness that enforces .pre-commit-config.yaml's hook revisions is not
+# itself the one floating thing in the job. Renovate's pip_requirements
+# manager tracks this file.
+pre-commit==4.6.2

--- a/tools/mermaid-lint.sh
+++ b/tools/mermaid-lint.sh
@@ -1,0 +1,529 @@
+#!/bin/bash
+#
+# Render every mermaid diagram in the repository's markdown and fail on
+# any that does not parse.
+#
+# Copied from shakenfist/development at templates/mermaid-lint/. Keep
+# it in step with that copy rather than editing it in place.
+#
+# Mermaid fails at render time, not at commit time, so a diagram with a
+# syntax error is a silently broken documentation page: GitHub shows an
+# error box and mkdocs shows nothing. Nothing else in CI reads a
+# diagram, which is why this exists as its own lane.
+#
+# Rendering is what mermaid-cli does, and rendering needs a browser, so
+# this runs in the upstream container rather than installing a
+# chromium and a node toolchain onto a runner. There is no lighter
+# path worth taking: mermaid's own parse() under plain node throws
+# "DOMPurify.addHook is not a function" for flowchart and
+# stateDiagram-v2 -- the two most common types here -- so a DOM-free
+# checker reports false failures on exactly the diagrams that matter.
+#
+# Usage:
+#   tools/mermaid-lint.sh            # every tracked markdown file
+#   tools/mermaid-lint.sh a.md b.md  # just these
+
+set -euo pipefail
+
+# Pinned deliberately, by digest as well as by tag: a tag is mutable
+# and this runs a third-party container on a runner with a docker
+# daemon. The tag is for a human reading this; the digest is what
+# actually pins. Renovate's stock managers do not read a docker
+# reference out of a shell script, so this moves when somebody moves
+# it; check for a newer tag when a mermaid feature is missing, and
+# take the new digest from the pull rather than trusting the tag
+# alone.
+IMAGE_TAG="ghcr.io/mermaid-js/mermaid-cli/mermaid-cli:11.4.2"
+IMAGE="${IMAGE_TAG}@sha256:99c983b3ab4e14033f2880bc1b9de17e5090b4515dabd63fe9cf8c0ae6130956"
+
+repo_root=$(git rev-parse --show-toplevel)
+
+# The workdir is made up here rather than at the render step, because
+# both the candidate listing and the scan write into it, and both do
+# so because a bash variable cannot hold a NUL byte.
+workdir=$(mktemp -d)
+trap 'rm -rf "${workdir}"' EXIT
+
+# Named files are resolved against the caller's directory and turned
+# into repository-relative paths, because everything below -- the cd,
+# the /src mount, the paths printed in the output -- is relative to
+# the repository root. A name that does not resolve is an error
+# rather than an empty run: the documented per-file usage is exactly
+# the invocation a typo reaches, and a linter that exits zero on a
+# path it never read is the failure this script exists to prevent.
+candidates=()
+if [ "$#" -gt 0 ]; then
+    for arg in "$@"; do
+        if [ ! -f "${arg}" ]; then
+            echo "mermaid-lint: no such file: ${arg}" >&2
+            exit 1
+        fi
+        rel=$(realpath --relative-to="${repo_root}" "${arg}")
+        if [ "${rel#../}" != "${rel}" ]; then
+            echo "mermaid-lint: outside the repository: ${arg}" >&2
+            exit 1
+        fi
+        candidates+=("${rel}")
+    done
+    cd "${repo_root}"
+else
+    # git ls-files rather than find, so vendored and ignored trees are
+    # excluded for free. A Rust project's .cargo-cache alone holds
+    # thousands of markdown files nobody here wrote, several of which
+    # contain diagrams that are not ours to fix.
+    cd "${repo_root}"
+    # NUL-delimited, because git C-quotes a path it cannot print
+    # literally: a non-ASCII byte unless core.quotePath is off, and a
+    # double quote, a backslash or a control character whatever that
+    # setting says. A quoted string names no file that exists and is
+    # dropped by the -f test below -- another diagram unlinted behind
+    # a green run. -z quotes nothing at all, so it subsumes the
+    # setting rather than covering one more case than it did.
+    #
+    # REVIEWS.md is excluded to match the workflow's path filter, which
+    # excludes it so that a review session or a bot prune does not cost
+    # a virtual machine. The two have to agree: a lane that never runs
+    # on the file that changed, but lints it on every other pull
+    # request, reports a broken diagram to whoever next touched an
+    # unrelated markdown file, and to every developer running the
+    # pre-push audit. Excluded here rather than un-excluded there
+    # because a diagram in generated review tracking is not what this
+    # lane is for; name the file on the command line to lint it anyway.
+    #
+    # The pathspec is a literal, so it matches the file at the
+    # repository root and not a docs/REVIEWS.md -- the same scope the
+    # workflow's '!REVIEWS.md' has.
+    #
+    # Into a file with the status checked, rather than through a
+    # process substitution. A process substitution does not trip
+    # set -e, so an ls-files that failed after rev-parse had
+    # succeeded -- a corrupt index, or a pathspec a future git
+    # rejects -- would leave the list empty, print "nothing to lint"
+    # and exit 0. That is the fail-open this script exists to
+    # prevent, and the awk scan below is already handled this way for
+    # the same reason. A file rather than a variable because the
+    # listing is NUL delimited and a bash variable cannot hold a NUL.
+    if ! git ls-files -z '*.md' ':(exclude)REVIEWS.md' \
+            > "${workdir}/candidates"; then
+        echo "mermaid-lint: could not list tracked markdown files" >&2
+        exit 1
+    fi
+    mapfile -d '' -t candidates < "${workdir}/candidates"
+fi
+
+# Exactly three backticks, then "mermaid", then nothing: that is what
+# mmdc recognises. Anything else renders nothing and exits zero, which
+# is why check_mermaid_lint_ci in the development repository matches
+# the same narrow form -- the audit must not call a repository covered
+# for a diagram this script cannot see.
+#
+# There are four ways to miss it, and GitHub renders all four as
+# diagrams: a tilde fence, a space between the fence and the language,
+# four or more backticks, and anything after the language in the info
+# string. Any of them would otherwise ship unlinted through the exact
+# gap this script exists to close. Rather than fail open, refuse the
+# file and say what to change: the narrow mmdc-compatible form stays
+# the only one that can be committed unnoticed.
+#
+# Selecting such a fence rather than refusing it is worse than
+# skipping it, which is what the two length and info-string cases used
+# to do. The file reaches the renderer, mmdc finds no chart in it,
+# the run prints "ok" and counts the file in "Linting N file(s)" --
+# a diagram nobody rendered, reported as one that rendered cleanly.
+#
+# Which means the scan has to track fence state rather than match bare
+# lines. A fence shown inside a longer fence is an example being
+# written about, not a diagram to render, and the page most likely to
+# contain one is the page explaining this very rule -- so a line
+# match would fail the repository for documenting its own linter. The
+# rules are CommonMark's: a fence opens on three or more backticks or
+# tildes and closes on the same character, at least as long, with no
+# info string, and only fences that open at the top level are
+# classified. mmdc reads nested examples too, so a file selected for
+# some other diagram is still rendered whole; what this decides is
+# which files are worth starting a container for, and which are
+# refused outright.
+#
+# Indented code blocks are deliberately not modelled. Four spaces
+# before a fence is far more often a fence inside a list item, which
+# must still be linted, than a fence being quoted -- so treating the
+# indent as a code block would fail open on real diagrams to spare a
+# rarer false positive. Quote a fence inside a longer fence instead;
+# the template README says so.
+#
+# Blockquotes are not modelled either, and that one does fail open: a
+# leading "> " leaves ch=">" and run=0, so the fence is neither
+# selected nor refused, while GitHub renders it and mmdc reports "No
+# mermaid charts found" -- measured against the pinned image, not
+# assumed. It is left that way because the audit's regex does not see
+# such a fence either, so the two halves agree and no repository is
+# called covered for a diagram nothing renders; and because refusing
+# one means deciding what a fence nested inside a blockquoted fence
+# is, which is a new rule with a new blind spot. Put a diagram at the
+# top level.
+existing=()
+newline_named=()
+for candidate in "${candidates[@]}"; do
+    # A newline in the name is refused rather than scanned. Everything
+    # downstream of the scan is line oriented -- files.txt, and the
+    # POSIX sh loop inside the container that reads it, which has no
+    # read -d to switch. Such a path would be silently truncated into
+    # a name that renders nothing, so it is named and the run made red
+    # instead. The scan itself is NUL delimited and would carry it
+    # fine; this is the container side that cannot.
+    if [ "${candidate}" != "${candidate%%$'\n'*}" ]; then
+        newline_named+=("${candidate%%$'\n'*}...")
+        continue
+    fi
+    # Only reachable on the git ls-files path, where an entry can be
+    # staged for deletion; a named file was checked above.
+    if [ -f "${candidate}" ]; then
+        # "./" prefixed, because awk reads an operand shaped like
+        # name=value as a variable assignment rather than a file, and
+        # a repository-root "a=b.md" would go unscanned. The prefix
+        # is taken back off FILENAME before anything is printed.
+        existing+=("./${candidate}")
+    fi
+done
+
+# Into a file rather than through a process substitution, so that an
+# awk that dies takes the script with it under set -e. A scan that
+# failed silently would report no diagrams and exit zero, which is the
+# shape of failure this whole lane exists to prevent.
+#
+# A file rather than a variable because the records are NUL delimited
+# and a bash variable cannot hold a NUL byte. NUL is what makes the
+# name unambiguous: a tracked path may begin or end with a space, and
+# a whitespace-delimited protocol here would undo the NUL-delimited
+# listing above one step later, handing the renderer a name that
+# matches no file.
+#
+# stdin is closed for the same reason the status is checked. awk with
+# no file operands reads stdin, so a list that somehow reduced to none
+# would not fail -- it would block forever waiting on a terminal, or
+# read whatever CI happened to hand it.
+: > "${workdir}/scan"
+if [ "${#existing[@]}" -ne 0 ]; then
+    awk '
+        FNR == 1 {
+            fence = ""; flen = 0; backtick = 0
+        }
+        {
+            line = $0
+            # A markdown file committed with CRLF endings would
+            # otherwise carry the carriage return into the info
+            # string, so no fence would open and none would close.
+            # mmdc reads such a file perfectly well, so the whole
+            # file would go unlinted while the run reported success.
+            sub(/\r$/, "", line)
+            sub(/^[ \t]*/, "", line)
+            ch = substr(line, 1, 1)
+            run = 0
+            if (ch == "`" || ch == "~")
+                while (substr(line, run + 1, 1) == ch)
+                    run++
+            if (run < 3)
+                next
+
+            # CommonMark: the info string of a backtick fence may
+            # not contain a backtick. That one rule is what separates
+            # an opening fence from a line of prose beginning with an
+            # inline code span -- which is how a sentence quoting a
+            # fence starts, and so how this very rule gets written
+            # about. Miss it and such a line opens a fence nothing
+            # closes, swallowing every diagram below it in the file
+            # behind a "nothing to lint" and an exit 0.
+            if (ch == "`" && index(substr(line, run + 1), "`"))
+                next
+
+            # Three readings of the info string, because mmdc reads
+            # one exact form and GitHub renders a family.
+            #
+            # info is the first word with surrounding whitespace
+            # stripped. It answers "is this fence about mermaid at
+            # all", and it is also the closing test, since a closing
+            # fence is one that carries nothing else.
+            #
+            # raw keeps the leading whitespace, because mmdc wants the
+            # language hard against the backticks: `` ` mermaid `` is
+            # a fence GitHub renders and mmdc reads nothing in.
+            #
+            # full is the whole info string, trimmed at both ends but
+            # not cut at the first word, because mmdc also wants the
+            # language to be all there is: ```` ```mermaid title=x ````
+            # is likewise rendered by GitHub and ignored by mmdc.
+            info = substr(line, run + 1)
+            sub(/^[ \t]+/, "", info)
+            sub(/[ \t].*$/, "", info)
+
+            raw = substr(line, run + 1)
+            sub(/[ \t].*$/, "", raw)
+
+            full = substr(line, run + 1)
+            sub(/^[ \t]+/, "", full)
+            sub(/[ \t]+$/, "", full)
+
+            if (fence != "") {
+                if (ch == fence && run >= flen && info == "")
+                    fence = ""
+                next
+            }
+
+            fence = ch
+            flen = run
+            if (info != "mermaid")
+                next
+
+            name = FILENAME
+            sub(/^\.\//, "", name)
+
+            # Every refusal is printed, not just the first of its
+            # kind in the file. Suppressing the rest would make an
+            # author fix one fence, re-run, and be told about the
+            # next -- the same round trip the refusals fall through
+            # to the render step to avoid. The selection is deduped
+            # instead, because each name printed there becomes an
+            # operand for the renderer and a file listed twice would
+            # be rendered twice.
+            #
+            # A record is kind, line and name joined by colons and
+            # terminated by a NUL, because a tracked path may begin
+            # or end with a space and a whitespace-delimited protocol
+            # would lose it. kind carries no colon and the line is
+            # digits, so the reader can split the two off the front
+            # and keep everything after as the name.
+            #
+            # Exactly one linted form: three backticks, then
+            # "mermaid", then nothing. Each of the three ways to
+            # depart from it is rendered by GitHub and ignored by
+            # mmdc, so each is refused rather than selected -- a
+            # selected fence mmdc cannot read is worse than a skipped
+            # one, because the file is then counted in the "Linting N
+            # file(s)" line and reported ok.
+            spaced_fault = (raw != "mermaid")
+            long_fault = (run > 3)
+            extra_fault = (full != "mermaid")
+
+            # Every remedy has to reach the linted form in one step,
+            # or the author fixes a fence, re-runs, and is told about
+            # the next fault in the same fence -- the round trip the
+            # refusals fall through to the render step to avoid. So a
+            # fence with one fault gets the message for that fault,
+            # and a fence with more than one is told the target form
+            # outright rather than the first of several corrections.
+            #
+            # The fence character is tested first for the same
+            # reason: told only to remove the space, the author of a
+            # spaced tilde fence is left with a tilde fence.
+            if (ch == "~") {
+                if (long_fault || extra_fault)
+                    printf "%s:%d:%s%c", "noncanonical", FNR, name, 0
+                else if (spaced_fault)
+                    printf "%s:%d:%s%c", "tilde_spaced", FNR, name, 0
+                else
+                    printf "%s:%d:%s%c", "tilde", FNR, name, 0
+                next
+            }
+            if (spaced_fault + long_fault + extra_fault > 1) {
+                printf "%s:%d:%s%c", "noncanonical", FNR, name, 0
+                next
+            }
+            if (spaced_fault) {
+                printf "%s:%d:%s%c", "spaced", FNR, name, 0
+                next
+            }
+            if (long_fault) {
+                printf "%s:%d:%s%c", "long", FNR, name, 0
+                next
+            }
+            if (extra_fault) {
+                printf "%s:%d:%s%c", "extra", FNR, name, 0
+                next
+            }
+            if (!backtick) {
+                backtick = 1
+                printf "%s:%d:%s%c", "backtick", FNR, name, 0
+            }
+        }
+    ' "${existing[@]}" < /dev/null > "${workdir}/scan"
+fi
+
+files=()
+tilde_fenced=()
+spaced_info=()
+tilde_spaced=()
+long_fenced=()
+extra_info=()
+noncanonical=()
+# IFS emptied and -d '' set, so a name keeping a leading or trailing
+# space arrives intact. The default read would strip both.
+while IFS= read -r -d '' record; do
+    kind=${record%%:*}
+    rest=${record#*:}
+    lineno=${rest%%:*}
+    scanned_file=${rest#*:}
+    case "${kind}" in
+        backtick) files+=("${scanned_file}") ;;
+        tilde) tilde_fenced+=("${scanned_file}:${lineno}") ;;
+        spaced) spaced_info+=("${scanned_file}:${lineno}") ;;
+        tilde_spaced) tilde_spaced+=("${scanned_file}:${lineno}") ;;
+        long) long_fenced+=("${scanned_file}:${lineno}") ;;
+        extra) extra_info+=("${scanned_file}:${lineno}") ;;
+        noncanonical) noncanonical+=("${scanned_file}:${lineno}") ;;
+    esac
+done < "${workdir}/scan"
+
+# Name the file, the line and the remedy. A linter that refuses a page
+# without saying where and what to change turns this into a support
+# burden, and the line number is free -- the scan is already there.
+refuse() {
+    local reason=$1
+    shift
+    local refused
+    for refused in "$@"; do
+        echo "mermaid-lint: ${refused}: ${reason}" >&2
+    done
+}
+
+rc=0
+docker_rc=0
+
+if [ "${#tilde_fenced[@]}" -ne 0 ]; then
+    refuse "mermaid in a tilde fence is not linted; use a backtick fence" \
+        "${tilde_fenced[@]}"
+    rc=1
+fi
+
+if [ "${#spaced_info[@]}" -ne 0 ]; then
+    refuse "mermaid after a space is not linted; remove the space" \
+        "${spaced_info[@]}"
+    rc=1
+fi
+
+# One remedy, not two applied in sequence. Told only to remove the
+# space, the author is left with a tilde fence the next run refuses.
+if [ "${#tilde_spaced[@]}" -ne 0 ]; then
+    both="mermaid in a spaced tilde fence is not linted;"
+    refuse "${both} use a backtick fence with no space" \
+        "${tilde_spaced[@]}"
+    rc=1
+fi
+
+# CommonMark opens a fence on three backticks *or more*, and GitHub
+# renders a four-backtick mermaid block as a diagram. mmdc reads only
+# the three-backtick form, so this was the worst shape of all: the
+# file was selected, sent to the renderer, found to contain no chart,
+# and reported ok inside the "Linting N file(s)" count.
+if [ "${#long_fenced[@]}" -ne 0 ]; then
+    long_msg="mermaid in a fence of more than three backticks is not"
+    refuse "${long_msg} linted; use exactly three" \
+        "${long_fenced[@]}"
+    rc=1
+fi
+
+# GitHub takes the first word of the info string as the language, so
+# it renders ```mermaid title=x. mmdc matches the info string whole
+# and reads nothing in it -- the same silent pass as above.
+if [ "${#extra_info[@]}" -ne 0 ]; then
+    extra_msg="mermaid followed by anything else in the info string is"
+    refuse "${extra_msg} not linted; make it exactly mermaid" \
+        "${extra_info[@]}"
+    rc=1
+fi
+
+# More than one fault in the same fence. Naming the first correction
+# would leave the author to discover the rest one run at a time, so
+# this states the target form instead.
+if [ "${#noncanonical[@]}" -ne 0 ]; then
+    nc_msg="this mermaid fence is not the form mmdc reads; write it as"
+    refuse "${nc_msg} exactly three backticks followed by mermaid" \
+        "${noncanonical[@]}"
+    rc=1
+fi
+
+# A path the container's line-oriented loop cannot carry. Named rather
+# than skipped, for the same reason a tilde fence is.
+if [ "${#newline_named[@]}" -ne 0 ]; then
+    refuse "a newline in the path is not linted; rename the file" \
+        "${newline_named[@]}"
+    rc=1
+fi
+
+# Both refusals fall through rather than exiting here. A repository
+# with a refused fence and a diagram that does not parse should learn
+# about both from one run: the virtual machine this lane needs is the
+# expensive part, and the path filter exists to avoid spinning a
+# second one to deliver the second half of the same answer.
+
+if [ "${#files[@]}" -eq 0 ]; then
+    if [ "${rc}" -eq 0 ]; then
+        echo "No markdown files contain mermaid diagrams; nothing to lint."
+    fi
+    exit "${rc}"
+fi
+
+printf '%s\n' "${files[@]}" > "${workdir}/files.txt"
+
+echo "Linting ${#files[@]} file(s) containing mermaid diagrams."
+
+# One container for the whole run: startup dominates, so a container
+# per file roughly doubles the cost. The image's entrypoint supplies
+# -p /puppeteer-config.json, which the sandbox needs, so overriding
+# the entrypoint means passing it back by hand.
+#
+# The exit status of docker run is the inner shell's, and it is the
+# whole point of this script. Do not pipe this into tail or grep: the
+# pipeline would report the filter's status and turn every failure
+# green. Its status is captured rather than left to set -e, which
+# would abort here and lose the refusals already counted; taking $?
+# rather than a flat 1 keeps a 125 from a failed image pull
+# distinguishable from a diagram that does not parse.
+#
+# --network none because rendering a diagram is a local operation and
+# this is a third-party container driving a browser over repository
+# content. Chromium and mmdc talk over loopback, which a none network
+# still provides, so the sandbox is unaffected; what goes away is the
+# ability to fetch a remote font or icon pack, and a diagram that
+# needs one should fail loudly here rather than render differently on
+# a runner with a different egress path. The daemon pulls a missing
+# image before the container starts, so the pin still works.
+docker run --rm --network none -u "$(id -u):$(id -g)" \
+    -v "${repo_root}":/src:ro \
+    -v "${workdir}":/work \
+    --entrypoint /bin/sh "${IMAGE}" -c '
+        mmdc=/home/mermaidcli/node_modules/.bin/mmdc
+        rc=0
+        while IFS= read -r f; do
+            # stdin closed, for the reason the awk scan has it
+            # closed: this loop is reading files.txt, so a renderer
+            # that read stdin would swallow the rest of the list and
+            # the run would report success having rendered only the
+            # first file. The pinned image does not, measured rather
+            # than assumed; a future node or puppeteer might.
+            if "${mmdc}" -p /puppeteer-config.json \
+                    -i "/src/${f}" -o /work/rendered.md \
+                    </dev/null >/work/log 2>&1; then
+                echo "ok    ${f}"
+            else
+                rc=1
+                echo "FAIL  ${f}"
+                # Trim the puppeteer stack trace through mermaid.js,
+                # which says nothing about the diagram. What is left
+                # is the parse error and its caret, which is what a
+                # person needs.
+                sed "/mermaidcli\/node_modules/,\$d" /work/log \
+                    | sed "s/^/        /"
+            fi
+        done < /work/files.txt
+        exit "${rc}"
+    ' || docker_rc=$?
+
+# A refused fence outranks the renderer's status. Both are failures
+# and either alone is reported as itself, but when they coincide the
+# content failure is the one the author has to act on, and reporting
+# it as a 125 would send them looking at the image pull.
+if [ "${rc}" -eq 0 ]; then
+    rc="${docker_rc}"
+fi
+
+exit "${rc}"


### PR DESCRIPTION
Works through the consistency-audit issues open on this repository, one
commit per issue, each tagged so it autocloses on merge.

Fixes #3732
Fixes #3832
Fixes #3911
Fixes #3977
Fixes #3979

Verified with the development repository's own `scripts/audit-check.py`
run against this worktree before and after: **6 fail -> 1 fail**. The
remaining failure is #3892, deliberately left alone -- see below.
`pre-commit run --all-files` passes clean, all eleven hooks including
the unit suite and mypy.

| Commit | Issue | Change |
|---|---|---|
| `07d5005` | #3977 | Explicit `s` size on the two `vm` jobs relying on the xs fallback |
| `8782ed3` | #3911 | Four shared blocks into `PUSH-AUDIT.md` |
| `c2a0f60` | #3832 | skillsaw in pre-commit, plus an `Agent context` CI lane |
| `5f894c7` | #3979 | Mermaid linter and workflow, and twelve fence fixes |
| `6d5a0d5` | #3732 | 28 plan phase references reworded |

## #3892 is not in this branch

PR #4160 (`push-audit-backfill`) already installs the
`plan-push-audit-phase` v3 block in `PLAN-TEMPLATE.md`, which is
exactly what the `plan-template` check wants. Confirmed by running the
audit against that branch: `plan-template | pass`. Doing it here would
have conflicted with work already in flight.

## Where this went wider than the issue text

**#3911 installs four blocks, not the three the issue names.**
`diagram-discipline` became a required block after the issue was filed.
The three the issue does name -- `path-traversal-review`,
`python-version-discipline`, `functional-test-coverage` -- are the
criteria the audit delegates to a reviewer because no grep can judge
them. Each block goes into the sub-agent brief that already owns its
subject rather than into a section of its own.

**#3979 turned up a real defect.** Twelve diagrams in
`docs/developer_guide/state_machine.md` were fenced as `` ``` mermaid ``
with a space. GitHub renders those; `mmdc` reads nothing in them and
reports no charts found. They would have counted as linted while never
being read -- and they are precisely the state machine diagrams
`PUSH-AUDIT.md` tells a reviewer to check against each object's
`state_targets` map. The space is removed and the whole tree now lints
clean.

The mermaid lane needs a docker daemon, which static runners do not
have, so it runs on `debian-12-docker`; that label is added to
`.github/actionlint.yaml` or actionlint rejects the workflow. Both the
mermaid lane and the agent-context lane are path-filtered and therefore
deliberately **not** required checks -- a path-filtered workflow made
required reports pending forever on the pull requests it filters out.
`needs:` cannot cross workflow files either, so neither is named in
`can_enqueue` or `can_merge`. A red result on either is visible on the
pull request and blocks nothing automatically.

## Docs rewording (#3732)

Most of the 28 were describing history -- "consumed for admission as of
scheduler-reservations phase 3" -- and lose only the archaeology, which
remains recoverable from `docs/plans/`. Four were genuinely
forward-looking and now link the master plan instead of naming a phase
of it: the advisory-to-hard claim enforcement flip, the saturation
tests that will need the no-wait marker, and the provisional headroom
bounds. One was a retrospective about a mistake made while writing a
plan, which keeps its lesson without the phase numbering. No
information is deleted.

---

## Round 2: review response

The `Issue links` check was the only real CI failure -- the `Fixes`
stanzas were in the commit messages and in a backticked table, and
GitHub parses neither through a merge queue. They are now plain lines
in this description. `Can enqueue` failed only because it aggregates
that check.

The bot review raised **2 fix, 2 document, 9 consider**. Both fix items
are addressed, both document items are answered, and five of the nine
considers are taken.

### The substantive one: the mermaid lane read 664 files it may not fix

`docs/components/` is an hourly machine-sync of the sibling
repositories' documentation, which `AGENTS.md` forbids editing here. It
is 664 of this repository's 918 tracked markdown files, and it was 28
of the 30 the lane was reading. A diagram broken in instar or kerbside
would have failed this lane on the next pull request to touch any
markdown, naming a file whose author cannot fix it.

Fixed **upstream first** rather than by editing the vendored copy:
shakenfist/development#122 adds an optional
`tools/mermaid-lint-exclude` to the template, so `tools/mermaid-lint.sh`
here stays byte-identical and is synced rather than edited. A line in
that file matching no tracked file fails the run, because an exclusion
that silently matches nothing leaves a tree linted while the file says
it is not. Eight new tests upstream, mutation-tested five ways.

GitHub Actions cannot read that file, so `mermaid-lint.yml`'s two path
filters carry the same exclusion by hand -- those two lines plus a
comment are this repository's only divergence from the template, and
`ci.md` now records that. **This branch should land after
shakenfist/development#122**, or the vendored script is ahead of its
template.

The lane now reads two files and exits 0.

### The other fix item: a claim nothing backed

`tools/mermaid-lint.sh` justified an exclusion by its cost "to every
developer running the pre-push audit", and nothing here ran it. Rather
than delete the claim, wave 1 of `PUSH-AUDIT.md` now renders the
diagrams when the diff touches markdown -- which also gives the
`diagram-discipline` block this branch adds a mechanical half to go
with its judgment half.

### Documented

`ci.md`'s workflow table was missing both new workflows, and Branch
Protection listed neither as an exception. Both are now there, with the
reason they are advisory and where the vendored files come from.

A new section records the trust boundary the reviewer asked about:
`fork-pr-contributor-approval` on this repository is
`all_external_contributors`, not just first-time ones. That is what
makes the static pool safe for `agent-context.yml`, whose installed
dependency set is chosen by the pull request under test -- the first
lane here with that shape. The note also records that relaxing the
setting moves the lane to an ephemeral runner.

### Considers taken

- skillsaw pinned to `ec30cf07` with the tag in a comment. A tag is
  mutable and pre-commit caches by rev string, so a moved tag changes
  what runs without changing a line here -- the same argument this
  branch already makes for the container digest.
- The two skillsaw warnings on `CLAUDE.md` (~8,100 tokens against a
  6,000 threshold) recorded beside the hook, with the remedy if a
  release promotes them to errors.
- Three reflow artefacts rewrapped. The scheduler one also changed
  meaning: with its "Since ... phase 3" clause gone, the emphatic "do"
  contrasted with nothing. It is a plain assertion now.
- The one place the sweep deleted a citation rather than relinking it
  -- the 40-140x disk measurement in the operator guide -- now links
  the master plan, matching what the rest of the sweep did.

### Considers not taken

- **Tests for the script.** `MermaidLintScriptTest` in
  shakenfist/development already covers it; I added eight cases there
  rather than duplicating a fixture suite here.
- **Drift detection for the vendored copy.** The copy is byte-identical
  to the template again and `ci.md` says to sync rather than edit. A
  recorded stamp is worth doing once several template copies exist.
- **The nested-invalid-example escape hatch.** No such page exists, and
  the tradeoff is deliberate and documented upstream.
- **The proxy question.** Answered rather than changed: the lane passed
  cold in CI, 543MB pull included, because the daemon-side proxy is in
  the runner image. An `http_proxy` in the job would not reach the
  daemon doing the pull. Documented in the template README.
- **The two remaining ASCII diagrams** in `database_internals.md` and
  `locks.md`. Correctly out of scope here; no issue was auto-filed for
  this review, so this needs one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017v1294L3baikkLJNStGhdK
