### PR TITLE
Validate MAC address format on interface create

### DIFF
--- a/docs/developer_guide/api_reference/instances.md
+++ b/docs/developer_guide/api_reference/instances.md
@@ -97,8 +97,9 @@ A full example of a `diskspec` is therefore:
 Similarly, a `networkspec` consists of the following fields in a JSON dictionary:
 
 * network_uuid (uuid): the UUID of the network the interface should exist on.
-* macaddress (string): the MAC address of the interface. Omit this value to be allocated
-  a MAC address automatically.
+* macaddress (string): the MAC address of the interface, in the colon separated form
+  `02:00:00:ea:3a:28`. Either case is accepted. A value in any other form is rejected
+  with a 400. Omit this value to be allocated a MAC address automatically.
 * address (string): the IPv4 address to assign to the interface. Omit this value to be
   allocated a random address.
 * model (enum): the model of the network interface card. In general you should not have

--- a/docs/user_guide/usage.md
+++ b/docs/user_guide/usage.md
@@ -282,7 +282,9 @@ of the following keys:
   instance will fail to start. If you don't want an address on this interface,
   use "none" as the value for address. If you do not specify any value for
   address, an address on the network will be assigned to you.
-* _macaddress_ the mac address to use for the interface.
+* _macaddress_ the mac address to use for the interface, in the colon
+  separated form `02:00:00:ea:3a:28`. Either case is accepted, and a value
+  in any other form is rejected.
 * _model_ is the model of the network device, with options being ne2k_isa,
   i82551, i82557b, i82559er, ne2k_pci, pcnet, rtl8139, e1000, and virtio. The
   default model is virtio.

--- a/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_networking.py
+++ b/shakenfist/deploy/shakenfist_ci/guest_ci_tests/test_networking.py
@@ -119,6 +119,30 @@ class TestNetworking(base.BaseNamespacedTestCase):
         self.assertEqual('', results['stderr'])
         self.assertTrue('04:ed:33:c0:2e:6c' in results['stdout'])
 
+    def test_malformed_macaddress_request(self):
+        self.assertRaises(
+            apiclient.RequestMalformedException,
+            # raw-create: asserts the 400 a malformed MAC gets, which is
+            # raised validating the request, not scheduling it. Before
+            # issue 534 this was accepted, stored on the network
+            # interface, and only failed when libvirt was handed the
+            # domain XML.
+            self.test_client.create_instance,
+            'test-malformed-macaddress', 1, 1024,
+            [
+                {
+                    'network_uuid': self.net_four['uuid'],
+                    'macaddress': 'not-a-mac-address'
+                }
+            ],
+            [
+                {
+                    'size': 8,
+                    'base': 'sf://upload/system/debian-12',
+                    'type': 'disk'
+                }
+            ], None, None)
+
     def test_interface_delete(self):
         inst1 = self.create_instance(
             'test-iface-delete', 1, 1024,

--- a/shakenfist/external_api/base.py
+++ b/shakenfist/external_api/base.py
@@ -50,6 +50,7 @@ from shakenfist.util.access_tokens import parse_jwt_identity
 from shakenfist.util.access_tokens import request_namespace
 from shakenfist.util import exceptions as util_exceptions
 from shakenfist.util import general as util_general
+from shakenfist.util import network as util_network
 
 
 LOG, _ = logs.setup(__name__)
@@ -404,7 +405,7 @@ ARGTYPES: dict[str, dict[str, Any]] = {
     'ipv4': {'type': 'string', 'format': 'an IPv4 address as a string'},
     'macaddr': {
         'type': 'string', 'format': 'a MAC address',
-        'pattern': '^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$'},
+        'pattern': util_network.MACADDR_PATTERN},
     'namespace': {'type': 'string', 'format': 'the name of a namespace'},
     # Deliberately format-only, with no pattern. An IPv4 CIDR
     # pattern would describe the API as narrower than it is:

--- a/shakenfist/external_api/instance.py
+++ b/shakenfist/external_api/instance.py
@@ -63,6 +63,7 @@ from shakenfist.network.interface import NetworkInterface
 from shakenfist.node import Node
 from shakenfist.util.access_tokens import request_namespace
 from shakenfist.util import general as util_general
+from shakenfist.util import network as util_network
 from shakenfist.util import vdi_tokens
 
 
@@ -334,6 +335,19 @@ def _netdesc_safety_checks(netdesc, namespace):
     if 'network_uuid' not in netdesc:
         return sf_api.error(
             400, 'network specification is missing network_uuid')
+
+    # Check the caller supplied MAC before we go anywhere near the
+    # database. A malformed one used to be accepted here, stored on the
+    # network interface, and only rejected much later by libvirt when
+    # the domain XML was defined -- by which point the instance is
+    # mid-create and the error is a long way from the request that
+    # caused it. NetworkInterface.new() generates a MAC when the caller
+    # does not supply one, and those are always well formed.
+    if netdesc.get('macaddress'):
+        if not util_network.valid_macaddr(netdesc['macaddress']):
+            return sf_api.error(
+                400,
+                'network specification requests a malformed MAC address')
 
     # Allow network to be specified by name or UUID (and error early
     # if not found). Scope to the *instance's* namespace, not the

--- a/shakenfist/tests/test_macaddr_validation.py
+++ b/shakenfist/tests/test_macaddr_validation.py
@@ -1,0 +1,105 @@
+# Copyright 2019 Michael Still and contributors
+
+import json
+from unittest import mock
+
+from shakenfist.external_api import base as api_base
+from shakenfist.external_api.instance import _netdesc_safety_checks
+from shakenfist.tests import base
+from shakenfist.util import network as util_network
+
+
+class ValidMacaddrTestCase(base.ShakenFistTestCase):
+    def test_accepts_well_formed(self):
+        for macaddr in ['02:00:00:19:e4:b4', '1a:91:64:d2:15:39',
+                        'AA:BB:CC:DD:EE:FF', '00:00:00:00:00:00',
+                        'aA:bB:cC:dD:eE:fF']:
+            self.assertTrue(util_network.valid_macaddr(macaddr),
+                            f'{macaddr} should be valid')
+
+    def test_rejects_malformed(self):
+        for macaddr in [
+                '',
+                'banana',
+                '02:00:00:19:e4',              # too short
+                '02:00:00:19:e4:b4:c7',        # too long
+                '02-00-00-19-e4-b4',           # dash separated
+                '020000019e4b4',               # no separators
+                '02:00:00:19:e4:g0',           # not hex
+                '2:0:0:19:e4:b4',              # not zero padded
+                ' 02:00:00:19:e4:b4',          # leading whitespace
+                '02:00:00:19:e4:b4 ',          # trailing whitespace
+                '02:00:00:19:e4:b4\n',         # trailing newline
+        ]:
+            self.assertFalse(util_network.valid_macaddr(macaddr),
+                             f'{macaddr!r} should be invalid')
+
+    def test_rejects_non_strings(self):
+        for macaddr in [None, 42, ['02:00:00:19:e4:b4'],
+                        {'macaddress': '02:00:00:19:e4:b4'}]:
+            self.assertFalse(util_network.valid_macaddr(macaddr),
+                             f'{macaddr!r} should be invalid')
+
+    def test_generated_macaddrs_are_valid(self):
+        # A drift guard. If random_macaddr() ever changes shape, the
+        # validator has to keep accepting what we ourselves generate,
+        # or every interface we allocate a MAC for stops being creatable.
+        for _ in range(100):
+            macaddr = util_network.random_macaddr()
+            self.assertTrue(util_network.valid_macaddr(macaddr),
+                            f'generated {macaddr} should be valid')
+
+    def test_published_pattern_matches_validator(self):
+        # The REST API publishes MACADDR_PATTERN as the pattern for the
+        # 'macaddr' parameter type. If these two ever come apart the
+        # specification describes an API we do not implement.
+        self.assertEqual(util_network.MACADDR_PATTERN,
+                         api_base.ARGTYPES['macaddr']['pattern'])
+
+
+class NetdescMacaddrTestCase(base.ShakenFistTestCase):
+    """The MAC format check in _netdesc_safety_checks.
+
+    Both callers of _netdesc_safety_checks -- instance create and
+    interface hotplug -- go through this, so covering the helper covers
+    both entry points.
+    """
+
+    @mock.patch('shakenfist.network.network.Network.from_db_by_ref')
+    def test_malformed_macaddr_rejected(self, mock_from_db_by_ref):
+        resp = _netdesc_safety_checks(
+            {'network_uuid': 'notanetwork', 'macaddress': 'banana'}, 'ns')
+
+        self.assertIsNotNone(resp)
+        self.assertEqual(400, resp.status_code)
+        self.assertIn('malformed MAC address',
+                      json.loads(resp.get_data(as_text=True))['error'])
+
+        # The check happens before the database is consulted. A bad MAC
+        # is a bad request whether or not the network exists, and it
+        # costs nothing to say so without a round trip.
+        mock_from_db_by_ref.assert_not_called()
+
+    @mock.patch('shakenfist.network.network.Network.from_db_by_ref',
+                return_value=None)
+    def test_well_formed_macaddr_passes_the_check(self, mock_from_db_by_ref):
+        # Reaching the network lookup (and so the 404 for a network that
+        # does not exist) proves the MAC was accepted.
+        resp = _netdesc_safety_checks(
+            {'network_uuid': 'notanetwork',
+             'macaddress': '02:00:00:19:e4:b4'}, 'ns')
+
+        self.assertIsNotNone(resp)
+        self.assertEqual(404, resp.status_code)
+        mock_from_db_by_ref.assert_called()
+
+    @mock.patch('shakenfist.network.network.Network.from_db_by_ref',
+                return_value=None)
+    def test_absent_macaddr_is_not_rejected(self, mock_from_db_by_ref):
+        # Not supplying a MAC is the common case: NetworkInterface.new()
+        # generates one.
+        for netdesc in [{'network_uuid': 'notanetwork'},
+                        {'network_uuid': 'notanetwork', 'macaddress': None},
+                        {'network_uuid': 'notanetwork', 'macaddress': ''}]:
+            resp = _netdesc_safety_checks(netdesc, 'ns')
+            self.assertEqual(404, resp.status_code)

--- a/shakenfist/util/network.py
+++ b/shakenfist/util/network.py
@@ -411,6 +411,35 @@ def discover_interfaces() -> tuple[
     return mac_to_iface, iface_to_mac, vxid_to_mac
 
 
+# The one definition of what a MAC address looks like on the wire. The
+# REST API publishes this exact string as the pattern for the 'macaddr'
+# parameter type (see external_api/base.py ARGTYPES), and
+# valid_macaddr() enforces it, so the published contract and the check
+# cannot drift apart.
+_MACADDR_BODY = '([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}'
+MACADDR_PATTERN = f'^{_MACADDR_BODY}$'
+
+# Matched with fullmatch() against the unanchored body rather than
+# match() against MACADDR_PATTERN, because Python's '$' also matches
+# immediately before a trailing newline. '02:00:00:19:e4:b4\n' would
+# otherwise validate and go on to be written into the libvirt domain
+# XML. JSON Schema's '$' has no such quirk, so the published pattern
+# keeps its anchors.
+_MACADDR_RE = re.compile(_MACADDR_BODY)
+
+
+def valid_macaddr(macaddr: Any) -> bool:
+    """Is this a correctly formatted MAC address?
+
+    Colon separated hex only, which is the form libvirt wants in the
+    domain XML and the form random_macaddr() produces. Either case is
+    accepted because MAC addresses are not case sensitive.
+    """
+    if not isinstance(macaddr, str):
+        return False
+    return bool(_MACADDR_RE.fullmatch(macaddr))
+
+
 def random_macaddr() -> str:
     b1 = random.randint(0, 255)
     b2 = random.randint(0, 255)


### PR DESCRIPTION
A caller supplied MAC address was accepted without any format checking, written to `network_interfaces.macaddr`, and only rejected much later when it was interpolated into the libvirt domain XML. By then the instance is mid create, and the error is a long way from the request which caused it.

## What changed

- Format validation in `_netdesc_safety_checks()`, which both entry points accepting a networkspec already go through: instance create and interface hotplug. `NetworkInterface.new()` has only one production caller and it is downstream of this check, so the coverage is complete.
- The check runs *before* the network lookup, since a malformed MAC is a bad request whether or not the network exists.
- The regex moves to `util/network.py` beside `random_macaddr()`, and `external_api/base.py`'s `ARGTYPES` now sources the published `macaddr` pattern from it, so the OpenAPI contract and the enforcement cannot drift apart. The published pattern string is byte identical to before.

## One thing worth reviewing

Enforcement uses `fullmatch()` against an unanchored body rather than `match()` against the anchored pattern. Python's `$` also matches immediately before a trailing newline, so `02:00:00:19:e4:b4\n` validated against the obvious implementation and would have gone on into the domain XML. The test for it was written first and caught this. JSON Schema's `$` has no such quirk, so the published pattern keeps its anchors.

## Testing

- 8 unit tests in `test_macaddr_validation.py`, including two drift guards: that `random_macaddr()` output stays valid, and that the published `ARGTYPES` pattern equals the validator's.
- A functional test asserting the 400, next to the existing `test_specific_macaddress_request` and following the `test_specific_ip_request_invalid` raw-create precedent.
- `pre-commit run --all-files` clean; full unit suite 4777 passed, 0 failed.

Fixes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4hpoNWMBX3dB8epmeaMAB