### PR TITLE
Revoke trusts naming a deleted namespace

### DIFF
--- a/docs/developer_guide/security_model.md
+++ b/docs/developer_guide/security_model.md
@@ -188,6 +188,35 @@ the next artifact type minted against an instance URL does not have to
 rediscover the rule. When looking for write paths, grep for the sink
 (`add_index`) rather than for callers of the resolver.
 
+## Trusts do not outlive the namespace they name
+
+A trust names a namespace by *name*, not by uuid, and namespace names
+are reusable: the REST create handler refuses a name whose static row
+still exists, but the cluster maintainer hard deletes deleted
+namespaces after a delay and that removes the row. A trust which
+outlived the namespace it named would therefore be inherited by
+whoever created that name next, without the granting namespace acting
+or being told — the same hazard `Namespace.hard_delete()` already
+removes mapping rules to avoid.
+
+So deleting a namespace revokes every trust naming it. This happens in
+two places on purpose:
+
+- `DELETE /auth/namespaces/<namespace>` calls
+  `namespace.revoke_inbound_trust()` before it moves the namespace to
+  `deleted`. This is the path that matters: the trust goes when the
+  namespace does, not whenever the hard delete catches up.
+- `Namespace.hard_delete()` sweeps again, as a backstop for a namespace
+  which reached a final state by some path that did not revoke.
+
+Only active namespaces are swept. Deleting a namespace requires it to
+hold no instances or networks and cascade deletes its artifacts, so a
+deleted namespace has nothing left for an inherited trust to expose.
+
+Both revocations are audited: the trusting namespace records
+`trust revoked, trusted namespace is gone`, and the namespace being
+deleted records which namespaces it was removed from.
+
 ## VDI console token trust model
 
 The Kerbside VDI console proxy integration uses **offline signature

--- a/docs/operator_guide/authentication.md
+++ b/docs/operator_guide/authentication.md
@@ -410,6 +410,15 @@ namespaces, scaled down. A namespace you trust can list and read those
 objects. It cannot delete them, rename them, share them, or change their
 metadata — those all require the object's own namespace, or `system`.
 
+A trust also does not outlive the namespace it names. Deleting a namespace
+revokes every trust pointing at it, on every other namespace, at the moment
+of deletion. This matters because a trust names a namespace by name and
+namespace names can be reused once the cluster has finished cleaning the
+deleted one up: without the revocation, whoever created that name next would
+inherit your trust without you doing anything or being told. You will see a
+`trust revoked, trusted namespace is gone` event on your namespace when this
+happens.
+
 Giving is a separate question from taking, and it is still allowed: a
 namespace you trust may *create* an object in your namespace, which is exactly
 the "gift" step in the `ci-images` example above. Creation is additive, you

--- a/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_auth.py
+++ b/shakenfist/deploy/shakenfist_ci/smoke_ci_tests/test_auth.py
@@ -26,3 +26,42 @@ class TestAuth(base.BaseTestCase):
         self.system_client.delete_namespace(name)
         self.assertNotIn(
             name, base.namespace_names(self.system_client.get_namespaces()))
+
+    def test_deleting_a_namespace_revokes_trusts_naming_it(self):
+        """Issue 2074.
+
+        A trust names a namespace by name, and a name becomes reusable
+        once the cluster maintainer hard deletes the static row of the
+        namespace which held it. A trust left behind by a delete is
+        therefore inherited by whoever creates that name next, without
+        the granting namespace doing anything or being told.
+        """
+        truster = 'ci-truster-%s' % self._uniquifier()
+        doomed = 'ci-doomed-%s' % self._uniquifier()
+
+        for name in [truster, doomed]:
+            self.system_client.create_namespace(name)
+            self.addCleanup(self._delete_namespace_if_present, name)
+
+        self.system_client.add_namespace_trust(truster, doomed)
+        self.assertIn(
+            doomed,
+            self.system_client.get_namespace(truster)['trust']['full'])
+
+        self.system_client.delete_namespace(doomed)
+
+        # The trust is gone as soon as the namespace is, rather than
+        # whenever the hard delete happens to catch up.
+        self.assertNotIn(
+            doomed,
+            self.system_client.get_namespace(truster)['trust']['full'])
+
+        # And the trust every namespace is created with survives, or
+        # the cluster admin loses sight of the namespace.
+        self.assertIn(
+            'system',
+            self.system_client.get_namespace(truster)['trust']['full'])
+
+    def _delete_namespace_if_present(self, name):
+        if name in base.namespace_names(self.system_client.get_namespaces()):
+            self.system_client.delete_namespace(name)

--- a/shakenfist/external_api/auth.py
+++ b/shakenfist/external_api/auth.py
@@ -36,6 +36,7 @@ from shakenfist.mapping_rule import MAX_KEY_TTL_SECONDS
 from shakenfist.mapping_rule import RuleValidationError
 from shakenfist.namespace import Namespace
 from shakenfist.namespace import namespace_is_trusted
+from shakenfist.namespace import revoke_inbound_trust
 from shakenfist.namespace import Namespaces
 from shakenfist.namespace_claim import ClaimRefused
 from shakenfist.namespace_claim import NamespaceClaim
@@ -366,6 +367,21 @@ class AuthNamespaceEndpoint(api_base.Resource):
             a.add_event(
                 EVENT_TYPE_AUDIT, 'deletion request via namespace deletion from REST API')
             a.delete()
+
+        # Revoke every trust naming this namespace before it goes. A
+        # trust names a namespace by name and namespace names can be
+        # reused once the cluster maintainer hard deletes the static
+        # row, so a trust left behind is inherited by whoever creates
+        # the name next. Namespace.hard_delete() sweeps again as a
+        # backstop, but waiting for it would leave the trust standing
+        # for the length of the hard delete delay, and there is no
+        # reason for a deleted namespace to be trusted for a moment
+        # longer than it exists. See namespace.revoke_inbound_trust().
+        revoked = revoke_inbound_trust(namespace, 'namespace deleted')
+        if revoked:
+            namespace_from_db.add_event(
+                EVENT_TYPE_AUDIT, 'revoked trusts naming this namespace',
+                extra={'revoked-from': revoked})
 
         namespace_from_db.state = dbo.STATE_DELETED
         namespace_from_db.add_event(EVENT_TYPE_AUDIT, 'deletion request from REST API')

--- a/shakenfist/namespace.py
+++ b/shakenfist/namespace.py
@@ -354,6 +354,16 @@ class Namespace(dbo):
         for rule in mapping_rule.rules_in_namespace(self.uuid):
             rule.hard_delete()
 
+        # Trusts naming this namespace are *not* owned by it -- they
+        # live on whichever other namespaces granted them -- but they
+        # have to go for the same reason the mapping rules do, and the
+        # consequence of missing one is the same. See
+        # revoke_inbound_trust() for why a stale trust is dangerous
+        # rather than merely untidy. This is the backstop: the REST
+        # delete handler revokes at soft delete, so by the time we get
+        # here there is usually nothing left to do.
+        revoke_inbound_trust(self.uuid, 'namespace hard deleted')
+
         # Capacity claims are owned the same way, and leaving one behind
         # is worse than leaving a key or a rule behind: a claim holds
         # cluster capacity in cluster_capacity.claimed_*, and with its
@@ -387,6 +397,59 @@ class Namespace(dbo):
             retval['keys'].append(k)
 
         return retval
+
+
+def revoke_inbound_trust(namespace, reason):
+    """Remove `namespace` from the trust list of every other namespace.
+
+    A trust names a namespace by name, not by uuid, and namespace names
+    become available for reuse: the REST create handler refuses a name
+    whose static row still exists, but the cluster maintainer hard
+    deletes deleted namespaces after a delay and that removes the row.
+    So a trust which outlives the namespace it names is a latent
+    privilege escalation -- whoever next creates that name inherits
+    every trust still pointing at it, without the granting namespace
+    doing anything or being told.
+
+    Namespace.hard_delete() already removes this namespace's mapping
+    rules with exactly this reasoning. Trust was the other half of it.
+
+    Returns the names of the namespaces which were changed.
+
+    Only active namespaces are swept. A deleted namespace cannot be
+    the victim of an inherited trust: deleting one requires it to hold
+    no instances or networks and cascade deletes its artifacts, so
+    there is nothing left for a trust to expose.
+
+    This walks the active namespaces rather than querying for the ones
+    which trust `namespace`. Trust is a JSON list in
+    namespace_attributes, so a pushdown would need JSON_CONTAINS and a
+    new RPC; namespaces number in the tens and deleting one is rare and
+    already expensive, so the scan is not worth that. Revisit if either
+    changes.
+    """
+    revoked = []
+
+    for ns in Namespaces([], prefilter='active'):
+        if ns.uuid == namespace:
+            continue
+        if namespace not in ns.trust:
+            continue
+
+        ns.remove_trust(namespace)
+        ns.add_event(
+            EVENT_TYPE_AUDIT, 'trust revoked, trusted namespace is gone',
+            extra={'untrusted-namespace': namespace, 'reason': reason})
+        revoked.append(ns.uuid)
+
+    if revoked:
+        LOG.with_fields({
+            'namespace': namespace,
+            'revoked-from': revoked,
+            'reason': reason
+        }).info('Revoked trusts naming a deleted namespace')
+
+    return revoked
 
 
 class Namespaces(dbo_iter):

--- a/shakenfist/tests/test_namespace_trust_teardown.py
+++ b/shakenfist/tests/test_namespace_trust_teardown.py
@@ -1,0 +1,98 @@
+# Copyright 2019 Michael Still and contributors
+#
+# Issue 2074: a trust names a namespace by name, not by uuid, and
+# namespace names are reusable once the cluster maintainer hard deletes
+# the static row. A trust which outlives the namespace it names is
+# therefore inherited by whoever creates that name next.
+from unittest import mock
+
+from shakenfist.namespace import Namespace
+from shakenfist.namespace import revoke_inbound_trust
+from shakenfist.tests import base
+from shakenfist.tests.mock_mariadb import MockMariaDB
+
+
+class RevokeInboundTrustTestCase(base.ShakenFistTestCase):
+    def setUp(self):
+        super().setUp()
+        self.mock_mariadb = MockMariaDB(self, node_count=1)
+        self.mock_mariadb.setup()
+        for name in ['alpha', 'beta', 'gamma', 'doomed']:
+            self.mock_mariadb.create_namespace(name, 'key1', 'secret')
+
+    def test_revokes_from_every_truster(self):
+        Namespace.from_db('alpha').add_trust('doomed')
+        Namespace.from_db('beta').add_trust('doomed')
+
+        revoked = revoke_inbound_trust('doomed', 'unit test')
+
+        self.assertEqual(['alpha', 'beta'], sorted(revoked))
+        self.assertNotIn('doomed', Namespace.from_db('alpha').trust)
+        self.assertNotIn('doomed', Namespace.from_db('beta').trust)
+
+    def test_leaves_other_trusts_alone(self):
+        alpha = Namespace.from_db('alpha')
+        alpha.add_trust('doomed')
+        alpha.add_trust('gamma')
+
+        revoke_inbound_trust('doomed', 'unit test')
+
+        # Only the doomed namespace loses its trust. 'system' is granted
+        # to every namespace at creation and must survive too, or the
+        # cluster admin stops being able to see the namespace.
+        self.assertEqual(['system', 'gamma'],
+                         Namespace.from_db('alpha').trust)
+
+    def test_untrusting_namespaces_are_untouched(self):
+        Namespace.from_db('alpha').add_trust('doomed')
+
+        revoked = revoke_inbound_trust('doomed', 'unit test')
+
+        self.assertEqual(['alpha'], revoked)
+        self.assertEqual(['system'], Namespace.from_db('beta').trust)
+        self.assertEqual(['system'], Namespace.from_db('gamma').trust)
+
+    def test_no_trusts_is_not_an_error(self):
+        self.assertEqual([], revoke_inbound_trust('doomed', 'unit test'))
+
+    def test_self_trust_is_skipped(self):
+        # A namespace always trusts itself implicitly
+        # (namespace_is_trusted short circuits), but if a name somehow
+        # appears in its own list we must not trip over it while
+        # deleting that very namespace.
+        doomed = Namespace.from_db('doomed')
+        doomed.add_trust('doomed')
+
+        revoked = revoke_inbound_trust('doomed', 'unit test')
+
+        self.assertEqual([], revoked)
+
+    def test_audit_event_recorded_on_the_truster(self):
+        Namespace.from_db('alpha').add_trust('doomed')
+
+        with mock.patch('shakenfist.namespace.Namespace.add_event') as ae:
+            revoke_inbound_trust('doomed', 'namespace deleted')
+
+        messages = [c.args[1] for c in ae.call_args_list]
+        self.assertIn('trust revoked, trusted namespace is gone', messages)
+
+
+class HardDeleteRevokesTrustTestCase(base.ShakenFistTestCase):
+    """hard_delete() is the backstop behind the REST delete handler."""
+
+    def setUp(self):
+        super().setUp()
+        self.mock_mariadb = MockMariaDB(self, node_count=1)
+        self.mock_mariadb.setup()
+        for name in ['alpha', 'doomed']:
+            self.mock_mariadb.create_namespace(name, 'key1', 'secret')
+
+    def test_hard_delete_revokes_inbound_trust(self):
+        Namespace.from_db('alpha').add_trust('doomed')
+        self.assertIn('doomed', Namespace.from_db('alpha').trust)
+
+        Namespace.from_db('doomed').hard_delete()
+
+        # Without this the name 'doomed' is now free to be recreated by
+        # anyone, and whoever does inherits alpha's trust.
+        self.assertNotIn('doomed', Namespace.from_db('alpha').trust)


### PR DESCRIPTION
A trust names a namespace by *name* rather than by uuid, and namespace names are reusable. The REST create handler refuses a name whose static row still exists, but the cluster maintainer hard deletes deleted namespaces after a delay (`daemons/cluster/scheduled_tasks.py`) and `Namespace.hard_delete()` removes the row. A trust which outlived the namespace it named was therefore inherited by whoever created that name next, without the granting namespace acting or being told.

`Namespace.hard_delete()` already removed this namespace's mapping rules with exactly this reasoning, recorded in the comment there:

> a rule names its namespace by name, so if the name were ever recreated the new owner would inherit a federation trust they never asked for

Trust was the other half of that and was never swept.

## What changed

`namespace.revoke_inbound_trust()`, called from two places on purpose:

- **`DELETE /auth/namespaces/<namespace>`**, before the namespace moves to `deleted`. This is the path that matters: the trust goes when the namespace does, not whenever the hard delete catches up.
- **`Namespace.hard_delete()`**, as a backstop for a namespace which reached a final state by some path that did not revoke.

Both revocations are audited: the trusting namespace records `trust revoked, trusted namespace is gone`, and the namespace being deleted records which namespaces it was removed from.

## Two decisions worth reviewing

**Only active namespaces are swept.** Deleting a namespace requires it to hold no instances or networks and cascade deletes its artifacts, so a deleted namespace has nothing left for an inherited trust to expose.

My first version used `Namespaces([])`, which returns everything in production (an empty state list means "no filter" in `_direct_get_objects_by_state`) but returns nothing under `MockMariaDB`. That would have been a security fix that silently did nothing, with passing tests. `prefilter='active'` is also what every other `Namespaces(...)` caller in the tree uses.

**No SQL pushdown.** Trust is a JSON list in `namespace_attributes`, so filtering for "namespaces trusting X" would need `JSON_CONTAINS` and a new RPC. Namespaces number in the tens and deleting one is rare and already expensive, so the scan is not worth that. The tradeoff is recorded in the docstring rather than left implicit.

## Testing

- 7 unit tests covering the helper and the hard delete backstop.
- A functional test in `smoke_ci_tests/test_auth.py` driving the REST path end to end: create two namespaces, trust one, delete it, assert the trust is gone and that `system` survives.
- **Mutation tested**, per the standing rule that an assertion claiming to prove a fix must be shown to fail without it: removing the `hard_delete` sweep fails exactly 1 test, removing the revocation fails 3.
- `pre-commit run --all-files` clean; full unit suite 4776 passed, 0 failed.

Fixes #2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4hpoNWMBX3dB8epmeaMAB