### PR TITLE
Mark the saturation suite's raw creates

### DIFF
--- a/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_saturation.py
+++ b/shakenfist/deploy/shakenfist_ci/cluster_ci_tests/test_saturation.py
@@ -230,6 +230,10 @@ class TestSaturationRefusals(_CapacityReadingTestCase):
 
         exc = self.assertRaises(
             apiclient.InsufficientResourcesException,
+            # raw-create: the 507 is the assertion. The wrapper would wait
+            # the whole 420s deadline for capacity which cannot arrive --
+            # the request is beyond every node's ledger ceiling by
+            # construction -- and then fail for the wrong reason.
             self.test_client.create_instance,
             'impossible-cpu', requested_cpus, 128, None,
             [{'size': 1, 'type': 'disk'}], None, None)
@@ -289,6 +293,9 @@ class TestSaturationRefusals(_CapacityReadingTestCase):
 
         exc = self.assertRaises(
             apiclient.InsufficientResourcesException,
+            # raw-create: the 507 is the assertion, and the request is
+            # beyond every node's RAM ceiling by construction, so waiting
+            # for capacity can only burn the deadline. See the CPU test.
             self.test_client.create_instance,
             'impossible-memory', 1, requested_memory_mb, None,
             [{'size': 1, 'type': 'disk'}], None, None)
@@ -355,6 +362,9 @@ class TestSaturationRefusals(_CapacityReadingTestCase):
 
         exc = self.assertRaises(
             apiclient.InsufficientResourcesException,
+            # raw-create: the 507 is the assertion, and the request exceeds
+            # the whole cluster's free disk by construction, so waiting for
+            # capacity can only burn the deadline. See the CPU test.
             self.test_client.create_instance,
             'impossible-disk', 1, 128, None,
             [{'size': requested_disk_gb, 'type': 'disk'}], None, None)
@@ -507,6 +517,12 @@ class TestNodeFillRefusal(_CapacityReadingTestCase):
         test is best placed to catch, while leaving up to a whole create
         budget of stray instances on the siblings D23 exists to protect.
         """
+        # raw-create: filling a node to its ledger limit means walking
+        # into the refusal deliberately, and both callers below handle the
+        # InsufficientResourcesException themselves -- the fill loop reads
+        # it as "a sibling took the last slot", and the full-node test
+        # asserts it. A wrapper which waited one out would convert the
+        # boundary this file exists to measure into a timeout.
         inst = self.test_client.create_instance(
             'nodefill-%d' % index, 1, 128, None, [{'size': 1, 'type': 'disk'}],
             None, None, force_placement=node_name)


### PR DESCRIPTION
`develop` is currently failing `Sanity checks`, and the merge queue with it. This is the fix.

## What happened

`PLAN-transient-capacity-refusals` phase 2 ([#4166](https://github.com/shakenfist/shakenfist/pull/4166), merged 2026-09-11 23:54) added an AST guard which fails on any `create_instance()` call in the functional suite that neither goes through `BaseTestCase`'s waiting wrapper nor carries a `# raw-create: <reason>` marker.

`PLAN-ci-cloud-sizing` phase 3a ([#4170](https://github.com/shakenfist/shakenfist/pull/4170), merged 2026-09-12 04:47) landed `cluster_ci_tests/test_saturation.py` with four unmarked raw calls, about five hours later.

Neither change was wrong and neither could see the other: #4170's branch was cut before the guard existed, and the guard cannot see a file which does not exist yet. Each passed on its own base, so the merge queue did not catch the pair either. At least two subsequent `merge_group` runs have failed on it — [34681505274](https://github.com/shakenfist/shakenfist/actions/runs/34681505274) and [34685164595](https://github.com/shakenfist/shakenfist/actions/runs/34685164595), both on `test_ci_raw_creates.RawCreateInstanceMarkerTestCase.test_no_unmarked_raw_create_calls_in_the_suite`.

## The fix

Markers, not routing. All four sites must see the raw refusal, and phase 2's scope said so in advance: *"the sizing plan's phase 3 saturation tests must call the raw client and assert the refusal; the allowlist marker exists for them."*

- Three are the `assertRaises` in the impossible-request tests (`:233`, `:292`, `:358`). The 507 **is** the assertion, and the request exceeds every node's ceiling by construction — so the wrapper would wait the whole 420 s deadline for capacity that cannot arrive, then fail for the wrong reason.
- The fourth is `_create_fill_instance()` (`:510`), whose two callers each handle the `InsufficientResourcesException` themselves: the fill loop reads it as a sibling taking the last slot, and the full-node test asserts it. That site already carried a comment saying exactly this — *"Deliberately not wrapped in `retries.retry_while_transient()`: a refusal under assertion must never be retried away"* — so the marker just states the existing reasoning where the guard can see it.

No behaviour changes; comments only.

## Verification

- `test_ci_raw_creates` passes (13 tests).
- `pre-commit run --all-files` passes.

This is the guard doing its job on the first real collision, and it found it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Czfe1Jt9Tbh7cwhWBgMV9s